### PR TITLE
Fix .devcontainer init-toolset.sh to actually install the dotnet sdk

### DIFF
--- a/.devcontainer/init-toolset.sh
+++ b/.devcontainer/init-toolset.sh
@@ -3,4 +3,4 @@
 vmr_dir="${1:-/workspaces/dotnet}"
 . "$vmr_dir/eng/common/tools.sh"
 
-InitializeDotNetCli $false
+InitializeDotNetCli true


### PR DESCRIPTION
Otherwise the Codespaces creation fails