### PR TITLE
Allow VMR verification pipelines to run in CI mode

### DIFF
--- a/eng/pipelines/templates/stages/source-build-and-validate.yml
+++ b/eng/pipelines/templates/stages/source-build-and-validate.yml
@@ -103,7 +103,7 @@ stages:
         useMonoRuntime: ${{ leg.useMonoRuntime }}
         withPreviousSDK: ${{ leg.withPreviousSDK }}
 
-- ${{ if and(ne(variables['Build.Reason'], 'PullRequest'), eq(parameters.useMicrosoftBuildAssetsForTests, true)) }}:
+- ${{ if and(parameters.isBuiltFromVmr, ne(variables['Build.Reason'], 'PullRequest'), eq(parameters.useMicrosoftBuildAssetsForTests, true)) }}:
   - stage: VMR_SourceOnly_Validation
     displayName: VMR Source-Only Validation
     dependsOn:

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -34,6 +34,7 @@ parameters:
   - unified-build-browser-wasm
   - unified-build-iossimulator-arm64
   - unified-build-linux-buildtests
+  - unified-build-windows-buildtests
   - unified-build-windows-x64
   - unified-build-windows-x86
 

--- a/eng/pipelines/templates/stages/vmr-verticals.yml
+++ b/eng/pipelines/templates/stages/vmr-verticals.yml
@@ -74,7 +74,7 @@ parameters:
 stages:
 
 #### VERTICAL BUILD (Validation) ####
-- ${{ if or(and(eq(variables['Build.Reason'], 'PullRequest'), containsValue(parameters.verifications, 'unified-build-linux-buildtests')), and(ne(variables['Build.Reason'], 'PullRequest'), ne(variables['System.TeamProject'], 'internal'))) }}:
+- ${{ if or(and(eq(variables['Build.Reason'], 'PullRequest'), containsValue(parameters.verifications, 'unified-build-linux-buildtests')), and(ne(variables['Build.Reason'], 'PullRequest'), ne(variables['System.TeamProject'], 'internal'), containsValue(parameters.verifications, 'unified-build-windows-buildtests'))) }}:
   - stage: VMR_Vertical_Build_Validation
     displayName: VMR Vertical Build Validation
     templateContext:
@@ -97,7 +97,7 @@ stages:
           targetArchitecture: x64
           extraProperties: /p:DotNetBuildTests=true
 
-    - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    - ${{ if and(ne(variables['Build.Reason'], 'PullRequest'), containsValue(parameters.verifications, 'unified-build-windows-buildtests')) }}:
       - template: ../jobs/vmr-build.yml
         parameters:
           buildName: Windows_BuildTests


### PR DESCRIPTION
Follow up to https://github.com/dotnet/dotnet/pull/1189

This PR fixes two issues with running repo-level VMR verification pipelines in CI mode.

Fixes:
- `VMR_SourceOnly_Validation` stage can only run if built from VMR as it depends on two unified-build stages
- Adds a condition for a verification that only runs in CI mode - `unified-build-windows-buildtests`