### PR TITLE
Correctly set ContinueOnError when cleaning a repo

### DIFF
--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -623,7 +623,7 @@
 
     <!-- Cleanup everything else. Ignore errors as out-of-band build servers don't reliably shut down, even with the build-server shutdown command.
          https://github.com/dotnet/source-build/issues/4175 tracks a long term fix. -->
-    <RemoveDir Directories="@(DirsToDeleteWithTrailingSeparator)" ContinueOnError="true" />
+    <RemoveDir Directories="@(DirsToDeleteWithTrailingSeparator)" ContinueOnError="WarnAndContinue" />
 
     <Message Text="DirSize After CleanupRepo $(RepositoryName)" Importance="High" Condition="'$(BuildOS)' != 'windows'and '@(DirsToDeleteWithTrailingSeparator)' != ''" />
     <Exec Command="df -h $(RepoRoot)" Condition="'$(BuildOS)' != 'windows'and '@(DirsToDeleteWithTrailingSeparator)' != ''" />


### PR DESCRIPTION
Docs for the setting: https://learn.microsoft.com/en-us/visualstudio/msbuild/how-to-ignore-errors-in-tasks?view=vs-2022

Noticed in https://dev.azure.com/dnceng-public/public/_build/results?buildId=852266&view=logs&jobId=9050e078-31bf-5111-d8ec-8b6fa95caf9c&j=9050e078-31bf-5111-d8ec-8b6fa95caf9c&t=523d8a07-ca4d-5c7a-367a-d86c5fc4038b that this still errors out.