### PR TITLE
[DRAFT] Support building only source-only legs in VMR Verification

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -25,6 +25,7 @@ parameters:
   default: true
 
 # True when building the VMR in source-only mode
+# 'string' type as underlying value is usually set as pipeline's runtime variable
 - name: isSourceOnlyBuild
   type: string
   default: 'false'

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -24,6 +24,11 @@ parameters:
   type: boolean
   default: true
 
+# True when building the VMR in source-only mode
+- name: isSourceOnlyBuild
+  type: boolean
+  default: false
+
 # These are not expected to be passed it but rather just object variables reused below
 - name: pool_Linux
   type: object
@@ -67,32 +72,33 @@ parameters:
     os: linux
 
 stages:
-- template: vmr-build-with-join.yml
-  parameters:
-    verticalsStages:
-      - template: vmr-verticals.yml
-        parameters:
-          desiredSigning: ${{ parameters.desiredSigning }}
-          desiredIbc: ${{ parameters.desiredIbc }}
-          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-          scope: ${{ parameters.scope }}
-    finalJoinCondition: ${{ eq(parameters.scope, 'full') }}
-    isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-    postJoinStages:
-    - ${{ if and(parameters.isBuiltFromVmr, eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
-      - stage: Publish_Build_Assets
-        displayName: Publish Assets
-        jobs:
-        - template: /eng/common/templates-official/job/publish-build-assets.yml
+- ${{ if eq(parameters.isSourceOnlyBuild, 'false') }}:
+  - template: vmr-build-with-join.yml
+    parameters:
+      verticalsStages:
+        - template: vmr-verticals.yml
           parameters:
-            publishUsingPipelines: true
-            publishAssetsImmediately: true
-            pool: ${{ parameters.pool_Linux }}
-            symbolPublishingAdditionalParameters: '/p:PublishSpecialClrFiles=true'
+            desiredSigning: ${{ parameters.desiredSigning }}
+            desiredIbc: ${{ parameters.desiredIbc }}
+            isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+            scope: ${{ parameters.scope }}
+      finalJoinCondition: ${{ eq(parameters.scope, 'full') }}
+      isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+      postJoinStages:
+      - ${{ if and(parameters.isBuiltFromVmr, eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+        - stage: Publish_Build_Assets
+          displayName: Publish Assets
+          jobs:
+          - template: /eng/common/templates-official/job/publish-build-assets.yml
+            parameters:
+              publishUsingPipelines: true
+              publishAssetsImmediately: true
+              pool: ${{ parameters.pool_Linux }}
+              symbolPublishingAdditionalParameters: '/p:PublishSpecialClrFiles=true'
 
-      - template: vmr-validation.yml
-        parameters:
-          desiredSigning: ${{ parameters.desiredSigning }}
+        - template: vmr-validation.yml
+          parameters:
+            desiredSigning: ${{ parameters.desiredSigning }}
 
 - template: source-build-stages.yml
   parameters:

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -26,8 +26,8 @@ parameters:
 
 # True when building the VMR in source-only mode
 - name: isSourceOnlyBuild
-  type: boolean
-  default: false
+  type: string
+  default: 'false'
 
 # These are not expected to be passed it but rather just object variables reused below
 - name: pool_Linux


### PR DESCRIPTION
Contributes to: https://github.com/dotnet/source-build/issues/5226

This is necessary for allowing VMR verification in repo PRs to build just source-only legs, as is needed all that's needed in SBRP repo.

As repo-level VMR verification uses a shared pipeline YML under `eng/common`, conditioning legs is done via pipeline runtime variables. The necessary change to pass this variable into VMR build stage, via property, will be in an arcade PR, after this PR is merged. Here's a validation PR that uses private VMR branch and the arcade change in SBRP repo: https://github.com/dotnet/source-build-reference-packages/pull/1262

As discussed in that PR, we need to use parameters of the `string` type. For more on this, see https://github.com/dotnet/source-build-reference-packages/pull/1262#issuecomment-2945010398

Future PRs will add a support for Windows-only VMR builds, using the same model.