### PR TITLE
Skip failing on repos that we know don't publish assets

### DIFF
--- a/eng/tools/BuildComparer/BuildComparer.cs
+++ b/eng/tools/BuildComparer/BuildComparer.cs
@@ -184,6 +184,14 @@ public abstract class BuildComparer
 
             if (repoMergedManifestPath == null)
             {
+                // These repos don't publish assets, so we skip them
+                if (baseDirectory.EndsWith("scenario-tests")
+                    || baseDirectory.EndsWith("source-build-externals")
+                    || baseDirectory.EndsWith("source-build-reference-packages"))
+                {
+                    continue;
+                }
+
                 throw new FileNotFoundException($"MergedManifest.xml not found in {baseDirectory}");
             }
 


### PR DESCRIPTION
The asset and signing comparisons are failing because some repos no longer publish assets, which means that there's no merged manifests for those repos. We should skip throwing an error in the comparison when the merged manifests are not found for these repos.

[Test pipeline run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2704126&view=results)