### PR TITLE
Don't use --retry-all-errors in prep-source-build.sh

### DIFF
--- a/prep-source-build.sh
+++ b/prep-source-build.sh
@@ -175,7 +175,23 @@ function DownloadArchive {
     archiveUrl="https://builds.dotnet.microsoft.com/source-built-artifacts/assets/Private.SourceBuilt.$archiveType.$archiveVersion.$archiveRid.tar.gz"
 
     echo "  Downloading source-built $archiveType from $archiveUrl..."
-    (cd "$packagesArchiveDir" && curl -f --retry 5 --retry-all-errors --retry-delay 3 -O "$archiveUrl")
+    (
+      cd "$packagesArchiveDir" &&
+      for i in {1..5}; do
+        if curl -f --retry 5 -O "$archiveUrl"; then
+          exit 0
+        else
+          case $? in
+            18)
+              sleep 3
+              ;;
+            *)
+              exit 1
+              ;;
+          esac
+        fi
+      done
+    )
   elif [ "$isRequired" == true ]; then
     echo "  ERROR: $notFoundMessage"
     exit 1


### PR DESCRIPTION
Switch back to first version from https://github.com/dotnet/dotnet/pull/1151 as --retry-all-errors was only added in curl 7.71.0

Fixes https://github.com/dotnet/source-build/issues/5251