### PR TITLE
Fix overbuilding task projects when SkipScenarioTestsDependencies=true

### DIFF
--- a/repo-projects/scenario-tests.proj
+++ b/repo-projects/scenario-tests.proj
@@ -15,8 +15,12 @@
          as the scenario tests repo needs to be capable of being built by itself in a standalone validation job.
          This also requires the use of bootstrap arcade. -->
     <SkipScenarioTestsDependencies Condition="'$(DotNetSourceOnlyTestOnly)' == 'true'">true</SkipScenarioTestsDependencies>
-    <DisableTransitiveProjectReferences Condition="'$(SkipScenarioTestsDependencies)' == 'true'">true</DisableTransitiveProjectReferences>
-    <UseBootstrapArcade Condition="'$(SkipScenarioTestsDependencies)' == 'true'">true</UseBootstrapArcade>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(SkipScenarioTestsDependencies)' == 'true'">
+    <UseBootstrapArcade>true</UseBootstrapArcade>
+    <DisableTransitiveProjectReferences>true</DisableTransitiveProjectReferences>
+    <_GlobalPropertiesToRemoveFromProjectReferences>$(_GlobalPropertiesToRemoveFromProjectReferences);SkipScenarioTestsDependencies</_GlobalPropertiesToRemoveFromProjectReferences>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(SkipScenarioTestsDependencies)' != 'true'">


### PR DESCRIPTION
Noticed in https://dev.azure.com/dnceng/internal/_build/results?buildId=2727981&view=logs&j=6e593626-f6df-5699-84b9-2127a964bf7b&t=1790d872-a33d-57ac-2a4d-ca6c60215859

This one fixes task projects getting built twice because the `SkipScenarioTestsDependencies` global property was flowing to them.