### PR TITLE
Manually apply of "Remove MicroBuild workaround"

### DIFF
--- a/eng/common/core-templates/steps/install-microbuild.yml
+++ b/eng/common/core-templates/steps/install-microbuild.yml
@@ -48,38 +48,3 @@ steps:
             eq(variables['_SignType'], 'real')
           )
         ))
-
-    # Workaround for ESRP CLI on Linux - https://github.com/dotnet/source-build/issues/4964
-    - ${{ if eq(parameters.enableMicrobuildForMacAndLinux, 'true') }}:
-      - task: UseDotNet@2
-        displayName: Install .NET 9.0 SDK for ESRP CLI Workaround
-        inputs:
-          packageType: sdk
-          version: 9.0.x
-          installationPath: ${{ parameters.microBuildOutputFolder }}/.dotnet
-          workingDirectory: ${{ parameters.microBuildOutputFolder }}
-        condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))
-
-      - task: PowerShell@2
-        displayName: Workaround for ESRP CLI on Linux
-        inputs:
-          targetType: 'inline'
-          script: |
-            Write-Host "Copying Linux Path"
-            $MBSIGN_APPFOLDER = '$(MBSIGN_APPFOLDER)'
-            $MBSIGN_APPFOLDER = ($MBSIGN_APPFOLDER -replace '/build', '')
-
-            $versionRegex = '\d+\.\d+\.\d+'
-            $package = Get-ChildItem -Path $MBSIGN_APPFOLDER -Directory |
-              Where-Object { $_.Name -match $versionRegex }
-
-            if ($package.Count -ne 1) {
-                Write-Host "There should be exactly one matching subfolder, but found $($package.Count)."
-                exit 1
-            }
-
-            $MBSIGN_APPFOLDER = $package[0].FullName + '/build'
-            $MBSIGN_APPFOLDER | Write-Host
-            $SignConfigPath = $MBSIGN_APPFOLDER + '/signconfig.xml'
-            Copy-Item -Path "$(MBSIGN_APPFOLDER)/signconfig.xml" -Destination $SignConfigPath -Force
-        condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'))


### PR DESCRIPTION
Manual cherry-pick of https://github.com/dotnet/arcade/commit/12d3a9f5d6138e22270694574e73e4c58a815795

This fixes the broken official builds. We normally don't touch the toolset eng/common layout but this is one of the cases when we should.