### PR TITLE
Allow partial VMR verifications

### DIFF
--- a/eng/pipelines/templates/stages/source-build-stages.yml
+++ b/eng/pipelines/templates/stages/source-build-stages.yml
@@ -30,26 +30,27 @@ parameters:
   default: []
 
 stages:
-- template: source-build-and-validate.yml
-  parameters:
-    pool_Linux: ${{ parameters.pool_Linux }}
-    pool_LinuxArm64: ${{ parameters.pool_LinuxArm64 }}
-    useMicrosoftBuildAssetsForTests: ${{ parameters.useMicrosoftBuildAssetsForTests }}
-    isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-    
-    # Description of the source build legs to run.
-    # This is described here as a parameter to allow two separate stages to be produced from this list (one for building
-    # and one for validation). Because this template is not directly within a pipeline, stage, or job, we can't reference
-    # variables as template expressions. So we can't do things like '${{ format('{0}_Online_MsftSdk', variables.centOSStreamName) }}'.
-    # The variable value will be empty in that case. Instead, each leg defines a distro name that source-build-and-validate.yml uses
-    # to determine which variable to use for determining the various parameter values which are based on variables.
-    #
-    # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
-    legs:
+- ${{ if or(in(parameters.scope, 'full') , contains(join(';', parameters.verifications), 'source-build-')) }}:
+  - template: source-build-and-validate.yml
+    parameters:
+      pool_Linux: ${{ parameters.pool_Linux }}
+      pool_LinuxArm64: ${{ parameters.pool_LinuxArm64 }}
+      useMicrosoftBuildAssetsForTests: ${{ parameters.useMicrosoftBuildAssetsForTests }}
+      isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
       
-      ### Source-build verification legs ###
-      - ${{ if containsValue(parameters.verifications, 'source-build') }}:
+      # Description of the source build legs to run.
+      # This is described here as a parameter to allow two separate stages to be produced from this list (one for building
+      # and one for validation). Because this template is not directly within a pipeline, stage, or job, we can't reference
+      # variables as template expressions. So we can't do things like '${{ format('{0}_Online_MsftSdk', variables.centOSStreamName) }}'.
+      # The variable value will be empty in that case. Instead, each leg defines a distro name that source-build-and-validate.yml uses
+      # to determine which variable to use for determining the various parameter values which are based on variables.
+      #
+      # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
+      legs:
 
+        ### Source-build verification legs ###
+
+        # Stage 1 leg is built in full scope, or lite when any of the `source-build-` verifications are requested.
         - buildNameFormat: '{0}_Online_MsftSdk'
           distro: centos
           targetArchitecture: x64
@@ -59,117 +60,119 @@ stages:
           useMonoRuntime: false              # 🚫
           withPreviousSDK: false             # 🚫
 
-        - buildNameFormat: '{0}_Offline_CurrentSourceBuiltSdk'
-          distro: centos
-          targetArchitecture: x64
-          buildFromArchive: false            # 🚫
-          enablePoison: false                # 🚫
-          runOnline: false                   # 🚫
-          useMonoRuntime: false              # 🚫
-          withPreviousSDK: false             # 🚫
-          reuseBuildArtifactsFrom: '{0}_Online_MsftSdk_x64'
-      
-      ### Additional legs for full build ###
-      - ${{ if in(parameters.scope, 'full') }}:
-      
-        - buildNameFormat: '{0}_Offline_MsftSdk'
-          distro: ubuntu
-          targetArchitecture: x64
-          buildFromArchive: false            # 🚫
-          enablePoison: false                # 🚫
-          excludeOmniSharpTests: false       # 🚫
-          runOnline: false                   # 🚫
-          useMonoRuntime: false              # 🚫
-          withPreviousSDK: false             # 🚫
+        - ${{ if containsValue(parameters.verifications, 'source-build-stage2') }}:
 
-        - buildNameFormat: '{0}_Offline_PreviousSourceBuiltSdk'
-          distro: centos
-          targetArchitecture: x64
-          buildFromArchive: false            # 🚫
-          enablePoison: true                 # ✅
-          runOnline: false                   # 🚫
-          useMonoRuntime: false              # 🚫
-          withPreviousSDK: true              # ✅
+          - buildNameFormat: '{0}_Offline_CurrentSourceBuiltSdk'
+            distro: centos
+            targetArchitecture: x64
+            buildFromArchive: false            # 🚫
+            enablePoison: false                # 🚫
+            runOnline: false                   # 🚫
+            useMonoRuntime: false              # 🚫
+            withPreviousSDK: false             # 🚫
+            reuseBuildArtifactsFrom: '{0}_Online_MsftSdk_x64'
 
-        - buildNameFormat: '{0}_Offline_MsftSdk'
-          distro: almalinux
-          targetArchitecture: x64
-          buildFromArchive: false            # 🚫
-          enablePoison: false                # 🚫
-          runOnline: false                   # 🚫
-          useMonoRuntime: false              # 🚫
-          withPreviousSDK: false             # 🚫
+        ### Additional legs for full build ###
+        - ${{ if in(parameters.scope, 'full') }}:
 
-        - buildNameFormat: '{0}_Offline_MsftSdk'
-          distro: alpine
-          targetArchitecture: x64
-          buildFromArchive: false            # 🚫
-          enablePoison: false                # 🚫
-          runOnline: false                   # 🚫
-          useMonoRuntime: false              # 🚫
-          withPreviousSDK: false             # 🚫
+          - buildNameFormat: '{0}_Offline_MsftSdk'
+            distro: ubuntu
+            targetArchitecture: x64
+            buildFromArchive: false            # 🚫
+            enablePoison: false                # 🚫
+            excludeOmniSharpTests: false       # 🚫
+            runOnline: false                   # 🚫
+            useMonoRuntime: false              # 🚫
+            withPreviousSDK: false             # 🚫
 
-        - buildNameFormat: '{0}_Offline_MsftSdk'
-          distro: centos
-          targetArchitecture: x64
-          buildFromArchive: true             # ✅
-          enablePoison: false                # 🚫
-          runOnline: false                   # 🚫
-          useMonoRuntime: false              # 🚫
-          withPreviousSDK: false             # 🚫
+          - buildNameFormat: '{0}_Offline_PreviousSourceBuiltSdk'
+            distro: centos
+            targetArchitecture: x64
+            buildFromArchive: false            # 🚫
+            enablePoison: true                 # ✅
+            runOnline: false                   # 🚫
+            useMonoRuntime: false              # 🚫
+            withPreviousSDK: true              # ✅
 
-        - buildNameFormat: '{0}_Online_PreviousSourceBuiltSdk'
-          distro: centos
-          targetArchitecture: x64
-          buildFromArchive: false            # 🚫
-          enablePoison: false                # 🚫
-          runOnline: true                    # ✅
-          useMonoRuntime: false              # 🚫
-          withPreviousSDK: true              # ✅
+          - buildNameFormat: '{0}_Offline_MsftSdk'
+            distro: almalinux
+            targetArchitecture: x64
+            buildFromArchive: false            # 🚫
+            enablePoison: false                # 🚫
+            runOnline: false                   # 🚫
+            useMonoRuntime: false              # 🚫
+            withPreviousSDK: false             # 🚫
 
-        - buildNameFormat: '{0}_Mono_Offline_MsftSdk'
-          distro: centos
-          targetArchitecture: x64
-          buildFromArchive: true             # ✅
-          enablePoison: false                # 🚫
-          runOnline: false                   # 🚫
-          useMonoRuntime: true               # ✅
-          withPreviousSDK: false             # 🚫
+          - buildNameFormat: '{0}_Offline_MsftSdk'
+            distro: alpine
+            targetArchitecture: x64
+            buildFromArchive: false            # 🚫
+            enablePoison: false                # 🚫
+            runOnline: false                   # 🚫
+            useMonoRuntime: false              # 🚫
+            withPreviousSDK: false             # 🚫
 
-        - buildNameFormat: '{0}_Offline_MsftSdk'
-          distro: fedora
-          targetArchitecture: x64
-          buildFromArchive: true             # ✅
-          enablePoison: false                # 🚫
-          runOnline: false                   # 🚫
-          useMonoRuntime: false              # 🚫
-          withPreviousSDK: false             # 🚫
+          - buildNameFormat: '{0}_Offline_MsftSdk'
+            distro: centos
+            targetArchitecture: x64
+            buildFromArchive: true             # ✅
+            enablePoison: false                # 🚫
+            runOnline: false                   # 🚫
+            useMonoRuntime: false              # 🚫
+            withPreviousSDK: false             # 🚫
 
-        - buildNameFormat: '{0}Arm64_Offline_MsftSdk'
-          distro: ubuntu
-          targetArchitecture: arm64
-          buildFromArchive: false            # 🚫
-          enablePoison: false                # 🚫
-          runOnline: false                   # 🚫
-          useMonoRuntime: false              # 🚫
-          withPreviousSDK: false             # 🚫
+          - buildNameFormat: '{0}_Online_PreviousSourceBuiltSdk'
+            distro: centos
+            targetArchitecture: x64
+            buildFromArchive: false            # 🚫
+            enablePoison: false                # 🚫
+            runOnline: true                    # ✅
+            useMonoRuntime: false              # 🚫
+            withPreviousSDK: true              # ✅
 
-        - buildNameFormat: '{0}_Offline_CurrentSourceBuiltSdk'
-          distro: fedora
-          targetArchitecture: x64
-          buildFromArchive: false            # 🚫
-          enablePoison: false                # 🚫
-          runOnline: false                   # 🚫
-          useMonoRuntime: false              # 🚫
-          withPreviousSDK: false             # 🚫
-          reuseBuildArtifactsFrom: '{0}_Offline_MsftSdk_x64'
+          - buildNameFormat: '{0}_Mono_Offline_MsftSdk'
+            distro: centos
+            targetArchitecture: x64
+            buildFromArchive: true             # ✅
+            enablePoison: false                # 🚫
+            runOnline: false                   # 🚫
+            useMonoRuntime: true               # ✅
+            withPreviousSDK: false             # 🚫
 
-        - buildNameFormat: '{0}_Mono_Offline_CurrentSourceBuiltSdk'
-          distro: centos
-          targetArchitecture: x64
-          buildFromArchive: true             # ✅
-          enablePoison: false                # 🚫
-          runOnline: false                   # 🚫
-          useMonoRuntime: true               # ✅
-          withPreviousSDK: false             # 🚫
-          reuseBuildArtifactsFrom: '{0}_Mono_Offline_MsftSdk_x64'
+          - buildNameFormat: '{0}_Offline_MsftSdk'
+            distro: fedora
+            targetArchitecture: x64
+            buildFromArchive: true             # ✅
+            enablePoison: false                # 🚫
+            runOnline: false                   # 🚫
+            useMonoRuntime: false              # 🚫
+            withPreviousSDK: false             # 🚫
+
+          - buildNameFormat: '{0}Arm64_Offline_MsftSdk'
+            distro: ubuntu
+            targetArchitecture: arm64
+            buildFromArchive: false            # 🚫
+            enablePoison: false                # 🚫
+            runOnline: false                   # 🚫
+            useMonoRuntime: false              # 🚫
+            withPreviousSDK: false             # 🚫
+
+          - buildNameFormat: '{0}_Offline_CurrentSourceBuiltSdk'
+            distro: fedora
+            targetArchitecture: x64
+            buildFromArchive: false            # 🚫
+            enablePoison: false                # 🚫
+            runOnline: false                   # 🚫
+            useMonoRuntime: false              # 🚫
+            withPreviousSDK: false             # 🚫
+            reuseBuildArtifactsFrom: '{0}_Offline_MsftSdk_x64'
+
+          - buildNameFormat: '{0}_Mono_Offline_CurrentSourceBuiltSdk'
+            distro: centos
+            targetArchitecture: x64
+            buildFromArchive: true             # ✅
+            enablePoison: false                # 🚫
+            runOnline: false                   # 🚫
+            useMonoRuntime: true               # ✅
+            withPreviousSDK: false             # 🚫
+            reuseBuildArtifactsFrom: '{0}_Mono_Offline_MsftSdk_x64'

--- a/eng/pipelines/templates/stages/source-build-stages.yml
+++ b/eng/pipelines/templates/stages/source-build-stages.yml
@@ -24,6 +24,11 @@ parameters:
   type: boolean
   default: true
 
+# List of verifications to run during PRs.
+- name: verifications
+  type: object
+  default: []
+
 stages:
 - template: source-build-and-validate.yml
   parameters:
@@ -42,24 +47,27 @@ stages:
     # Changing the build name requires updating the referenced name in the source-build-sdk-diff-tests.yml pipeline
     legs:
       
-      - buildNameFormat: '{0}_Online_MsftSdk'
-        distro: centos
-        targetArchitecture: x64
-        buildFromArchive: false            # 🚫
-        enablePoison: false                # 🚫
-        runOnline: true                    # ✅
-        useMonoRuntime: false              # 🚫
-        withPreviousSDK: false             # 🚫
-      
-      - buildNameFormat: '{0}_Offline_CurrentSourceBuiltSdk'
-        distro: centos
-        targetArchitecture: x64
-        buildFromArchive: false            # 🚫
-        enablePoison: false                # 🚫
-        runOnline: false                   # 🚫
-        useMonoRuntime: false              # 🚫
-        withPreviousSDK: false             # 🚫
-        reuseBuildArtifactsFrom: '{0}_Online_MsftSdk_x64'
+      ### Source-build verification legs ###
+      - ${{ if containsValue(parameters.verifications, 'source-build') }}:
+
+        - buildNameFormat: '{0}_Online_MsftSdk'
+          distro: centos
+          targetArchitecture: x64
+          buildFromArchive: false            # 🚫
+          enablePoison: false                # 🚫
+          runOnline: true                    # ✅
+          useMonoRuntime: false              # 🚫
+          withPreviousSDK: false             # 🚫
+
+        - buildNameFormat: '{0}_Offline_CurrentSourceBuiltSdk'
+          distro: centos
+          targetArchitecture: x64
+          buildFromArchive: false            # 🚫
+          enablePoison: false                # 🚫
+          runOnline: false                   # 🚫
+          useMonoRuntime: false              # 🚫
+          withPreviousSDK: false             # 🚫
+          reuseBuildArtifactsFrom: '{0}_Online_MsftSdk_x64'
       
       ### Additional legs for full build ###
       - ${{ if in(parameters.scope, 'full') }}:

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -24,6 +24,18 @@ parameters:
   type: boolean
   default: true
 
+# List of verifications to run during PRs.
+- name: verifications
+  type: object
+  default:
+  - source-build
+  - unified-build-android-arm64
+  - unified-build-browser-wasm
+  - unified-build-iossimulator-arm64
+  - unified-build-linux-buildtests
+  - unified-build-windows-x64
+  - unified-build-windows-x86
+
 # These are not expected to be passed it but rather just object variables reused below
 - name: pool_Linux
   type: object
@@ -73,6 +85,7 @@ stages:
     desiredIbc: ${{ parameters.desiredIbc }}
     isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
     scope: ${{ parameters.scope }}
+    verifications: ${{ parameters.verifications }}
 
 - ${{ if and(parameters.isBuiltFromVmr, eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - stage: Publish_Build_Assets
@@ -99,9 +112,10 @@ stages:
     pool_Linux: ${{ parameters.pool_Linux }}
     pool_LinuxArm64: ${{ parameters.pool_LinuxArm64 }}
     scope: ${{ parameters.scope }}
+    isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+    verifications: ${{ parameters.verifications }}
     ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
       # For PR builds, we don't rely on Microsoft build assets for testing because not all of the required assets
       # are available from the subset of jobs that get build in PRs compared to the full build. Instead, we run
       # the tests in the same job as the build and filter out some of the tests that can't be executed in this state.
       useMicrosoftBuildAssetsForTests: false
-      isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -28,7 +28,8 @@ parameters:
 - name: verifications
   type: object
   default:
-  - source-build
+  - source-build-stage1
+  - source-build-stage2
   - unified-build-android-arm64
   - unified-build-browser-wasm
   - unified-build-iossimulator-arm64

--- a/eng/pipelines/templates/stages/vmr-verticals.yml
+++ b/eng/pipelines/templates/stages/vmr-verticals.yml
@@ -24,6 +24,11 @@ parameters:
   type: boolean
   default: true
 
+# List of verifications to run during PRs.
+- name: verifications
+  type: object
+  default: []
+
 # These are not expected to be passed it but rather just object variables reused below
 - name: pool_Linux
   type: object
@@ -79,17 +84,18 @@ stages:
     - template: ../variables/vmr-build.yml
     jobs:
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: ${{ format('{0}_Ubuntu_BuildTests', variables.ubuntuName) }}
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        pool: ${{ parameters.pool_Linux }}
-        container:
-          name: ${{ variables.ubuntuContainerName }}
-          image: ${{ variables.ubuntuContainerImage }}
-        targetOS: linux
-        targetArchitecture: x64
-        extraProperties: /p:DotNetBuildTests=true
+    - ${{ if containsValue(parameters.verifications, 'unified-build-linux-buildtests') }}:
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: ${{ format('{0}_Ubuntu_BuildTests', variables.ubuntuName) }}
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          pool: ${{ parameters.pool_Linux }}
+          container:
+            name: ${{ variables.ubuntuContainerName }}
+            image: ${{ variables.ubuntuContainerImage }}
+          targetOS: linux
+          targetArchitecture: x64
+          extraProperties: /p:DotNetBuildTests=true
 
     - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
       - template: ../jobs/vmr-build.yml
@@ -112,60 +118,65 @@ stages:
       desiredIBC: ${{ parameters.desiredIBC }}
   jobs:
 
-  - template: ../jobs/vmr-build.yml
-    parameters:
-      buildName: Windows
-      isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-      sign: ${{ variables.signEnabled }}
-      signDac: ${{ variables.signDacEnabled }}
-      pool: ${{ parameters.pool_Windows }}
-      targetOS: windows
-      targetArchitecture: x64
-      enableIBCOptimization: ${{ variables.ibcEnabled }}
+  - ${{ if containsValue(parameters.verifications, 'unified-build-windows-x64') }}:
+    - template: ../jobs/vmr-build.yml
+      parameters:
+        buildName: Windows
+        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+        sign: ${{ variables.signEnabled }}
+        signDac: ${{ variables.signDacEnabled }}
+        pool: ${{ parameters.pool_Windows }}
+        targetOS: windows
+        targetArchitecture: x64
+        enableIBCOptimization: ${{ variables.ibcEnabled }}
 
-  - template: ../jobs/vmr-build.yml
-    parameters:
-      buildName: Windows
-      isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-      sign: ${{ variables.signEnabled }}
-      signDac: ${{ variables.signDacEnabled }}
-      pool: ${{ parameters.pool_Windows }}
-      targetOS: windows
-      targetArchitecture: x86
+  - ${{ if containsValue(parameters.verifications, 'unified-build-windows-x86') }}:
+    - template: ../jobs/vmr-build.yml
+      parameters:
+        buildName: Windows
+        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+        sign: ${{ variables.signEnabled }}
+        signDac: ${{ variables.signDacEnabled }}
+        pool: ${{ parameters.pool_Windows }}
+        targetOS: windows
+        targetArchitecture: x86
 
-  - template: ../jobs/vmr-build.yml
-    parameters:
-      buildName: Android_Shortstack
-      isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-      sign: ${{ variables.signEnabled }}
-      pool: ${{ parameters.pool_Linux_Shortstack }}
-      container:
-        name: ${{ variables.androidCrossContainerName }}
-        image: ${{ variables.androidCrossContainerImage }}
-      targetOS: android
-      targetArchitecture: arm64
+  - ${{ if containsValue(parameters.verifications, 'unified-build-android-arm64') }}:
+    - template: ../jobs/vmr-build.yml
+      parameters:
+        buildName: Android_Shortstack
+        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+        sign: ${{ variables.signEnabled }}
+        pool: ${{ parameters.pool_Linux_Shortstack }}
+        container:
+          name: ${{ variables.androidCrossContainerName }}
+          image: ${{ variables.androidCrossContainerImage }}
+        targetOS: android
+        targetArchitecture: arm64
 
-  - template: ../jobs/vmr-build.yml
-    parameters:
-      buildName: Browser_Shortstack
-      isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-      sign: ${{ variables.signEnabled }}
-      pool: ${{ parameters.pool_Linux_Shortstack }}
-      container:
-        name: ${{ variables.browserCrossContainerName }}
-        image: ${{ variables.browserCrossContainerImage }}
-      crossRootFs: '/crossrootfs/x64'
-      targetOS: browser
-      targetArchitecture: wasm
+  - ${{ if containsValue(parameters.verifications, 'unified-build-browser-wasm') }}:
+    - template: ../jobs/vmr-build.yml
+      parameters:
+        buildName: Browser_Shortstack
+        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+        sign: ${{ variables.signEnabled }}
+        pool: ${{ parameters.pool_Linux_Shortstack }}
+        container:
+          name: ${{ variables.browserCrossContainerName }}
+          image: ${{ variables.browserCrossContainerImage }}
+        crossRootFs: '/crossrootfs/x64'
+        targetOS: browser
+        targetArchitecture: wasm
 
-  - template: ../jobs/vmr-build.yml
-    parameters:
-      buildName: iOSSimulator_Shortstack
-      isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-      sign: ${{ variables.signEnabled }}
-      pool: ${{ parameters.pool_Mac }}
-      targetOS: iossimulator
-      targetArchitecture: arm64
+  - ${{ if containsValue(parameters.verifications, 'unified-build-iossimulator-arm64') }}:
+    - template: ../jobs/vmr-build.yml
+      parameters:
+        buildName: iOSSimulator_Shortstack
+        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+        sign: ${{ variables.signEnabled }}
+        pool: ${{ parameters.pool_Mac }}
+        targetOS: iossimulator
+        targetArchitecture: arm64
 
   ### Additional jobs for full build ###
   - ${{ if in(parameters.scope, 'full') }}:

--- a/eng/pipelines/templates/stages/vmr-verticals.yml
+++ b/eng/pipelines/templates/stages/vmr-verticals.yml
@@ -74,7 +74,7 @@ parameters:
 stages:
 
 #### VERTICAL BUILD (Validation) ####
-- ${{ if or(eq(variables['Build.Reason'], 'PullRequest'), ne(variables['System.TeamProject'], 'internal')) }}:
+- ${{ if or(and(eq(variables['Build.Reason'], 'PullRequest'), containsValue(parameters.verifications, 'unified-build-linux-buildtests')), and(ne(variables['Build.Reason'], 'PullRequest'), ne(variables['System.TeamProject'], 'internal'))) }}:
   - stage: VMR_Vertical_Build_Validation
     displayName: VMR Vertical Build Validation
     templateContext:
@@ -108,565 +108,566 @@ stages:
           extraProperties: /p:DotNetBuildTests=true
 
 #### VERTICAL BUILD (Official) ####
-- stage: VMR_Vertical_Build
-  displayName: VMR Vertical Build
-  dependsOn: []
-  variables:
-  - template: ../variables/vmr-build.yml
-    parameters:
-      desiredSigning: ${{ parameters.desiredSigning }}
-      desiredIBC: ${{ parameters.desiredIBC }}
-  jobs:
-
-  - ${{ if containsValue(parameters.verifications, 'unified-build-windows-x64') }}:
-    - template: ../jobs/vmr-build.yml
+- ${{ if or(in(parameters.scope, 'full') , contains(join(';', parameters.verifications), 'unified-build-')) }}:
+  - stage: VMR_Vertical_Build
+    displayName: VMR Vertical Build
+    dependsOn: []
+    variables:
+    - template: ../variables/vmr-build.yml
       parameters:
-        buildName: Windows
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        signDac: ${{ variables.signDacEnabled }}
-        pool: ${{ parameters.pool_Windows }}
-        targetOS: windows
-        targetArchitecture: x64
-        enableIBCOptimization: ${{ variables.ibcEnabled }}
+        desiredSigning: ${{ parameters.desiredSigning }}
+        desiredIBC: ${{ parameters.desiredIBC }}
+    jobs:
 
-  - ${{ if containsValue(parameters.verifications, 'unified-build-windows-x86') }}:
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: Windows
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        signDac: ${{ variables.signDacEnabled }}
-        pool: ${{ parameters.pool_Windows }}
-        targetOS: windows
-        targetArchitecture: x86
+    - ${{ if containsValue(parameters.verifications, 'unified-build-windows-x64') }}:
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: Windows
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          signDac: ${{ variables.signDacEnabled }}
+          pool: ${{ parameters.pool_Windows }}
+          targetOS: windows
+          targetArchitecture: x64
+          enableIBCOptimization: ${{ variables.ibcEnabled }}
 
-  - ${{ if containsValue(parameters.verifications, 'unified-build-android-arm64') }}:
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: Android_Shortstack
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Linux_Shortstack }}
-        container:
-          name: ${{ variables.androidCrossContainerName }}
-          image: ${{ variables.androidCrossContainerImage }}
-        targetOS: android
-        targetArchitecture: arm64
+    - ${{ if containsValue(parameters.verifications, 'unified-build-windows-x86') }}:
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: Windows
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          signDac: ${{ variables.signDacEnabled }}
+          pool: ${{ parameters.pool_Windows }}
+          targetOS: windows
+          targetArchitecture: x86
 
-  - ${{ if containsValue(parameters.verifications, 'unified-build-browser-wasm') }}:
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: Browser_Shortstack
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Linux_Shortstack }}
-        container:
-          name: ${{ variables.browserCrossContainerName }}
-          image: ${{ variables.browserCrossContainerImage }}
-        crossRootFs: '/crossrootfs/x64'
-        targetOS: browser
-        targetArchitecture: wasm
+    - ${{ if containsValue(parameters.verifications, 'unified-build-android-arm64') }}:
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: Android_Shortstack
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Linux_Shortstack }}
+          container:
+            name: ${{ variables.androidCrossContainerName }}
+            image: ${{ variables.androidCrossContainerImage }}
+          targetOS: android
+          targetArchitecture: arm64
 
-  - ${{ if containsValue(parameters.verifications, 'unified-build-iossimulator-arm64') }}:
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: iOSSimulator_Shortstack
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Mac }}
-        targetOS: iossimulator
-        targetArchitecture: arm64
+    - ${{ if containsValue(parameters.verifications, 'unified-build-browser-wasm') }}:
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: Browser_Shortstack
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Linux_Shortstack }}
+          container:
+            name: ${{ variables.browserCrossContainerName }}
+            image: ${{ variables.browserCrossContainerImage }}
+          crossRootFs: '/crossrootfs/x64'
+          targetOS: browser
+          targetArchitecture: wasm
 
-  ### Additional jobs for full build ###
-  - ${{ if in(parameters.scope, 'full') }}:
+    - ${{ if containsValue(parameters.verifications, 'unified-build-iossimulator-arm64') }}:
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: iOSSimulator_Shortstack
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Mac }}
+          targetOS: iossimulator
+          targetArchitecture: arm64
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: Android_Shortstack
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Linux_Shortstack }}
-        container:
-          name: ${{ variables.androidCrossContainerName }}
-          image: ${{ variables.androidCrossContainerImage }}
-        targetOS: android
-        targetArchitecture: arm
+    ### Additional jobs for full build ###
+    - ${{ if in(parameters.scope, 'full') }}:
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: Android_Shortstack
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Linux_Shortstack }}
-        container:
-          name: ${{ variables.androidCrossContainerName }}
-          image: ${{ variables.androidCrossContainerImage }}
-        targetOS: android
-        targetArchitecture: x64
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: Android_Shortstack
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Linux_Shortstack }}
+          container:
+            name: ${{ variables.androidCrossContainerName }}
+            image: ${{ variables.androidCrossContainerImage }}
+          targetOS: android
+          targetArchitecture: arm
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: Android_Shortstack
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Linux_Shortstack }}
-        container:
-          name: ${{ variables.androidCrossContainerName }}
-          image: ${{ variables.androidCrossContainerImage }}
-        targetOS: android
-        targetArchitecture: x86
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: Android_Shortstack
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Linux_Shortstack }}
+          container:
+            name: ${{ variables.androidCrossContainerName }}
+            image: ${{ variables.androidCrossContainerImage }}
+          targetOS: android
+          targetArchitecture: x64
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: Browser_Multithreaded_Shortstack
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Linux_Shortstack }}
-        container:
-          name: ${{ variables.browserCrossContainerName }}
-          image: ${{ variables.browserCrossContainerImage }}
-        crossRootFs: '/crossrootfs/x64'
-        targetOS: browser
-        targetArchitecture: wasm
-        extraProperties: /p:WasmEnableThreads=true
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: Android_Shortstack
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Linux_Shortstack }}
+          container:
+            name: ${{ variables.androidCrossContainerName }}
+            image: ${{ variables.androidCrossContainerImage }}
+          targetOS: android
+          targetArchitecture: x86
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: LinuxBionic_Shortstack
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Linux_Shortstack }}
-        container:
-          name: ${{ variables.linuxBionicCrossContainerName }}
-          image: ${{ variables.linuxBionicCrossContainerImage }}
-        targetOS: linux-bionic
-        targetArchitecture: arm64
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: Browser_Multithreaded_Shortstack
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Linux_Shortstack }}
+          container:
+            name: ${{ variables.browserCrossContainerName }}
+            image: ${{ variables.browserCrossContainerImage }}
+          crossRootFs: '/crossrootfs/x64'
+          targetOS: browser
+          targetArchitecture: wasm
+          extraProperties: /p:WasmEnableThreads=true
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: LinuxBionic_Shortstack
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Linux_Shortstack }}
-        container:
-          name: ${{ variables.linuxBionicCrossContainerName }}
-          image: ${{ variables.linuxBionicCrossContainerImage }}
-        targetOS: linux-bionic
-        targetArchitecture: arm
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: LinuxBionic_Shortstack
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Linux_Shortstack }}
+          container:
+            name: ${{ variables.linuxBionicCrossContainerName }}
+            image: ${{ variables.linuxBionicCrossContainerImage }}
+          targetOS: linux-bionic
+          targetArchitecture: arm64
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: LinuxBionic_Shortstack
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Linux_Shortstack }}
-        container:
-          name: ${{ variables.linuxBionicCrossContainerName }}
-          image: ${{ variables.linuxBionicCrossContainerImage }}
-        targetOS: linux-bionic
-        targetArchitecture: x64
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: LinuxBionic_Shortstack
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Linux_Shortstack }}
+          container:
+            name: ${{ variables.linuxBionicCrossContainerName }}
+            image: ${{ variables.linuxBionicCrossContainerImage }}
+          targetOS: linux-bionic
+          targetArchitecture: arm
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: iOS_Shortstack
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Mac }}
-        targetOS: ios
-        targetArchitecture: arm64
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: LinuxBionic_Shortstack
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Linux_Shortstack }}
+          container:
+            name: ${{ variables.linuxBionicCrossContainerName }}
+            image: ${{ variables.linuxBionicCrossContainerImage }}
+          targetOS: linux-bionic
+          targetArchitecture: x64
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: iOSSimulator_Shortstack
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Mac }}
-        targetOS: iossimulator
-        targetArchitecture: x64
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: iOS_Shortstack
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Mac }}
+          targetOS: ios
+          targetArchitecture: arm64
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: MacCatalyst_Shortstack
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Mac }}
-        targetOS: maccatalyst
-        targetArchitecture: arm64
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: iOSSimulator_Shortstack
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Mac }}
+          targetOS: iossimulator
+          targetArchitecture: x64
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: MacCatalyst_Shortstack
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Mac }}
-        targetOS: maccatalyst
-        targetArchitecture: x64
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: MacCatalyst_Shortstack
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Mac }}
+          targetOS: maccatalyst
+          targetArchitecture: arm64
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: tvOS_Shortstack
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Mac }}
-        targetOS: tvos
-        targetArchitecture: arm64
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: MacCatalyst_Shortstack
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Mac }}
+          targetOS: maccatalyst
+          targetArchitecture: x64
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: tvOSSimulator_Shortstack
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Mac }}
-        targetOS: tvossimulator
-        targetArchitecture: arm64
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: tvOS_Shortstack
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Mac }}
+          targetOS: tvos
+          targetArchitecture: arm64
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: tvOSSimulator_Shortstack
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Mac }}
-        targetOS: tvossimulator
-        targetArchitecture: x64
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: tvOSSimulator_Shortstack
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Mac }}
+          targetOS: tvossimulator
+          targetArchitecture: arm64
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: Wasi_Shortstack
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Linux_Shortstack }}
-        container:
-          name: ${{ variables.wasiCrossContainerName }}
-          image: ${{ variables.wasiCrossContainerImage }}
-        crossRootFs: '/crossrootfs/x64'
-        targetOS: wasi
-        targetArchitecture: wasm
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: tvOSSimulator_Shortstack
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Mac }}
+          targetOS: tvossimulator
+          targetArchitecture: x64
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: OSX
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Mac }}
-        targetOS: osx
-        targetArchitecture: x64
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: Wasi_Shortstack
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Linux_Shortstack }}
+          container:
+            name: ${{ variables.wasiCrossContainerName }}
+            image: ${{ variables.wasiCrossContainerImage }}
+          crossRootFs: '/crossrootfs/x64'
+          targetOS: wasi
+          targetArchitecture: wasm
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: OSX_Shortstack_Mono_LLVMAOT
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Mac }}
-        useMonoRuntime: true
-        targetOS: osx
-        targetArchitecture: x64
-        extraProperties: /p:MonoEnableLLVM=true /p:MonoAOTEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: OSX
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Mac }}
+          targetOS: osx
+          targetArchitecture: x64
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: AzureLinux_x64_Cross
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Linux }}
-        container:
-          name: ${{ variables.azurelinuxX64CrossContainerName }}
-          image: ${{ variables.azurelinuxX64CrossContainerImage }}
-        crossRootFs: '/crossrootfs/x64'
-        targetOS: linux
-        targetArchitecture: x64
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: OSX_Shortstack_Mono_LLVMAOT
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Mac }}
+          useMonoRuntime: true
+          targetOS: osx
+          targetArchitecture: x64
+          extraProperties: /p:MonoEnableLLVM=true /p:MonoAOTEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: AzureLinux_x64_Cross_Pgo
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: false
-        pool: ${{ parameters.pool_Linux }}
-        container:
-          name: ${{ variables.azurelinuxX64CrossContainerName }}
-          image: ${{ variables.azurelinuxX64CrossContainerImage }}
-        crossRootFs: '/crossrootfs/x64'
-        targetOS: linux
-        targetArchitecture: x64
-        extraProperties: /p:PgoInstrument=true
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: AzureLinux_x64_Cross
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Linux }}
+          container:
+            name: ${{ variables.azurelinuxX64CrossContainerName }}
+            image: ${{ variables.azurelinuxX64CrossContainerImage }}
+          crossRootFs: '/crossrootfs/x64'
+          targetOS: linux
+          targetArchitecture: x64
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: AzureLinux_x64_Cross_Shortstack_Mono_LLVMAOT
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Linux_Shortstack }}
-        container:
-          name: ${{ variables.azurelinuxX64CrossContainerName }}
-          image: ${{ variables.azurelinuxX64CrossContainerImage }}
-        crossRootFs: '/crossrootfs/x64'
-        useMonoRuntime: true
-        targetOS: linux
-        targetArchitecture: x64
-        extraProperties: /p:MonoEnableLLVM=true /p:MonoAOTEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: AzureLinux_x64_Cross_Pgo
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: false
+          pool: ${{ parameters.pool_Linux }}
+          container:
+            name: ${{ variables.azurelinuxX64CrossContainerName }}
+            image: ${{ variables.azurelinuxX64CrossContainerImage }}
+          crossRootFs: '/crossrootfs/x64'
+          targetOS: linux
+          targetArchitecture: x64
+          extraProperties: /p:PgoInstrument=true
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: AzureLinux_x64_Cross
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Linux }}
-        container:
-          name: ${{ variables.azurelinuxArmCrossContainerName }}
-          image: ${{ variables.azurelinuxArmCrossContainerImage }}
-        crossRootFs: '/crossrootfs/arm'
-        targetOS: linux
-        targetArchitecture: arm
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: AzureLinux_x64_Cross_Shortstack_Mono_LLVMAOT
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Linux_Shortstack }}
+          container:
+            name: ${{ variables.azurelinuxX64CrossContainerName }}
+            image: ${{ variables.azurelinuxX64CrossContainerImage }}
+          crossRootFs: '/crossrootfs/x64'
+          useMonoRuntime: true
+          targetOS: linux
+          targetArchitecture: x64
+          extraProperties: /p:MonoEnableLLVM=true /p:MonoAOTEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: AzureLinux_x64_Cross
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Linux }}
-        container:
-          name: ${{ variables.azurelinuxArm64CrossContainerName }}
-          image: ${{ variables.azurelinuxArm64CrossContainerImage }}
-        crossRootFs: '/crossrootfs/arm64'
-        targetOS: linux
-        targetArchitecture: arm64
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: AzureLinux_x64_Cross
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Linux }}
+          container:
+            name: ${{ variables.azurelinuxArmCrossContainerName }}
+            image: ${{ variables.azurelinuxArmCrossContainerImage }}
+          crossRootFs: '/crossrootfs/arm'
+          targetOS: linux
+          targetArchitecture: arm
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: AzureLinux_x64_Cross_Pgo
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: false
-        pool: ${{ parameters.pool_Linux }}
-        container:
-          name: ${{ variables.azurelinuxArm64CrossContainerName }}
-          image: ${{ variables.azurelinuxArm64CrossContainerImage }}
-        crossRootFs: '/crossrootfs/arm64'
-        targetOS: linux
-        targetArchitecture: arm64
-        extraProperties: /p:PgoInstrument=true
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: AzureLinux_x64_Cross
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Linux }}
+          container:
+            name: ${{ variables.azurelinuxArm64CrossContainerName }}
+            image: ${{ variables.azurelinuxArm64CrossContainerImage }}
+          crossRootFs: '/crossrootfs/arm64'
+          targetOS: linux
+          targetArchitecture: arm64
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: AzureLinux_x64_Cross_Alpine
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Linux }}
-        container:
-          name: ${{ variables.azurelinuxX64MuslCrossContainerName }}
-          image: ${{ variables.azurelinuxX64MuslCrossContainerImage }}
-        crossRootFs: '/crossrootfs/x64'
-        targetOS: linux-musl
-        targetArchitecture: x64
-        targetRid: ${{ variables.linuxMuslX64Rid }}
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: AzureLinux_x64_Cross_Pgo
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: false
+          pool: ${{ parameters.pool_Linux }}
+          container:
+            name: ${{ variables.azurelinuxArm64CrossContainerName }}
+            image: ${{ variables.azurelinuxArm64CrossContainerImage }}
+          crossRootFs: '/crossrootfs/arm64'
+          targetOS: linux
+          targetArchitecture: arm64
+          extraProperties: /p:PgoInstrument=true
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: AzureLinux_x64_Cross_Alpine
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Linux }}
-        container:
-          name: ${{ variables.azurelinuxArmMuslCrossContainerName }}
-          image: ${{ variables.azurelinuxArmMuslCrossContainerImage }}
-        crossRootFs: '/crossrootfs/arm'
-        targetOS: linux-musl
-        targetArchitecture: arm
-        targetRid: ${{ variables.linuxMuslArmRid }}
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: AzureLinux_x64_Cross_Alpine
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Linux }}
+          container:
+            name: ${{ variables.azurelinuxX64MuslCrossContainerName }}
+            image: ${{ variables.azurelinuxX64MuslCrossContainerImage }}
+          crossRootFs: '/crossrootfs/x64'
+          targetOS: linux-musl
+          targetArchitecture: x64
+          targetRid: ${{ variables.linuxMuslX64Rid }}
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: AzureLinux_x64_Cross_Alpine
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Linux }}
-        container:
-          name: ${{ variables.azurelinuxArm64MuslCrossContainerName }}
-          image: ${{ variables.azurelinuxArm64MuslCrossContainerImage }}
-        crossRootFs: '/crossrootfs/arm64'
-        targetOS: linux-musl
-        targetArchitecture: arm64
-        targetRid: ${{ variables.linuxMuslArm64Rid }}
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: AzureLinux_x64_Cross_Alpine
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Linux }}
+          container:
+            name: ${{ variables.azurelinuxArmMuslCrossContainerName }}
+            image: ${{ variables.azurelinuxArmMuslCrossContainerImage }}
+          crossRootFs: '/crossrootfs/arm'
+          targetOS: linux-musl
+          targetArchitecture: arm
+          targetRid: ${{ variables.linuxMuslArmRid }}
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: AzureLinux_x64_Cross_Shortstack_Mono_LLVMAOT
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Linux_Shortstack }}
-        container:
-          name: ${{ variables.azurelinuxArm64CrossContainerName }}
-          image: ${{ variables.azurelinuxArm64CrossContainerImage }}
-        crossRootFs: '/crossrootfs/arm64'
-        useMonoRuntime: true
-        targetOS: linux
-        targetArchitecture: arm64
-        extraProperties: /p:MonoEnableLLVM=true /p:MonoAOTEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: AzureLinux_x64_Cross_Alpine
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Linux }}
+          container:
+            name: ${{ variables.azurelinuxArm64MuslCrossContainerName }}
+            image: ${{ variables.azurelinuxArm64MuslCrossContainerImage }}
+          crossRootFs: '/crossrootfs/arm64'
+          targetOS: linux-musl
+          targetArchitecture: arm64
+          targetRid: ${{ variables.linuxMuslArm64Rid }}
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: OSX
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Mac }}
-        targetOS: osx
-        targetArchitecture: arm64
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: AzureLinux_x64_Cross_Shortstack_Mono_LLVMAOT
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Linux_Shortstack }}
+          container:
+            name: ${{ variables.azurelinuxArm64CrossContainerName }}
+            image: ${{ variables.azurelinuxArm64CrossContainerImage }}
+          crossRootFs: '/crossrootfs/arm64'
+          useMonoRuntime: true
+          targetOS: linux
+          targetArchitecture: arm64
+          extraProperties: /p:MonoEnableLLVM=true /p:MonoAOTEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: Windows
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        signDac: ${{ variables.signDacEnabled }}
-        pool: ${{ parameters.pool_Windows }}
-        targetOS: windows
-        targetArchitecture: arm64
-        enableIBCOptimization: ${{ variables.ibcEnabled }}
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: OSX
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Mac }}
+          targetOS: osx
+          targetArchitecture: arm64
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: Windows_Pgo
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: false
-        pool: ${{ parameters.pool_Windows }}
-        targetOS: windows
-        targetArchitecture: x64
-        extraProperties: /p:PgoInstrument=true
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: Windows
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          signDac: ${{ variables.signDacEnabled }}
+          pool: ${{ parameters.pool_Windows }}
+          targetOS: windows
+          targetArchitecture: arm64
+          enableIBCOptimization: ${{ variables.ibcEnabled }}
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: Windows_Pgo
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: false
-        pool: ${{ parameters.pool_Windows }}
-        targetOS: windows
-        targetArchitecture: x86
-        extraProperties: /p:PgoInstrument=true
-        enableIBCOptimization: ${{ variables.ibcEnabled }}
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: Windows_Pgo
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: false
+          pool: ${{ parameters.pool_Windows }}
+          targetOS: windows
+          targetArchitecture: x64
+          extraProperties: /p:PgoInstrument=true
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: Windows_Pgo
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: false
-        pool: ${{ parameters.pool_Windows }}
-        targetOS: windows
-        targetArchitecture: arm64
-        extraProperties: /p:PgoInstrument=true
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: Windows_Pgo
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: false
+          pool: ${{ parameters.pool_Windows }}
+          targetOS: windows
+          targetArchitecture: x86
+          extraProperties: /p:PgoInstrument=true
+          enableIBCOptimization: ${{ variables.ibcEnabled }}
 
-    ## Build Pass 2 verticals
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: Windows_Pgo
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: false
+          pool: ${{ parameters.pool_Windows }}
+          targetOS: windows
+          targetArchitecture: arm64
+          extraProperties: /p:PgoInstrument=true
 
-    # build the cross-OS DACs
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: Windows
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        signDac: ${{ variables.signDacEnabled }}
-        pool: ${{ parameters.pool_Windows }}
-        targetOS: windows
-        targetArchitecture: x86
-        buildPass: 2
-        reuseBuildArtifactsFrom:
-        - Windows_x64
-        - Windows_x86
-        - Windows_arm64
-        - AzureLinux_x64_Cross_x64
-        - AzureLinux_x64_Cross_Alpine_x64
-        - AzureLinux_x64_Cross_arm64
-        - AzureLinux_x64_Cross_Alpine_arm64
-        - AzureLinux_x64_Cross_arm
-        - AzureLinux_x64_Cross_Alpine_arm
+      ## Build Pass 2 verticals
 
-    # build the ASP.NET Core hosting bundle and VS components
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: Windows
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Windows }}
-        targetOS: windows
-        targetArchitecture: x64
-        buildPass: 2
-        reuseBuildArtifactsFrom:
-        - Windows_x64
-        - Windows_x86
-        - Windows_arm64
+      # build the cross-OS DACs
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: Windows
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          signDac: ${{ variables.signDacEnabled }}
+          pool: ${{ parameters.pool_Windows }}
+          targetOS: windows
+          targetArchitecture: x86
+          buildPass: 2
+          reuseBuildArtifactsFrom:
+          - Windows_x64
+          - Windows_x86
+          - Windows_arm64
+          - AzureLinux_x64_Cross_x64
+          - AzureLinux_x64_Cross_Alpine_x64
+          - AzureLinux_x64_Cross_arm64
+          - AzureLinux_x64_Cross_Alpine_arm64
+          - AzureLinux_x64_Cross_arm
+          - AzureLinux_x64_Cross_Alpine_arm
 
-    # build the workloads
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: Windows_Workloads
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Windows }}
-        targetOS: windows
-        targetArchitecture: x64
-        buildPass: 2
-        extraProperties: /p:BuildWorkloads=true
-        reuseBuildArtifactsFrom:
-        - Windows_x64
-        - Windows_x86
-        - Windows_arm64
-        - Browser_Shortstack_wasm
-        - Browser_Multithreaded_Shortstack_wasm
-        - Wasi_Shortstack_wasm
-        - Android_Shortstack_arm64
-        - Android_Shortstack_arm
-        - Android_Shortstack_x64
-        - Android_Shortstack_x86
-        - iOS_Shortstack_arm64
-        - iOSSimulator_Shortstack_arm64
-        - iOSSimulator_Shortstack_x64
-        - tvOS_Shortstack_arm64
-        - tvOSSimulator_Shortstack_arm64
-        - tvOSSimulator_Shortstack_x64
-        - MacCatalyst_Shortstack_arm64
-        - MacCatalyst_Shortstack_x64
+      # build the ASP.NET Core hosting bundle and VS components
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: Windows
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Windows }}
+          targetOS: windows
+          targetArchitecture: x64
+          buildPass: 2
+          reuseBuildArtifactsFrom:
+          - Windows_x64
+          - Windows_x86
+          - Windows_arm64
 
-    ## Build Pass 3 verticals
+      # build the workloads
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: Windows_Workloads
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Windows }}
+          targetOS: windows
+          targetArchitecture: x64
+          buildPass: 2
+          extraProperties: /p:BuildWorkloads=true
+          reuseBuildArtifactsFrom:
+          - Windows_x64
+          - Windows_x86
+          - Windows_arm64
+          - Browser_Shortstack_wasm
+          - Browser_Multithreaded_Shortstack_wasm
+          - Wasi_Shortstack_wasm
+          - Android_Shortstack_arm64
+          - Android_Shortstack_arm
+          - Android_Shortstack_x64
+          - Android_Shortstack_x86
+          - iOS_Shortstack_arm64
+          - iOSSimulator_Shortstack_arm64
+          - iOSSimulator_Shortstack_x64
+          - tvOS_Shortstack_arm64
+          - tvOSSimulator_Shortstack_arm64
+          - tvOSSimulator_Shortstack_x64
+          - MacCatalyst_Shortstack_arm64
+          - MacCatalyst_Shortstack_x64
 
-    # build the Windows SDK bundles
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: Windows
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Windows }}
-        targetOS: windows
-        targetArchitecture: x64
-        buildPass: 3
-        reuseBuildArtifactsFrom:
-        - Windows_Workloads_x64_BuildPass2
-        - Windows_x64
-        - Windows_x86
-        - Windows_arm64
+      ## Build Pass 3 verticals
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: Windows
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Windows }}
-        targetOS: windows
-        targetArchitecture: x86
-        buildPass: 3
-        reuseBuildArtifactsFrom:
-        - Windows_Workloads_x64_BuildPass2
-        - Windows_x64
-        - Windows_x86
-        - Windows_arm64
+      # build the Windows SDK bundles
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: Windows
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Windows }}
+          targetOS: windows
+          targetArchitecture: x64
+          buildPass: 3
+          reuseBuildArtifactsFrom:
+          - Windows_Workloads_x64_BuildPass2
+          - Windows_x64
+          - Windows_x86
+          - Windows_arm64
 
-    - template: ../jobs/vmr-build.yml
-      parameters:
-        buildName: Windows
-        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
-        sign: ${{ variables.signEnabled }}
-        pool: ${{ parameters.pool_Windows }}
-        targetOS: windows
-        targetArchitecture: arm64
-        buildPass: 3
-        reuseBuildArtifactsFrom:
-        - Windows_Workloads_x64_BuildPass2
-        - Windows_x64
-        - Windows_x86
-        - Windows_arm64
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: Windows
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Windows }}
+          targetOS: windows
+          targetArchitecture: x86
+          buildPass: 3
+          reuseBuildArtifactsFrom:
+          - Windows_Workloads_x64_BuildPass2
+          - Windows_x64
+          - Windows_x86
+          - Windows_arm64
+
+      - template: ../jobs/vmr-build.yml
+        parameters:
+          buildName: Windows
+          isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+          sign: ${{ variables.signEnabled }}
+          pool: ${{ parameters.pool_Windows }}
+          targetOS: windows
+          targetArchitecture: arm64
+          buildPass: 3
+          reuseBuildArtifactsFrom:
+          - Windows_Workloads_x64_BuildPass2
+          - Windows_x64
+          - Windows_x86
+          - Windows_arm64


### PR DESCRIPTION
Many repo owners want to run VMR verifications in their repo PRs. For a lot of repos, doing the full set of verifications is too slow and resource intensive. This PR allows repos to select specific verification jobs.

For instance SBRP repo can simply specify source-build stage 1 job, using:
```
    verifications: [ "source-build-stage1" ]
```

Other repos, like WinForms, can elect to verify a single Windows leg, with:
```
    verifications: [ "unified-build-windows-x64" ]
```

For repos that prefer a full set of verifications, `verifications` parameter can be omitted.

To further simplify pipeline customizations on the repo side, another PR will be coming soon that will remove the existing pipeline template from arcade (https://github.com/dotnet/arcade/blob/main/eng/common/templates/vmr-build-pr.yml) and create a repo-specific template in the appropriate source location. Repo owners will be able to simply copy this template from whichever repo they choose and modify the list of verifications if necessary. Template will have the necessary documentation explaining the `verifications` parameter use cases.

This PR also enables creation of various VMR pipelines, one of them might be "vmr-lite" that would run just the verification jobs.

## Validations

Full VMR build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2729174

### Repo-level verifications

Full set of verification jobs: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1069116
Just source-build jobs: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1066740
One unified-build job: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1069248