### PR TITLE
[preview5] Move SIGN NoWarn to Signing.props

### DIFF
--- a/src/aspnetcore/Directory.Build.props
+++ b/src/aspnetcore/Directory.Build.props
@@ -133,9 +133,6 @@
 
     <!-- // Temporary diagnostic code from https://github.com/dotnet/extensions/pull/4130 for metrics APIs used in test. -->
     <NoWarn>$(NoWarn);TBD</NoWarn>
-
-    <!-- In Preview5 only, NoWarn this signing error about mismatched 1st/3rd party .dll/signatures. SignTool mistakenly sees R2R images as 3rd-party -->
-    <NoWarn>$(NoWarn);SIGN004</NoWarn>
   </PropertyGroup>
 
   <!-- Source code settings -->

--- a/src/aspnetcore/eng/Signing.props
+++ b/src/aspnetcore/eng/Signing.props
@@ -7,6 +7,11 @@
     <UseDotNetCertificate>true</UseDotNetCertificate>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- In Preview5 only, NoWarn this signing error about mismatched 1st/3rd party .dll/signatures. SignTool mistakenly sees R2R images as 3rd-party -->
+    <NoWarn>$(NoWarn);SIGN004</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup Label="File signing information">
     <!-- Third-party components which should be signed.  -->
     <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/aspnetcore/pull/62048. `Sign.proj` doesn't import D.B.P, but it does import eng/signing.props.