### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,11 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @dotnet/product-construction and @dotnet/source-build will be
+# requested for review when someone opens a pull request.
+* @dotnet/product-construction @dotnet/source-build
+
+# Exclude the src folder which is team specific
+/src/


### PR DESCRIPTION
I noticed that in contrast to dotnet/sdk we don't have a CODEOWNERS policy for the VMR orchestrator files. Adding a CODEOWNERS file that ignores the _src_ folder.