### PR TITLE
Support having spaces in OfficialBuilder

### DIFF
--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -113,7 +113,7 @@
     <CommonArgs Condition="'$(CrossBuild)' == 'true'">$(CommonArgs) /p:CrossBuild=true</CommonArgs>
     <CommonArgs Condition="'$(DotNetBuildUseMonoRuntime)' == 'true'">$(CommonArgs) /p:DotNetBuildUseMonoRuntime=$(DotNetBuildUseMonoRuntime)</CommonArgs>
     <CommonArgs Condition="'$(OfficialBuildId)' != ''">$(CommonArgs) /p:OfficialBuildId=$(OfficialBuildId)</CommonArgs>
-    <CommonArgs Condition="'$(OfficialBuilder)' != ''">$(CommonArgs) /p:OfficialBuilder=$(OfficialBuilder)</CommonArgs>
+    <CommonArgs Condition="'$(OfficialBuilder)' != ''">$(CommonArgs) /p:OfficialBuilder="$(OfficialBuilder)"</CommonArgs>
     <CommonArgs Condition="'$(ForceDryRunSigning)' != ''">$(CommonArgs) /p:ForceDryRunSigning=$(ForceDryRunSigning)</CommonArgs>
 
     <CommonArgs>$(CommonArgs) /p:DotNetPackageVersionPropsPath=$(PackageVersionPropsPath)</CommonArgs>

--- a/src/arcade/eng/common/build.sh
+++ b/src/arcade/eng/common/build.sh
@@ -91,7 +91,7 @@ verbosity='minimal'
 runtime_source_feed=''
 runtime_source_feed_key=''
 
-properties=''
+properties=()
 while [[ $# > 0 ]]; do
   opt="$(echo "${1/#--/-}" | tr "[:upper:]" "[:lower:]")"
   case "$opt" in
@@ -192,7 +192,7 @@ while [[ $# > 0 ]]; do
       shift
       ;;
     *)
-      properties="$properties $1"
+      properties+=("$1")
       ;;
   esac
 
@@ -226,7 +226,7 @@ function Build {
   InitializeCustomToolset
 
   if [[ ! -z "$projects" ]]; then
-    properties="$properties /p:Projects=$projects"
+    properties+=("/p:Projects=$projects")
   fi
 
   local bl=""
@@ -257,7 +257,7 @@ function Build {
     /p:Sign=$sign \
     /p:Publish=$publish \
     /p:RestoreStaticGraphEnableBinaryLogger=$binary_log \
-    $properties
+    "${properties[@]}"
 
   ExitWithExitCode 0
 }

--- a/src/fsharp/build.sh
+++ b/src/fsharp/build.sh
@@ -13,4 +13,4 @@ while [[ -h $source ]]; do
 done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
-time "$scriptroot/eng/build.sh" --build --restore $@
+time "$scriptroot/eng/build.sh" --build --restore "$@"

--- a/src/fsharp/eng/build.sh
+++ b/src/fsharp/eng/build.sh
@@ -78,7 +78,7 @@ source_build=false
 product_build=false
 from_vmr=false
 buildnorealsig=true
-properties=""
+properties=()
 
 docker=false
 args=""
@@ -183,7 +183,7 @@ while [[ $# > 0 ]]; do
       shift
       ;;
     /p:*)
-      properties="$properties $1"
+      properties+=("$1")
       ;;
     *)
       echo "Invalid argument: $1"
@@ -295,9 +295,9 @@ function BuildSolution {
 
     BuildMessage="Error building tools"
     # TODO: Remove DotNetBuildRepo property when fsharp is on Arcade 10
-    local args=" publish $repo_root/proto.proj $blrestore $bltools /p:Configuration=Proto /p:DotNetBuildRepo=$product_build /p:DotNetBuild=$product_build /p:DotNetBuildSourceOnly=$source_build /p:DotNetBuildFromVMR=$from_vmr $properties"
+    local args=("publish" "$repo_root/proto.proj" "$blrestore" "$bltools" "/p:Configuration=Proto" "/p:DotNetBuildRepo=$product_build" "/p:DotNetBuild=$product_build" "/p:DotNetBuildSourceOnly=$source_build" "/p:DotNetBuildFromVMR=$from_vmr" "${properties[@]}")
     echo $args
-    "$DOTNET_INSTALL_DIR/dotnet" $args  #$args || exit $?
+    "$DOTNET_INSTALL_DIR/dotnet" "${args[@]}"  #$args || exit $?
   fi
 
   if [[ "$skip_build" != true ]]; then
@@ -325,7 +325,7 @@ function BuildSolution {
       /p:DotNetBuild=$product_build \
       /p:DotNetBuildSourceOnly=$source_build \
       /p:DotNetBuildFromVMR=$from_vmr \
-      $properties
+      "${properties[@]}"
   fi
 }
 

--- a/src/nuget-client/eng/dotnet-build/build.sh
+++ b/src/nuget-client/eng/dotnet-build/build.sh
@@ -5,12 +5,13 @@ git config --global protocol.file.allow always
 
 source="${BASH_SOURCE[0]}"
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+args=()
 configuration='Release'
 verbosity='minimal'
 source_build=false
 product_build=false
 from_vmr=false
-properties=''
+properties=()
 
 # resolve $SOURCE until the file is no longer a symlink
 while [[ -h $source ]]; do
@@ -52,7 +53,7 @@ while [[ $# > 0 ]]; do
             export DOTNET_CORESDK_NOPRETTYPRINT=1
             ;;
         *)
-            args="$args $1"
+            args+=("$1")
             ;;
     esac
     shift
@@ -97,11 +98,11 @@ ReadGlobalVersion Microsoft.DotNet.Arcade.Sdk
 export ARCADE_VERSION=$_ReadGlobalVersion
 export NUGET_PACKAGES=${repo_root}artifacts/.packages/
 
-properties="$properties /p:DotNetBuild=$product_build"
-properties="$properties /p:DotNetBuildSourceOnly=$source_build"
-properties="$properties /p:DotNetBuildFromVMR=$from_vmr"
+properties+=("/p:DotNetBuild=$product_build")
+properties+=("/p:DotNetBuildSourceOnly=$source_build")
+properties+=("/p:DotNetBuildFromVMR=$from_vmr")
 
-properties="$properties /p:Configuration=$configuration"
-properties="$properties /p:RepoRoot=$repo_root"
+properties+=("/p:Configuration=$configuration")
+properties+=("/p:RepoRoot=$repo_root")
 
-"$DOTNET" msbuild -v:$verbosity "$scriptroot/dotnet-build.proj" "/bl:${repo_root}artifacts/log/${configuration}/Build.binlog" $properties $args
+"$DOTNET" msbuild -v:$verbosity "$scriptroot/dotnet-build.proj" "/bl:${repo_root}artifacts/log/${configuration}/Build.binlog" "${properties[@]}" "${args[@]}"

--- a/src/roslyn/build.sh
+++ b/src/roslyn/build.sh
@@ -13,4 +13,4 @@ while [[ -h $source ]]; do
 done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
-"$scriptroot/eng/build.sh" --build --solution  Roslyn.sln $@
+"$scriptroot/eng/build.sh" --build --solution  Roslyn.sln "$@"

--- a/src/roslyn/eng/build.sh
+++ b/src/roslyn/eng/build.sh
@@ -80,7 +80,7 @@ run_analyzers=false
 skip_documentation=false
 prepare_machine=false
 warn_as_error=false
-properties=""
+properties=()
 source_build=false
 product_build=false
 from_vmr=false
@@ -193,7 +193,7 @@ while [[ $# > 0 ]]; do
       shift
       ;;
     /p:*)
-      properties="$properties $1"
+      properties+=("$1")
       ;;
     *)
       echo "Invalid argument: $1"
@@ -323,7 +323,7 @@ function BuildSolution {
     $mono_tool \
     $generate_documentation_file \
     $roslyn_use_hard_links \
-    $properties
+    "${properties[@]}"
 }
 
 function GetCompilerTestAssembliesIncludePaths {

--- a/src/runtime/build.sh
+++ b/src/runtime/build.sh
@@ -26,7 +26,7 @@ scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 if is_cygwin_or_mingw; then
   # if bash shell running on Windows (not WSL),
   # pass control to batch build script.
-  "$scriptroot/build.cmd" $@
+  "$scriptroot/build.cmd" "$@"
 else
-  "$scriptroot/eng/build.sh" $@
+  "$scriptroot/eng/build.sh" "$@"
 fi

--- a/src/runtime/eng/build.sh
+++ b/src/runtime/eng/build.sh
@@ -153,9 +153,9 @@ showSubsetHelp()
   "$scriptroot/common/build.sh" "-restore" "-build" "/p:Subset=help" "/clp:nosummary /tl:false"
 }
 
-arguments=''
+arguments=()
 cmakeargs=''
-extraargs=''
+extraargs=()
 crossBuild=0
 portableBuild=1
 bootstrap=0
@@ -178,7 +178,7 @@ while [[ $# > 0 ]]; do
       exit 0
     fi
 
-    arguments="$arguments /p:Subset=$1"
+    arguments+=("/p:Subset=$1")
     shift 1
     continue
   fi
@@ -201,7 +201,7 @@ while [[ $# > 0 ]]; do
           showSubsetHelp
           exit 0
         fi
-        arguments="$arguments /p:Subset=$2"
+        arguments+=("/p:Subset=$2")
         shift 2
       fi
       ;;
@@ -241,7 +241,7 @@ while [[ $# > 0 ]]; do
           exit 1
           ;;
       esac
-      arguments="$arguments -configuration $val"
+      arguments+=("-configuration" "$val")
       shift 2
       ;;
 
@@ -251,7 +251,7 @@ while [[ $# > 0 ]]; do
         exit 1
       fi
       val="$(echo "$2" | tr "[:upper:]" "[:lower:]")"
-      arguments="$arguments /p:BuildTargetFramework=$val"
+      arguments+=("/p:BuildTargetFramework=$val")
       shift 2
       ;;
 
@@ -306,12 +306,12 @@ while [[ $# > 0 ]]; do
           exit 1
           ;;
       esac
-      arguments="$arguments /p:TargetOS=$os"
+      arguments+=("/p:TargetOS=$os")
       shift 2
       ;;
 
      -pack)
-      arguments="$arguments --pack /p:BuildAllConfigurations=true"
+      arguments+=("--pack" "/p:BuildAllConfigurations=true")
       shift 1
       ;;
 
@@ -320,17 +320,17 @@ while [[ $# > 0 ]]; do
         echo "No test scope supplied. See help (--help) for supported test scope values." 1>&2
         exit 1
       fi
-      arguments="$arguments /p:TestScope=$2"
+      arguments+=("/p:TestScope=$2")
       shift 2
       ;;
 
      -testnobuild)
-      arguments="$arguments /p:TestNoBuild=true"
+      arguments+=("/p:TestNoBuild=true")
       shift 1
       ;;
 
      -coverage)
-      arguments="$arguments /p:Coverage=true"
+      arguments+=("/p:Coverage=true")
       shift 1
       ;;
 
@@ -350,7 +350,7 @@ while [[ $# > 0 ]]; do
           exit 1
           ;;
       esac
-      arguments="$arguments /p:RuntimeConfiguration=$val"
+      arguments+=("/p:RuntimeConfiguration=$val")
       shift 2
       ;;
 
@@ -370,12 +370,12 @@ while [[ $# > 0 ]]; do
           exit 1
           ;;
       esac
-      arguments="$arguments /p:RuntimeFlavor=$val"
+      arguments+=("/p:RuntimeFlavor=$val")
       shift 2
       ;;
 
      -usemonoruntime)
-      arguments="$arguments /p:PrimaryRuntimeFlavor=Mono"
+      arguments+=("/p:PrimaryRuntimeFlavor=Mono")
       shift 1
       ;;
 
@@ -395,7 +395,7 @@ while [[ $# > 0 ]]; do
           exit 1
           ;;
       esac
-      arguments="$arguments /p:LibrariesConfiguration=$val"
+      arguments+=("/p:LibrariesConfiguration=$val")
       shift 2
       ;;
 
@@ -415,25 +415,25 @@ while [[ $# > 0 ]]; do
           exit 1
           ;;
       esac
-      arguments="$arguments /p:HostConfiguration=$val"
+      arguments+=("/p:HostConfiguration=$val")
       shift 2
       ;;
 
      -cross)
       crossBuild=1
-      arguments="$arguments /p:CrossBuild=True"
+      arguments+=("/p:CrossBuild=True")
       shift 1
       ;;
 
      *crossbuild=true*)
       crossBuild=1
-      extraargs="$extraargs $1"
+      extraargs+=("$1")
       shift 1
       ;;
 
      -clang*)
       compiler="${opt/#-/}" # -clang-9 => clang-9 or clang-9 => (unchanged)
-      arguments="$arguments /p:Compiler=$compiler /p:CppCompilerAndLinker=$compiler"
+      arguments+=("/p:Compiler=$compiler" "/p:CppCompilerAndLinker=$compiler")
       shift 1
       ;;
 
@@ -448,7 +448,7 @@ while [[ $# > 0 ]]; do
 
      -gcc*)
       compiler="${opt/#-/}" # -gcc-9 => gcc-9 or gcc-9 => (unchanged)
-      arguments="$arguments /p:Compiler=$compiler /p:CppCompilerAndLinker=$compiler"
+      arguments+=("/p:Compiler=$compiler" "/p:CppCompilerAndLinker=$compiler")
       shift 1
       ;;
 
@@ -457,7 +457,7 @@ while [[ $# > 0 ]]; do
         echo "No value for outputrid is supplied. See help (--help) for supported values." 1>&2
         exit 1
       fi
-      arguments="$arguments /p:OutputRID=$(echo "$2" | tr "[:upper:]" "[:lower:]")"
+      arguments+=("/p:OutputRID=$(echo "$2" | tr "[:upper:]" "[:lower:]")")
       shift 2
       ;;
 
@@ -469,7 +469,7 @@ while [[ $# > 0 ]]; do
       passedPortable="$(echo "$2" | tr "[:upper:]" "[:lower:]")"
       if [ "$passedPortable" = false ]; then
         portableBuild=0
-        arguments="$arguments /p:PortableBuild=false"
+        arguments+=("/p:PortableBuild=false")
       fi
       shift 2
       ;;
@@ -481,7 +481,7 @@ while [[ $# > 0 ]]; do
       fi
       passedKeepNativeSymbols="$(echo "$2" | tr "[:upper:]" "[:lower:]")"
       if [ "$passedKeepNativeSymbols" = true ]; then
-        arguments="$arguments /p:KeepNativeSymbols=true"
+        arguments+=("/p:KeepNativeSymbols=true")
       fi
       shift 2
       ;;
@@ -489,30 +489,30 @@ while [[ $# > 0 ]]; do
 
       -ninja)
       if [ -z ${2+x} ]; then
-        arguments="$arguments /p:Ninja=true"
+        arguments+=("/p:Ninja=true")
         shift 1
       else
         ninja="$(echo "$2" | tr "[:upper:]" "[:lower:]")"
         if [ "$ninja" = true ]; then
-          arguments="$arguments /p:Ninja=true"
+          arguments+=("/p:Ninja=true")
           shift 2
         elif [ "$ninja" = false ]; then
-          arguments="$arguments /p:Ninja=false"
+          arguments+=("/p:Ninja=false")
           shift 2
         else
-          arguments="$arguments /p:Ninja=true"
+          arguments+=("/p:Ninja=true")
           shift 1
         fi
       fi
       ;;
 
       -pgoinstrument)
-      arguments="$arguments /p:PgoInstrument=true"
+      arguments+=("/p:PgoInstrument=true")
       shift 1
       ;;
 
       -use-bootstrap)
-      arguments="$arguments /p:UseBootstrap=true"
+      arguments+=("/p:UseBootstrap=true")
       shift 1
       ;;
 
@@ -526,30 +526,30 @@ while [[ $# > 0 ]]; do
         echo "No value for -fsanitize is supplied. See help (--help) for supported values." 1>&2
         exit 1
       fi
-      arguments="$arguments /p:EnableNativeSanitizers=$2"
+      arguments+=("/p:EnableNativeSanitizers=$2")
       shift 2
       ;;
 
       -fsanitize=*)
       sanitizers="${opt/#-fsanitize=/}" # -fsanitize=address => address
-      arguments="$arguments /p:EnableNativeSanitizers=$sanitizers"
+      arguments+=("/p:EnableNativeSanitizers=$sanitizers")
       shift 2
       ;;
 
       -verbose)
-      arguments="$arguments /p:CoreclrVerbose=true"
+      arguments+=("/p:CoreclrVerbose=true")
       shift 1
       ;;
 
       *)
-      extraargs="$extraargs $1"
+      extraargs+=("$1")
       shift 1
       ;;
   esac
 done
 
 if [ ${#actInt[@]} -eq 0 ]; then
-    arguments="-restore -build $arguments"
+    arguments=("-restore" "-build" "${arguments[@]}")
 fi
 
 if [[ "$os" == "browser" ]]; then
@@ -566,11 +566,11 @@ if [[ "$os" == "wasi" ]]; then
 fi
 
 if [[ "${TreatWarningsAsErrors:-}" == "false" ]]; then
-    arguments="$arguments -warnAsError false"
+    arguments+=("-warnAsError" "false")
 fi
 
 # disable terminal logger for now: https://github.com/dotnet/runtime/issues/97211
-arguments="$arguments -tl:false"
+arguments+=("-tl:false")
 
 initDistroRid "$os" "$arch" "$crossBuild"
 
@@ -581,23 +581,31 @@ export DOTNETSDK_ALLOW_TARGETING_PACK_CACHING=0
 # URL-encode space (%20) to avoid quoting issues until the msbuild call in /eng/common/tools.sh.
 # In *proj files (XML docs), URL-encoded string are rendered in their decoded form.
 cmakeargs="${cmakeargs// /%20}"
-arguments="$arguments /p:TargetArchitecture=$arch /p:BuildArchitecture=$hostArch"
-arguments="$arguments /p:CMakeArgs=\"$cmakeargs\" $extraargs"
+arguments+=("/p:TargetArchitecture=$arch" "/p:BuildArchitecture=$hostArch")
+arguments+=("/p:CMakeArgs=\"$cmakeargs\"" "${extraargs[@]}")
 
 if [[ "$bootstrap" == "1" ]]; then
   # Strip build actions other than -restore and -build from the arguments for the bootstrap build.
-  bootstrapArguments="$arguments"
-  for flag in --sign --publish --pack --test -sign -publish -pack -test; do
-    bootstrapArguments="${bootstrapArguments//$flag/}"
+  bootstrapArguments=()
+  for argument in "${arguments[@]}"; do
+    add=1
+    for flag in --sign --publish --pack --test -sign -publish -pack -test; do
+      if [[ "$argument" == "$flag" ]]; then
+        add=0
+      fi
+    done
+    if [[ $add == 1 ]]; then
+      bootstrapArguments+=("$argument")
+    fi
   done
-  "$scriptroot/common/build.sh" $bootstrapArguments /p:Subset=bootstrap -bl:$scriptroot/../artifacts/log/bootstrap.binlog
+  "$scriptroot/common/build.sh" "${bootstrapArguments[@]}" /p:Subset=bootstrap -bl:$scriptroot/../artifacts/log/bootstrap.binlog
 
   # Remove artifacts from the bootstrap build so the product build is a "clean" build.
   echo "Cleaning up artifacts from bootstrap build..."
   rm -r "$scriptroot/../artifacts/bin"
   # Remove all directories in obj except for the source-built-upstream-cache directory to avoid breaking SourceBuild.
   find "$scriptroot/../artifacts/obj" -mindepth 1 -maxdepth 1 ! -name 'source-built-upstream-cache' -exec rm -rf {} +
-  arguments="$arguments /p:UseBootstrap=true"
+  arguments+=("/p:UseBootstrap=true")
 fi
 
-"$scriptroot/common/build.sh" $arguments
+"$scriptroot/common/build.sh" "${arguments[@]}"


### PR DESCRIPTION
Currently, running the following command fails:

    $ ./build.sh --prep --source-build /p:OfficialBuilder='Red Hat'

Lots of scripts and projects assume that there are no spaces in OfficialBuilder (and other properties). Having spaces breaks in all sorts of places. This is a minimal fix to try and resolve that.

The primary change is to use bash arrays to store values (properties and arguments) to make sure they are quoted correctly when passed to other places.