### PR TITLE
Copy repo symbols in VMR orchestrator

### DIFF
--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -43,7 +43,6 @@
     <NuGetConfigFile Condition="'$(OriginalNuGetConfigFile)' != ''">$(BaseIntermediateOutputPath)$([System.IO.Path]::GetFileName('$(OriginalNuGetConfigFile)'))</NuGetConfigFile>
 
     <RepoAssetManifestsDir>$([MSBuild]::NormalizeDirectory('$(AssetManifestsIntermediateDir)', '$(RepositoryName)'))</RepoAssetManifestsDir>
-    <IntermediateSymbolsRepoDir>$([MSBuild]::NormalizeDirectory('$(IntermediateSymbolsRootDir)', '$(RepositoryName)'))</IntermediateSymbolsRepoDir>
 
     <RepoArtifactsDir>$([MSBuild]::NormalizeDirectory('$(ProjectDirectory)', 'artifacts'))</RepoArtifactsDir>
     <RepoArtifactsPackageCache>$([MSBuild]::NormalizeDirectory('$(RepoArtifactsDir)', 'sb', 'package-cache'))</RepoArtifactsPackageCache>
@@ -147,7 +146,6 @@
     <BuildArgs>$(BuildArgs) /p:RepositoryUrl=$(DotNetRepositoryUrl)</BuildArgs>
   </PropertyGroup>
   <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
-    <BuildArgs>$(BuildArgs) /p:SourceBuiltSymbolsDir=$(IntermediateSymbolsRepoDir)</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:DotNetBuildSourceOnly=true</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:PreviouslySourceBuiltNupkgCacheDir="$(PreviouslySourceBuiltPackagesPath)"</BuildArgs>
     <BuildArgs>$(BuildArgs) /p:ReferencePackageNupkgCacheDir="$(ReferencePackagesDir)"</BuildArgs>

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -659,6 +659,31 @@
     </MSBuild>
   </Target>
 
+  <Target Name="CopyRepoSymbols" Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(IsUtilityProject)' != 'true'">
+    <PropertyGroup>
+      <IntermediateSymbolsRepoDir>$([MSBuild]::NormalizeDirectory('$(IntermediateSymbolsRootDir)', '$(RepositoryName)'))</IntermediateSymbolsRepoDir>
+
+      <SymbolsRoot>$(RepoArtifactsDir)</SymbolsRoot>
+      <!-- Fall back to repo root for source-build-externals. -->
+      <SymbolsRoot Condition="'$(RepositoryName)' == 'source-build-externals'">$(ProjectDirectory)</SymbolsRoot>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <AbsoluteSymbolPath Include="$(SymbolsRoot)**\obj\**\*.pdb" />
+      <AbsoluteSymbolPath Condition="'@(AbsoluteSymbolPath)' != ''">
+        <RelativePath>$([MSBuild]::MakeRelative($(SymbolsRoot), %(FullPath)))</RelativePath>
+      </AbsoluteSymbolPath>
+    </ItemGroup>
+
+    <MakeDir Directories="$(IntermediateSymbolsRepoDir)" />
+
+    <Copy
+      SourceFiles="@(AbsoluteSymbolPath)"
+      DestinationFolder="$(IntermediateSymbolsRepoDir)%(RecursiveDir)"
+      SkipUnchangedFiles="true"
+      UseHardlinksIfPossible="true" />
+  </Target>
+
   <!-- Copy restored packages from inner build to ensure they're included in the
        main build prebuilt check -->
   <Target Name="CopyInnerBuildRestoredPackages"
@@ -822,6 +847,7 @@
     RepoBuild;
     MoveDotNetBuildLogs;
     LogRepoArtifacts;
+    CopyRepoSymbols;
     CopyInnerBuildRestoredPackages;
     ExtractToolPackage;
     CleanupRepo" />

--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/AfterSourceBuild.proj
@@ -1,5 +1,5 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
-<Project DefaultTargets="AfterSourceBuildInnerBuild;AfterSourceBuild">
+<Project DefaultTargets="AfterSourceBuild">
 
   <Import Project="..\BuildStep.props" />
 
@@ -11,18 +11,6 @@
   </PropertyGroup>
 
   <Import Project="$(MicrosoftDotNetSourceBuildTasksBuildDir)Microsoft.DotNet.SourceBuild.Tasks.props" />
-
-  <Target Name="AfterSourceBuildInnerBuild"
-          Condition="'$(DotNetBuildInnerRepo)' == 'true' and
-                     '$(DotNetBuildOrchestrator)' == 'true'"
-          DependsOnTargets="CopyRepoSymbolsToIntermediates;ClearPreviousSBRP" />
-
-  <Target Name="ClearPreviousSBRP"
-          Condition="'$(GitHubRepositoryName)' == 'source-build-reference-packages'">
-    <!-- Building SBRP: At this point the References directory contains the previously-source-built SBRPs,
-         clear it before publishing current SBRPs.  This ensures n-1 SBRPs aren't required to build the product repos. -->
-    <RemoveDir Directories="$(ReferencePackageNupkgCacheDir)" />
-  </Target>
 
   <Target Name="AfterSourceBuild"
           Condition="'$(DotNetBuildInnerRepo)' != 'true'"

--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/SourceBuild/SourceBuildArcade.targets
@@ -202,16 +202,6 @@
     <Delete Files="$(SymbolsList)" Condition="Exists($(SymbolsList))" />
   </Target>
 
-  <Target Name="CopyRepoSymbolsToIntermediates"
-          DependsOnTargets="DiscoverRepoSymbols"
-          Condition="'$(SourceBuiltSymbolsDir)' != ''">
-    <MakeDir Directories="$(SourceBuiltSymbolsDir)" />
-    <Copy
-      SourceFiles="@(AbsoluteSymbolPath)"
-      DestinationFolder="$(SourceBuiltSymbolsDir)%(RecursiveDir)"
-      UseHardlinksIfPossible="true" />
-  </Target>
-
   <!--
     This target can be removed once we enable standard repo assets manifests and SB orchestrator
     starts using it - https://github.com/dotnet/source-build/issues/3970


### PR DESCRIPTION
Move the CopyRepoSymbolsToIntermediates target into hte VMR orchestrator and sequence it into the repo build. Remove it from ArPow Arcade