### PR TITLE
Build scenario-tests in installers validation job

### DIFF
--- a/eng/pipelines/templates/steps/vmr-validate-installers.yml
+++ b/eng/pipelines/templates/steps/vmr-validate-installers.yml
@@ -36,8 +36,7 @@ steps:
       -t \
       --projects test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj \
       /p:TestRpmPackages=true \
-      /p:TestDebPackages=true \
-      /p:SkipScenarioTestsDependencies=true
+      /p:TestDebPackages=true
     displayName: Validate installer packages
     workingDirectory: $(Build.SourcesDirectory)
 

--- a/eng/pipelines/templates/steps/vmr-validate-installers.yml
+++ b/eng/pipelines/templates/steps/vmr-validate-installers.yml
@@ -36,7 +36,8 @@ steps:
       -t \
       --projects test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj \
       /p:TestRpmPackages=true \
-      /p:TestDebPackages=true
+      /p:TestDebPackages=true \
+      /p:SkipScenarioTestsDependencies=true
     displayName: Validate installer packages
     workingDirectory: $(Build.SourcesDirectory)
 

--- a/repo-projects/scenario-tests.proj
+++ b/repo-projects/scenario-tests.proj
@@ -13,8 +13,8 @@
     <UseBootstrapArcade Condition="('$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetSourceOnlyTestOnly)' == 'true') or '$(SkipScenarioTestsDependencies)' == 'true'">true</UseBootstrapArcade>
   </PropertyGroup>
 
-  <!-- In source only test mode, do not depend on other repositories as the scenario tests repo needs to be capable of being built
-       by itself in a standalone validation job. -->
+  <!-- In source only test mode, or if SkipScenarioTestsDependencies is set to 'true', do not depend on other repositories
+       as the scenario tests repo needs to be capable of being built by itself in a standalone validation job. -->
   <ItemGroup Condition="'$(DotNetSourceOnlyTestOnly)' != 'true' and '$(SkipScenarioTestsDependencies)' != 'true'">
     <RepositoryReference Include="arcade" />
     <RepositoryReference Include="command-line-api" />

--- a/repo-projects/scenario-tests.proj
+++ b/repo-projects/scenario-tests.proj
@@ -10,12 +10,15 @@
     <!-- Don't use the updated NuGet.config file that includes the live package feeds when testing source-only as in that configuration
          the Microsoft built packages should be used. -->
     <TestArgs Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetSourceOnlyTestOnly)' != 'true'">$(TestArgs) /p:TestRestoreConfigFile=$(OriginalNuGetConfigFile)</TestArgs>
-    <UseBootstrapArcade Condition="('$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetSourceOnlyTestOnly)' == 'true') or '$(SkipScenarioTestsDependencies)' == 'true'">true</UseBootstrapArcade>
+
+    <!-- In source only test mode, or if SkipScenarioTestsDependencies is 'true', do not depend on other repositories
+         as the scenario tests repo needs to be capable of being built by itself in a standalone validation job.
+         This also requires the use of bootstrap arcade. -->
+    <SkipScenarioTestsDependencies Condition="'$(DotNetSourceOnlyTestOnly)' == 'true'">true</SkipScenarioTestsDependencies>
+    <UseBootstrapArcade Condition="'$(SkipScenarioTestsDependencies)' == 'true'">true</UseBootstrapArcade>
   </PropertyGroup>
 
-  <!-- In source only test mode, or if SkipScenarioTestsDependencies is set to 'true', do not depend on other repositories
-       as the scenario tests repo needs to be capable of being built by itself in a standalone validation job. -->
-  <ItemGroup Condition="'$(DotNetSourceOnlyTestOnly)' != 'true' and '$(SkipScenarioTestsDependencies)' != 'true'">
+  <ItemGroup Condition="'$(SkipScenarioTestsDependencies)' != 'true'">
     <RepositoryReference Include="arcade" />
     <RepositoryReference Include="command-line-api" />
     <!-- Depend on NuGet packages from the sdk repo and transitive repositories. -->

--- a/repo-projects/scenario-tests.proj
+++ b/repo-projects/scenario-tests.proj
@@ -10,12 +10,12 @@
     <!-- Don't use the updated NuGet.config file that includes the live package feeds when testing source-only as in that configuration
          the Microsoft built packages should be used. -->
     <TestArgs Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetSourceOnlyTestOnly)' != 'true'">$(TestArgs) /p:TestRestoreConfigFile=$(OriginalNuGetConfigFile)</TestArgs>
-    <UseBootstrapArcade Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetSourceOnlyTestOnly)' == 'true'">true</UseBootstrapArcade>
+    <UseBootstrapArcade Condition="('$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetSourceOnlyTestOnly)' == 'true') or '$(SkipScenarioTestsDependencies)' == 'true'">true</UseBootstrapArcade>
   </PropertyGroup>
 
   <!-- In source only test mode, do not depend on other repositories as the scenario tests repo needs to be capable of being built
        by itself in a standalone validation job. -->
-  <ItemGroup Condition="'$(DotNetSourceOnlyTestOnly)' != 'true'">
+  <ItemGroup Condition="'$(DotNetSourceOnlyTestOnly)' != 'true' and '$(SkipScenarioTestsDependencies)' != 'true'">
     <RepositoryReference Include="arcade" />
     <RepositoryReference Include="command-line-api" />
     <!-- Depend on NuGet packages from the sdk repo and transitive repositories. -->

--- a/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
+++ b/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
@@ -13,6 +13,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
+    <!--
+      Installer tests require scenario-tests artifacts. Microsoft.DotNet.UnifiedBuild.Tasks project needs to be built
+      before scenario-tests project. Separate traversal project is needed so projects can be built in specific order.
+    -->
+    <ProjectReference Include="installer-tests-prereqs.proj" />
   </ItemGroup>
 
   <Target Name="SetRuntimeConfigOptions"

--- a/test/Microsoft.DotNet.Installer.Tests/installer-tests-prereqs.proj
+++ b/test/Microsoft.DotNet.Installer.Tests/installer-tests-prereqs.proj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.Build.Traversal">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
+  </PropertyGroup>
+
+  <!-- Make sure that Microsoft.DotNet.UnifiedBuild.Tasks is built before building the scenario-tests project -->
+  <ItemGroup>
+    <ProjectReference Include="$(TasksDir)Microsoft.DotNet.UnifiedBuild.Tasks/Microsoft.DotNet.UnifiedBuild.Tasks.csproj" BuildInParallel="false" />
+    <ProjectReference Include="$(RepoProjectsDir)scenario-tests.proj" BuildInParallel="false" />
+  </ItemGroup>
+
+</Project>

--- a/test/Microsoft.DotNet.Installer.Tests/installer-tests-prereqs.proj
+++ b/test/Microsoft.DotNet.Installer.Tests/installer-tests-prereqs.proj
@@ -7,7 +7,7 @@
   <!-- Make sure that Microsoft.DotNet.UnifiedBuild.Tasks is built before building the scenario-tests project -->
   <ItemGroup>
     <ProjectReference Include="$(TasksDir)Microsoft.DotNet.UnifiedBuild.Tasks/Microsoft.DotNet.UnifiedBuild.Tasks.csproj" BuildInParallel="false" />
-    <ProjectReference Include="$(RepoProjectsDir)scenario-tests.proj" BuildInParallel="false" />
+    <ProjectReference Include="$(RepoProjectsDir)scenario-tests.proj" BuildInParallel="false" AdditionalProperties="SkipScenarioTestsDependencies=true" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/5053

Installer tests require scenario-tests package, which is not published anymore from any vertical.

This PR modifies installer tests project to build scenario-tests repo, as a dependency (project reference). Building scenario-tests, like any other repo in VMR, requires that UnifiedBuild.Tasks assembly is built first. That project is now also built as a required dependency of installer tests project.

- Separate traversal project was needed for build ordering of the dependencies.
- We don't want and don't need to build dependencies for scenario-tests project (repo), it builds OK without them. This required a new property, `SkipScenarioTestsDependencies`, to skip the build of project's references/dependencies.
- When skipping dependencies, we need to use the bootstrap arcade - same property is used in that condition. I think this is OK and self-explaining, without additional comments in the code.

Verification build was successful: https://dev.azure.com/dnceng/internal/_build/results?buildId=2699510&view=results