### PR TITLE
Fix scenario-tests invocation in ValidateInstallers jobs

### DIFF
--- a/repo-projects/scenario-tests.proj
+++ b/repo-projects/scenario-tests.proj
@@ -23,11 +23,12 @@
     <_GlobalPropertiesToRemoveFromProjectReferences>$(_GlobalPropertiesToRemoveFromProjectReferences);SkipScenarioTestsDependencies</_GlobalPropertiesToRemoveFromProjectReferences>
   </PropertyGroup>
 
+  <!-- Use PrivateAssets="all" to not flow repo dependencies to consuming projects (for installer tests). -->
   <ItemGroup Condition="'$(SkipScenarioTestsDependencies)' != 'true'">
-    <RepositoryReference Include="arcade" />
-    <RepositoryReference Include="command-line-api" />
+    <RepositoryReference Include="arcade" PrivateAssets="all" />
+    <RepositoryReference Include="command-line-api" PrivateAssets="all" />
     <!-- Depend on NuGet packages from the sdk repo and transitive repositories. -->
-    <RepositoryReference Include="sdk" />
+    <RepositoryReference Include="sdk" PrivateAssets="all" />
   </ItemGroup>
 
   <Target Name="PrepareScenarioTestsInputs"


### PR DESCRIPTION
The ValidateInstallers jobs need to build scenario-tests in isolation without any of its dependencies. Due to P2Ps and their transitive nature when using NuGet, they were still flowing into
Microsoft.DotNet.Installers.Tests.csproj as transitive P2Ps.

Use PrivateAssets="all" in scenario-tests.proj to make them non-transitive.