### PR TITLE
Pass repository last flow sha to the repo build

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -39,11 +39,6 @@
     <ArtifactVisibilityToPublish Include="Internal;External" />
   </ItemGroup>
 
-  <!-- Build task assembly paths -->
-  <PropertyGroup>
-    <MicrosoftDotNetUnifiedBuildTasksAssembly>$([MSBuild]::NormalizePath('$(ArtifactsBinDir)', 'Microsoft.DotNet.UnifiedBuild.Tasks', '$(Configuration)', 'Microsoft.DotNet.UnifiedBuild.Tasks.dll'))</MicrosoftDotNetUnifiedBuildTasksAssembly>
-  </PropertyGroup>
-
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.GetKnownArtifactsFromAssetManifests" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
 
   <Target Name="DiscoverArtifacts">

--- a/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/ReadRepoInfoFromSourceManifest.cs
+++ b/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/ReadRepoInfoFromSourceManifest.cs
@@ -24,11 +24,7 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
         public string RepositoryName { get; set; } = "";
 
         /// <summary>
-        /// Returns metadata about the repository from source-manifest.json:
-        /// - PackageVersion
-        /// - BarId
-        /// - RemoteUri
-        /// - CommitSha
+        /// Returns metadata about the repository from source-manifest.json.
         /// </summary>
         [Output]
         public ITaskItem? RepoInfo { get; set; }
@@ -43,7 +39,7 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
 
             JsonArray? repositories = JsonNode.Parse(File.OpenRead(SourceManifest))?["repositories"]?.AsArray();
 
-            JsonNode? repo = repositories
+            JsonObject? repo = repositories
                 ?.Where(p => p?["path"]?.ToString() == RepositoryName)
                 .FirstOrDefault()
                 ?.AsObject();
@@ -54,15 +50,7 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
                 return false;
             }
 
-            RepoInfo = new TaskItem(
-                        RepositoryName,
-                        new Dictionary<string, string?>
-                        {
-                            ["PackageVersion"] = repo?["packageVersion"]?.ToString(),
-                            ["BarId"] = repo?["barId"]?.ToString(),
-                            ["RemoteUri"] = repo?["remoteUri"]?.ToString(),
-                            ["CommitSha"] = repo?["commitSha"]?.ToString()
-                        });
+            RepoInfo = new TaskItem(RepositoryName, repo.ToDictionary(p => p.Key, p => p.Value?.ToString()));
 
             return true;
         }

--- a/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/ReadRepoInfoFromSourceManifest.cs
+++ b/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/ReadRepoInfoFromSourceManifest.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.UnifiedBuild.Tasks
+{
+    // Takes a path to a source-manifest.json file and
+    // reads the information for a specific repo from it.
+    public class ReadRepoInfoFromSourceManifest : Task
+    {
+        [Required]
+        public string SourceManifest { get; set; } = "";
+
+        [Required]
+        public string RepositoryName { get; set; } = "";
+
+        /// <summary>
+        /// Returns metadata about the repository from source-manifest.json:
+        /// - PackageVersion
+        /// - BarId
+        /// - RemoteUri
+        /// - CommitSha
+        /// </summary>
+        [Output]
+        public ITaskItem? RepoInfo { get; set; }
+
+        public override bool Execute()
+        {
+            if (!File.Exists(SourceManifest))
+            {
+                Log.LogError($"Source manifest file not found: {SourceManifest}");
+                return false;
+            }
+
+            JsonArray? repositories = JsonNode.Parse(File.OpenRead(SourceManifest))?["repositories"]?.AsArray();
+
+            JsonNode? repo = repositories
+                ?.Where(p => p?["path"]?.ToString() == RepositoryName)
+                .FirstOrDefault()
+                ?.AsObject();
+
+            if (repo == null)
+            {
+                Log.LogError($"Repository {RepositoryName} not found in source manifest.");
+                return false;
+            }
+
+            RepoInfo = new TaskItem(
+                        RepositoryName,
+                        new Dictionary<string, string?>
+                        {
+                            ["PackageVersion"] = repo?["packageVersion"]?.ToString(),
+                            ["BarId"] = repo?["barId"]?.ToString(),
+                            ["RemoteUri"] = repo?["remoteUri"]?.ToString(),
+                            ["CommitSha"] = repo?["commitSha"]?.ToString()
+                        });
+
+            return true;
+        }
+    }
+}

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -447,8 +447,23 @@
     </ItemGroup>
   </Target>
 
+  <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.ReadRepoInfoFromSourceManifest" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
+  <Target Name="SetRepoOriginalSourceRevisionId">
+    <ReadRepoInfoFromSourceManifest SourceManifest="$(SrcDir)/source-manifest.json"
+                                    RepositoryName="$(RepositoryName)">
+      <Output TaskParameter="RepoInfo" ItemName="RepoInfo" />
+    </ReadRepoInfoFromSourceManifest>
+
+    <Error Condition="'%(RepoInfo.CommitSha)' == ''"
+           Text="Unable to find the commit SHA for the repository $(RepositoryName) in the source-manifest.json file." />
+
+    <PropertyGroup>
+      <CommonArgs>$(CommonArgs) /p:RepoOriginalSourceRevisionId=%(RepoInfo.CommitSha)</CommonArgs>
+    </PropertyGroup>
+  </Target>
+
   <Target Name="SetBuildProperties"
-          DependsOnTargets="GetTransitiveRepositoryReferences">
+          DependsOnTargets="GetTransitiveRepositoryReferences;SetRepoOriginalSourceRevisionId">
     <PropertyGroup>
       <!-- Infer the projects runtime identifier as the vertical's RID when doing a vertical build
            and filter down RID lists to the target RID in such a scenario. This is necessary when the host (SDK) rid

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -448,8 +448,8 @@
   </Target>
 
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.ReadRepoInfoFromSourceManifest" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
-  <Target Name="SetRepoOriginalSourceRevisionId">
-    <ReadRepoInfoFromSourceManifest SourceManifest="$(SrcDir)/source-manifest.json"
+  <Target Name="SetRepoOriginalSourceRevisionId" Condition="'$(IsUtilityProject)' != 'true'">
+    <ReadRepoInfoFromSourceManifest SourceManifest="$(SrcDir)source-manifest.json"
                                     RepositoryName="$(RepositoryName)">
       <Output TaskParameter="RepoInfo" ItemName="RepoInfo" />
     </ReadRepoInfoFromSourceManifest>


### PR DESCRIPTION
Adds RepoOriginalSourceRevisionId to the repo build parameters which is the commit sha from the source-manifest.json, i.e. the last merged forward flow commit of the repository.

Fixes https://github.com/dotnet/source-build/issues/5155