### PR TITLE
Build nuget-client and vstest in deterministic mode

### DIFF
--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -175,8 +175,7 @@
     <EnvironmentVariables Include="_InitializeToolset=$(SourceBuiltSdksDir)Microsoft.DotNet.Arcade.Sdk/tools/Build.proj"
                           Condition="'$(UseBootstrapArcade)' != 'true'" />
 
-    <EnvironmentVariables Include="DeterministicSourcePaths=true" Condition="'$(DeterministicBuildOptOut)' != 'true'" />
-    <EnvironmentVariables Include="DeterministicSourcePaths=false" Condition="'$(DeterministicBuildOptOut)' == 'true'" />
+    <EnvironmentVariables Include="DeterministicSourcePaths=true" />
 
     <EnvironmentVariables Include="SourceRoot=$(ProjectDirectory)" />
 

--- a/repo-projects/nuget-client.proj
+++ b/repo-projects/nuget-client.proj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <NuGetKeyFilePath>$(KeysDir)NuGet.Client.snk</NuGetKeyFilePath>
-    <DeterministicBuildOptOut>true</DeterministicBuildOptOut>
 
     <!-- Don't pass any build actions because the repo doesn't support them. -->
     <BuildActions></BuildActions>

--- a/repo-projects/vstest.proj
+++ b/repo-projects/vstest.proj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.Build.NoTargets">
 
-  <PropertyGroup>
-    <DeterministicBuildOptOut>true</DeterministicBuildOptOut>
-  </PropertyGroup>
-
   <ItemGroup>
     <RepositoryReference Include="arcade" />
     <RepositoryReference Include="diagnostics" />


### PR DESCRIPTION
We don't know why they opted out. Local builds seem to be just fine without this.

Closes: https://github.com/dotnet/dotnet/issues/1583