### PR TITLE
Remove now unnecessary env vars

### DIFF
--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -172,14 +172,6 @@
     <EnvironmentVariables Include="_InitializeToolset=$(SourceBuiltSdksDir)Microsoft.DotNet.Arcade.Sdk/tools/Build.proj"
                           Condition="'$(UseBootstrapArcade)' != 'true'" />
 
-    <!-- We pass '-ci', but also apply ci mode via env var for edge cases. (E.g. misbehaving inner builds.). -->
-    <EnvironmentVariables Condition="'$(ContinuousIntegrationBuild)' == 'true'" Include="ContinuousIntegrationBuild=true" />
-
-    <!-- Turn off node reuse for source build because repos use conflicting versions
-         of compilers which cause assembly load errors.
-         See https://github.com/dotnet/source-build/issues/541 -->
-    <EnvironmentVariables Include="MSBUILDDISABLENODEREUSE=1" />
-
     <EnvironmentVariables Include="DeterministicSourcePaths=true" Condition="'$(DeterministicBuildOptOut)' != 'true'" />
     <EnvironmentVariables Include="DeterministicSourcePaths=false" Condition="'$(DeterministicBuildOptOut)' == 'true'" />
 
@@ -188,7 +180,7 @@
     <!-- Needed for miscellanous projects in various repos - see https://github.com/dotnet/source-build/issues/4081-->
     <EnvironmentVariables Include="RestoreConfigFile=$(NuGetConfigFile)" Condition="'$(NuGetConfigFile)' != ''" />
 
-    <!-- Need to be passed in here so that outer and inner builds don't restore into the orchestrator package cache (CI builds)
+    <!-- Need to be passed in here so that repo builds don't restore into the orchestrator package cache (CI builds)
          or the user package cache (local dev builds). -->
     <EnvironmentVariables Include="NUGET_PACKAGES=$(RepoArtifactsPackageCache)" />
   </ItemGroup>


### PR DESCRIPTION
Disable node_reuse shouldn't be necessary anymore as the VMR now consistently builds with the compiler from the SDK when using dotnet msbuild.

The ContinuousIntegrationBuild env var shouldn't be necessary anymore as there's no outer -> inner build translation anymore which required this.