### PR TITLE
Rename vmr-sync template reference

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -325,7 +325,7 @@ jobs:
   steps:
   - ${{ if not(parameters.isBuiltFromVmr) }}:
     # Synchronize new content in the VMR during PRs
-    - template: /eng/common/templates/steps/vmr-pull-updates.yml@self
+    - template: /eng/common/templates/steps/vmr-sync.yml@self
       parameters:
         vmrPath: $(vmrPath)
         targetRef: $(Build.SourceVersion) # Synchronize the current repo commit

--- a/eng/pipelines/templates/stages/vmr-build-with-join.yml
+++ b/eng/pipelines/templates/stages/vmr-build-with-join.yml
@@ -139,7 +139,7 @@ stages:
                     path: $(Build.ArtifactStagingDirectory)/VerticalArtifacts/${{ vertical.job }}
                     artifactName: ${{ vertical.job }}_Artifacts
         - ${{ if not(parameters.isBuiltFromVmr) }}:
-          - template: /eng/common/templates/steps/vmr-pull-updates.yml@self
+          - template: /eng/common/templates/steps/vmr-sync.yml@self
             parameters:
               vmrPath: ${{ variables.vmrPath }}
               targetRef: $(Build.SourceVersion) # Synchronize the current repo commit


### PR DESCRIPTION
Contributes to: https://github.com/dotnet/arcade-services/issues/4539

Small update in template name as discussed in https://github.com/dotnet/arcade/pull/15840#discussion_r2093238054