### PR TITLE
Update allowed binaries files

### DIFF
--- a/eng/allowed-sb-binaries.txt
+++ b/eng/allowed-sb-binaries.txt
@@ -54,9 +54,9 @@ src/runtime/src/libraries/System.Text.Encoding.CodePages/src/Data/codepages.nlp 
 src/runtime/src/native/external/brotli/common/dictionary.bin.br
 
 # source-build-externals
-src/source-build-externals/src/humanizer/src/Humanizer.Tests**/*.pfx
-src/source-build-externals/src/newtonsoft-json/Src/Newtonsoft.Json.Tests/SpaceShipV2.bson
-src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/build/strongNameBypass.reg # UTF16-LE text file
-src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/build/strongNameBypass2.reg # UTF16-LE text file
-src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/test/Certs/*.pfx
-src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/test/Certs/*.cer
+src/source-build-externals/src/repos/src/humanizer/src/Humanizer.Tests**/*.pfx
+src/source-build-externals/src/repos/src/newtonsoft-json/Src/Newtonsoft.Json.Tests/SpaceShipV2.bson
+src/source-build-externals/src/repos/src/azure-activedirectory-identitymodel-extensions-for-dotnet/build/strongNameBypass.reg # UTF16-LE text file
+src/source-build-externals/src/repos/src/azure-activedirectory-identitymodel-extensions-for-dotnet/build/strongNameBypass2.reg # UTF16-LE text file
+src/source-build-externals/src/repos/src/azure-activedirectory-identitymodel-extensions-for-dotnet/test/Certs/*.pfx
+src/source-build-externals/src/repos/src/azure-activedirectory-identitymodel-extensions-for-dotnet/test/Certs/*.cer

--- a/eng/allowed-vmr-binaries.txt
+++ b/eng/allowed-vmr-binaries.txt
@@ -122,7 +122,7 @@ src/sdk/test/dotnet.Tests/ShellShimTests/WpfBinaryTestAssets/*.dll
 src/sdk/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/Resources/*.zip
 
 # source-build-externals
-src/source-build-externals/src/application-insights*/WEB/Src/WindowsServer/WindowsServer.Tests/**/*.dll
+src/source-build-externals/src/repos/src/application-insights*/WEB/Src/WindowsServer/WindowsServer.Tests/**/*.dll
 
 # symreader
 src/symreader/src/PdbTestResources/Resources/*


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/5157

These files are already allowed in VMR.