### PR TITLE
Make devcontainer usable in VS Code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,5 +18,8 @@
             ]
         }
     },
+    "remoteEnv": {
+        "PATH": "${containerEnv:PATH}:/workspaces/dotnet/.dotnet"
+    },
     "onCreateCommand": ".devcontainer/init.sh"
 }

--- a/.devcontainer/init-toolset.sh
+++ b/.devcontainer/init-toolset.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+vmr_dir="${1:-/workspaces/dotnet}"
+. "$vmr_dir/eng/common/tools.sh"
+
+InitializeDotNetCli $false

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -9,6 +9,8 @@ workspace_dir=$(realpath "$script_root/../../")
 tmp_dir=$(realpath "$workspace_dir/tmp")
 vmr_dir=$(realpath "$workspace_dir/dotnet")
 
+$vmr_dir/.devcontainer/init-toolset.sh $vmr_dir
+
 cp "$vmr_dir/.devcontainer/synchronize-vmr.sh" "$workspace_dir"
 
 mkdir -p "$tmp_dir"


### PR DESCRIPTION
This does a few things:

- Changes init.sh so that it installs the .NET SDK
- Puts `dotnet` on `$PATH` so it can be used in VS Code