### PR TITLE
Disable dotnet.defaultSolution for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.defaultSolution": "disable"
+}


### PR DESCRIPTION
We can't pick a default solution so disable the popup that asks about that everytime in Codespaces.