### PR TITLE
Baseline 2 more missing assets

### DIFF
--- a/eng/vmr-msft-comparison-baseline.json
+++ b/eng/vmr-msft-comparison-baseline.json
@@ -528,5 +528,5 @@
     "issueType": "MissingShipping",
     "idMatch": ".*dotnet-suggest.*",
     "justification": "command-line-api is not built from the VMR"
-  },
+  }
 ]

--- a/eng/vmr-msft-comparison-baseline.json
+++ b/eng/vmr-msft-comparison-baseline.json
@@ -330,6 +330,11 @@
   },
   {
     "issueType": "MissingNonShipping",
+    "idMatch": ".*Microsoft.DotNet.ApiDiff.Tests.*",
+    "justification": "sdk non-shipping test packages are not published"
+  },
+  {
+    "issueType": "MissingNonShipping",
     "idMatch": ".*Microsoft.DotNet.Cli.Utils.Tests.*",
     "justification": "sdk non-shipping test packages are not published"
   },
@@ -518,5 +523,10 @@
     "idMatch": ".*/dotnet-sdk-pgo-.*.tar.gz",
     "descriptionMatch": ".* is Excluded in the VMR but should be Signed",
     "justification": "The VMR build purposely excludes signing the PGO builds."
-  }
+  },
+  {
+    "issueType": "MissingShipping",
+    "idMatch": ".*dotnet-suggest.*",
+    "justification": "command-line-api is not built from the VMR"
+  },
 ]


### PR DESCRIPTION
Part of https://github.com/dotnet/source-build/issues/5196. Command-line-api isn't built out of the VMR, and we have a new non-shipping SDK package.