### PR TITLE
Include runtime tarballs in SB artifacts

### DIFF
--- a/eng/PublishSourceBuild.props
+++ b/eng/PublishSourceBuild.props
@@ -102,6 +102,17 @@
           DestinationFolder="$(SourceBuiltLayoutDir)"
           UseSymbolicLinksIfPossible="true" />
 
+    <ItemGroup>
+      <_RuntimeTarballs Include="$(ArtifactsAssetsDir)Runtime/**/dotnet-runtime-*$(ArchiveExtension)" />
+      <_RuntimeTarballs Include="$(ArtifactsAssetsDir)aspnetcore/Runtime/**/aspnetcore-runtime-*$(ArchiveExtension)"
+                        Exclude="$(ArtifactsAssetsDir)aspnetcore/Runtime/**/aspnetcore-runtime-composite-*$(ArchiveExtension)" />
+    </ItemGroup>
+
+    <!-- Copy runtime tarballs into the tarball preserving directory structure -->
+    <Copy SourceFiles="@(_RuntimeTarballs)"
+      DestinationFiles="@(_RuntimeTarballs->'$(SourceBuiltLayoutDir)$([MSBuild]::MakeRelative('$(ArtifactsAssetsDir)', '%(FullPath)'))')"
+      UseSymbolicLinksIfPossible="true" />
+
     <!-- Create a PackageVersions.props file that includes entries for all packages. -->
     <WritePackageVersionsProps KnownPackages="@(ProducedPackage->Metadata('PackageId'))"
                                ExtraProperties="@(ExtraPackageVersionPropsPackageInfo)"


### PR DESCRIPTION
Contributes to https://github.com/dotnet/dotnet/issues/1111

In order to consume 1xx artifacts in a 2xx source-only build, the build of sdk repo needs access to the dotnet-runtime and aspnetcore-runtime tarballs so that it can include them as part of its redist.

I've placed these runtime tarballs into the existing artifacts tarball. I feel this is preferable because it doesn't require a new file to be introduced that would otherwise require a way to feed that into build. Instead, it can piggyback on the existing artifacts tarball input method.

The directory structure within the tarball follows the same structure as the `assets` directory. The intention is for the 2xx to build to simply extract this `assets` directory onto the existing `assets` directory of the repo to effectively simulate the output of these runtime tarballs.

Related: https://github.com/dotnet/source-build/issues/5280