### PR TITLE
Use the crossgen2 that matches the incoming SDK RID

### DIFF
--- a/src/sdk/src/Layout/redist/targets/Crossgen.targets
+++ b/src/sdk/src/Layout/redist/targets/Crossgen.targets
@@ -7,9 +7,7 @@
                                     '$(TargetArchitecture)' != 'ppc64le' and
                                     '$(DotNetBuildUseMonoRuntime)' != 'true'">true</IsCrossgenSupported>
 
-    <Crossgen2Rid>$(HostOSName)-$(BuildArchitecture)</Crossgen2Rid>
-
-    <RuntimeNETCrossgenPackageName>microsoft.netcore.app.crossgen2.$(Crossgen2Rid)</RuntimeNETCrossgenPackageName>
+    <RuntimeNETCrossgenPackageName>microsoft.netcore.app.crossgen2.$(NETCoreSdkRuntimeIdentifier)</RuntimeNETCrossgenPackageName>
   </PropertyGroup>
 
   <!-- Download the runtime package with the crossgen executable in it -->


### PR DESCRIPTION
Fixes failures in the Alpine Source-Build leg and failures in the Centos Stream 9 Stage2 Source-Build leg seen in https://dev.azure.com/dnceng/internal/_build/results?buildId=2707689&view=results