### PR TITLE
Disable transitive P2Ps when building scenario-tests standalone

### DIFF
--- a/repo-projects/scenario-tests.proj
+++ b/repo-projects/scenario-tests.proj
@@ -15,6 +15,7 @@
          as the scenario tests repo needs to be capable of being built by itself in a standalone validation job.
          This also requires the use of bootstrap arcade. -->
     <SkipScenarioTestsDependencies Condition="'$(DotNetSourceOnlyTestOnly)' == 'true'">true</SkipScenarioTestsDependencies>
+    <DisableTransitiveProjectReferences Condition="'$(SkipScenarioTestsDependencies)' == 'true'">true</DisableTransitiveProjectReferences>
     <UseBootstrapArcade Condition="'$(SkipScenarioTestsDependencies)' == 'true'">true</UseBootstrapArcade>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/dotnet/issues/1079

Microsoft.DotNet.Installer.Tests.csproj which is invoked by the vmr-validate-installers.yml references scenario-tests.proj and passes an additional global property in: SkipScenarioTestsDependencies=true.

NuGet intentionally drops additional properties from P2Ps to flatten the restore graph. Due to that, transitive P2Ps which are calculated and then provided by NuGet still flow into scenario-tests.proj.

Explicitly disable transitive P2Ps when SkipScenarioTestsDependencies=true.