### PR TITLE
Revert "Retry all errors to handle curl (18) (#1151)"

### DIFF
--- a/prep-source-build.sh
+++ b/prep-source-build.sh
@@ -175,7 +175,7 @@ function DownloadArchive {
     archiveUrl="https://builds.dotnet.microsoft.com/source-built-artifacts/assets/Private.SourceBuilt.$archiveType.$archiveVersion.$archiveRid.tar.gz"
 
     echo "  Downloading source-built $archiveType from $archiveUrl..."
-    (cd "$packagesArchiveDir" && curl -f --retry 5 --retry-all-errors --retry-delay 3 -O "$archiveUrl")
+    (cd "$packagesArchiveDir" && curl -f --retry 5 -O "$archiveUrl")
   elif [ "$isRequired" == true ]; then
     echo "  ERROR: $notFoundMessage"
     exit 1


### PR DESCRIPTION
Reverts the changes from #1151 due to a regression in AlmaLinux 8: https://github.com/dotnet/source-build/issues/5251