### PR TITLE
Clean up remaining OutputRid usages.

### DIFF
--- a/eng/RuntimeIdentifier.props
+++ b/eng/RuntimeIdentifier.props
@@ -1,5 +1,5 @@
 <Project>
-  <!-- TargetRID calculations should go in this file. -->
+  <!-- TargetRid calculations should go in this file. -->
   <PropertyGroup Label="CalculateTargetOS">
     <BuildOS>linux</BuildOS>
     <BuildOS Condition="$([MSBuild]::IsOSPlatform('OSX'))">osx</BuildOS>

--- a/repo-projects/runtime.proj
+++ b/repo-projects/runtime.proj
@@ -26,9 +26,6 @@
     <TargetsMobile Condition="'$(TargetOS)' == 'ios' or '$(TargetOS)' == 'iossimulator' or '$(TargetOS)' == 'maccatalyst' or '$(TargetOS)' == 'tvos' or '$(TargetOS)' == 'tvossimulator' or '$(TargetOS)' == 'android' or '$(TargetOS)' == 'browser' or '$(TargetOS)' == 'wasi'">true</TargetsMobile>
     <BuildArgs Condition="'$(CrossBuild)' == 'true' or ('$(TargetOS)-$(TargetArchitecture)' != '$(TargetOS)-$(BuildArchitecture)' and '$(TargetsMobile)' != 'true' and '$(TargetOS)' != 'windows' and '$(TargetOS)' != 'linux-bionic')">$(BuildArgs) $(FlagParameterPrefix)cross</BuildArgs>
 
-    <!-- TODO: This parameter is only available on the Unix script. Intentional? -->
-    <BuildArgs Condition="'$(BuildOS)' != 'windows'">$(BuildArgs) --outputrid $(TargetRid)</BuildArgs>
-
     <!-- Source-build will use non-portable RIDs. To build for these non-portable RID scenarios, we must do a bootstrapped build. -->
     <BuildArgs Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetBuildUseMonoRuntime)' != 'true'">$(BuildArgs) --bootstrap</BuildArgs>
 

--- a/src/diagnostics/Directory.Build.props
+++ b/src/diagnostics/Directory.Build.props
@@ -27,7 +27,7 @@
         This represents the minimum supported .NET Version, so the min version that the tools must
         be able to run against for a simple customer experience.
 
-        When bumping this, bump __targetRid in build.sh/build-native.cmd and modify the
+        When bumping this, bump __targetFramework in build.sh/build-native.cmd and modify the
         Debugger.Tests.Configs to reflect the new TFMs
      -->
     <NetCoreAppMinVersion>8.0</NetCoreAppMinVersion>

--- a/src/diagnostics/eng/Build-Native.cmd
+++ b/src/diagnostics/eng/Build-Native.cmd
@@ -222,9 +222,9 @@ if %__BuildNative% EQU 1 (
 
 REM Copy the native SOS binaries to where these tools expect for CI & VS testing
 
-set "__targetRid=net8.0"
-set "__dotnet_sos=%__RootBinDir%\bin\dotnet-sos\%__BuildType%\%__targetRid%"
-set "__dotnet_dump=%__RootBinDir%\bin\dotnet-dump\%__BuildType%\%__targetRid%"
+set "__targetFramework=net8.0"
+set "__dotnet_sos=%__RootBinDir%\bin\dotnet-sos\%__BuildType%\%__targetFramework%"
+set "__dotnet_dump=%__RootBinDir%\bin\dotnet-dump\%__BuildType%\%__targetFramework%"
 mkdir %__dotnet_sos%\win-%__TargetArch%
 mkdir %__dotnet_sos%\publish\win-%__TargetArch%
 mkdir %__dotnet_dump%\win-%__TargetArch%

--- a/src/diagnostics/eng/build.sh
+++ b/src/diagnostics/eng/build.sh
@@ -228,9 +228,9 @@ fi
 #
 
 if [[ "$__NativeBuild" == 1 || "$__Test" == 1 ]]; then
-    __targetRid=net8.0
-    __dotnet_sos=$__RootBinDir/bin/dotnet-sos/$__BuildType/$__targetRid/publish/$__OutputRid
-    __dotnet_dump=$__RootBinDir/bin/dotnet-dump/$__BuildType/$__targetRid/publish/$__OutputRid
+    __targetFramework=net8.0
+    __dotnet_sos=$__RootBinDir/bin/dotnet-sos/$__BuildType/$__targetFramework/publish/$__TargetRid
+    __dotnet_dump=$__RootBinDir/bin/dotnet-dump/$__BuildType/$__targetFramework/publish/$__TargetRid
 
     mkdir -p "$__dotnet_sos"
     mkdir -p "$__dotnet_dump"

--- a/src/diagnostics/eng/native/build-commons.sh
+++ b/src/diagnostics/eng/native/build-commons.sh
@@ -266,7 +266,7 @@ usage()
     echo "-gccx.y: optional argument to build using gcc version x.y."
     echo "-ninja: target ninja instead of GNU make"
     echo "-numproc: set the number of build processes."
-    echo "-outputrid: optional argument that overrides the target rid name."
+    echo "-targetrid: optional argument that overrides the target rid name."
     echo "-portablebuild: pass -portablebuild=false to force a non-portable build."
     echo "-skipconfigure: skip build configuration."
     echo "-keepnativesymbols: keep native/unmanaged debug symbols."
@@ -286,7 +286,7 @@ source "$__RepoRootDir/eng/common/native/init-os-and-arch.sh"
 
 __TargetArch=$arch
 __TargetOS=$os
-__OutputRid=''
+__TargetRid=''
 
 # Get the number of processors available to the scheduler
 platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
@@ -458,12 +458,12 @@ while :; do
             __TargetArch=wasm
             ;;
 
-        outputrid|-outputrid)
+        targetrid|-targetrid|outputrid|-outputrid)
             if [[ -n "$2" ]]; then
-                __OutputRid="$2"
+                __TargetRid="$2"
                 shift
             else
-                echo "ERROR: 'outputrid' requires a non-empty option argument"
+                echo "ERROR: 'targetrid' requires a non-empty option argument"
                 exit 1
             fi
             ;;
@@ -565,15 +565,15 @@ fi
 
 # init the target distro name (__DistroRid) and target portable os (__PortableTargetOS).
 initTargetDistroRid
-if [ -z "$__OutputRid" ]; then
+if [ -z "$__TargetRid" ]; then
     if [[ "$__PortableBuild" == 0 ]]; then
-        __OutputRid="$__DistroRid"
+        __TargetRid="$__DistroRid"
     else
-        __OutputRid="$__PortableTargetOS-$__TargetArch"
+        __TargetRid="$__PortableTargetOS-$__TargetArch"
     fi
 fi
-export __OutputRid
-echo "__OutputRid: ${__OutputRid}"
+export __TargetRid
+echo "__TargetRid: ${__TargetRid}"
 
 # When the host runs on an unknown rid, it falls back to the output rid
-__HostFallbackOS="${__OutputRid%-*}" # Strip architecture
+__HostFallbackOS="${__TargetRid%-*}" # Strip architecture

--- a/src/sdk/src/Layout/redist/targets/GenerateBundledVersions.targets
+++ b/src/sdk/src/Layout/redist/targets/GenerateBundledVersions.targets
@@ -394,7 +394,7 @@
         win-x86;
         " />
 
-      <!-- ILCompiler target RIDs that are officially supported, plus the architecture we are building the product for (OutputRID). See:
+      <!-- ILCompiler target RIDs that are officially supported, plus the architecture we are building the product for (TargetRid). See:
            https://github.com/dotnet/runtime/blob/main/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/ILCompilerRIDs.props -->
       <ILCompilerSupportedRids Include="
         @(Net90ILCompilerSupportedRids);


### PR DESCRIPTION
Cleans up usages of OutputRid that weren't covered in https://github.com/dotnet/runtime/pull/116259.

@ViktorHofer ptal.