### PR TITLE
Include symbols in SB artifacts

### DIFF
--- a/eng/PublishSourceBuild.props
+++ b/eng/PublishSourceBuild.props
@@ -103,14 +103,15 @@
           UseSymbolicLinksIfPossible="true" />
 
     <ItemGroup>
-      <_RuntimeTarballs Include="$(ArtifactsAssetsDir)Runtime/**/dotnet-runtime-*$(ArchiveExtension)" />
-      <_RuntimeTarballs Include="$(ArtifactsAssetsDir)aspnetcore/Runtime/**/aspnetcore-runtime-*$(ArchiveExtension)"
-                        Exclude="$(ArtifactsAssetsDir)aspnetcore/Runtime/**/aspnetcore-runtime-composite-*$(ArchiveExtension)" />
+      <_AdditionalAssets Include="$(ArtifactsAssetsDir)Runtime/**/dotnet-runtime-*$(ArchiveExtension)" />
+      <_AdditionalAssets Include="$(ArtifactsAssetsDir)aspnetcore/Runtime/**/aspnetcore-runtime-*$(ArchiveExtension)"
+                         Exclude="$(ArtifactsAssetsDir)aspnetcore/Runtime/**/aspnetcore-runtime-composite-*$(ArchiveExtension)" />
+      <_AdditionalAssets Include="$(ArtifactsAssetsDir)$(SourceBuiltSymbolsAllTarballName)-*$(ArchiveExtension)" />
     </ItemGroup>
 
     <!-- Copy runtime tarballs into the tarball preserving directory structure -->
-    <Copy SourceFiles="@(_RuntimeTarballs)"
-          DestinationFiles="@(_RuntimeTarballs->'$(SourceBuiltLayoutDir)$([MSBuild]::MakeRelative('$(ArtifactsAssetsDir)../../', '%(FullPath)'))')"
+    <Copy SourceFiles="@(_AdditionalAssets)"
+          DestinationFiles="@(_AdditionalAssets->'$(SourceBuiltLayoutDir)$([MSBuild]::MakeRelative('$(ArtifactsAssetsDir)../../', '%(FullPath)'))')"
           UseSymbolicLinksIfPossible="true" />
 
     <!-- Create a PackageVersions.props file that includes entries for all packages. -->

--- a/eng/VmrLayout.props
+++ b/eng/VmrLayout.props
@@ -46,6 +46,8 @@
     <SourceBuiltArtifactsTarballName>Private.SourceBuilt.Artifacts</SourceBuiltArtifactsTarballName>
     <SourceBuiltSharedComponentsTarballName>Private.SourceBuilt.SharedComponents</SourceBuiltSharedComponentsTarballName>
     <SourceBuiltPrebuiltsTarballName>Private.SourceBuilt.Prebuilts</SourceBuiltPrebuiltsTarballName>
+    <SourceBuiltSymbolsAllTarballName>dotnet-symbols-all</SourceBuiltSymbolsAllTarballName>
+    <SourceBuiltSymbolsSdkTarballName>dotnet-symbols-sdk</SourceBuiltSymbolsSdkTarballName>
 
     <BaselineDataFile>$(ToolsDir)prebuilt-baseline.xml</BaselineDataFile>
     <PackageVersionsDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsObjDir)', 'PackageVersions'))</PackageVersionsDir>

--- a/eng/finish-source-only.proj
+++ b/eng/finish-source-only.proj
@@ -193,8 +193,8 @@
           AfterTargets="Build"
           DependsOnTargets="DetermineSourceBuiltSdkNonStableVersion">
     <PropertyGroup>
-      <UnifiedSymbolsTarball>$(ArtifactsAssetsDir)dotnet-symbols-all-$(SourceBuiltSdkNonStableVersion)-$(TargetRid)$(ArchiveExtension)</UnifiedSymbolsTarball>
-      <SdkSymbolsTarball>$(ArtifactsAssetsDir)dotnet-symbols-sdk-$(SourceBuiltSdkNonStableVersion)-$(TargetRid)$(ArchiveExtension)</SdkSymbolsTarball>
+      <UnifiedSymbolsTarball>$(ArtifactsAssetsDir)$(SourceBuiltSymbolsAllTarballName)-$(SourceBuiltSdkNonStableVersion)-$(TargetRid)$(ArchiveExtension)</UnifiedSymbolsTarball>
+      <SdkSymbolsTarball>$(ArtifactsAssetsDir)$(SourceBuiltSymbolsSdkTarballName)-$(SourceBuiltSdkNonStableVersion)-$(TargetRid)$(ArchiveExtension)</SdkSymbolsTarball>
     </PropertyGroup>
     <ItemGroup>
       <IntermediateSymbol Include="$(IntermediateSymbolsRootDir)**/*" />


### PR DESCRIPTION
Contributes to #1465

For building the VMR from a 2xx branch, we won't be building the repos of the shared component repos like runtime and aspnetcore. That means we don't have access to the symbols that would have been produced from these builds in order to include in the `dotnet-symbols-all` tarball produced by a source-only build. These PDBs are necessary to include in that tarball.

In order to get these PDBs included, we first need to have access to the PDBs that were produced from the build that produced the shared components. This updates the build so that the `dotnet-symbols-all` tarball is added to the source build artifacts tarball. This will provide a 2xx build with access to these PDBs since it will consume the artifacts tarball as input.