### PR TITLE
Use new SB secrets variable group

### DIFF
--- a/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -39,7 +39,7 @@ variables:
 - template: /eng/pipelines/templates/variables/vmr-build.yml@self
 
 # GH access token for SB bot - BotAccount-dotnet-sb-bot-pat
-- group: DotNet-Source-Build-Bot-Secrets-MVP
+- group: Dotnet-SourceBuild-Secrets
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates

--- a/eng/pipelines/vmr-license-scan.yml
+++ b/eng/pipelines/vmr-license-scan.yml
@@ -34,7 +34,7 @@ parameters:
 
 variables:
   # GH access token for SB bot - BotAccount-dotnet-sb-bot-pat
-- group: DotNet-Source-Build-Bot-Secrets-MVP
+- group: Dotnet-SourceBuild-Secrets
 
 resources:
   repositories:


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/5212

The `DotNet-Source-Build-Bot-Secrets-MVP` is obsolete, pointing to a secret with an expired PAT four the source build bot. Replacing it with the new variable group that has a valid PAT.