### PR TITLE
Add command-line-api dependency to roslyn.proj

### DIFF
--- a/repo-projects/roslyn.proj
+++ b/repo-projects/roslyn.proj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <RepositoryReference Include="arcade" />
+    <RepositoryReference Include="command-line-api" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">


### PR DESCRIPTION
roslyn has a live subscription on command-line-api and therefore we should have a repo dependency in the VMR

```
https://github.com/dotnet/command-line-api (.NET Libraries) ==> 'https://github.com/dotnet/roslyn' ('main')
  - Id: 865c4ec8-62fa-4945-9bea-08d947dddb07
  - Update Frequency: EveryDay
  - Enabled: True
  - Batchable: False
  - PR Failure Notification tags:
  - Source-enabled: False
  - Merge Policies: []
  - Last Build: 20250506.1 (493a1d270887d7c51372fd17f774ea44b0c3101a)
```