### PR TITLE
Publish build logs for installer tests jobs

### DIFF
--- a/eng/pipelines/templates/stages/vmr-validation.yml
+++ b/eng/pipelines/templates/stages/vmr-validation.yml
@@ -52,7 +52,6 @@ stages:
   - group: DotNetBot-GitHub-AllBranches
   jobs:
   - job: ValidateInstallers_Linux_x64
-    displayName: Validate Installers - Linux x64
     pool: ${{ parameters.pool_Linux }}
     timeoutInMinutes: 30
     steps:
@@ -61,11 +60,9 @@ stages:
         targetArchitecture: x64
         OS: Linux
         reuseBuildArtifactsFrom:
-        # Scenario-tests package is built/published by Windows_x64 job
         - Windows_x64
         - AzureLinux_x64_Cross_x64
   - job: ValidateInstallers_Linux_arm64
-    displayName: Validate Installers - Linux arm64
     pool: ${{ parameters.pool_LinuxArm64 }}
     timeoutInMinutes: 60
     steps:
@@ -74,7 +71,6 @@ stages:
         targetArchitecture: arm64
         OS: Linux
         reuseBuildArtifactsFrom:
-        # Scenario-tests package is built/published by Windows_x64 job
         - Windows_x64
         - AzureLinux_x64_Cross_arm64
   - ${{ if eq(variables.signEnabled, 'true') }}:

--- a/eng/pipelines/templates/steps/vmr-validate-installers.yml
+++ b/eng/pipelines/templates/steps/vmr-validate-installers.yml
@@ -63,3 +63,12 @@ steps:
       mergeTestResults: true
       publishRunAttachments: true
       testRunTitle: ScenarioTests_$(Agent.JobName)
+
+  - task: 1ES.PublishPipelineArtifact@1
+    displayName: Publish InstallerTest Logs
+    continueOnError: true
+    inputs:
+      path: $(Build.SourcesDirectory)/artifacts/log/
+      artifactName: $(Agent.JobName)_BuildLogs_Attempt$(System.JobAttempt)
+      artifactType: Container
+      parallel: true


### PR DESCRIPTION
Fixes: https://github.com/dotnet/dotnet/issues/707

[Verification build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2720053&view=artifacts&pathAsName=false&type=publishedArtifacts)
