### PR TITLE
Update PipelineAutobaseliningConfig.yml

### DIFF
--- a/.config/1espt/PipelineAutobaseliningConfig.yml
+++ b/.config/1espt/PipelineAutobaseliningConfig.yml
@@ -12,10 +12,12 @@ pipelines:
           lastModifiedDate: 2024-03-25
         armory:
           lastModifiedDate: 2024-03-25
+        policheck:
+          lastModifiedDate: 2025-03-27
       binary:
         credscan:
           lastModifiedDate: 2024-03-25
         binskim:
-          lastModifiedDate: 2024-03-25
+          lastModifiedDate: 2025-01-23
         spotbugs:
           lastModifiedDate: 2024-03-25


### PR DESCRIPTION
This adds the recent copy of this file from the `users/merlinbot/1es-pt-auto-baselining-pr` branch in the internal repo.

It gets rid of the warning on new preview branches going forward:
> 1ES PT Warning: Your pipeline is already baselined but there is at least one new tool being enabled or required new baselines in this run thus requiring a new baseline.