### PR TITLE
Add back file that was somehow removed during a SB patch removal

### DIFF
--- a/src/source-build-externals/src/application-insights/LOGGING/test/Shared/CustomTelemetryChannel.cs
+++ b/src/source-build-externals/src/application-insights/LOGGING/test/Shared/CustomTelemetryChannel.cs
@@ -1,0 +1,102 @@
+﻿//-----------------------------------------------------------------------------------
+// <copyright file='CustomTelemetryChannel.cs' company='Microsoft Corporation'>
+//     Copyright (c) Microsoft Corporation. All Rights Reserved.
+//     Information Contained Herein is Proprietary and Confidential.
+// </copyright>
+//-----------------------------------------------------------------------------------
+
+namespace Microsoft.ApplicationInsights
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+
+    internal sealed class CustomTelemetryChannel : ITelemetryChannel
+    {
+        private EventWaitHandle waitHandle;
+
+        public CustomTelemetryChannel()
+        {
+            this.waitHandle = new AutoResetEvent(false);
+#if NET452
+            this.SentItems = new ITelemetry[0];
+#else
+            this.SentItems = Array.Empty<ITelemetry>();
+#endif
+        }
+
+        public bool? DeveloperMode { get; set; }
+
+        public string EndpointAddress { get; set; }
+
+        public ITelemetry[] SentItems { get; private set; }
+
+        public void Send(ITelemetry item)
+        {
+            lock (this)
+            {
+                ITelemetry[] current = this.SentItems;
+                List<ITelemetry> temp = new List<ITelemetry>(current);
+                temp.Add(item);
+                this.SentItems = temp.ToArray();
+                this.waitHandle.Set();
+            }
+        }
+
+        public Task<int?> WaitForItemsCaptured(TimeSpan timeout)
+        {
+            // Pattern for Wait Handles from: https://msdn.microsoft.com/en-us/library/hh873178%28v=vs.110%29.aspx#WaitHandles
+            var tcs = new TaskCompletionSource<int?>();
+
+            var rwh = ThreadPool.RegisterWaitForSingleObject(
+                this.waitHandle, 
+                (state, timedOut) =>
+                {
+                    if (timedOut)
+                    {
+                        tcs.SetResult(null);
+                    }
+                    else
+                    {
+                        lock (this)
+                        {
+                            tcs.SetResult(this.SentItems.Length);
+                        }
+                    }
+                }, 
+                state: null, 
+                millisecondsTimeOutInterval: Convert.ToUInt32(timeout.TotalMilliseconds), 
+                executeOnlyOnce: true);
+
+            var t = tcs.Task;
+            t.ContinueWith((previousTask) => rwh.Unregister(null));
+            return t;
+        }
+
+        public void Flush()
+        {
+            throw new Exception("Flush called");
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public CustomTelemetryChannel Reset()
+        {
+            lock (this)
+            {
+#if NET452
+                this.SentItems = new ITelemetry[0];
+#else
+                this.SentItems = Array.Empty<ITelemetry>();
+#endif
+            }
+
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
This is an attempt to unblock the sync issue in https://github.com/dotnet/installer/pull/18875.

This file appears to have incorrectly removed in https://github.com/dotnet/dotnet/commit/224de31151c1aee28ab32ee36eceab6eb9cfef34.  With the changes in https://github.com/dotnet/installer/pull/18875, this file is being changed.  It's absence appears to be breaking the sync process.