### PR TITLE
Use RepoOriginalSourceRevisionId in ASP.NET Core

### DIFF
--- a/src/aspnetcore/eng/targets/CSharp.Common.targets
+++ b/src/aspnetcore/eng/targets/CSharp.Common.targets
@@ -94,7 +94,12 @@
         <_Parameter2>$(RepositoryUrl)/tree/$(SourceRevisionId)</_Parameter2>
       </AssemblyAttribute>
 
-      <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition="'$(Serviceable)' == 'true'">
+      <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition="'$(RepoOriginalSourceRevisionId)' != ''">
+        <_Parameter1>OriginalRepoCommitHash</_Parameter1>
+        <_Parameter2>$(RepoOriginalSourceRevisionId)</_Parameter2>
+      </AssemblyAttribute>
+
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition="'$(Serviceable)' == 'true'">
         <_Parameter1>Serviceable</_Parameter1>
         <_Parameter2>True</_Parameter2>
       </AssemblyAttribute>


### PR DESCRIPTION
This should reenable us to have repo specific commit diffs for benchmarking regression/improvement analysis.

Will probably want to do the same in dotnet/runtime assuming this works.

Question: Do we only want to do this for nightlies? Should it be disabled for official builds?

Edit: Maybe we want `OriginalRepoCommitUrl` as well?
e.g. Today we have:
```
[assembly: AssemblyMetadata("CommitHash", "67889d9d2f21a890ac29bcd175c0d1937a401781")]
[assembly: AssemblyMetadata("SourceCommitUrl", "https://github.com/dotnet/dotnet/tree/67889d9d2f21a890ac29bcd175c0d1937a401781")]
```