### PR TITLE
Don't clean while building on Windows internal builds

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -215,8 +215,8 @@ jobs:
 
   ### Basic arguments
   - name: cleanArgument
-    # Don't clean while building on Windows as the pool's disk space is sufficient.
     ${{ if eq(parameters.targetOS, 'windows') }}:
+      # Don't clean while building on Windows as the pool's disk space is sufficient.
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         value: ''
       ${{ else }}:


### PR DESCRIPTION
This makes the build faster and allows governance tools to collect intermediates, i.e. Component Governance.

Validation build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2741161&view=results