### PR TITLE
Keep subdirectory for repo log files

### DIFF
--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -682,7 +682,7 @@
 
     <!-- Move the build logs -->
     <Move SourceFiles="@(LogFilesToMove)"
-          DestinationFolder="$(ArtifactsLogRepoDir)"
+          DestinationFolder="$(ArtifactsLogRepoDir)%(LogFilesToMove.RecursiveDir)"
           Condition="'@(LogFilesToMove)' != ''" />
   </Target>
 


### PR DESCRIPTION
I noticed in a recent PR that the log files for source-build-externals were flattened and not all logs kept due to name clashes.

We need to keep the directory structure when moving the log files.