### PR TITLE
Fix double shift args in nuget-client

### DIFF
--- a/src/nuget-client/eng/dotnet-build/build.sh
+++ b/src/nuget-client/eng/dotnet-build/build.sh
@@ -38,11 +38,9 @@ while [[ $# > 0 ]]; do
         --source-build|--sourcebuild|-sb)
             source_build=true
             product_build=true
-            shift
             ;;
         --product-build|--productbuild|-pb)
             product_build=true
-            shift
             ;;
         -*)
             # just eat this so we don't try to pass it along to MSBuild


### PR DESCRIPTION
These two are flags and don't need double shift.

Was trying https://github.com/dotnet/source-build/issues/5135#issuecomment-2887537250 and ran into

```sh
$ ./build.sh --clean-while-building --prep -sb --os linux --arch riscv64 -p:OfficialBuildId=$(date +%Y%m%d).1

...
  DirSize Before Building nuget-client
  Filesystem      Size  Used Avail Use% Mounted on
  /dev/root        72G   39G   34G  54% /dotnet
/dotnet/repo-projects/Directory.Build.targets(517,5): error MSB3073: The command "/dotnet/src/nuget-client/eng/dotnet-build/build.sh   --sourceBuild --configuration Release --verbosity minimal /p:TargetRid=linux-riscv64 /p:OfficialBuildId=20250516.101 /p:DotNetPackageVersionPropsPath=/dotnet/artifacts/obj/PackageVersions/PackageVersions.nuget-client.props /p:SourceBuiltAssetsDir=/dotnet/artifacts/assets/Release/ /p:SourceBuiltAssetManifestsDir=/dotnet/artifacts/obj/manifests/Release/nuget-client/ /p:GitHubRepositoryName=nuget-client /p:DotNetBuildOrchestrator=true /p:RepositoryUrl=https://github.com/dotnet/dotnet /p:PreviouslySourceBuiltNupkgCacheDir="/dotnet/prereqs/packages/previously-source-built/" /p:ReferencePackageNupkgCacheDir="/dotnet/prereqs/packages/reference/" /p:TrackPrebuiltUsageReportDir="/dotnet/artifacts/log/Release/nuget-client/" /p:TargetArchitecture=riscv64 /p:TargetOS=linux /p:SourceBuiltShippingPackagesDir=/dotnet/artifacts/packages/Release/Shipping/nuget-client/ /p:SourceBuiltNonShippingPackagesDir=/dotnet/artifacts/packages/Release/NonShipping/nuget-client/ /p:SourceBuiltPdbArtifactsDir=/dotnet/artifacts/SymStore/Release/nuget-client/ /p:SourceBuiltNonShippingPackagesDir=/dotnet/artifacts/packages/Release/NonShipping/nuget-client/ /p:UsingToolMicrosoftNetCompilers=false /p:PortableBuild=true /p:BaseRid=linux-riscv64 /p:RepoOriginalSourceRevisionId=e4e3b79701686199bc804a06533d2df054924d7e  -bl /p:GenerateResourceUsePreserializedResources=true > /dotnet/artifacts/log/Release/nuget-client/nuget-client.log 2>&1" exited with code 1. [/dotnet/repo-projects/nuget-client.proj]
  git config --global protocol.file.allow always
  MSBuild version 17.15.0-preview-25265-106+b1ecb85a1 for .NET
  MSBUILD : error MSB1008: Only one project can be specified.
      Full command line: '/dotnet/.dotnet/sdk/10.0.100-preview.5.25265.106/MSBuild.dll -maxcpucount -verbosity:m -tlp:default=auto -v:minimal /dotnet/src/nuget-client/eng/dotnet-build/dotnet-build.proj /bl:/dotnet/src/nuget-client/artifacts/log/Release/Build.binlog /p:DotNetBuild=true /p:DotNetBuildSourceOnly=true /p:Configuration=Release /p:RepoRoot=/dotnet/src/nuget-client/ Release /p:TargetRid=linux-riscv64 /p:OfficialBuildId=20250516.101 /p:DotNetPackageVersionPropsPath=/dotnet/artifacts/obj/PackageVersions/PackageVersions.nuget-client.props /p:SourceBuiltAssetsDir=/dotnet/artifacts/assets/Release/ /p:SourceBuiltAssetManifestsDir=/dotnet/artifacts/obj/manifests/Release/nuget-client/ /p:GitHubRepositoryName=nuget-client /p:DotNetBuildOrchestrator=true /p:RepositoryUrl=https://github.com/dotnet/dotnet /p:PreviouslySourceBuiltNupkgCacheDir=/dotnet/prereqs/packages/previously-source-built/ /p:ReferencePackageNupkgCacheDir=/dotnet/prereqs/packages/reference/ /p:TrackPrebuiltUsageReportDir=/dotnet/artifacts/log/Release/nuget-client/ /p:TargetArchitecture=riscv64 /p:TargetOS=linux /p:SourceBuiltShippingPackagesDir=/dotnet/artifacts/packages/Release/Shipping/nuget-client/ /p:SourceBuiltNonShippingPackagesDir=/dotnet/artifacts/packages/Release/NonShipping/nuget-client/ /p:SourceBuiltPdbArtifactsDir=/dotnet/artifacts/SymStore/Release/nuget-client/ /p:SourceBuiltNonShippingPackagesDir=/dotnet/artifacts/packages/Release/NonShipping/nuget-client/ /p:UsingToolMicrosoftNetCompilers=false /p:PortableBuild=true /p:BaseRid=linux-riscv64 /p:RepoOriginalSourceRevisionId=e4e3b79701686199bc804a06533d2df054924d7e /p:GenerateResourceUsePreserializedResources=true -distributedlogger:Microsoft.DotNet.Cli.Commands.MSBuild.MSBuildLogger,/dotnet/.dotnet/sdk/10.0.100-preview.5.25265.106/dotnet.dll*Microsoft.DotNet.Cli.Commands.MSBuild.MSBuildForwardingLogger,/dotnet/.dotnet/sdk/10.0.100-preview.5.25265.106/dotnet.dll'
    Switches appended by response files:
  Switch: Release
```

https://github.com/am11/dotnet-riscv/actions/runs/15078863178