### PR TITLE
Remove UsingToolNetFrameworkReferenceAssemblies

### DIFF
--- a/src/installer/eng/Versions.props
+++ b/src/installer/eng/Versions.props
@@ -1,9 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
   <!-- Arcade features -->
-  <PropertyGroup>
-    <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
-  </PropertyGroup>
   <PropertyGroup>
     <VersionMajor>9</VersionMajor>
     <VersionMinor>0</VersionMinor>


### PR DESCRIPTION
UsingToolNetFrameworkReferenceAssemblies got removed from Arcade a while ago as the SDK supports that natively.