### PR TITLE
Exclude runtime from VMR comparison

### DIFF
--- a/eng/tools/BuildComparer/BuildComparer.cs
+++ b/eng/tools/BuildComparer/BuildComparer.cs
@@ -187,7 +187,8 @@ public abstract class BuildComparer
                 // These repos don't publish assets, so we skip them
                 if (baseDirectory.EndsWith("scenario-tests")
                     || baseDirectory.EndsWith("source-build-externals")
-                    || baseDirectory.EndsWith("source-build-reference-packages"))
+                    || baseDirectory.EndsWith("source-build-reference-packages")
+                    || baseDirectory.EndsWith("runtime"))
                 {
                     continue;
                 }


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/5137

We are turning on `isAssetlessBuild` in VMR repos that don't need to retain their official build. As a result, VMR comparison is failing for these repos, so these repos need to be excluded from the VMR comparison.

This PR adds runtime to the exclusion list.