### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,55 @@
+*.doc  diff=astextplain
+*.DOC	diff=astextplain
+*.docx	diff=astextplain
+*.DOCX	diff=astextplain
+*.dot	diff=astextplain
+*.DOT	diff=astextplain
+*.pdf	diff=astextplain
+*.PDF	diff=astextplain
+*.rtf	diff=astextplain
+*.RTF	diff=astextplain
+
+*.jpg  	binary
+*.png 	binary
+*.gif 	binary
+
+*.sh eol=lf
+
+*.cs text=auto diff=csharp 
+*.vb text=auto
+*.resx text=auto
+*.c text=auto
+*.cpp text=auto
+*.cxx text=auto
+*.h text=auto
+*.hxx text=auto
+*.py text=auto
+*.rb text=auto
+*.java text=auto
+*.html text=auto
+*.htm text=auto
+*.css text=auto
+*.scss text=auto
+*.sass text=auto
+*.less text=auto
+*.js text=auto
+*.lisp text=auto
+*.clj text=auto
+*.sql text=auto
+*.php text=auto
+*.lua text=auto
+*.m text=auto
+*.asm text=auto
+*.erl text=auto
+*.fs text=auto
+*.fsx text=auto
+*.hs text=auto
+
+*.props text=auto
+*.targets text=auto
+*.csproj text=auto
+*.vbproj text=auto
+*.fsproj text=auto
+*.dbproj text=auto
+*.xlf text=auto
+*.sln text=auto eol=crlf


### PR DESCRIPTION
Adds a `.gitattributes` file to ensure consistent attributes for file types. It is an exact duplicate of the same file from the dotnet/installer repo: https://github.com/dotnet/installer/blob/b779a08108728457fafe44a70294ecdb7f14634e/.gitattributes

I originally ran into issues with the .sh scripts in the repo as a result of cloning on Windows and attempting to run the scripts in WSL. The .sh scripts had CRLF line endings instead of LF. This `.gitattributes` file ensures that all .sh scripts will have LF line endings no matter platform is used.