### PR TITLE
Fix installer tests entry project path

### DIFF
--- a/eng/pipelines/templates/steps/vmr-validate-installers.yml
+++ b/eng/pipelines/templates/steps/vmr-validate-installers.yml
@@ -34,7 +34,7 @@ steps:
       ./build.sh \
       --ci \
       -t \
-      --projects test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj \
+      --projects $(Build.SourcesDirectory)/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj \
       /p:TestRpmPackages=true \
       /p:TestDebPackages=true
     displayName: Validate installer packages


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/5154

With PR https://github.com/dotnet/dotnet/pull/306 invocation of custom projects was updated to use `/p:Projects=<project>` instead of just passing the project as a cmd argument.

This requires that the project be specified with absolute path - originally this was a relative path.