### PR TITLE
Fix signing builds failures

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
@@ -74,7 +74,7 @@
       <_DotNetCorePath>$(DotNetTool)</_DotNetCorePath>
     </PropertyGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="$(_DotNetCoreRequired)">
       <_SigningGlobalJsonLines Include="{" />
       <_SigningGlobalJsonLines Include="  &quot;sdk&quot;: {" />
       <_SigningGlobalJsonLines Include="    &quot;paths&quot;: [" />
@@ -90,7 +90,7 @@
                       Encoding="utf-8"
                       WriteOnlyWhenDifferent="true" />
 
-    <ItemGroup>
+    <ItemGroup Condition="$(_DotNetCoreRequired)">
       <FileWrites Include="$(SigningTempPath)/global.json" />
     </ItemGroup>
 


### PR DESCRIPTION
Write a global.json in the temp dir pointing to the toolset SDK in case any repo (such as the sdk repo) drops one in the artifacts folder.

Fixes #1486

Official build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2750867&view=results