### PR TITLE
Provide a way to skip binary detection

### DIFF
--- a/eng/init-detect-binaries.proj
+++ b/eng/init-detect-binaries.proj
@@ -5,7 +5,8 @@
   </PropertyGroup>
 
   <Target Name="DetectBinaries"
-          BeforeTargets="Build">
+          BeforeTargets="Build"
+          Condition="'$(SkipDetectBinaries)' != 'true'">
     
     <PropertyGroup>
       <DetectBinariesLogLevel Condition="'$(DetectBinariesLogLevel)' == ''">None</DetectBinariesLogLevel>


### PR DESCRIPTION
For whatever reason, binary detection runs really slow in my dev container (7 minutes). I see it runs quickly in the pipelines though. But I'd like a way to skip it.