### PR TITLE
Fix productbuild switch in bootstrap eng/common layout

### DIFF
--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -136,7 +136,7 @@ while [[ $# > 0 ]]; do
       restore=true
       pack=true
       ;;
-    -productBuild|-pb)
+    -productbuild|-pb)
       build=true
       product_build=true
       restore=true


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/5191

This originally got fixed in https://github.com/dotnet/arcade/commit/d7540e540636883d3d080d087223d28b6b7395ae and is already part of the VMR non-bootstrap (live) eng/common layout.

But until we re-bootstrap to a newer Arcade that brings the updated eng/common files with the fix, manually backport this to the bootstrap layout.