### PR TITLE
Clean up OS/RID controls used for Source-Build

### DIFF
--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -35,10 +35,9 @@
     <RuntimeOS>$(NETCoreSdkRuntimeIdentifier.Substring(0, $(_platformIndex)))</RuntimeOS>
 
     <_platformIndex>$(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))</_platformIndex>
-    <BaseOS>$(NETCoreSdkPortableRuntimeIdentifier.Substring(0, $(_platformIndex)))-$(TargetArchitecture)</BaseOS>
+    <BaseRid>$(NETCoreSdkPortableRuntimeIdentifier.Substring(0, $(_platformIndex)))-$(TargetArchitecture)</BaseRid>
     <CommonArgs>$(CommonArgs) /p:PortableBuild=$(PortableBuild)</CommonArgs>
-    <CommonArgs Condition="'$(ShortStack)' != 'true' and '$(TargetOS)' != 'linux-musl'">$(CommonArgs) /p:RuntimeOS=$(RuntimeOS)</CommonArgs>
-    <CommonArgs Condition="'$(ShortStack)' != 'true' and '$(TargetOS)' != 'linux-musl'">$(CommonArgs) /p:BaseOS=$(BaseOS)</CommonArgs>
+    <CommonArgs Condition="'$(ShortStack)' != 'true' and '$(TargetOS)' != 'linux-musl'">$(CommonArgs) /p:BaseRid=$(BaseRid)</CommonArgs>
     <CommonArgs Condition="'$(DefaultArtifactVisibility)' != ''">$(CommonArgs) /p:DefaultArtifactVisibility=$(DefaultArtifactVisibility)</CommonArgs>
 
     <!-- Only pass these properites through when necessary to reduce command line noise. -->

--- a/src/arcade/Documentation/UnifiedBuild/Unified-Build-Controls.md
+++ b/src/arcade/Documentation/UnifiedBuild/Unified-Build-Controls.md
@@ -142,8 +142,9 @@ In addition to these default high level controls, there may be additional compon
 | TargetOS | Same as `BuildOS` | `BuildOS` | The operating system of the machine that will run the binary -> the end user’s machine. |
 | HostOS | Same as `BuildOS` | `TargetOS` | The operating system of the machine that will run the produced tool (i.e. compiler) to generate the binary for the target operating system. |
 | BuildRid | Valid RIDs | RID of the the currently executing runtime | The RID of the runtime that is running the build |
-| TargetRid | Valid RIDs | When building non-portable, the OS of build Rid + TargetArchitecture. When building portable, `TargetOS-TargetArchitecture`. | The RID of the runtime that will run the binary -> the end user’s machine. |
-| HostRid | Valid RIDs | `TargetRid` | The RID of the runtime that will run the produced tool (i.e. compiler) to generate the binary for the target operating system. |
+| TargetRid | Valid RIDs or custom RID | When building non-portable, the OS of build Rid + TargetArchitecture. When building portable, `TargetOS-TargetArchitecture`. | The RID of the runtime that will run the binary -> the end user’s machine. |
+| HostRid | Valid RIDs or `TargetRid` | `TargetRid` | The RID of the runtime that will run the produced tool (i.e. compiler) to generate the binary for the target operating system. |
+| BaseRid | Valid RIDs | OS portion of `NETCoreSdkPortableRuntimeIdentifier` appended with `-TargetArchitecture` | A known RID to use as a parent of a custom RID specified in `TargetRid` if `TargetRid` is unknown. |
 | BuildArchitecture | "x64", "x86", "arm", "arm64", ... | The architecture of the build environment | The architecture of the machine that is built on. Lower-case string. |
 | TargetArchitecture | Same as `BuildArchitecture` | `BuildArchitecture` | The architecture of the machine that will run the binary -> the end user's machine. |
 | HostArchitecture | Same as `BuildArchitecture` | `TargetArchitecture` | The architecture of the machine that will run the produced tool (i.e. compiler) to generate the binary for the target architecture |

--- a/src/arcade/eng/common/core-templates/steps/source-build.yml
+++ b/src/arcade/eng/common/core-templates/steps/source-build.yml
@@ -38,14 +38,9 @@ steps:
       targetRidArgs='/p:TargetRid=${{ parameters.platform.targetRID }}'
     fi
 
-    runtimeOsArgs=
-    if [ '${{ parameters.platform.runtimeOS }}' != '' ]; then
-      runtimeOsArgs='/p:RuntimeOS=${{ parameters.platform.runtimeOS }}'
-    fi
-
-    baseOsArgs=
-    if [ '${{ parameters.platform.baseOS }}' != '' ]; then
-      baseOsArgs='/p:BaseOS=${{ parameters.platform.baseOS }}'
+    baseRidArgs=
+    if [ '${{ parameters.platform.baseRID }}' != '' ]; then
+      baseRidArgs='/p:BaseRid=${{ parameters.platform.baseRID }}'
     fi
 
     portableBuildArgs=
@@ -59,8 +54,7 @@ steps:
       ${{ parameters.platform.buildArguments }} \
       $internalRuntimeDownloadArgs \
       $targetRidArgs \
-      $runtimeOsArgs \
-      $baseOsArgs \
+      $baseRidArgs \
       $portableBuildArgs \
       /p:DotNetBuildSourceOnly=true \
       /p:DotNetBuildRepo=true \

--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/RuntimeIdentifierInference.BeforeNETSdkTargets.targets
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/RuntimeIdentifierInference.BeforeNETSdkTargets.targets
@@ -67,8 +67,8 @@
       We can't actually use the RID graph here as RID graph filtering is only possible in a task, and we need to do this during property evaluation.
     -->
     <_FilterRuntimeIdentifier>$(TargetRid)</_FilterRuntimeIdentifier>
-    <!-- If we're introducing a new runtime identifier with TargetRid, filter instead on BaseOS. -->
-    <_FilterRuntimeIdentifier Condition="'$(BaseOS)' != ''">$(BaseOS)</_FilterRuntimeIdentifier>
+    <!-- If we're introducing a new runtime identifier with TargetRid, filter instead on BaseRid. -->
+    <_FilterRuntimeIdentifier Condition="'$(BaseRid)' != ''">$(BaseRid)</_FilterRuntimeIdentifier>
 
     <!-- If a project builds for a set of RIDs specified in the project file and this vertical isn't in the list, suppress building this project. -->
     <_SuppressAllTargets Condition="'$(DisableArcadeExcludeFromBuildSupport)' != 'true' and $(_ExplicitlySpecifiedRuntimeIdentifiers).Contains(';$(_FilterRuntimeIdentifier);')) == 'false'">true</_SuppressAllTargets>

--- a/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.targets
+++ b/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.targets
@@ -121,8 +121,8 @@
   <PropertyGroup>
     <InstallerRuntimeIdentifiers Condition="'$(InstallerRuntimeIdentifiers)' == ''">$(RuntimeIdentifiers)</InstallerRuntimeIdentifiers>
     <InstallerRuntimeIdentifier Condition="'$(InstallerRuntimeIdentifier)' == ''">$(RuntimeIdentifier)</InstallerRuntimeIdentifier>
-    <!-- When building a non-portable build, BaseOS can specify a known (portable) RID that is a parent of the curent runtime identifier. -->
-    <InstallerRuntimeIdentifier Condition="'$(PortableBuild)' == 'false' and '$(BaseOS)' != '' and '$(BaseOS)' != '$(RuntimeIdentifier)'">$(BaseOS)</InstallerRuntimeIdentifier>
+    <!-- When building a non-portable build, BaseRid can specify a known (portable) RID that is a parent of the curent runtime identifier. -->
+    <InstallerRuntimeIdentifier Condition="'$(PortableBuild)' == 'false' and '$(BaseRid)' != '' and '$(BaseRid)' != '$(RuntimeIdentifier)'">$(BaseRid)</InstallerRuntimeIdentifier>
   </PropertyGroup>
   
   <Import Project="$(MSBuildThisFileDirectory)installer.singlerid.targets"

--- a/src/aspnetcore/src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
+++ b/src/aspnetcore/src/SiteExtensions/LoggingAggregate/src/Microsoft.AspNetCore.AzureAppServices.SiteExtension/Microsoft.AspNetCore.AzureAppServices.SiteExtension.csproj
@@ -65,7 +65,7 @@
         Targets="_VmrBuild" />
     <MSBuild Projects="..\..\..\Runtime\Microsoft.AspNetCore.Runtime.SiteExtension.pkgproj"
         BuildInParallel="false"
-        Properties="Platform=x86;TargetRid=win-x86;BaseOS=win-x86;TargetRuntimeIdentifier=win-x86;TargetArchitecture=x86"
+        Properties="Platform=x86;TargetRid=win-x86;BaseRid=win-x86;TargetRuntimeIdentifier=win-x86;TargetArchitecture=x86"
         Targets="_VmrBuild" />
     <MSBuild Projects="..\..\..\LoggingBranch\LB.csproj"
         BuildInParallel="false"
@@ -73,7 +73,7 @@
         Targets="_VmrBuild" />
     <MSBuild Projects="..\..\..\LoggingBranch\LB.csproj"
         BuildInParallel="false"
-        Properties="Platform=x86;TargetRid=win-x86;BaseOS=win-x86;TargetRuntimeIdentifier=win-x86;TargetArchitecture=x86;DisableTransitiveFrameworkReferences=true"
+        Properties="Platform=x86;TargetRid=win-x86;BaseRid=win-x86;TargetRuntimeIdentifier=win-x86;TargetArchitecture=x86;DisableTransitiveFrameworkReferences=true"
         Targets="_VmrBuild" />
   </Target>
 
@@ -112,7 +112,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(DotNetBuild)' == 'true'">
-      <_SiteExtensionsReference Include="$(ArtifactsNonShippingPackagesDir)Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorMinorVersion).x64.%(_ResolvedPackageVersionInfo.PackageVersion).nupkg" 
+      <_SiteExtensionsReference Include="$(ArtifactsNonShippingPackagesDir)Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorMinorVersion).x64.%(_ResolvedPackageVersionInfo.PackageVersion).nupkg"
           Name="Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorMinorVersion).x64" />
       <_SiteExtensionsReference Include="$(ArtifactsNonShippingPackagesDir)Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorMinorVersion).x86.%(_ResolvedPackageVersionInfo.PackageVersion).nupkg"
           Name="Microsoft.AspNetCore.AzureAppServices.SiteExtension.$(AspNetCoreMajorMinorVersion).x86" />

--- a/src/roslyn/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
+++ b/src/roslyn/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer/Microsoft.CodeAnalysis.LanguageServer.csproj
@@ -45,13 +45,13 @@
     <PublishDir Condition="'$(RuntimeIdentifier)' == ''">$(ArtifactsDir)/LanguageServer/$(Configuration)/$(TargetFramework)/neutral</PublishDir>
 
     <!-- List of runtime identifiers that we want to publish an executable for. -->
-    <!-- When building a VMR vertical, we don't need to pack everything. Just pack the passed in TargetRid or BaseOS.
-         TargetRid and BaseOS are provided to roslyn via the build arguments passed in the VMR orchestrator's repo project.
+    <!-- When building a VMR vertical, we don't need to pack everything. Just pack the passed in TargetRid or BaseRid.
+         TargetRid and BaseRid are provided to roslyn via the build arguments passed in the VMR orchestrator's repo project.
          https://github.com/dotnet/dotnet/blob/main/repo-projects/roslyn.proj. For definitions of the TargetRid
          and other common properties, see https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/Unified-Build-Controls.md -->
     <RuntimeIdentifiers Condition="'$(TargetRid)' != ''">$(TargetRid)</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="'$(BaseOS)' != ''">$(BaseOS)</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="'$(TargetRid)' == '' and '$(BaseOS)' == ''">win-x64;win-arm64;linux-x64;linux-arm64;linux-musl-x64;linux-musl-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(BaseRid)' != ''">$(BaseRid)</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(TargetRid)' == '' and '$(BaseRid)' == ''">win-x64;win-arm64;linux-x64;linux-arm64;linux-musl-x64;linux-musl-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
 
     <!-- These indicate that the runtime/apphost packages should not be downloaded as part of build/restore -->
     <EnableRuntimePackDownload>false</EnableRuntimePackDownload>

--- a/src/runtime/eng/pipelines/runtime.yml
+++ b/src/runtime/eng/pipelines/runtime.yml
@@ -1768,12 +1768,12 @@ extends:
           parameters:
             platforms:
               - name: CentOS9
-                baseOS: linux-x64
+                baseRID: linux-x64
                 targetRID: centos.9-x64
                 portableBuild: false
                 container: SourceBuild_centos_x64
               - name: NonexistentRID
-                baseOS: linux-x64
+                baseRID: linux-x64
                 targetRID: banana.24-x64
                 portableBuild: false
                 container: SourceBuild_centos_x64

--- a/src/runtime/eng/toolAot.targets
+++ b/src/runtime/eng/toolAot.targets
@@ -18,7 +18,7 @@
       NativeAOT's targets don't handle cross-targeting to a non-portable RID.
       Change the RID when importing the NativeAOT targets to the corresponding portable RID if specified.
     -->
-    <RuntimeIdentifier Condition="'$(BaseOS)' != ''">$(BaseOS)</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(BaseRid)' != ''">$(BaseRid)</RuntimeIdentifier>
   </PropertyGroup>
   <Import Project="$(CoreCLRBuildIntegrationDir)Microsoft.DotNet.ILCompiler.SingleEntry.targets" Condition="'$(PublishAot)' == 'true' and '$(UseBootstrapLayout)' == 'true'" />
   <PropertyGroup>

--- a/src/runtime/src/coreclr/runtime.proj
+++ b/src/runtime/src/coreclr/runtime.proj
@@ -47,9 +47,9 @@
       <_CoreClrBuildArg Condition="'$(EnableNativeSanitizers)' != ''" Include="-fsanitize $(EnableNativeSanitizers)" />
       <_CoreClrBuildArg Condition="'$(HostCrossOS)' != ''" Include="-hostos $(HostCrossOS)" />
       <_CoreClrBuildArg Include="-outputrid $(OutputRID)" />
-      <!-- Set CLR_DOTNET_RID to be the portable RID value. When $(BaseOS) is set, it will be the portable RID and $(OutputRID) may be non-portable. -->
-      <_CoreClrBuildArg Condition="'$(BaseOS)' == ''" Include="-cmakeargs &quot;-DCLR_DOTNET_RID=$(OutputRID)&quot;" />
-      <_CoreClrBuildArg Condition="'$(BaseOS)' != ''" Include="-cmakeargs &quot;-DCLR_DOTNET_RID=$(BaseOS)&quot;" />
+      <!-- Set CLR_DOTNET_RID to be the portable RID value. When $(BaseRid) is set, it will be the portable RID and $(OutputRID) may be non-portable. -->
+      <_CoreClrBuildArg Condition="'$(BaseRid)' == ''" Include="-cmakeargs &quot;-DCLR_DOTNET_RID=$(OutputRID)&quot;" />
+      <_CoreClrBuildArg Condition="'$(BaseRid)' != ''" Include="-cmakeargs &quot;-DCLR_DOTNET_RID=$(BaseRid)&quot;" />
       <_CoreClrBuildArg Condition="'$(BuildSubdirectory)' != ''" Include="-subdir $(BuildSubdirectory)" />
       <_CoreClrBuildArg Include="-cmakeargs &quot;-DCLR_DOTNET_HOST_PATH=$(DOTNET_HOST_PATH)&quot;" />
       <_CoreClrBuildArg Condition="'$(HasCdacBuildTool)' == 'true'" Include="-cmakeargs &quot;-DCDAC_BUILD_TOOL_BINARY_PATH=$(RuntimeBinDir)cdac-build-tool\cdac-build-tool.dll&quot;" />

--- a/src/runtime/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/runtime/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -19,9 +19,9 @@
     <_generateRuntimeGraphTargetFramework Condition="'$(MSBuildRuntimeType)' != 'core'">$(NetFrameworkToolCurrent)</_generateRuntimeGraphTargetFramework>
     <_generateRuntimeGraphTask>$([MSBuild]::NormalizePath('$(BaseOutputPath)', $(Configuration), '$(_generateRuntimeGraphTargetFramework)', '$(AssemblyName).dll'))</_generateRuntimeGraphTask>
 
-    <!-- BaseOS is an expected known rid in the graph that OutputRID is compatible with.
+    <!-- BaseRid is an expected known rid in the graph that OutputRID is compatible with.
          It's used to add OutputRID in the graph if the parent can't be detected. -->
-    <AdditionalRuntimeIdentifierParent Condition="'$(AdditionalRuntimeIdentifierParent)' == ''">$(BaseOS)</AdditionalRuntimeIdentifierParent>
+    <AdditionalRuntimeIdentifierParent Condition="'$(AdditionalRuntimeIdentifierParent)' == ''">$(BaseRid)</AdditionalRuntimeIdentifierParent>
     <OutputRIDParent Condition="'$(OutputRIDParent)' == ''">$(AdditionalRuntimeIdentifierParent)</OutputRIDParent>
   </PropertyGroup>
 


### PR DESCRIPTION
Remove `RuntimeOS` as we removed the last usage in the runtime repo a few weeks ago.

Rename `BaseOS` to `BaseRid` as various components in the stack have taken a dependency on the fact that `BaseOS` was a full RID and the name just caused confusion.

cc: @tmds @am11 @omajid