### PR TITLE
Fixup deletion command to pick up wildcarded directories

### DIFF
--- a/eng/pipelines/templates/steps/vmr-compare.yml
+++ b/eng/pipelines/templates/steps/vmr-compare.yml
@@ -198,7 +198,8 @@ steps:
     downloadPath: '$(Build.ArtifactStagingDirectory)/vmr-assets/'
     continueOnError: ${{ parameters.continueOnError }}
 
-- powershell: rm -r "$(Build.ArtifactStagingDirectory)/vmr-assets/*Sdk_*_Artifacts"
+- powershell: |
+    Remove-Item -Path "$(Build.ArtifactStagingDirectory)/vmr-assets/*Sdk_*_Artifacts" -Recurse -Force -ErrorAction SilentlyContinue
   displayName: Remove Source-Build Artifacts
   continueOnError: ${{ parameters.continueOnError }}
 

--- a/eng/pipelines/templates/steps/vmr-validate-signing.yml
+++ b/eng/pipelines/templates/steps/vmr-validate-signing.yml
@@ -37,14 +37,10 @@ steps:
     downloadPath: '${{ parameters.signCheckFilesDirectory }}'
 
 # SourceBuild jobs may have succeeded already, so remove those artifacts in case we downloaded them.
-- ${{ if eq(parameters.OS, 'Windows_NT') }}:
-  - powershell: rm -r "${{ parameters.signCheckFilesDirectory }}/*Sdk_*_Artifacts"
-    displayName: Remove Source-Build Artifacts
-    continueOnError: ${{ parameters.continueOnError }}
-- ${{ else }}:
-  - script: rm -r ${{ parameters.signCheckFilesDirectory }}/*Sdk_*_Artifacts
-    displayName: Remove Source-Build Artifacts
-    continueOnError: ${{ parameters.continueOnError }}
+- powershell: |
+    Remove-Item -Path "$(Build.ArtifactStagingDirectory)/vmr-assets/*Sdk_*_Artifacts" -Recurse -Force -ErrorAction SilentlyContinue
+  displayName: Remove Source-Build Artifacts
+  continueOnError: ${{ parameters.continueOnError }}
 
 # This is necessary whenever we want to publish/restore to an AzDO private feed
 # Since sdk-task.ps1 tries to restore packages we need to do this authentication here


### PR DESCRIPTION
The `rm` form launches the executable and interprets the quoted version as a literal path. Avoid this by using Remove-Item