### PR TITLE
Update allowed-sb-binaries.txt to exclude MicroBuild

### DIFF
--- a/eng/allowed-sb-binaries.txt
+++ b/eng/allowed-sb-binaries.txt
@@ -9,6 +9,7 @@ artifacts/
 .git/
 .packages/
 prereqs/packages/
+MicroBuild/
 
 **/*.bmp
 **/*.doc

--- a/eng/allowed-sb-binaries.txt
+++ b/eng/allowed-sb-binaries.txt
@@ -9,7 +9,6 @@ artifacts/
 .git/
 .packages/
 prereqs/packages/
-MicroBuild/
 
 **/*.bmp
 **/*.doc

--- a/eng/allowed-vmr-binaries.txt
+++ b/eng/allowed-vmr-binaries.txt
@@ -5,6 +5,8 @@
 # Import the allowed souce-build binaries (a stricter set).
 import:allowed-sb-binaries.txt
 
+MicroBuild/
+
 **/testCert*.pfx
 **/TestCert*.pfx
 


### PR DESCRIPTION
Working around dotnet/arcade#15731

Fixes https://github.com/dotnet/dotnet/issues/650