### PR TITLE
VMR signing validation should fail when no files are processed

### DIFF
--- a/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/SigningValidation.cs
+++ b/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/SigningValidation.cs
@@ -217,6 +217,13 @@ public class SigningValidation : Microsoft.Build.Utilities.Task
                 Log.LogError($"SignCheck failed with exit code {process.ExitCode}: {errorLogContent}");
             }
 
+            string stdoutLog = GetLogPath(_signCheckStdoutLogFileName);
+            string stdoutLogContent = File.Exists(stdoutLog) ? File.ReadAllText(stdoutLog).Trim() : string.Empty;
+            if (!string.IsNullOrWhiteSpace(stdoutLogContent) && stdoutLogContent.Contains("No files were processed"))
+            {
+                Log.LogError("SignCheck did not process any files.");
+            }
+
             Log.LogMessage(MessageImportance.High, $"SignCheck completed.");
         }
     }


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/5117

The VMR validation is currently green despite no files being processed, which is confusing from a UX perspective because it looks like the validation was successful. To fix this, we should log an error when no files are processed.