### PR TITLE
officialBuildId argument for build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ set -e
 usage()
 {
   echo "Common settings:"
-echo "  --binaryLog                         Create MSBuild binary log (short: -bl)"
+  echo "  --binaryLog                       Create MSBuild binary log (short: -bl)"
   echo "  --configuration <value>           Build configuration: 'Debug' or 'Release' (short: -c)"
   echo "  --rid, --target-rid <value>       Overrides the rid that is produced by the build. e.g. alpine.3.18-arm64, fedora.37-x64, freebsd.13-arm64, ubuntu.19.10-x64"
   echo "  --os, --target-os <value>         Target operating system: e.g. linux, osx, freebsd. Note: this is the base OS name, not the distro"
@@ -18,6 +18,7 @@ echo "  --binaryLog                         Create MSBuild binary log (short: -b
   echo "  --branding <preview|rtm|default>  Specify versioning for shipping packages/assets. 'preview' will produce assets suffixed with '.final', 'rtm' will not contain a pre-release suffix. Default or unspecified will use VMR repo defaults."
   echo "  --verbosity <value>               Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
   echo "  --with-system-libs <libs>         Use system versions of these libraries. Combine with a plus. eg brotli+libunwind+rapidjson+zlib"
+  echo "  --official-build-id <YYYYMMDD.X>  Official build ID to use for the build. This is used to set the OfficialBuildId MSBuild property."
   echo ""
 
   echo "Actions:"
@@ -139,6 +140,10 @@ while [[ $# > 0 ]]; do
       ;;
     -with-system-libs)
       properties+=( "/p:UseSystemLibs=$2" )
+      shift
+      ;;
+    -official-build-id)
+      properties+=( "/p:OfficialBuildId=$2" )
       shift
       ;;
     -verbosity|-v)

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -9,6 +9,7 @@ Param(
   [string][Alias('v')]$verbosity = "minimal",
   [Parameter()][ValidateSet("preview", "rtm", "default")]
   [string]$branding = "default",
+  [string][Alias('obid')]$officialBuildId,
 
   # Actions
   [switch]$clean,
@@ -31,13 +32,14 @@ Param(
 
 function Get-Usage() {
   Write-Host "Common settings:"
-  Write-Host "  -binaryLog                  Output binary log (short: -bl)"
-  Write-Host "  -configuration <value>      Build configuration: 'Debug' or 'Release' (short: -c). [Default: Release]"
-  Write-Host "  -rid, -targetRid <value>    Overrides the rid that is produced by the build. e.g. win-arm64, win-x64"
-  Write-Host "  -os, -targetOS <value>      Target operating system: e.g. windows."
-  Write-Host "  -arch, -targetArch <value>  Target architecture: e.g. x64, x86, arm64, arm, riscv64"
-  Write-Host "  -verbosity <value>          Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
+  Write-Host "  -binaryLog                       Output binary log (short: -bl)"
+  Write-Host "  -configuration <value>           Build configuration: 'Debug' or 'Release' (short: -c). [Default: Release]"
+  Write-Host "  -rid, -targetRid <value>         Overrides the rid that is produced by the build. e.g. win-arm64, win-x64"
+  Write-Host "  -os, -targetOS <value>           Target operating system: e.g. windows."
+  Write-Host "  -arch, -targetArch <value>       Target architecture: e.g. x64, x86, arm64, arm, riscv64"
+  Write-Host "  -verbosity <value>               Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
   Write-Host "  -branding <preview|rtm|default>  Specify versioning for shipping packages/assets. 'preview' will produce assets suffixed with '.final', 'rtm' will not contain a pre-release suffix. Default or unspecified will use VMR repo defaults."
+  Write-Host "  -officialBuildId <YYYYMMDD.X>    Official build ID to use for the build. This is used to set the OfficialBuildId MSBuild property."
   Write-Host ""
 
   Write-Host "Actions:"
@@ -95,6 +97,7 @@ if ($branding) {
         "default" { $arguments += "" }
     }
 }
+if ($officialBuildId) { $arguments += "/p:OfficialBuildId=$officialBuildId" }
 
 function Build {
   $toolsetBuildProj = InitializeToolset

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -227,8 +227,18 @@ jobs:
   - name: brandingArgument
     value: $(commandPrefix)branding $(brandingType)
 
+  - ${{ if and(eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - name: officialBuildArgument
+      ${{ if eq(parameters.targetOS, 'windows') }}:
+        value: $(commandPrefix)officialBuildId $(Build.BuildNumber)
+      ${{ else }}:
+        value: $(commandPrefix)official-build-id $(Build.BuildNumber)
+  - ${{ else }}:
+    - name: officialBuildArgument
+      value: ''
+
   - name: baseArguments
-    value: $(commandPrefix)ci $(cleanArgument) $(commandPrefix)prepareMachine -c ${{ parameters.configuration }} $(brandingArgument)
+    value: $(commandPrefix)ci $(cleanArgument) $(commandPrefix)prepareMachine -c ${{ parameters.configuration }} $(brandingArgument) $(officialBuildArgument)
 
   - name: baseProperties
     value: $(officialBuildProperties) /p:VerticalName=$(Agent.JobName)

--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -73,7 +73,7 @@ variables:
 
 - ${{ if eq(variables['isOfficialBuild'], true) }}:
   - name: officialBuildProperties
-    value: '/p:OfficialBuildId=$(Build.BuildNumber) $(officialBuilderProperty)'
+    value: '$(officialBuilderProperty)'
 - ${{ else }}:
   - name: officialBuildProperties
     value: ''


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/5109

Setting an official build ID will be a required part of the workflow for distro maintainers. This adds it as an argument to the build script to make it first-class and discoverable. Also updates the pipeline to make use of this argument.