### PR TITLE
Add rolling CI job running on the Scouting queue

### DIFF
--- a/eng/pipelines/scout-build.yml
+++ b/eng/pipelines/scout-build.yml
@@ -1,0 +1,28 @@
+# This yml is used by these pipelines:
+# - dotnet-unified-build-scout (public)
+
+# Only run daily on schedule to save resources
+trigger: none
+
+schedules:
+  - cron: "0 13 * * *" # run at 013:00 (UTC)
+    branches:
+      include:
+      - main
+      - release/*
+    always: false # run only if there were changes since the last successful scheduled run.
+
+variables:
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  - name: skipComponentGovernanceDetection  # we run CG on internal builds only
+    value: true
+
+  - name: Codeql.Enabled  # we run CodeQL on internal builds only
+    value: false
+
+- template: /eng/common/templates/variables/pool-providers.yml@self
+
+stages:
+- template: /eng/pipelines/templates/stages/vmr-build.yml
+  parameters:
+    scope: scout

--- a/eng/pipelines/templates/stages/source-build-stages.yml
+++ b/eng/pipelines/templates/stages/source-build-stages.yml
@@ -10,6 +10,8 @@ parameters:
 - name: scope
   type: string
   values:
+  # run only windows jobs
+  - scout
   # run several legs e.g. stage1/stage2 for basic testing
   - lite
   # run everything

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -18,7 +18,9 @@ parameters:
 - name: scope
   type: string
   values:
-  # run several legs e.g. win/linux/mac for basic testing
+  # run only windows jobs
+  - scout
+  # run several legs e.g. stage1/stage2 for basic testing
   - lite
   # run everything
   - full

--- a/eng/pipelines/templates/stages/vmr-verticals.yml
+++ b/eng/pipelines/templates/stages/vmr-verticals.yml
@@ -18,7 +18,9 @@ parameters:
 - name: scope
   type: string
   values:
-  # run several legs e.g. win/linux/mac for basic testing
+  # run only windows jobs
+  - scout
+  # run several legs e.g. stage1/stage2 for basic testing
   - lite
   # run everything
   - full
@@ -677,3 +679,49 @@ stages:
           - Windows_x64
           - Windows_x86
           - Windows_arm64
+
+#### VERTICAL BUILD (Scouting) ####
+- ${{ if in(parameters.scope, 'scout') }}:
+  - stage: VMR_Vertical_Build
+    displayName: VMR Vertical Build
+    dependsOn: []
+    variables:
+    - template: ../variables/vmr-build.yml
+      parameters:
+        desiredSigning: ${{ parameters.desiredSigning }}
+        desiredIBC: ${{ parameters.desiredIBC }}
+        desiredFinalVersionKind: ${{ parameters.desiredFinalVersionKind }}
+        isScoutingJob: true
+    jobs:
+
+    - template: ../jobs/vmr-build.yml
+      parameters:
+        buildName: Windows
+        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+        sign: ${{ variables.signEnabled }}
+        signDac: ${{ variables.signDacEnabled }}
+        pool: ${{ parameters.pool_Windows }}
+        targetOS: windows
+        targetArchitecture: x64
+        enableIBCOptimization: ${{ variables.ibcEnabled }}
+
+    - template: ../jobs/vmr-build.yml
+      parameters:
+        buildName: Windows
+        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+        sign: ${{ variables.signEnabled }}
+        signDac: ${{ variables.signDacEnabled }}
+        pool: ${{ parameters.pool_Windows }}
+        targetOS: windows
+        targetArchitecture: x86
+
+    - template: ../jobs/vmr-build.yml
+      parameters:
+        buildName: Windows
+        isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+        sign: ${{ variables.signEnabled }}
+        signDac: ${{ variables.signDacEnabled }}
+        pool: ${{ parameters.pool_Windows }}
+        targetOS: windows
+        targetArchitecture: arm64
+        enableIBCOptimization: ${{ variables.ibcEnabled }}

--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -18,6 +18,11 @@ parameters:
   type: string
   default: ''
 
+- name: isScoutingJob
+  displayName: Scope
+  type: boolean
+  default: false
+
 variables:
 - name: _TeamName
   value: DotNetCore
@@ -245,8 +250,12 @@ variables:
     value: Docker-Linux-Arm-Public
   - name: poolImage_Mac
     value: macos-13
-  - name: poolImage_Windows
-    value: windows.vs2022preview.amd64.open
+  - ${{ if eq(parameters.isScoutingJob, true) }}:
+    - name: poolImage_Windows
+      value: windows.vs2022preview.scout.amd64.open
+  - ${{ else }}:
+    - name: poolImage_Windows
+      value: windows.vs2022preview.amd64.open
 - ${{ else }}:
   - name: defaultPoolName
     value: NetCore1ESPool-Internal


### PR DESCRIPTION
https://github.com/dotnet/dotnet/issues/1588

Adds a Win-only job that runs on the scouting queue. Should allow us to catch tooling related build-breaks early