### PR TITLE
[tests] Don't use File.OpenWrite when trying to overwrite a file

### DIFF
--- a/test/Microsoft.DotNet.Tests/PackageSourceMappingsTests.cs
+++ b/test/Microsoft.DotNet.Tests/PackageSourceMappingsTests.cs
@@ -228,7 +228,7 @@ namespace Microsoft.DotNet.Tests
                 string nuspecPath = GenerateNuspecFile(folder, name, version);
                 string packagePath = Path.ChangeExtension(nuspecPath, ".nupkg");
 
-                using FileStream stream = File.OpenWrite(packagePath);
+                using FileStream stream = File.Create(packagePath);
                 using ZipArchive zipArchive = new(stream, ZipArchiveMode.Create);
                 ZipArchiveEntry entry = zipArchive.CreateEntryFromFile(nuspecPath, Path.GetFileName(nuspecPath));
                 File.Delete(nuspecPath);

--- a/test/Microsoft.DotNet.UnifiedBuild.Tests/NugetPackageContentTests.cs
+++ b/test/Microsoft.DotNet.UnifiedBuild.Tests/NugetPackageContentTests.cs
@@ -77,8 +77,8 @@ public class NugetPackageContentTests : TestBase
         {
             string baselineFileName = Path.GetTempFileName();
             string testFileName = Path.GetTempFileName();
-            using (FileStream baselineFile = File.OpenWrite(baselineFileName))
-            using (FileStream testFile = File.OpenWrite(testFileName))
+            using (FileStream baselineFile = File.Create(baselineFileName))
+            using (FileStream testFile = File.Create(testFileName))
             {
                 await baselinePackageReader.GetEntry(fileName).Open().CopyToAsync(baselineFile);
                 await testPackageReader.GetEntry(fileName).Open().CopyToAsync(testFile);


### PR DESCRIPTION
File.OpenWrite will open an existing file which means if you write data that is shorter than the existing data the file will be corrupt. This is documented on https://learn.microsoft.com/en-us/dotnet/api/system.io.file.openwrite

> The OpenWrite method opens a file if one already exists for the file path, or creates a new file if one does not exist. For an existing file, it does not append the new text to the existing text. Instead, it overwrites the existing characters with the new characters. If you overwrite a longer string (such as "This is a test of the OpenWrite method") with a shorter string (such as "Second run"), the file will contain a mix of the strings ("Second runtest of the OpenWrite method").

Use File.Create instead in cases where we want to actually create or write into a new file.