### PR TITLE
Build RepositoryReferences as P2Ps and use NuGet's transitive P2P calculation

### DIFF
--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -16,6 +16,8 @@
 
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
+    <NoTargetsDoNotReferenceOutputAssemblies>false</NoTargetsDoNotReferenceOutputAssemblies>
+
     <ProjectDirectory>$([MSBuild]::NormalizeDirectory('$(SrcDir)', '$(RepositoryName)'))</ProjectDirectory>
 
     <!-- Paths to the version props files -->
@@ -226,9 +228,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(TasksDir)Microsoft.DotNet.UnifiedBuild.Tasks\Microsoft.DotNet.UnifiedBuild.Tasks.csproj" />
+    <ProjectReference Include="$(TasksDir)Microsoft.DotNet.UnifiedBuild.Tasks\Microsoft.DotNet.UnifiedBuild.Tasks.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" />
     <!-- Skip the sdk resolver in source-only mode as it already got built in the previous msbuild node execution triggered in build.sh. -->
-    <ProjectReference Include="$(TasksDir)Microsoft.DotNet.UnifiedBuild.MSBuildSdkResolver\Microsoft.DotNet.UnifiedBuild.MSBuildSdkResolver.csproj" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
+    <ProjectReference Include="$(TasksDir)Microsoft.DotNet.UnifiedBuild.MSBuildSdkResolver\Microsoft.DotNet.UnifiedBuild.MSBuildSdkResolver.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
   </ItemGroup>
 
 </Project>

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -57,29 +57,20 @@
 
   <!-- Use the P2P protocol for RepositoryReference items. -->
   <ItemGroup>
-    <ProjectReference Include="@(RepositoryReference->'%(Identity).proj')" IsRepositoryReference="true" BuildReference="false" />
+    <ProjectReference Include="@(RepositoryReference->'%(Identity).proj')" IsRepositoryReference="true" BuildReference="false" ReferenceOutputAssembly="true" />
   </ItemGroup>
 
   <!-- Returns the repository references of this project and all the projects this project references, recursively -->
-  <Target Name="GetTransitiveRepositoryReferences" Returns="@(TransitiveRepositoryReference)">
+  <Target Name="GetTransitiveRepositoryReferences" Returns="@(TransitiveRepositoryReference)" DependsOnTargets="IncludeTransitiveProjectReferences">
     <ItemGroup>
-      <_TransitiveRepositoryReference Include="@(RepositoryReference)" />
-    </ItemGroup>
+      <_projectReferenceWithName Include="@(ProjectReference->Metadata('Filename'))" />
+      <_repositoryReference Include="$(MSBuildThisFileDirectory)*.proj" />
+      <_repositoryReferenceWithName Include="@(_repositoryReference->Metadata('Filename'))" />
 
-    <MSBuild Projects="@(RepositoryReference->'%(Identity).proj')"
-             Targets="GetTransitiveRepositoryReferences"
-             BuildInParallel="true">
-      <Output TaskParameter="TargetOutputs" ItemName="_DependencyTransitiveRepositoryReference" />
-    </MSBuild>
+      <_repositoryReferenceWithNameExcluded Include="@(_repositoryReferenceWithName)" Exclude="@(_projectReferenceWithName)" />
+      <_repositoryReferenceWithNameIncluded Include="@(_repositoryReferenceWithName)" Exclude="@(_repositoryReferenceWithNameExcluded)" />
 
-    <!-- When items are transferred between projects, they get metadata indicating their source (e.g. MSBuildSourceProjectFile).
-         This is problematic because it causes introduces distinctness on the items. For example, an arcade RepositoryReference
-         that comes from both msbuild and source-build-externals will be treated as two separate items. But we only want one arcade
-         reference. To prevent this from happening, we need to remove the extra metadata so the two references can be seen as duplicates. -->
-    <ItemGroup>
-      <_TransitiveRepositoryReference Include="@(_DependencyTransitiveRepositoryReference)"
-                                      RemoveMetadata="MSBuildSourceProjectFile;MSBuildSourceTargetName;OriginalItemSpec;DotNetBuildPass" />
-      <TransitiveRepositoryReference Include="@(_TransitiveRepositoryReference)" KeepDuplicates="false" />
+      <TransitiveRepositoryReference Include="@(_repositoryReferenceWithNameIncluded)" />
     </ItemGroup>
   </Target>
 

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -73,14 +73,16 @@
     <ProjectReference Include="@(RepositoryReference->'%(Identity).proj')" />
   </ItemGroup>
 
-  <!-- Returns the repository references of this project and all the projects this project references. -->
+  <!-- Add the BuildReference="false" metadata to transitives that shouldn't be built in the current build pass and
+      return the repository references (including transitives). -->
   <Target Name="PrepareRepositoryReferences" Returns="@(TransitiveRepositoryReference)" DependsOnTargets="PrepareProjectReferences" BeforeTargets="ResolveProjectReferences">
-    <!-- Add the BuildReference="false" metadata to transitives that shouldn't be built in the current build pass. -->
+    <!-- Read from the 'ExcludedRepositoryReferences' state retrieved by the PrepareProjectReferences target. -->
     <XmlPeek Condition="'%(_MSBuildProjectReferenceExistent.AdditionalPropertiesFromProject)' != ''"
              XmlContent="%(_MSBuildProjectReferenceExistent.AdditionalPropertiesFromProject)" Query="//ExcludedRepositoryReferences/text()">
       <Output TaskParameter="Result" ItemName="_excludedRepositoryReference" />
     </XmlPeek>
 
+    <!-- Unescape and add metadata to make msbuild treat the XmlPeek returned items correctly. -->
     <ItemGroup>
       <_excludedRepositoryReferenceNormalized Include="$([MSBuild]::Unescape('%(_excludedRepositoryReference.Identity)'))" />
       <_excludedRepositoryReferenceNormalized Project="%(Identity).proj" />
@@ -98,9 +100,11 @@
       <!-- Remove transitives that are also direct dependencies. -->
       <_MSBuildProjectReferenceExistentTransitive Remove="@(_MSBuildProjectReferenceExistent)" Condition="'%(_MSBuildProjectReferenceExistent.NuGetPackageId)' == ''" />
 
+      <!-- Find the transitive project references that shouldn't be built in the current build pass. -->
       <_projectReferenceWithBuildReferenceExcluded Include="@(_MSBuildProjectReferenceExistentTransitive)" Exclude="@(_excludedRepositoryReferenceNormalizedWithProject)" />
       <_projectReferenceWithBuildReferenceIncluded Include="@(_MSBuildProjectReferenceExistentTransitive)" Exclude="@(_projectReferenceWithBuildReferenceExcluded)" />
 
+      <!-- Add the BuildReference="false" metadata (via Remove&Include as Update doesn't work in targets) to the transitive project references that shouldn't be built. -->
       <_MSBuildProjectReferenceExistent Remove="@(_projectReferenceWithBuildReferenceIncluded)" />
       <_MSBuildProjectReferenceExistent Include="@(_projectReferenceWithBuildReferenceIncluded)" BuildReference="false" />
     </ItemGroup>

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -70,7 +70,7 @@
 
   <!-- Use the P2P protocol for RepositoryReference items. -->
   <ItemGroup>
-    <ProjectReference Include="@(RepositoryReference->'%(Identity).proj')" ReferenceOutputAssembly="true" />
+    <ProjectReference Include="@(RepositoryReference->'%(Identity).proj')" />
   </ItemGroup>
 
   <!-- Returns the repository references of this project and all the projects this project references. -->
@@ -412,6 +412,7 @@
 
   <Target Name="LogDependentRepos"
           BeforeTargets="ResolveProjectReferences"
+          DependsOnTargets="PrepareRepositoryReferences"
           Condition="'@(TransitiveRepositoryReference->AnyHaveMetadataValue('BuildReference', 'true'))' == 'true'">
     <Message Importance="High" Text="Building dependencies [@(TransitiveRepositoryReference->WithMetadataValue('BuildReference', 'true'))] needed by '$(RepositoryName)'." />
   </Target>
@@ -419,8 +420,8 @@
   <!-- Repos that are skipped in later build passes and don't build, still need to be called in order to
        extract tool packages (i.e. Arcade.Sdk). This is necessary due to the custom sdk resolver. -->
   <Target Name="ExtractToolPackagesForSkippedRepos"
-          DependsOnTargets="PrepareRepositoryReferences;ResolveProjectReferences"
-          Condition="'@(RepositoryReference)' != ''">
+          DependsOnTargets="PrepareRepositoryReferences"
+          Condition="'@(TransitiveRepositoryReference)' != '' and '$(SkipRepoReferences)' != 'true'">
     <ItemGroup>
       <_SkippedTransitiveRepositoryReference
         Include="@(TransitiveRepositoryReference->WithMetadataValue('BuildReference', 'false')->Metadata('Project'))"
@@ -430,7 +431,7 @@
 
     <MSBuild Projects="@(_SkippedTransitiveRepositoryReference)"
              Targets="ExtractToolPackage"
-             BuildInParallel="$(BuildInParallel)" />
+             BuildInParallel="true" />
   </Target>
 
   <Target Name="DiscoverBuiltSdkOverrides" DependsOnTargets="GetProducedPackagesFromTransitiveReferences;GetProducedPackagesFromTransitiveReferencesFromPreviousBuildPasses">

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -55,28 +55,78 @@
     <MinimalConsoleLogOutput Condition="'$(MinimalConsoleLogOutput)' == ''">$(BuildInParallel)</MinimalConsoleLogOutput>
   </PropertyGroup>
 
-  <!-- Use the P2P protocol for RepositoryReference items. -->
-  <ItemGroup>
-    <ProjectReference Include="@(RepositoryReference->'%(Identity).proj')" IsRepositoryReference="true" BuildReference="false" ReferenceOutputAssembly="true" />
+  <!-- Don't build repositories that aren't part of the current build pass. -->
+  <ItemGroup Condition="'$(DotNetBuildPass)' != '' and '$(DotNetBuildPass)' != '1'">
+    <_repositoryReferenceIncluded Include="@(RepositoryReference->WithMetadataValue('DotNetBuildPass', '$(DotNetBuildPass)'))" />
+    <_repositoryReferenceExcluded Include="@(RepositoryReference)" Exclude="@(_repositoryReferenceIncluded)" />
+
+    <RepositoryReference Update="@(_repositoryReferenceExcluded)" BuildReference="false" />
   </ItemGroup>
 
-  <!-- Returns the repository references of this project and all the projects this project references, recursively -->
-  <Target Name="GetTransitiveRepositoryReferences" Returns="@(TransitiveRepositoryReference)" DependsOnTargets="IncludeTransitiveProjectReferences">
+  <!-- Read by the P2P protocol to transfer state. -->
+  <ItemGroup>
+    <_AdditionalTargetFrameworkInfoPropertyWithValue Include="ExcludedRepositoryReferences" Value="@(RepositoryReference->WithMetadataValue('BuildReference', 'false')->Metadata('Filename'))" />
+  </ItemGroup>
+
+  <!-- Use the P2P protocol for RepositoryReference items. -->
+  <ItemGroup>
+    <ProjectReference Include="@(RepositoryReference->'%(Identity).proj')" ReferenceOutputAssembly="true" />
+  </ItemGroup>
+
+  <!-- Returns the repository references of this project and all the projects this project references. -->
+  <Target Name="PrepareRepositoryReferences" Returns="@(TransitiveRepositoryReference)" DependsOnTargets="PrepareProjectReferences" BeforeTargets="ResolveProjectReferences">
+    <!-- Add the BuildReference="false" metadata to transitives that shouldn't be built in the current build pass. -->
+    <XmlPeek Condition="'%(_MSBuildProjectReferenceExistent.AdditionalPropertiesFromProject)' != ''"
+             XmlContent="%(_MSBuildProjectReferenceExistent.AdditionalPropertiesFromProject)" Query="//ExcludedRepositoryReferences/text()">
+      <Output TaskParameter="Result" ItemName="_excludedRepositoryReference" />
+    </XmlPeek>
+
     <ItemGroup>
-      <_projectReferenceWithName Include="@(ProjectReference->Metadata('Filename'))" />
+      <_excludedRepositoryReferenceNormalized Include="$([MSBuild]::Unescape('%(_excludedRepositoryReference.Identity)'))" />
+      <_excludedRepositoryReferenceNormalized Project="%(Identity).proj" />
+    </ItemGroup>
+
+    <RemoveDuplicates Inputs="@(_excludedRepositoryReferenceNormalized)">
+      <Output TaskParameter="Filtered" ItemName="_excludedRepositoryReferenceNormalizedFiltered" />
+    </RemoveDuplicates>
+
+    <ItemGroup>
+      <_excludedRepositoryReferenceNormalizedWithProject Include="@(_excludedRepositoryReferenceNormalizedFiltered->Metadata('Project'))" />
+    
+      <!-- P2Ps with the NuGetPackageId metadata are transitives. -->
+      <_MSBuildProjectReferenceExistentTransitive Include="@(_MSBuildProjectReferenceExistent->HasMetadata('NuGetPackageId'))" />
+      <!-- Remove transitives that are also direct dependencies. -->
+      <_MSBuildProjectReferenceExistentTransitive Remove="@(_MSBuildProjectReferenceExistent)" Condition="'%(_MSBuildProjectReferenceExistent.NuGetPackageId)' == ''" />
+
+      <_projectReferenceWithBuildReferenceExcluded Include="@(_MSBuildProjectReferenceExistentTransitive)" Exclude="@(_excludedRepositoryReferenceNormalizedWithProject)" />
+      <_projectReferenceWithBuildReferenceIncluded Include="@(_MSBuildProjectReferenceExistentTransitive)" Exclude="@(_projectReferenceWithBuildReferenceExcluded)" />
+
+      <_MSBuildProjectReferenceExistent Remove="@(_projectReferenceWithBuildReferenceIncluded)" />
+      <_MSBuildProjectReferenceExistent Include="@(_projectReferenceWithBuildReferenceIncluded)" BuildReference="false" />
+    </ItemGroup>
+
+    <!-- Calculate TransitiveRepositoryReference and ignore P2Ps that don't point to repo projects. -->
+    <ItemGroup>
+      <_projectReferenceWithName Include="@(_MSBuildProjectReferenceExistent->Metadata('Filename'))" />
       <_repositoryReference Include="$(MSBuildThisFileDirectory)*.proj" />
       <_repositoryReferenceWithName Include="@(_repositoryReference->Metadata('Filename'))" />
 
-      <_repositoryReferenceWithNameExcluded Include="@(_repositoryReferenceWithName)" Exclude="@(_projectReferenceWithName)" />
-      <_repositoryReferenceWithNameIncluded Include="@(_repositoryReferenceWithName)" Exclude="@(_repositoryReferenceWithNameExcluded)" />
+      <_repositoryReferenceWithNameExcluded Include="@(_projectReferenceWithName)" Exclude="@(_repositoryReferenceWithName)" />
+      <_repositoryReferenceWithNameIncluded Include="@(_projectReferenceWithName)" Exclude="@(_repositoryReferenceWithNameExcluded)" />
 
-      <TransitiveRepositoryReference Include="@(_repositoryReferenceWithNameIncluded)" />
+      <TransitiveRepositoryReference Include="@(_repositoryReferenceWithNameIncluded)" Project="%(Identity).proj" />
+    </ItemGroup>
+
+    <!-- SkipRepoReferences is a developer innerloop switch to skip building repo dependencies. -->
+    <ItemGroup Condition="'$(SkipRepoReferences)' == 'true'">
+      <_MSBuildProjectReferenceExistent Remove="@(TransitiveRepositoryReference->Metadata('Project'))" />
+      <_MSBuildProjectReferenceExistent Include="@(TransitiveRepositoryReference->Metadata('Project'))" BuildReference="false"  />
     </ItemGroup>
   </Target>
 
   <!-- Wraps the transitive repo references with additional metadata -->
   <Target Name="GetRepositoryReferenceInfo"
-          DependsOnTargets="GetTransitiveRepositoryReferences">
+          DependsOnTargets="PrepareRepositoryReferences">
     <!-- SBRP is explicitly excluded since it is output to its own special directory, $(ReferencePackagesDir). -->
     <ItemGroup Condition="'@(TransitiveRepositoryReference)' != ''">
       <RepositoryReferenceInfo Include="@(TransitiveRepositoryReference)"
@@ -282,7 +332,6 @@
           DependsOnTargets="ResolveProjectReferences;GetProducedPackagesFromTransitiveReferences;GetProducedPackagesFromTransitiveReferencesFromPreviousBuildPasses"
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(BaseIntermediateOutputPath)CreateBuildInputProps.complete">
-
     <!-- Get the previously-built-source-built package information from the manifest from that build. -->
     <ItemGroup>
       <_PreviouslySourceBuiltAssetManifests Include="$(PreviouslySourceBuiltPackagesPath)VerticalManifest.xml" />
@@ -361,41 +410,26 @@
     </Touch>
   </Target>
 
-  <!-- SkipRepoReferences is a developer innerloop switch to skip building dependencies. -->
-  <Target Name="BuildRepoReferences"
-          DependsOnTargets="GetTransitiveRepositoryReferences"
-          Condition="'@(RepositoryReference)' != '' and '$(SkipRepoReferences)' != 'true'">
+  <Target Name="LogDependentRepos"
+          BeforeTargets="ResolveProjectReferences"
+          Condition="'@(TransitiveRepositoryReference->AnyHaveMetadataValue('BuildReference', 'true'))' == 'true'">
+    <Message Importance="High" Text="Building dependencies [@(TransitiveRepositoryReference->WithMetadataValue('BuildReference', 'true'))] needed by '$(RepositoryName)'." />
+  </Target>
+
+  <!-- Repos that are skipped in later build passes and don't build, still need to be called in order to
+       extract tool packages (i.e. Arcade.Sdk). This is necessary due to the custom sdk resolver. -->
+  <Target Name="ExtractToolPackagesForSkippedRepos"
+          DependsOnTargets="PrepareRepositoryReferences;ResolveProjectReferences"
+          Condition="'@(RepositoryReference)' != ''">
     <ItemGroup>
-      <_DependentProject Include="@(TransitiveRepositoryReference)"
-                         Project="%(Identity).proj" />
+      <_SkippedTransitiveRepositoryReference
+        Include="@(TransitiveRepositoryReference->WithMetadataValue('BuildReference', 'false')->Metadata('Project'))"
+        AdditionalProperties="GetDependentVerticalAssetsOnly=true" />
     </ItemGroup>
 
-    <!-- Filter out projects that aren't part of the current build pass. -->
-    <ItemGroup Condition="'$(DotNetBuildPass)' != '' and '$(DotNetBuildPass)' != '1'">
-      <_DependentProjectCurrentBuildPass Include="@(_DependentProject->WithMetadataValue('DotNetBuildPass', '$(DotNetBuildPass)'))" />
-
-      <_DependentProjectToSkip Include="@(_DependentProject)" Exclude="@(_DependentProjectCurrentBuildPass)" />
-      <_DependentProjectToSkip AdditionalProperties="GetDependentVerticalAssetsOnly=true" />
-
-      <_DependentProject Remove="@(_DependentProject)" />
-      <_DependentProject Include="@(_DependentProjectCurrentBuildPass)" />
-    </ItemGroup>
-
-    <Message Importance="High" Text="Building dependencies [@(_DependentProject)] needed by '$(RepositoryName)'." Condition="'@(_DependentProject)' != ''" />
-
-    <MSBuild Projects="@(_DependentProject->Metadata('Project'))"
-             Targets="Build"
-             BuildInParallel="$(BuildInParallel)"
-             StopOnFirstFailure="true"
-             RunEachTargetSeparately="$(RunEachTargetSeparately)"
-             Condition="'@(_DependentProject)' != ''" />
-
-    <!-- Repos that are skipped in later build passes and don't build, still need to be called in order to
-         extract tool packages (i.e. Arcade.Sdk). This is necessary as we use a custom sdk resolver. -->
-    <MSBuild Projects="@(_DependentProjectToSkip->Metadata('Project'))"
+    <MSBuild Projects="@(_SkippedTransitiveRepositoryReference)"
              Targets="ExtractToolPackage"
-             BuildInParallel="$(BuildInParallel)"
-             Condition="'@(_DependentProjectToSkip)' != ''" />
+             BuildInParallel="$(BuildInParallel)" />
   </Target>
 
   <Target Name="DiscoverBuiltSdkOverrides" DependsOnTargets="GetProducedPackagesFromTransitiveReferences;GetProducedPackagesFromTransitiveReferencesFromPreviousBuildPasses">
@@ -464,7 +498,7 @@
   </Target>
 
   <Target Name="SetBuildProperties"
-          DependsOnTargets="GetTransitiveRepositoryReferences;SetRepoOriginalSourceRevisionId">
+          DependsOnTargets="PrepareRepositoryReferences;SetRepoOriginalSourceRevisionId">
     <PropertyGroup>
       <!-- Infer the projects runtime identifier as the vertical's RID when doing a vertical build
            and filter down RID lists to the target RID in such a scenario. This is necessary when the host (SDK) rid
@@ -481,7 +515,7 @@
           Inputs="$(MSBuildProjectFullPath)"
           Outputs="$(BaseIntermediateOutputPath)Build.complete"
           Condition="'$(BuildCommand)' != ''"
-          DependsOnTargets="BuildRepoReferences;
+          DependsOnTargets="ExtractToolPackagesForSkippedRepos;
                             UpdateNuGetConfig;
                             UpdateGlobalJsonVersions;
                             UpdateEngCommonFiles;
@@ -601,21 +635,20 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="GetProducedPackagesFromTransitiveReferencesFromPreviousBuildPasses" DependsOnTargets="GetTransitiveRepositoryReferences" Returns="@(_DependencyProducedPackage)">
-    <ItemGroup>
-      <_TransitivelyThisBuildPassReferencedRepo Include="@(TransitiveRepositoryReference->WithMetadataValue('DotNetBuildPass','$(DotNetBuildPass)'))" />
-      <_TransitivelyPreviousBuildPassReferencedRepo Include="@(TransitiveRepositoryReference)"
-                                                    Exclude="@(_TransitivelyThisBuildPassReferencedRepo)" />
-    </ItemGroup>
-    <MSBuild Projects="@(_TransitivelyPreviousBuildPassReferencedRepo->'%(Identity).proj')"
+  <Target Name="GetProducedPackagesFromTransitiveReferencesFromPreviousBuildPasses"
+          DependsOnTargets="PrepareRepositoryReferences"
+          Returns="@(_DependencyProducedPackage)">
+    <MSBuild Projects="@(TransitiveRepositoryReference->WithMetadataValue('BuildReference', 'false')->Metadata('Project'))"
              Targets="GetProducedPackagesFromDependentVerticals"
              BuildInParallel="true">
       <Output TaskParameter="TargetOutputs" ItemName="_DependencyProducedPackage" />
     </MSBuild>
   </Target>
 
-  <Target Name="GetProducedPackagesFromTransitiveReferences" DependsOnTargets="GetTransitiveRepositoryReferences" Returns="@(_DependencyProducedPackage)">
-    <MSBuild Projects="@(TransitiveRepositoryReference->WithMetadataValue('DotNetBuildPass','$(DotNetBuildPass)')->'%(Identity).proj')"
+  <Target Name="GetProducedPackagesFromTransitiveReferences"
+          DependsOnTargets="PrepareRepositoryReferences"
+          Returns="@(_DependencyProducedPackage)">
+    <MSBuild Projects="@(TransitiveRepositoryReference->WithMetadataValue('BuildReference', 'true')->Metadata('Project'))"
              Targets="GetProducedPackages"
              BuildInParallel="true">
       <Output TaskParameter="TargetOutputs" ItemName="_DependencyProducedPackage" />
@@ -797,7 +830,7 @@
   <Target Name="AfterBuild"
           DependsOnTargets="
     ResolveProjectReferences;
-    BuildRepoReferences;
+    ExtractToolPackagesForSkippedRepos;
     SetBuildProperties;
     RepoBuild;
     MoveDotNetBuildLogs;
@@ -853,7 +886,7 @@
 
   <!-- Recursively walks the repo dependency graph gathering each repo's dependencies which are returned as a YAML string representation -->
   <Target Name="GetDependencyGraphString"
-          DependsOnTargets="GetTransitiveRepositoryReferences"
+          DependsOnTargets="PrepareRepositoryReferences"
           Returns="$(DependencyGraphString)">
     <PropertyGroup>
       <!-- Each step deeper in the graph builds up the indentation used for the YAML representation.

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -116,12 +116,6 @@
 
       <TransitiveRepositoryReference Include="@(_repositoryReferenceWithNameIncluded)" Project="%(Identity).proj" />
     </ItemGroup>
-
-    <!-- SkipRepoReferences is a developer innerloop switch to skip building repo dependencies. -->
-    <ItemGroup Condition="'$(SkipRepoReferences)' == 'true'">
-      <_MSBuildProjectReferenceExistent Remove="@(TransitiveRepositoryReference->Metadata('Project'))" />
-      <_MSBuildProjectReferenceExistent Include="@(TransitiveRepositoryReference->Metadata('Project'))" BuildReference="false"  />
-    </ItemGroup>
   </Target>
 
   <!-- Wraps the transitive repo references with additional metadata -->
@@ -421,7 +415,7 @@
        extract tool packages (i.e. Arcade.Sdk). This is necessary due to the custom sdk resolver. -->
   <Target Name="ExtractToolPackagesForSkippedRepos"
           DependsOnTargets="PrepareRepositoryReferences"
-          Condition="'@(TransitiveRepositoryReference)' != '' and '$(SkipRepoReferences)' != 'true'">
+          Condition="'@(TransitiveRepositoryReference)' != '' and '$(BuildProjectReferences)' == 'true'">
     <ItemGroup>
       <_SkippedTransitiveRepositoryReference
         Include="@(TransitiveRepositoryReference->WithMetadataValue('BuildReference', 'false')->Metadata('Project'))"

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -424,7 +424,8 @@
     <ItemGroup>
       <_SkippedTransitiveRepositoryReference
         Include="@(TransitiveRepositoryReference->WithMetadataValue('BuildReference', 'false')->Metadata('Project'))"
-        AdditionalProperties="GetDependentVerticalAssetsOnly=true" />
+        AdditionalProperties="GetDependentVerticalAssetsOnly=true"
+        GlobalPropertiesToRemove="GetDependentVerticalAssetsOnly" />
     </ItemGroup>
 
     <MSBuild Projects="@(_SkippedTransitiveRepositoryReference)"


### PR DESCRIPTION
Continuation of https://github.com/dotnet/dotnet/commit/1801a223d0cc621cb94e43a272014985bee87113

This improves scheduling the inner repos and with that reduces the overall build time by getting runtime (which is on the hot path) to start to build earlier. Additionally, this makes the VMR build more aligned with the rest of the product by using P2Ps to build dependencies.

---

NuGet is responsible for calculating transitive project references in general. A project's project.assets.json file contains a node for the transitive p2ps. At build time a target then runs that reads that information and adds the transitive p2ps to an item group so that transitives are also getting built as part of the `ResolveProjectReferences` target. That's how the product works.
 
In the VMR we weren't defining P2P for the repo projects and therefore we never had that information available in the "default" way. Instead we had a custom target that retrieved that information. My PR basically removes that custom target and gets us onto the common path. Of course with some additional complexity... mostly because of BuildPass stuff.

The PR also removes the `BuildRepoReferences` target as we now build RepositoryReference items as P2Ps directly and rely on the `ResolveProjectReferences` SDK target.