### PR TITLE
Fix signing globs for cross-arch MSIs

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -111,9 +111,16 @@
       - VS.Redist.Common.*.*_$(TargetArchitecture).*.nupkg
       
       These packages are always non-shipping, so only look there.
+
+      As these installer packages are inserted into VS as-is, .NET doesn't ship them
+      but must ensure that they're validated as though they were shipped by .NET (so they don't break when inserted into VS).
     -->
-    <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.$(TargetArchitecture).*.nupkg" IsShipping="false" Kind="Package" />
-    <Artifact Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.*_$(TargetArchitecture).*.nupkg" IsShipping="false" Kind="Package" />
+    <VSRedistArtifact Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.$(TargetArchitecture).*.nupkg" IsShipping="false" Kind="Package" />
+    <VSRedistArtifact Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.*_$(TargetArchitecture).*.nupkg" IsShipping="false" Kind="Package" />
+
+    <Artifact Include="@(VSRedistArtifact)">
+      <DotNetReleaseShipping Condition="'$(ProducesDotNetReleaseShippingAssets)' == 'true'">true</DotNetReleaseShipping>
+    </Artifact>
 
     <!--
       In the VMR, don't publish packages that didn't match the above conditions externally.
@@ -312,6 +319,8 @@
              An item is a Package if Kind wasn't already set, and PublishFlatContainer is not set. -->
         <Kind Condition="'%(ItemsToPushToBlobFeed.Kind)' == '' and '%(ItemsToPushToBlobFeed.PublishFlatContainer)' == 'true'">Blob</Kind>
         <Kind Condition="'%(ItemsToPushToBlobFeed.Kind)' == '' and '%(ItemsToPushToBlobFeed.PublishFlatContainer)' != 'true'">Package</Kind>
+        <!-- DotNetReleaseShipping=true if IsShipping=true and ProducesDotNetReleaseShippingAssets=true-->
+        <DotNetReleaseShipping Condition="'%(ItemsToPushToBlobFeed.DotNetReleaseShipping)' == '' and '%(ItemsToPushToBlobFeed.IsShipping)' == 'true' and '$(ProducesDotNetReleaseShippingAssets)' == 'true'">true</DotNetReleaseShipping>
       </ItemsToPushToBlobFeed>
     </ItemGroup>
 
@@ -319,7 +328,7 @@
     <ItemGroup>
       <ItemsToPushToBlobFeed>
         <ManifestArtifactData Condition="'%(ItemsToPushToBlobFeed.IsShipping)' != 'true'">%(ItemsToPushToBlobFeed.ManifestArtifactData);NonShipping=true</ManifestArtifactData>
-        <ManifestArtifactData Condition="'%(ItemsToPushToBlobFeed.IsShipping)' == 'true' and '$(ProducesDotNetReleaseShippingAssets)' == 'true'">%(ItemsToPushToBlobFeed.ManifestArtifactData);DotNetReleaseShipping=true</ManifestArtifactData>
+        <ManifestArtifactData Condition="'%(ItemsToPushToBlobFeed.DotNetReleaseShipping)' == 'true'">%(ItemsToPushToBlobFeed.ManifestArtifactData);DotNetReleaseShipping=true</ManifestArtifactData>
       </ItemsToPushToBlobFeed>
     </ItemGroup>
 

--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -41,12 +41,12 @@
       Integration with Microsoft.DotNet.Build.Tasks.Installers: Publish packages of the following formats as well.
       These are arch-specific Visual Studio insertion packages. As they're Windows-only, they only include architecture in the name:
       - VS.Redist.Common.*.$(TargetArchitecture).*.nupkg
-      - VS.Redist.Common.*.$(TargetArchitecture)-*.*.nupkg
+      - VS.Redist.Common.*.*_$(TargetArchitecture).*.nupkg
       
       These packages are always non-shipping, so only look there.
     -->
     <ItemsToSign Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.$(TargetArchitecture).*.nupkg" />
-    <ItemsToSign Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.$(TargetArchitecture)-*.*.nupkg" />
+    <ItemsToSign Include="$(ArtifactsNonShippingPackagesDir)**/VS.Redist.Common.*.*_$(TargetArchitecture).*.nupkg" />
 
     <!-- Always sign all vsix packages and VS Build Packages. These may be arch specific or agnostic, but they likely won't have the RID included. -->
     <ItemsToSign Include="$(VisualStudioSetupOutputPath)**\*.vsix" />


### PR DESCRIPTION
We missed the signing glob in https://github.com/dotnet/arcade/pull/15678, so they haven't been getting signed.

Our SigningValidation jobs missed this because we don't currently validate signing for non-shipping assets.

Also, mark all of the "VS Redist" installer packages as DotNetReleaseShipping to get the right validation run on them.