### PR TITLE
Fix dotnet version in arcade global.json

### DIFF
--- a/src/arcade/global.json
+++ b/src/arcade/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "10.0.100-preview.5.25302.104",
+    "version": "10.0.100-preview.6.25302.104",
     "rollForward": "latestFeature"
   },
   "tools": {
-    "dotnet": "10.0.100-preview.5.25302.104"
+    "dotnet": "10.0.100-preview.6.25302.104"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25302.104",


### PR DESCRIPTION
Mistake from https://github.com/dotnet/dotnet/pull/933