### PR TITLE
Remove warnAsError=false from wpf

### DIFF
--- a/repo-projects/wpf.proj
+++ b/repo-projects/wpf.proj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <ForceDotNetMSBuildEngine>false</ForceDotNetMSBuildEngine>
 
-    <BuildArgs>$(BuildArgs) $(FlagParameterPrefix)warnAsError $(ArcadeFalseBoolBuildArg)</BuildArgs>
     <!-- TODO setting Platform shouldn't be necesary: https://github.com/dotnet/source-build/issues/4314 -->
     <BuildArgs>$(BuildArgs) /p:Platform=$(TargetArchitecture)</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:BuildWithNetFrameworkHostedCompiler=true</BuildArgs>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/3539 & https://github.com/dotnet/source-build/issues/3795

Got fixed with the latest source flow.