### PR TITLE
Remove UsingToolNetFrameworkReferenceAssemblies

### DIFF
--- a/src/roslyn/eng/Versions.props
+++ b/src/roslyn/eng/Versions.props
@@ -64,7 +64,6 @@
     <UsingToolPdbConverter>false</UsingToolPdbConverter>
     <UsingToolSymbolUploader>true</UsingToolSymbolUploader>
     <UsingToolNuGetRepack>true</UsingToolNuGetRepack>
-    <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
     <UsingToolIbcOptimization>true</UsingToolIbcOptimization>
     <UsingToolVisualStudioIbcTraining>true</UsingToolVisualStudioIbcTraining>
     <UsingToolXliff>true</UsingToolXliff>


### PR DESCRIPTION
UsingToolNetFrameworkReferenceAssemblies got removed from Arcade a while ago as the SDK supports that natively.