### PR TITLE
Don't publish binary report with `SkipDetectBinaries` enabled

### DIFF
--- a/eng/PublishSourceBuild.props
+++ b/eng/PublishSourceBuild.props
@@ -122,7 +122,8 @@
   </Target>
 
   <Target Name="PublishBinaryReport"
-          AfterTargets="PublishToAzureDevOpsArtifacts">
+          AfterTargets="PublishToAzureDevOpsArtifacts"
+          Condition="'$(SkipDetectBinaries)' != 'true'">
     <MakeDir Directories="$(ArtifactsPublishStagingDir)/log" />
     <Copy SourceFiles="$(BinariesReportFile)"
           DestinationFolder="$(ArtifactsPublishStagingDir)/log"


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/5253

The binary report: `$(BinariesReportDir)/NewBinaries.txt` will not be created when `SkipDetectBinaries` enabled.