### PR TITLE
Always include native .pdb in aspnetcore SharedFx

### DIFF
--- a/src/aspnetcore/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.Composite.sfxproj
+++ b/src/aspnetcore/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.Composite.sfxproj
@@ -101,7 +101,8 @@
 
     <NativeRuntimeAsset Condition=" '$(UseIisNativeAssets)' == 'true' AND !$(BuildNative) "
         Include="$(ArtifactsBinDir)InProcessRequestHandler\$(NativePlatform)\$(Configuration)\aspnetcorev2_inprocess.dll" />
-    <NativeRuntimeAsset Condition=" '$(UseIisNativeAssets)' == 'true' AND !$(BuildNative) "
+    <!-- Always explicitly include the .pdb -->
+    <NativeRuntimeAsset Condition=" '$(UseIisNativeAssets)' == 'true' "
         Include="$(ArtifactsBinDir)InProcessRequestHandler\$(NativePlatform)\$(Configuration)\aspnetcorev2_inprocess.pdb" />
   </ItemGroup>
 

--- a/src/aspnetcore/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
+++ b/src/aspnetcore/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
@@ -98,7 +98,8 @@
 
     <NativeRuntimeAsset Condition=" '$(UseIisNativeAssets)' == 'true' AND !$(BuildNative) "
         Include="$(ArtifactsBinDir)InProcessRequestHandler\$(NativePlatform)\$(Configuration)\aspnetcorev2_inprocess.dll" />
-    <NativeRuntimeAsset Condition=" '$(UseIisNativeAssets)' == 'true' AND !$(BuildNative) "
+    <!-- Always explicitly include the .pdb -->
+    <NativeRuntimeAsset Condition=" '$(UseIisNativeAssets)' == 'true' "
         Include="$(ArtifactsBinDir)InProcessRequestHandler\$(NativePlatform)\$(Configuration)\aspnetcorev2_inprocess.pdb" />
   </ItemGroup>
 


### PR DESCRIPTION
I recently made a change in aspnetcore to explicitly include the native .pdb in aspnetcore's SharedFx: https://github.com/dotnet/aspnetcore/pull/62124. However, that change didn't work in the VMR since `BuildNative` is set to `true` in the vertical that builds the SharedFx. We should always include that .pdb, not just when `BuildNative` is false.