### PR TITLE
Remove dependency from Cross-OS DAC join job on the Windows verticals.

### DIFF
--- a/eng/pipelines/templates/stages/vmr-verticals.yml
+++ b/eng/pipelines/templates/stages/vmr-verticals.yml
@@ -556,9 +556,6 @@ stages:
         targetArchitecture: x86
         buildPass: 2
         reuseBuildArtifactsFrom:
-        - Windows_x64
-        - Windows_x86
-        - Windows_arm64
         - AzureLinux_x64_Cross_x64
         - AzureLinux_x64_Cross_Alpine_x64
         - AzureLinux_x64_Cross_arm64

--- a/repo-projects/arcade.proj
+++ b/repo-projects/arcade.proj
@@ -5,6 +5,16 @@
     <UseBootstrapArcade>true</UseBootstrapArcade>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetOS)' == 'linux' and '$(TargetArchitecture)' == 'x64' and '$(EnableDefaultRidSpecificArtifacts)' == 'true'">
+    <!--
+      We have a BuildPass2 leg that has no dependencies on Windows artifacts except for Arcade.
+      To make sure that job doesn't need to wait for the Windows verticals,
+      we'll build all of Arcade with Internal visibility.
+    -->
+    <EnableDefaultRidSpecificArtifacts></EnableDefaultRidSpecificArtifacts>
+    <DefaultArtifactVisibility>Internal</DefaultArtifactVisibility>
+  </PropertyGroup>
+
   <ItemGroup>
     <RepositoryReference Include="source-build-reference-packages" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
   </ItemGroup>


### PR DESCRIPTION
This will allow the cross-OS DAC join job to start while some of the buildpass1 windows verticals are running, reducing the load on the pool when the rest of the buildpass2 jobs can start.

Internal PR: https://dev.azure.com/dnceng/internal/_build/results?buildId=2729119&view=results