### PR TITLE
Exclude sdk from VMR comparison

### DIFF
--- a/eng/tools/BuildComparer/BuildComparer.cs
+++ b/eng/tools/BuildComparer/BuildComparer.cs
@@ -188,7 +188,8 @@ public abstract class BuildComparer
                 if (baseDirectory.EndsWith("scenario-tests")
                     || baseDirectory.EndsWith("source-build-externals")
                     || baseDirectory.EndsWith("source-build-reference-packages")
-                    || baseDirectory.EndsWith("runtime"))
+                    || baseDirectory.EndsWith("runtime")
+                    || baseDirectory.EndsWith("sdk"))
                 {
                     continue;
                 }


### PR DESCRIPTION
Related to https://github.com/dotnet/dotnet/issues/711

SDK was made assetless in https://github.com/dotnet/sdk/commit/d767333b77a71b7d2b66cf2f6010c6d5ae237aa7 and https://github.com/dotnet/sdk/commit/5983b6e5ad3fa9047115a455d022af0af545d524