### PR TITLE
Continue on error when publishing artifacts on failure

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -300,6 +300,7 @@ jobs:
       artifact: $(failedJobArtifactName)
       displayName: Publish Artifacts (On Failure)
       condition: failed()
+      continueOnError: true
       sbomEnabled: true
 
     # Using build artifacts to enable publishing the vertical manifests to a single artifact from different jobs


### PR DESCRIPTION
Resolves https://github.com/dotnet/source-build/issues/5181 Sometimes the pre-publish path doesn't exist