### PR TITLE
Require user interaction when merge conflicts are encountered

### DIFF
--- a/eng/update-band.ps1
+++ b/eng/update-band.ps1
@@ -1,25 +1,41 @@
 [CmdletBinding(PositionalBinding=$false)]
 Param(
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $false)]
     [string]$Remote,
 
-    [Parameter(Mandatory = $true)]
-    [Alias("branch-1xx")]
+    [Parameter(Mandatory = $false)]
     [string]$Branch1xx,
+
+    [switch]$Continue = $false,
 
     [switch][Alias('h')]$help
 )
 
 function Get-Usage {
     Write-Host "  -Remote <name>           Git remote to pull from (e.g., upstream)"
-    Write-Host "  -1xx-branch <branch>     1xx branch name to merge in (e.g., main)"
+    Write-Host "  -Branch1xx <branch>     1xx branch name to merge in (e.g., main)"
+    Write-Host "  -Continue                Continue after manually fixing merge conflicts"
     Write-Host ""
     Write-Host "  -help                    Print help and exit (short: -h)"
 }
 
-if ($help) {
-  Get-Usage
-  exit 0
+if ($help -or !$PSBoundParameters.Keys.Count) {
+    Get-Usage
+    exit 0
+}
+
+function Attempt-Merge {
+    $conflicts = git diff --check | Out-String
+    $unmergedFiles = git ls-files -u
+
+    if ($conflicts.Trim() -ne "" -or $unmergedFiles.Count -gt 0) {
+        Write-Error "There are unresolved conflicts. Please resolve them before continuing."
+        exit 1
+    } else {
+        Write-Output "Continuing with merge..."
+        $mergeMsg = Get-Content ".git/MERGE_MSG" -TotalCount 1
+        git commit -m "$mergeMsg"
+    }
 }
 
 # List of deleted repos
@@ -29,22 +45,48 @@ $DeletedRepos = @(
     "sourcelink", "symreader", "windowsdesktop", "winforms", "wpf", "xdt"
 )
 
-# Attempt merge
-$mergeSuccess = git merge --no-commit --no-ff "$Remote/$Branch1xx" 2>$null
-
-if (-not $?) {
-    Write-Output "Cleaning excluded paths..."
-
-    foreach ($repo in $DeletedRepos) {
-        if (Test-Path "src/$repo") {
-            git reset HEAD -- "$path" 2>$null
-            git rm -rf --cached "$path" 2>$null
-            Remove-Item -Recurse -Force "$path" -ErrorAction SilentlyContinue
-        }
+if (-not $Continue) {
+    if (-not $Remote) {
+        Write-Error "Error: Remote is required."
+        Show-Usage
+        exit 1
+    }
+    if (-not $Branch1xx) {
+        Write-Error "Error: Branch1xx is required."
+        Show-Usage
+        exit 1
     }
 
-    $mergeMsg = Get-Content ".git/MERGE_MSG" -TotalCount 1
-    git commit -m "$mergeMsg"
+    git diff --quiet
+    $diffExit = $LASTEXITCODE
+
+    git diff --cached --quiet
+    $cachedExit = $LASTEXITCODE
+
+    if ($diffExit -ne 0 -or $cachedExit -ne 0) {
+        Write-Error "You have uncommitted changes. Please commit or stash them before continuing."
+        exit 1
+    }
+
+    # Attempt merge
+    $mergeTarget = "$Remote/$Branch1xx"
+    $mergeResult = & git merge --no-commit --no-ff "$mergeTarget" 2>&1
+    $mergeExitCode = $LASTEXITCODE
+
+    if ($mergeExitCode -ne 0) {
+        Write-Output "Cleaning excluded paths..."
+
+        foreach ($repo in $DeletedRepos) {
+            $repoPath = Join-Path -Path "src" -ChildPath $repo
+            if (Test-Path $repoPath -PathType Container) {
+                git reset HEAD -- "$repoPath" 2>$null -ErrorAction SilentlyContinue
+                git rm -rf --cached "$repoPath" 2>$null -ErrorAction SilentlyContinue
+                Remove-Item -Recurse -Force "$repoPath" -ErrorAction SilentlyContinue
+            }
+        }
+    }
 }
+
+Attempt-Merge
 
 Write-Output "Completed merge"

--- a/eng/update-band.ps1
+++ b/eng/update-band.ps1
@@ -1,3 +1,21 @@
+<#
+.SYNOPSIS
+    Updates a non-1xx branch of the VMR with the latest from a 1xx branch.
+
+.DESCRIPTION
+    This script pulls in updates from the target remote and branch, ignoring paths to repos that are excluded from non-1xx branches.
+
+.PARAMETER Remote
+    Git remote to pull from (e.g., upstream)
+
+.PARAMETER Branch1xx
+    1xx branch name to merge in (e.g., main)
+
+.PARAMETER ContinueMerge
+    Continue after manually fixing merge conflicts
+
+#>
+
 [CmdletBinding(PositionalBinding=$false)]
 Param(
     [Parameter(Mandatory = $false)]
@@ -6,23 +24,8 @@ Param(
     [Parameter(Mandatory = $false)]
     [string]$Branch1xx,
 
-    [switch]$Continue = $false,
-
-    [switch][Alias('h')]$help
+    [switch]$ContinueMerge = $false
 )
-
-function Get-Usage {
-    Write-Host "  -Remote <name>           Git remote to pull from (e.g., upstream)"
-    Write-Host "  -Branch1xx <branch>     1xx branch name to merge in (e.g., main)"
-    Write-Host "  -Continue                Continue after manually fixing merge conflicts"
-    Write-Host ""
-    Write-Host "  -help                    Print help and exit (short: -h)"
-}
-
-if ($help -or !$PSBoundParameters.Keys.Count) {
-    Get-Usage
-    exit 0
-}
 
 function Attempt-Merge {
     $conflicts = git diff --check | Out-String
@@ -45,7 +48,7 @@ $DeletedRepos = @(
     "sourcelink", "symreader", "windowsdesktop", "winforms", "wpf", "xdt"
 )
 
-if (-not $Continue) {
+if (-not $ContinueMerge) {
     if (-not $Remote) {
         Write-Error "Error: Remote is required."
         Show-Usage

--- a/eng/update-band.sh
+++ b/eng/update-band.sh
@@ -6,7 +6,7 @@ usage() {
   echo ""
   echo "  --remote <name>         Git remote to pull from (e.g., upstream)"
   echo "  --1xx-branch <branch>   1xx branch name to merge in (e.g., main)"
-  echo "  --continue              Continue after manually fixing merge conflicts"
+  echo "  --continue-merge        Continue after manually fixing merge conflicts"
   echo "  --help, -help           Show this help message and exit"
   echo ""
   echo "  Arguments may also be passed with a single dash."
@@ -14,7 +14,7 @@ usage() {
 
 remote=''
 branch_1xx=''
-continue='false'
+continue_merge='false'
 
 attempt_merge() {
   if { git diff --check | grep -q .; } || [ -n "$(git ls-files -u)" ]; then
@@ -49,8 +49,8 @@ while [[ $# > 0 ]]; do
       branch_1xx=$2
       shift
       ;;
-    -continue)
-      continue=true
+    -continue-merge)
+      continue_merge=true
       ;;
     *)
       echo "Error: Unknown argument."
@@ -61,7 +61,7 @@ while [[ $# > 0 ]]; do
   shift
 done
 
-if [[ "$continue" == 'true' ]]; then
+if [[ "$continue_merge" == 'true' ]]; then
   attempt_merge
 elif [[ -z "$remote" ]]; then
   echo "Error: --remote is required."
@@ -79,7 +79,7 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
 fi
 
 # Attempt merge
-if [ "$continue" != "true" ] && ! git merge --no-commit --no-ff "$remote/$branch_1xx" >/dev/null 2>&1; then
+if [ "$continue_merge" != "true" ] && ! git merge --no-commit --no-ff "$remote/$branch_1xx" >/dev/null 2>&1; then
   echo "Cleaning excluded paths..."
 
   for repo in "${deleted_repos[@]}"; do


### PR DESCRIPTION
This PR includes some updates to the bash and powershell scripts to handle merge conflicts in repos that _are_ included in the non-1xx branches.