### PR TITLE
Initial branding for 2xx

### DIFF
--- a/src/sdk/eng/Versions.props
+++ b/src/sdk/eng/Versions.props
@@ -5,7 +5,7 @@
   <PropertyGroup Label="Repo version information">
     <VersionMajor>10</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionSDKMinor>1</VersionSDKMinor>
+    <VersionSDKMinor>2</VersionSDKMinor>
     <VersionFeature>00</VersionFeature>
     <!-- This property powers the SdkAnalysisLevel property in end-user MSBuild code.
          It should always be the hundreds-value of the current SDK version, never any

--- a/src/templating/eng/Versions.props
+++ b/src/templating/eng/Versions.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>10.0.100</VersionPrefix>
+    <VersionPrefix>10.0.200</VersionPrefix>
     <!-- When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>


### PR DESCRIPTION
Related to https://github.com/dotnet/dotnet/issues/1106

Updates to 2xx branding. Based off of https://github.com/dotnet/sdk/commit/038ac58fa1 and https://github.com/dotnet/templating/commit/4503bd8728053b06932cd2c45f918dbf1a914b30