### PR TITLE
Update centos version in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // Container contains checked-out source code only
 {
     "name": "Default",
-    "image": "mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9",
+    "image": "mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream-10-amd64",
     "hostRequirements": {
         // A completely source built .NET is >64 GB with all the repos/artifacts
         "storage": "128gb"

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ You can also build the repository using a Docker image which has the required pr
 The example below creates a Docker volume named `vmr` and clones and builds the VMR there.
 
 ```sh
-docker run --rm -it -v vmr:/vmr -w /vmr mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9
+docker run --rm -it -v vmr:/vmr -w /vmr mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream-10-amd64
 git clone https://github.com/dotnet/dotnet .
 
 # - Microsoft based build


### PR DESCRIPTION
I noticed that we are still using the older centOS version which means if you download the AzDO build into the Codespace to do an offline SB it won't work due to the downloaded dotnet binary relying on newer libc.