### PR TITLE
Add a dependency on the source-build build for publishing

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -97,7 +97,9 @@ stages:
 - ${{ if and(parameters.isBuiltFromVmr, eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - stage: Publish_Build_Assets
     displayName: Publish Assets
-    dependsOn: VMR_Vertical_Build
+    dependsOn:
+    - VMR_Vertical_Build
+    - VMR_SourceOnly_Build
     jobs:
     - template: /eng/common/templates-official/job/publish-build-assets.yml
       parameters:


### PR DESCRIPTION
Publishing now pushes out the source-built assets. Add the missing stage dependency