### PR TITLE
Always use the .NET SDK compiler

### DIFF
--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -33,7 +33,7 @@
     <CommonArgs>$(CommonArgs) /p:SourceBuiltPdbArtifactsDir=$(RepoArtifactsPdbArtifactsDir.TrimEnd('\'))</CommonArgs>
     <CommonArgs>$(CommonArgs) /p:SourceBuiltNonShippingPackagesDir=$(RepoArtifactsNonShippingPackagesDir.TrimEnd('\'))</CommonArgs>
 
-    <!-- Prefer the .NET SDK compiler -->
+    <!-- Force the use of the compiler in the .NET SDK compiler to avoid torn state issues in inner repos. -->
     <CommonArgs>$(CommonArgs) /p:UsingToolMicrosoftNetCompilers=false</CommonArgs>
 
     <!-- Pass RID and Portable/non-portable information -->

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -33,6 +33,9 @@
     <CommonArgs>$(CommonArgs) /p:SourceBuiltPdbArtifactsDir=$(RepoArtifactsPdbArtifactsDir.TrimEnd('\'))</CommonArgs>
     <CommonArgs>$(CommonArgs) /p:SourceBuiltNonShippingPackagesDir=$(RepoArtifactsNonShippingPackagesDir.TrimEnd('\'))</CommonArgs>
 
+    <!-- Prefer the .NET SDK compiler -->
+    <CommonArgs>$(CommonArgs) /p:UsingToolMicrosoftNetCompilers=false</CommonArgs>
+
     <!-- Pass RID and Portable/non-portable information -->
     <_platformIndex>$(NETCoreSdkRuntimeIdentifier.LastIndexOf('-'))</_platformIndex>
     <RuntimeOS>$(NETCoreSdkRuntimeIdentifier.Substring(0, $(_platformIndex)))</RuntimeOS>

--- a/repo-projects/runtime.proj
+++ b/repo-projects/runtime.proj
@@ -45,10 +45,6 @@
     <EnableDefaultRidSpecificArtifacts Condition="'$(EnableDefaultRidSpecificArtifacts)' != 'true'">false</EnableDefaultRidSpecificArtifacts>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
-    <BuildArgs>$(BuildArgs) /p:UsingToolMicrosoftNetCompilers=false</BuildArgs>
-  </PropertyGroup>
-
   <ItemGroup>
     <RepositoryReference Include="arcade" />
     <RepositoryReference Include="cecil" />


### PR DESCRIPTION
This avoids torn state when a repo uses an older Toolset compiler package.

Partially unblocks https://github.com/dotnet/dotnet/pull/233