### PR TITLE
Add ThirdPartyNoticesTemplatePath to source mappings

### DIFF
--- a/src/source-mappings.json
+++ b/src/source-mappings.json
@@ -14,6 +14,8 @@
 
     "sourceMappingsPath": "src/sdk/src/VirtualMonoRepo/source-mappings.json",
 
+    "thirdPartyNoticesTemplatePath": "src/sdk/src/VirtualMonoRepo/THIRD-PARTY-NOTICES.template.txt"
+
     // Some files are copied outside of the src/ directory into other locations
     // When files in the source paths are changed, they are automatically synchronized too
     "additionalMappings": [


### PR DESCRIPTION
In https://github.com/dotnet/arcade-services/pull/4473 we made PCS read ThirdPartyNoticesTemplatePath from the source-mappings, so we're updating them here too. This is only used in the service, so we don't need to backport this change, as older branches use the `darc vmr` commands