### PR TITLE
Do not publish symbols packages in source-only build

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Publish.proj
@@ -138,8 +138,7 @@
 
   <Target Name="BeforePublish" Condition="'@(Artifact)' != ''">
     <ItemGroup>
-      <!-- Exclude all existing *.symbols.nupkg in source-only build - we create a unified symbols archive instead. -->
-      <_ExistingSymbolPackage Include="@(Artifact)" Condition="'$(DotNetBuildSourceOnly)' != 'true' and '%(Artifact.SkipPublish)' != 'true' and $([System.String]::Copy('%(Filename)%(Extension)').EndsWith('.symbols.nupkg'))">
+      <_ExistingSymbolPackage Include="@(Artifact)" Condition="'%(Artifact.SkipPublish)' != 'true' and $([System.String]::Copy('%(Filename)%(Extension)').EndsWith('.symbols.nupkg'))">
         <!-- Update the kind of the symbol packages to blob -->
         <Kind>Blob</Kind>
         <!-- Set the category to Symbols (otherwise it will inherit the original package category -->
@@ -147,6 +146,11 @@
         <RelativeBlobPath>$(SymbolPackageBaseRelativeBlobPath)%(Filename)%(Extension)</RelativeBlobPath>
       </_ExistingSymbolPackage>
       <_PackageToPublish Include="@(Artifact)" Exclude="@(_ExistingSymbolPackage)" Condition="'%(Artifact.SkipPublish)' != 'true' and '%(Extension)' == '.nupkg'" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <!-- Exclude all existing *.symbols.nupkg in source-only build - we create a unified symbols archive instead. -->
+      <_ExistingSymbolPackage Remove="@(_ExistingSymbolPackage)" Condition="'$(DotNetBuildSourceOnly)' == 'true'"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/roslyn/eng/Publishing.props
+++ b/src/roslyn/eng/Publishing.props
@@ -17,11 +17,14 @@
   <!--
     During PR Validation we only need to publish symbols with Arcade,
     since our packages are published separately to the CoreXT feed.
+
+    Also, do not publish any symbols packages in source-only builds.
   -->
   <Target Name="_ResolvePublishRoslynNuGetPackages"
           DependsOnTargets="BeforePublish"
           BeforeTargets="PublishToAzureDevOpsArtifacts"
-          Condition=" '$(PreReleaseVersionLabel)' == 'pr-validation' ">
+          Condition=" '$(PreReleaseVersionLabel)' == 'pr-validation' or '$(DotNetBuildSourceOnly)' == 'true' ">
+
     <ItemGroup>
       <!-- Determine all NuGet packages being published -->
       <_NuGetPackagesToPush Include="@(ItemsToPushToBlobFeed)"
@@ -30,13 +33,25 @@
       <!-- Determine all symbol packages being published -->
       <_SymbolPackagesToPush Include="@(_NuGetPackagesToPush)"
                              Condition="$([System.String]::Copy(%(FullPath)).EndsWith('.symbols.nupkg'))" />
+      <_SymbolPackagesToPush Include="@(_NuGetPackagesToPush)"
+                             Condition="$([System.String]::Copy(%(FullPath)).Contains('.Symbols.'))" />
+    </ItemGroup>
 
+    <ItemGroup Condition=" '$(PreReleaseVersionLabel)' == 'pr-validation' ">
       <!-- Remove all NuGet packages from being published -->
       <ItemsToPushToBlobFeed Remove="@(_NuGetPackagesToPush)" />
+    </ItemGroup>
 
-      <!-- Include symbol packages for publishing -->
+    <ItemGroup Condition=" '$(DotNetBuildSourceOnly)' == 'true' ">
+      <!-- Remove all symbols packages from being published -->
+      <ItemsToPushToBlobFeed Remove="@(_SymbolPackagesToPush)" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(PreReleaseVersionLabel)' == 'pr-validation' and '$(DotNetBuildSourceOnly)' != 'true' ">
+      <!-- Include symbol packages for publishing-->
       <ItemsToPushToBlobFeed Include="@(_SymbolPackagesToPush)" />
     </ItemGroup>
+
   </Target>
 
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/4453

Currently repos are publishing, to disk, in source-only build, all `*.symbols.nupkg`. Additionally, `roslyn` repo is publishing 9 custom named symbols packages in the following format: `<id>.Symbols.<version>.nupkg`.

This PR:
- Updates arcade to bring back the filtering of symbols nupkgs in source-only build. This was originally implemented with https://github.com/dotnet/arcade/pull/14559, but has since regressed.
- Updates `roslyn`'s `Publishing.props` to additionally filter all custom named packages.
- Adds a source-only test to ensure that no symbols packages are included in previously source-build archive.