### PR TITLE
Remove publish arg from SB repo template

### DIFF
--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -303,12 +303,12 @@
   </Target>
 
   <!-- TODO: Remove when all repos use a consistent set of eng/common files: https://github.com/dotnet/source-build/issues/3710. -->
-  <Target Name="UpdateEngCommonFiles">
+  <Target Name="UpdateEngCommonFiles" Condition="'$(UseBootstrapArcade)' != 'true'">
     <ItemGroup>
-      <OrchestratorEngCommonFile Include="$(RepositoryEngineeringDir)common\**\*" />
+      <InputEngCommonFile Include="$(RepoRoot)src\arcade\eng\common\**\*" />
     </ItemGroup>
 
-    <Copy SourceFiles="@(OrchestratorEngCommonFile)"
+    <Copy SourceFiles="@(InputEngCommonFile)"
           DestinationFolder="$(ProjectDirectory)eng\common\%(RecursiveDir)"
           SkipUnchangedFiles="true" />
   </Target>

--- a/src/arcade/eng/common/core-templates/steps/source-build.yml
+++ b/src/arcade/eng/common/core-templates/steps/source-build.yml
@@ -46,11 +46,6 @@ steps:
       buildConfig='$(_BuildConfig)'
     fi
 
-    officialBuildArgs=
-    if [ '${{ and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}' = 'True' ]; then
-      officialBuildArgs='/p:DotNetPublishUsingPipelines=true /p:OfficialBuildId=$(BUILD.BUILDNUMBER)'
-    fi
-
     targetRidArgs=
     if [ '${{ parameters.platform.targetRID }}' != '' ]; then
       targetRidArgs='/p:TargetRid=${{ parameters.platform.targetRID }}'
@@ -66,16 +61,6 @@ steps:
       baseOsArgs='/p:BaseOS=${{ parameters.platform.baseOS }}'
     fi
 
-    publishArgs=
-    if [ '${{ parameters.platform.skipPublishValidation }}' != 'true' ]; then
-      publishArgs='--publish'
-    fi
-
-    assetManifestFileName=SourceBuild_RidSpecific.xml
-    if [ '${{ parameters.platform.name }}' != '' ]; then
-      assetManifestFileName=SourceBuild_${{ parameters.platform.name }}.xml
-    fi
-
     portableBuildArgs=
     if [ '${{ parameters.platform.portableBuild }}' != '' ]; then
       portableBuildArgs='/p:PortableBuild=${{ parameters.platform.portableBuild }}'
@@ -83,9 +68,8 @@ steps:
 
     ${{ coalesce(parameters.platform.buildScript, './build.sh') }} --ci \
       --configuration $buildConfig \
-      --restore --build --pack $publishArgs -bl \
+      --restore --build --pack -bl \
       ${{ parameters.platform.buildArguments }} \
-      $officialBuildArgs \
       $internalRuntimeDownloadArgs \
       $internalRestoreArgs \
       $targetRidArgs \
@@ -94,7 +78,6 @@ steps:
       $portableBuildArgs \
       /p:DotNetBuildSourceOnly=true \
       /p:DotNetBuildRepo=true \
-      /p:AssetManifestFileName=$assetManifestFileName
   displayName: Build
 
 # Upload build logs for diagnosis.


### PR DESCRIPTION
The SB repo template shouldn't publish as it doesn't produce the intermediate package anymore.

... and copy eng/common files from arcade instead of VMR orchestrator. That one is the source when flowing eng/common to external repos, not the VMR orchestrator ones.



Unblocks https://github.com/dotnet/source-build-externals/pull/477