### PR TITLE
Consume branding from source-build manifest

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -58,6 +58,33 @@ usage()
   echo "Arguments can also be passed in with a single hyphen."
 }
 
+function SetBranding()
+{
+  local brandingValue="$1"
+  
+  if [[ "$brandingValue" == "preview" ]]; then
+    properties+=( "/p:DotNetFinalVersionKind=prerelease" )
+  elif [[ "$brandingValue" == "rtm" ]]; then
+    properties+=( "/p:DotNetFinalVersionKind=release" )
+  elif [[ "$brandingValue" == "default" ]]; then
+    # default branding; no extra property needed
+    :
+  else
+    echo "ERROR: Invalid branding '$brandingValue'. Allowed values are 'preview', 'rtm', or 'default'."
+    exit 1
+  fi
+}
+
+function SetOfficialBuildId()
+{
+  local officialBuildIdValue="$1"
+  if [[ ! "$officialBuildIdValue" =~ ^[0-9]{8}\.[0-9]{1,3}$ ]]; then
+    echo "ERROR: Invalid official-build-id format. Expected format: YYYYYMMDD.X"
+    exit 1
+  fi
+  properties+=( "/p:OfficialBuildId=$officialBuildIdValue" )
+}
+
 source="${BASH_SOURCE[0]}"
 
 # resolve $source until the file is no longer a symlink
@@ -74,6 +101,8 @@ scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 binary_log=''
 configuration='Release'
 verbosity='minimal'
+officialBuildId=''
+branding=''
 
 # Actions
 clean=false
@@ -126,17 +155,8 @@ while [[ $# > 0 ]]; do
       shift
       ;;
     -branding)
-      if [[ "$2" == "preview" ]]; then
-        properties+=( "/p:DotNetFinalVersionKind=prerelease" )
-      elif [[ "$2" == "rtm" ]]; then
-        properties+=( "/p:DotNetFinalVersionKind=release" )
-      elif [[ "$2" == "default" ]]; then
-        # default branding; no extra property needed
-        :
-      else
-        echo "ERROR: Invalid branding '$2'. Allowed values are 'preview', 'rtm', or 'default'."
-        exit 1
-      fi
+      branding="$2"
+      SetBranding "$branding"
       shift
       ;;
     -with-system-libs)
@@ -150,11 +170,7 @@ while [[ $# > 0 ]]; do
       ;;
     -official-build-id)
       officialBuildId="$2"
-      if [[ ! "$officialBuildId" =~ ^[0-9]{8}\.[0-9]{1,3}$ ]]; then
-        echo "ERROR: Invalid official-build-id format. Expected format: YYYYYMMDD.X"
-        #exit 1
-      fi
-      properties+=( "/p:OfficialBuildId=$officialBuildId" )
+      SetOfficialBuildId "$officialBuildId"
       shift
       ;;
     -verbosity|-v)
@@ -322,16 +338,18 @@ function Build {
     check="/check"
   fi
 
-  InitializeToolset
+  echo "Building with properties: ${properties[*]}"
 
-  MSBuild $_InitializeToolset \
-    $bl \
-    $check \
-    "-tl:off" \
-    "${actions[@]}" \
-    "${properties[@]}"
+  # InitializeToolset
 
-  ExitWithExitCode 0
+  # MSBuild $_InitializeToolset \
+  #   $bl \
+  #   $check \
+  #   "-tl:off" \
+  #   "${actions[@]}" \
+  #   "${properties[@]}"
+
+  # ExitWithExitCode 0
 }
 
 if [[ "$clean" == true ]]; then
@@ -406,20 +424,18 @@ if [[ "$sourceOnly" == "true" ]]; then
 
     # If the release manifest is provided
     if [ -n "$releaseManifest" ] ; then
-      # Check if OfficialBuildId was explicitly provided as an MSBuild property. This overrides any value in the release manifest.
-      officialBuildIdProvided=false
-      for prop in "${properties[@]}"; do
-        if [[ $prop =~ ^[-/]p:OfficialBuildId=[^\s]+$ ]]; then
-          officialBuildIdProvided=true
-          break
-        fi
-      done
-
       # If OfficialBuildId was not provided, extract it from the release manifest
-      if [ "$officialBuildIdProvided" == "false" ]; then
+      if [ "$officialBuildId" == "" ]; then
         officialBuildId=$(get_property "$releaseManifest" officialBuildId) \
             || (echo "ERROR: Failed to find officialBuildId in $releaseManifest" && exit 1)
-        properties+=( "/p:OfficialBuildId=$officialBuildId" )
+        SetOfficialBuildId "$officialBuildId"
+      fi
+
+      # If branding was not provided, extract it from the release manifest
+      if [[ "$branding" == "" ]]; then
+        branding=$(get_property "$releaseManifest" branding) \
+          || (echo "ERROR: Failed to find branding in $releaseManifest" && exit 1)
+        SetBranding "$branding"
       fi
     fi
   fi


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/5109

Part of the distro maintainer UX for configuring official builds is to set the branding option. This should be provided within the source-build release manifest and read from when that manifest is provided as input to the build script.

This updates the build script to read that value and set the `DotNetFinalVersionKind` MSBuild appropriately.

It also refactors the use of OfficialBuildId to follow the same pattern. This includes removing the behavior which checked whether `OfficialBuildId` was explicitly provided as an MSBuild property in the build script arguments. My assertion is that we shouldn't check for these properties when we already have specific build script arguments for such values (in this case `--official-build-id` from https://github.com/dotnet/dotnet/pull/1497).