### PR TITLE
Don't include license file in sfx packages with license expressions

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/arcade/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -169,7 +169,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <FilesToPackage Include="$(LicenseFile)" GeneratedBuildFile="true" TargetPath="" />
+      <!-- Don't include the license file in the package as that's already handled via PackageLicenseFile above in L5. -->
+      <FilesToPackage Include="$(LicenseFile)" GeneratedBuildFile="true" TargetPath="" PublishOnly="true" />
     </ItemGroup>
 
     <RemoveDuplicates Inputs="@(FilesToPackage)">


### PR DESCRIPTION
Very similar to https://github.com/dotnet/runtime/pull/115518

Don't include the LICENSE file in the shared framework produced packages if those set a PackageLicenseExpression.

As mentioned in the other issue, Arcade already validates that either the license expression or the license file is set.