### PR TITLE
Search subdirectories for manifest files

### DIFF
--- a/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/SigningValidation.cs
+++ b/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/SigningValidation.cs
@@ -105,7 +105,7 @@ public class SigningValidation : Microsoft.Build.Utilities.Task
 
         foreach (string artifactDirectory in Directory.EnumerateDirectories(ArtifactDownloadDirectory))
         {
-            foreach (string manifest in Directory.EnumerateFiles(Path.Combine(artifactDirectory, "manifests"), "*.xml", SearchOption.TopDirectoryOnly))
+            foreach (string manifest in Directory.EnumerateFiles(Path.Combine(artifactDirectory, "manifests"), "*.xml", SearchOption.AllDirectories))
             {
                 using (Stream xmlStream = File.OpenRead(manifest))
                 {


### PR DESCRIPTION
Fixes signing validation not finding any files to sign: https://dev.azure.com/dnceng/internal/_build/results?buildId=2729581&view=logs&j=2e220694-fd2b-5e09-0c04-ea9444ccf11c&t=aff2499f-2ea2-5f35-dcec-09ac00ac494f