### PR TITLE
Put poison results under ArtifactsLogDir

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -194,9 +194,9 @@
 
   <PropertyGroup Condition="'$(EnablePoison)' == 'true'">
     <PoisonMarkerFile>.prebuilt.xml</PoisonMarkerFile>
-    <PoisonReportDataFile>$(PackageReportDir)poison-catalog.xml</PoisonReportDataFile>
-    <PoisonedReportFile>$(PackageReportDir)poisoned.txt</PoisonedReportFile>
-    <PoisonUsageReportFile>$(PackageReportDir)poison-usage.xml</PoisonUsageReportFile>
+    <PoisonReportDataFile>$(ArtifactsLogDir)poison-catalog.xml</PoisonReportDataFile>
+    <PoisonedReportFile>$(ArtifactsLogDir)poisoned.txt</PoisonedReportFile>
+    <PoisonUsageReportFile>$(ArtifactsLogDir)poison-usage.xml</PoisonUsageReportFile>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/init-poison.proj
+++ b/eng/init-poison.proj
@@ -15,7 +15,7 @@
           Outputs="$(BaseIntermediateOutputPath)PoisonPrebuiltPackages.complete">
     <PropertyGroup>
       <SourceBuiltPoisonMarkerFile>.source-built.xml</SourceBuiltPoisonMarkerFile>
-      <SourceBuiltPoisonReportDataFile>$(PackageReportDir)poison-source-built-catalog.xml</SourceBuiltPoisonReportDataFile>
+      <SourceBuiltPoisonReportDataFile>$(ArtifactsLogDir)poison-source-built-catalog.xml</SourceBuiltPoisonReportDataFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -606,16 +606,6 @@ jobs:
     continueOnError: true
     condition: succeededOrFailed()
 
-  - ${{ if eq(parameters.buildSourceOnly, 'True') }}:
-    - task: CopyFiles@2
-      displayName: Copy prebuilt-report to BuildLogs
-      inputs:
-        SourceFolder: '$(sourcesPath)'
-        Contents: artifacts/prebuilt-report/**
-        TargetFolder: '$(Build.ArtifactStagingDirectory)/BuildLogs'
-      continueOnError: true
-      condition: succeededOrFailed()
-
   - ${{ if or(ne(variables['System.TeamProject'], 'internal'), eq(variables['Build.Reason'], 'PullRequest')) }}:
     - publish: $(Build.ArtifactStagingDirectory)/BuildLogs
       artifact: $(Agent.JobName)_BuildLogs_Attempt$(System.JobAttempt)

--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -56,7 +56,6 @@
     <ArcadeBootstrapVersion>$([MSBuild]::ValueOrDefault('$(ARCADE_BOOTSTRAP_VERSION)', '$(ArcadeSdkVersion)'))</ArcadeBootstrapVersion>
 
     <ArtifactsLogRepoDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsLogDir)', '$(RepositoryName)'))</ArtifactsLogRepoDir>
-    <PackageReportRepoDir>$([MSBuild]::NormalizeDirectory('$(PackageReportDir)', '$(RepositoryName)'))</PackageReportRepoDir>
 
     <RidAgnosticVerticalName>Windows_x64</RidAgnosticVerticalName>
 

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -701,23 +701,15 @@
   </Target>
 
   <Target Name="MoveDotNetBuildLogs"
-        Condition="'$(IsUtilityProject)' != 'true' and
-                    Exists('$(RepoArtifactsDir)')">
+        Condition="'$(IsUtilityProject)' != 'true'">
     <ItemGroup>
-      <LogFilesToMove Include="$(RepoArtifactsDir)**/*.log" />
-      <LogFilesToMove Include="$(RepoArtifactsDir)**/*.binlog" />
-      <PrebuiltReportsToMove Include="$(RepoArtifactsDir)sb/prebuilt-report/*" />
+      <LogFilesToMove Include="$(RepoArtifactsDir)log\$(Configuration)\**\*" />
     </ItemGroup>
 
     <!-- Move the build logs -->
     <Move SourceFiles="@(LogFilesToMove)"
           DestinationFolder="$(ArtifactsLogRepoDir)"
           Condition="'@(LogFilesToMove)' != ''" />
-
-    <!-- Move the prebuilt reports -->
-    <Move SourceFiles="@(PrebuiltReportsToMove)"
-          DestinationFolder="$(PackageReportRepoDir)"
-          Condition="'@(PrebuiltReportsToMove)' != ''" />
   </Target>
 
   <!-- Make a copy of project.assets.json files for prebuilt report generation. -->


### PR DESCRIPTION
Extracted from https://github.com/dotnet/dotnet/pull/176

Put the poison result files under `artifacts\log\<config>\`  and avoid the now unnecessary copy step in the YML.
Also remove the unnecessary `PrebuiltReportsToMove` Move operation as the files already get written to the VMR log directory.

This makes everything nicely contained under the log directory (prebuilt + poison + sbrpusage + repo logs)