### PR TITLE
Revert global.json SDK change

### DIFF
--- a/src/arcade/global.json
+++ b/src/arcade/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "10.0.100-preview.3.25201.16",
+    "version": "10.0.100-preview.5.25265.106",
     "rollForward": "latestFeature"
   },
   "tools": {
-    "dotnet": "10.0.100-preview.3.25201.16"
+    "dotnet": "10.0.100-preview.5.25265.106"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25259.2",


### PR DESCRIPTION
The .NET SDK version got incorrectly downgraded in yesterday's arcade -> forward flow PR: https://github.com/dotnet/dotnet/commit/f2198a60a6a84945ffcffb6cf319e937b44fa0a0#r157738288