### PR TITLE
Fix bash array expansion on macOS

### DIFF
--- a/src/arcade/eng/common/build.sh
+++ b/src/arcade/eng/common/build.sh
@@ -257,7 +257,7 @@ function Build {
     /p:Sign=$sign \
     /p:Publish=$publish \
     /p:RestoreStaticGraphEnableBinaryLogger=$binary_log \
-    "${properties[@]}"
+    ${properties[@]+"${properties[@]}"}
 
   ExitWithExitCode 0
 }

--- a/src/fsharp/eng/build.sh
+++ b/src/fsharp/eng/build.sh
@@ -295,7 +295,7 @@ function BuildSolution {
 
     BuildMessage="Error building tools"
     # TODO: Remove DotNetBuildRepo property when fsharp is on Arcade 10
-    local args=("publish" "$repo_root/proto.proj" "$blrestore" "$bltools" "/p:Configuration=Proto" "/p:DotNetBuildRepo=$product_build" "/p:DotNetBuild=$product_build" "/p:DotNetBuildSourceOnly=$source_build" "/p:DotNetBuildFromVMR=$from_vmr" "${properties[@]}")
+    local args=("publish" "$repo_root/proto.proj" "$blrestore" "$bltools" "/p:Configuration=Proto" "/p:DotNetBuildRepo=$product_build" "/p:DotNetBuild=$product_build" "/p:DotNetBuildSourceOnly=$source_build" "/p:DotNetBuildFromVMR=$from_vmr" ${properties[@]+"${properties[@]}"})
     echo $args
     "$DOTNET_INSTALL_DIR/dotnet" "${args[@]}"  #$args || exit $?
   fi
@@ -325,7 +325,7 @@ function BuildSolution {
       /p:DotNetBuild=$product_build \
       /p:DotNetBuildSourceOnly=$source_build \
       /p:DotNetBuildFromVMR=$from_vmr \
-      "${properties[@]}"
+      ${properties[@]+"${properties[@]}"}
   fi
 }
 

--- a/src/nuget-client/eng/dotnet-build/build.sh
+++ b/src/nuget-client/eng/dotnet-build/build.sh
@@ -138,4 +138,4 @@ if [[ $warn_as_error == true ]]; then
   warnaserror_switch="/warnaserror"
 fi
 
-"$DOTNET" msbuild /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch /p:TreatWarningsAsErrors=$warn_as_error /p:ContinuousIntegrationBuild=$ci $bl  "${dotnetArguments[@]}" "${args[@]}"
+"$DOTNET" msbuild /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch /p:TreatWarningsAsErrors=$warn_as_error /p:ContinuousIntegrationBuild=$ci $bl ${dotnetArguments[@]+"${dotnetArguments[@]}"} ${args[@]+"${args[@]}"}

--- a/src/roslyn/eng/build.sh
+++ b/src/roslyn/eng/build.sh
@@ -323,7 +323,7 @@ function BuildSolution {
     $mono_tool \
     $generate_documentation_file \
     $roslyn_use_hard_links \
-    "${properties[@]}"
+    ${properties[@]+"${properties[@]}"}
 }
 
 function GetCompilerTestAssembliesIncludePaths {

--- a/src/runtime/eng/build.sh
+++ b/src/runtime/eng/build.sh
@@ -582,7 +582,7 @@ export DOTNETSDK_ALLOW_TARGETING_PACK_CACHING=0
 # In *proj files (XML docs), URL-encoded string are rendered in their decoded form.
 cmakeargs="${cmakeargs// /%20}"
 arguments+=("/p:TargetArchitecture=$arch" "/p:BuildArchitecture=$hostArch")
-arguments+=("/p:CMakeArgs=\"$cmakeargs\"" "${extraargs[@]}")
+arguments+=("/p:CMakeArgs=\"$cmakeargs\"" ${extraargs[@]+"${extraargs[@]}"})
 
 if [[ "$bootstrap" == "1" ]]; then
   # Strip build actions other than -restore and -build from the arguments for the bootstrap build.
@@ -598,7 +598,7 @@ if [[ "$bootstrap" == "1" ]]; then
       bootstrapArguments+=("$argument")
     fi
   done
-  "$scriptroot/common/build.sh" "${bootstrapArguments[@]}" /p:Subset=bootstrap -bl:$scriptroot/../artifacts/log/bootstrap.binlog
+  "$scriptroot/common/build.sh" ${bootstrapArguments[@]+"${bootstrapArguments[@]}"} /p:Subset=bootstrap -bl:$scriptroot/../artifacts/log/bootstrap.binlog
 
   # Remove artifacts from the bootstrap build so the product build is a "clean" build.
   echo "Cleaning up artifacts from bootstrap build..."
@@ -608,4 +608,4 @@ if [[ "$bootstrap" == "1" ]]; then
   arguments+=("/p:UseBootstrap=true")
 fi
 
-"$scriptroot/common/build.sh" "${arguments[@]}"
+"$scriptroot/common/build.sh" ${arguments[@]+"${arguments[@]}"}


### PR DESCRIPTION
Fix broken builds on macOS. macOS ships with an older version of bash, which doesn't expand empty arrays correctly. So check that arrays are not empty before expanding them.