### PR TITLE
Update vmr-validate-installers.yml

### DIFF
--- a/eng/pipelines/templates/steps/vmr-validate-installers.yml
+++ b/eng/pipelines/templates/steps/vmr-validate-installers.yml
@@ -66,4 +66,4 @@ steps:
       artifactName: $(Agent.JobName)_BuildLogs_Attempt$(System.JobAttempt)
       artifactType: Container
       parallel: true
-    condition: succeededOrFailed()
+    condition: always()


### PR DESCRIPTION
I at least temporarily need a binlog even when jobs time out to diagnose an issue further: https://dev.azure.com/dnceng/internal/_build/results?buildId=2729497&view=results