### PR TITLE
[release/10.0.1xx-preview5] Copy files for MSI layout from the post-crossgen'd location

### DIFF
--- a/src/sdk/src/Layout/redist/targets/GenerateInstallerLayout.targets
+++ b/src/sdk/src/Layout/redist/targets/GenerateInstallerLayout.targets
@@ -94,7 +94,7 @@
 
     <!-- Create "SDK Internal" layout. -->
     <ItemGroup>
-      <SdkOutputFile Include="$(OutputPath)**\*" />
+      <SdkOutputFile Include="$(InstallerOutputDirectory)**\*" />
     </ItemGroup>
 
     <Copy SourceFiles="@(SdkOutputFile)"


### PR DESCRIPTION
Fixes internal issue reported where the .NET 10.0.100 Preview 4 SDK didn't have R2Rd Roslyn in the Exe/Msi installers.

Main PR at https://github.com/dotnet/sdk/pull/49096