### PR TITLE
Set External visibility for dotnet-runtime-pgo artifacts

### DIFF
--- a/eng/vmr-msft-comparison-baseline.json
+++ b/eng/vmr-msft-comparison-baseline.json
@@ -295,11 +295,6 @@
   },
   {
     "issueType": "MissingNonShipping",
-    "idMatch": ".*dotnet-runtime-pgo.*",
-    "justification": "PGO blobs for runtime are not required. Only SDK"
-  },
-  {
-    "issueType": "MissingNonShipping",
     "idMatch": ".*containerize.UnitTests.*",
     "justification": "sdk non-shipping test packages are not published"
   },

--- a/src/runtime/eng/Publishing.props
+++ b/src/runtime/eng/Publishing.props
@@ -41,6 +41,11 @@
     <Artifact Remove="$(ArtifactsShippingPackagesDir)*.Manifest-*.nupkg" />
   </ItemGroup>
 
+  <!-- The PGO runtime should always have External visibility, even if someone changes the default artifact visibility -->    
+  <ItemGroup>    
+    <Artifact Update="$(ArtifactsShippingPackagesDir)dotnet-runtime-pgo-*" Visibility="External" />    
+  </ItemGroup>
+
   <!--
     Mark host-RID-targeting assets as Vertical visibility when building in the VMR.
     We can't use NETCoreSdkRuntimeIdentifier here as the Arcade SDK projects don't import the .NET SDK.


### PR DESCRIPTION
It turns out we still need to keep this for now because the current sdk official build relies on it. We didn't notice since we suppressed it in the asset baseline comparison.