### PR TITLE
Fix VMR signing validation

### DIFF
--- a/eng/pipelines/templates/steps/vmr-validate-signing.yml
+++ b/eng/pipelines/templates/steps/vmr-validate-signing.yml
@@ -42,7 +42,7 @@ steps:
     displayName: Remove Source-Build Artifacts
     continueOnError: ${{ parameters.continueOnError }}
 - ${{ else }}:
-  - script: rm -r "${{ parameters.signCheckFilesDirectory }}/*Sdk_*_Artifacts"
+  - script: rm -r ${{ parameters.signCheckFilesDirectory }}/*Sdk_*_Artifacts
     displayName: Remove Source-Build Artifacts
     continueOnError: ${{ parameters.continueOnError }}
 


### PR DESCRIPTION
A few fixes for VMR signing validation:
- Move files rather than copying to save space
- Only check externally visible, release shipping files
- Fix a couple failures where Dir.EnumerateFiles could not find the input directory because it did not exist.
- Because we pre-delete files on Mac, do not log warnings when a file could not be found. This causes an AzDO failure.
- Fix the deletion logic so that it correctly evaluates the glob paths on non-Windows.