### PR TITLE
tests: ExecuteRunWeb: update expected SIGTERM exit code on mono.

### DIFF
--- a/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
+++ b/test/Microsoft.DotNet.SourceBuild.SmokeTests/DotNetHelper.cs
@@ -14,6 +14,7 @@ internal class DotNetHelper
 {
     private static readonly object s_lockObj = new();
 
+    private static bool IsMonoRuntime { get; } = DetermineIsMonoRuntime();
     public static string DotNetPath { get; } = Path.Combine(Config.DotNetDirectory, "dotnet");
     public static string LogsDirectory { get; } = Path.Combine(Directory.GetCurrentDirectory(), "logs");
     public static string PackagesDirectory { get; } = Path.Combine(Directory.GetCurrentDirectory(), "packages");
@@ -198,10 +199,13 @@ internal class DotNetHelper
 
     public void ExecuteRunWeb(string projectName)
     {
+        // 'dotnet run' exit code differs between CoreCLR and Mono (https://github.com/dotnet/sdk/issues/30095).
+        int expectedExitCode = IsMonoRuntime ? 143 : 0;
         ExecuteCmd(
             $"run {GetBinLogOption(projectName, "run")}",
             GetProjectDirectory(projectName),
             additionalProcessConfigCallback: processConfigCallback,
+            expectedExitCode,
             millisecondTimeout: 30000);
 
         void processConfigCallback(Process process)
@@ -228,6 +232,28 @@ internal class DotNetHelper
         }
 
         return $"/bl:{Path.Combine(LogsDirectory, $"{fileName}.binlog")}";
+    }
+
+    private static bool DetermineIsMonoRuntime()
+    {
+        string dotnetRoot = Config.DotNetDirectory;
+
+        string sharedFrameworkRoot = Path.Combine(dotnetRoot, "shared", "Microsoft.NETCore.App");
+        if (!Directory.Exists(sharedFrameworkRoot))
+        {
+            return false;
+        }
+
+        string? version = Directory.GetDirectories(sharedFrameworkRoot).FirstOrDefault();
+        if (version is null)
+        {
+            return false;
+        }
+
+        string sharedFramework = Path.Combine(sharedFrameworkRoot, version);
+
+        // Check the presence of one of the mono header files.
+        return File.Exists(Path.Combine(sharedFramework, "mono-gc.h"));
     }
 
     private static string GetProjectDirectory(string projectName) => Path.Combine(ProjectsDirectory, projectName);


### PR DESCRIPTION
Adjust the expected exit code of the WebScenarioTests smoke test so it passes on Mono.

With this change, all smoke tests pass on mono.

https://github.com/dotnet/runtime/issues/81093 tracks fixing Mono so the exit code is the same value as CoreCLR.

cc @crummel @MichaelSimons @omajid @uweigand