### PR TITLE
Refactor how SB repo prebuilt detection is disabled

### DIFF
--- a/src/arcade/eng/common/core-templates/steps/source-build.yml
+++ b/src/arcade/eng/common/core-templates/steps/source-build.yml
@@ -93,9 +93,7 @@ steps:
       $portableBuildArgs \
       /p:DotNetBuildSourceOnly=true \
       /p:DotNetBuildRepo=true \
-      /p:AssetManifestFileName=$assetManifestFileName \
-      /p:SetUpSourceBuildIntermediateNupkgCache=false \
-      /p:ReportPrebuiltUsage=false
+      /p:AssetManifestFileName=$assetManifestFileName
   displayName: Build
 
 # Upload build logs for diagnosis.

--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
@@ -7,7 +7,7 @@
 
   <PropertyGroup>
     <MicrosoftDotNetSourceBuildTasksBuildDir>$(NuGetPackageRoot)microsoft.dotnet.sourcebuild.tasks\$(MicrosoftDotNetSourceBuildTasksVersion)\build\</MicrosoftDotNetSourceBuildTasksBuildDir>
-    <ReportPrebuiltUsage Condition="'$(ReportPrebuiltUsage)' == '' and '$(DotNetBuildSourceOnly)' == 'true'">true</ReportPrebuiltUsage>
+    <ReportPrebuiltUsage Condition="'$(ReportPrebuiltUsage)' == '' and '$(DotNetBuildSourceOnly)' == 'true'">$(DotNetBuildOrchestrator)</ReportPrebuiltUsage>
   </PropertyGroup>
 
   <Import Project="$(MicrosoftDotNetSourceBuildTasksBuildDir)Microsoft.DotNet.SourceBuild.Tasks.props" />

--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcadeTools.targets
@@ -11,6 +11,10 @@
     <PackageReference Include="Microsoft.DotNet.SourceBuild.Tasks" Version="$(MicrosoftDotNetSourceBuildTasksVersion)" IsImplicitlyDefined="true" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <SetUpSourceBuildIntermediateNupkgCache Condition="'$(SetUpSourceBuildIntermediateNupkgCache)' == ''">false</SetUpSourceBuildIntermediateNupkgCache>
+  </PropertyGroup>
+
   <!-- Because the condition here is rather complex, it should read as the following:
       - Don't collect intermediates if running the product build or the intermediate nupkg cache feature is explicitly disabled
       - Otherwise, collect if Building from source and we're in the inner build -->


### PR DESCRIPTION
This moves the logic to disable repo level source build prebuilt detection out of the source build pipeline template so that the local dev experience has the detection disabled as well.