### PR TITLE
Split up setting NonShipping and DotNetReleaseShipping ManifestArtifactData

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -374,6 +374,11 @@
     <ItemGroup>
       <ItemsToPushToBlobFeed>
         <ManifestArtifactData Condition="'%(ItemsToPushToBlobFeed.IsShipping)' != 'true'">%(ItemsToPushToBlobFeed.ManifestArtifactData);NonShipping=true</ManifestArtifactData>
+      </ItemsToPushToBlobFeed>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ItemsToPushToBlobFeed>
         <ManifestArtifactData Condition="'%(ItemsToPushToBlobFeed.DotNetReleaseShipping)' == 'true'">%(ItemsToPushToBlobFeed.ManifestArtifactData);DotNetReleaseShipping=true</ManifestArtifactData>
       </ItemsToPushToBlobFeed>
     </ItemGroup>


### PR DESCRIPTION
Fixes issues with staging these artifacts based on the manifest.