### PR TITLE
Fix error message truncation

### DIFF
--- a/test/Microsoft.DotNet.SourceBuild.Tests/BaselineHelper.cs
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/BaselineHelper.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.SourceBuild.Tests
                 message += $"Extra entries in '{baselineFileName}' baseline: {Environment.NewLine}{string.Join(Environment.NewLine, extraEntries)}{Environment.NewLine}{Environment.NewLine}";
             }
 
-            Assert.Null(message);
+            Assert.True(message == null, message);
         }
 
         public static void CompareBaselineContents(string baselineFileName, string actualContents, ITestOutputHelper outputHelper, string baselineSubDir = "")
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.SourceBuild.Tests
                     + $"{diff}{Environment.NewLine}";
             }
 
-            Assert.Null(message);
+            Assert.True(message == null, message);
         }
 
         public static string DiffFiles(string file1Path, string file2Path, ITestOutputHelper outputHelper)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/5141

Updated all instances of `Assert.Null(message);` with `Assert.True(message == null, message);`

Verified locally. Here's the produced output for a sample injected failure in poison tests:

Before:
```
  Error Message:
   Assert.Null() Failure: Value is not null
Expected: null
Actual:   "\nExpected file '/src/git/dotnet3/artifacts/bin/Mi"···
```

After:
```
  Error Message:

Expected file '/src/git/dotnet3/artifacts/bin/Microsoft.DotNet.SourceBuild.Tests/Release/assets/PoisonTests/PoisonUsage.txt' does not match actual file '/src/git/dotnet3/artifacts/TestResults/Release/UpdatedPoisonUsage.txt`.
diff --git a/src/git/dotnet3/artifacts/bin/Microsoft.DotNet.SourceBuild.Tests/Release/assets/PoisonTests/PoisonUsage.txt b/src/git/dotnet3/artifacts/TestResults/Release/UpdatedPoisonUsage.txt
index ebe355d179d..dbe36e0d43b 100644
--- a/src/git/dotnet3/artifacts/bin/Microsoft.DotNet.SourceBuild.Tests/Release/assets/PoisonTests/PoisonUsage.txt
+++ b/src/git/dotnet3/artifacts/TestResults/Release/UpdatedPoisonUsage.txt
@@ -1,6 +1,6 @@
 <PrebuiltLeakReport>
   <File Path="artifacts/assets/Release/Sdk/x.y.z/dotnet-sdk-x.y.z/packs/NETStandard.Library.Ref/x.y.z/ref/netstandard2.1/Microsoft.Win32.Primitives.dll">
-    <Type>bad</Type>
+    <Type>SourceBuildReferenceAssembly</Type>
   </File>
   <File Path="artifacts/assets/Release/Sdk/x.y.z/dotnet-sdk-x.y.z/packs/NETStandard.Library.Ref/x.y.z/ref/netstandard2.1/mscorlib.dll">
     <Type>SourceBuildReferenceAssembly</Type>
```