### PR TITLE
Poisoning support for shared components

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,7 @@
 <Project>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" Condition="'$(SkipArcadeSdkImport)' != 'true'" />
+  <Import Project="$(RepositoryEngineeringDir)VmrCommon.targets" />
 
   <!-- The SkipPrepareSdkArchive switch exists so that outside components like the license scan test pipeline
        can run a subset of tests that don't need the SDK archive without building the VMR.

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,6 +1,7 @@
 <Project InitialTargets="DiscoverArtifacts">
   <Import Project="$(RepositoryEngineeringDir)RuntimeIdentifier.props" />
   <Import Project="$(RepositoryEngineeringDir)VmrLayout.props" />
+  <Import Project="$(RepositoryEngineeringDir)VmrCommon.targets" />
 
   <PropertyGroup>
     <PublishingVersion>4</PublishingVersion>

--- a/eng/VmrCommon.targets
+++ b/eng/VmrCommon.targets
@@ -1,0 +1,47 @@
+<Project>
+  
+  <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.GetKnownArtifactsFromAssetManifests" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
+
+  <Target Name="GetFilteredSharedComponentPackages"
+          Outputs="@(_SharedComponentFilteredPackages)">
+
+    <PropertyGroup>
+      <_PreviouslySourceBuiltSharedComponentAssetManifests>$(SharedComponentsArtifactsPath)VerticalManifest.xml</_PreviouslySourceBuiltSharedComponentAssetManifests>
+      <SharedRepositoryReferenceString>;@(SharedRepositoryReference);</SharedRepositoryReferenceString>
+      <!-- Property to control filtering mode: true = include only tooling components, false = exclude tooling components (default) -->
+      <IncludeOnlyToolingComponents Condition="'$(IncludeOnlyToolingComponents)' == ''">false</IncludeOnlyToolingComponents>
+    </PropertyGroup>
+
+    <GetKnownArtifactsFromAssetManifests AssetManifests="$(_PreviouslySourceBuiltSharedComponentAssetManifests)"
+                                         Condition="Exists($(_PreviouslySourceBuiltSharedComponentAssetManifests))">
+      <Output TaskParameter="KnownPackages" ItemName="_SharedComponentFilteredPackages" />
+    </GetKnownArtifactsFromAssetManifests>
+
+    <!-- Filter tooling components based on the mode -->
+    <ItemGroup Condition="'$(IncludeOnlyToolingComponents)' == 'false'">
+      <!-- Default mode: Remove tooling components from the shared packages -->
+      <_ItemsToRemove Include="@(_SharedComponentFilteredPackages)"
+                      Condition="!$(SharedRepositoryReferenceString.Contains(';%(RepoOrigin);')) or %(RepoOrigin) == 'arcade' or %(RepoOrigin) == 'source-build-reference-packages'" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(IncludeOnlyToolingComponents)' == 'true'">
+      <!-- Alternate mode: Keep only tooling components, remove everything else -->
+      <_ItemsToRemove Include="@(_SharedComponentFilteredPackages)"
+                      Condition="$(SharedRepositoryReferenceString.Contains(';%(RepoOrigin);')) and %(RepoOrigin) != 'arcade' and %(RepoOrigin) != 'source-build-reference-packages'" />
+    </ItemGroup>
+
+    <!-- Create a lookup string of items to remove -->
+    <PropertyGroup>
+      <_ItemsToRemoveString>@(_ItemsToRemove->'%(Identity)::%(Version)', ';')</_ItemsToRemoveString>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_SharedComponentFilteredPackages Remove="@(_SharedComponentFilteredPackages)" 
+                                        Condition="'@(_ItemsToRemove)' != '' and 
+                                                '$(_ItemsToRemoveString)' != '' and
+                                                $(_ItemsToRemoveString.Contains($([System.String]::Concat('%(Identity)', '::', '%(Version)'))))" />
+    </ItemGroup>
+
+  </Target>
+
+</Project>

--- a/eng/VmrLayout.props
+++ b/eng/VmrLayout.props
@@ -93,4 +93,22 @@
     <PreviousPackageVersionPropertySuffixes Include="@(DefaultPackageVersionPropertySuffixes);$(PackagePreviousVersionPropertySuffix)" />
   </ItemGroup>
 
+  <!-- Shared repository references. These repositories are excluded from the build when we're not building shared components. -->
+  <ItemGroup>
+    <SharedRepositoryReference Include="aspnetcore" />
+    <SharedRepositoryReference Include="cecil" />
+    <SharedRepositoryReference Include="command-line-api" />
+    <SharedRepositoryReference Include="deployment-tools" />
+    <SharedRepositoryReference Include="diagnostics" />
+    <SharedRepositoryReference Include="efcore" />
+    <SharedRepositoryReference Include="emsdk" />
+    <SharedRepositoryReference Include="runtime" />
+    <SharedRepositoryReference Include="sourcelink" />
+    <SharedRepositoryReference Include="symreader" />
+    <SharedRepositoryReference Include="windowsdesktop" />
+    <SharedRepositoryReference Include="winforms" />
+    <SharedRepositoryReference Include="wpf" />
+    <SharedRepositoryReference Include="xdt" />
+  </ItemGroup>
+
 </Project>

--- a/eng/init-poison.proj
+++ b/eng/init-poison.proj
@@ -23,6 +23,27 @@
       <PreviouslySourceBuiltPackages Include="$(PreviouslySourceBuiltPackagesPath)**/*.nupkg" />
     </ItemGroup>
 
+    <Error Condition="'@(PreviouslySourceBuiltPackages)' == ''" Text="Expected NuGet packages to be present within the path '$(PreviouslySourceBuiltPackagesPath)'." />
+
+    <!-- Get the packages that come from the tooling repos in the shared components. Only those packages should be marked for poisoning.
+         The packages from the runtime-related components should not be marked for poisoning as it is intentional for them to be
+         redistributed in the SDK. -->
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="GetFilteredSharedComponentPackages"
+             Condition="'$(RepositoryName)' != 'source-build-reference-packages' and '$(RepositoryName)' != 'arcade'"
+             Properties="IncludeOnlyToolingComponents=true">
+      <Output TaskParameter="TargetOutputs" ItemName="_FilteredSharedComponentPackages" />
+    </MSBuild>
+
+    <Error Condition="'@(_FilteredSharedComponentPackages)' == ''" Text="Expected NuGet packages to be present from shared components artifacts." />
+
+    <ItemGroup>
+      <_SharedComponentFilenames Include="@(_FilteredSharedComponentPackages)">
+        <PackagePath>$(SharedComponentsArtifactsPath)$([System.IO.Path]::GetFileName('%(PipelineArtifactPath)'))</PackagePath>
+      </_SharedComponentFilenames>
+      <PreviouslySourceBuiltPackages Include="@(_SharedComponentFilenames->'%(PackagePath)')" />
+    </ItemGroup>
+
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Poisoning existing packages for leak detection." />
 
     <MarkAndCatalogPackages PackagesToMark="@(PrebuiltPackages)" CatalogOutputFilePath="$(PoisonReportDataFile)" MarkerFileName="$(PoisonMarkerFile)" />

--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -228,22 +228,4 @@
     <ProjectReference Include="$(TasksDir)Microsoft.DotNet.UnifiedBuild.MSBuildSdkResolver\Microsoft.DotNet.UnifiedBuild.MSBuildSdkResolver.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Condition="'$(DotNetBuildSourceOnly)' != 'true'" />
   </ItemGroup>
 
-  <!-- Shared repository references. These repositories are excluded from the build when we're not building shared components. -->
-  <ItemGroup>
-    <SharedRepositoryReference Include="aspnetcore" />
-    <SharedRepositoryReference Include="cecil" />
-    <SharedRepositoryReference Include="command-line-api" />
-    <SharedRepositoryReference Include="deployment-tools" />
-    <SharedRepositoryReference Include="diagnostics" />
-    <SharedRepositoryReference Include="efcore" />
-    <SharedRepositoryReference Include="emsdk" />
-    <SharedRepositoryReference Include="runtime" />
-    <SharedRepositoryReference Include="sourcelink" />
-    <SharedRepositoryReference Include="symreader" />
-    <SharedRepositoryReference Include="windowsdesktop" />
-    <SharedRepositoryReference Include="winforms" />
-    <SharedRepositoryReference Include="wpf" />
-    <SharedRepositoryReference Include="xdt" />
-  </ItemGroup>
-
 </Project>

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -200,14 +200,6 @@
       <NetSdkSupportingFeed>https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json</NetSdkSupportingFeed>
     </PropertyGroup>
 
-    <ItemGroup>
-      <_BuildSources Include="$(PrebuiltNuGetSourceName);$(PreviouslySourceBuiltNuGetSourceName);$(ReferencePackagesNuGetSourceName)"
-                     Condition="'$(AddPrebuiltFeeds)' == 'true'"/>
-      <_BuildSources Include="@(_CommonBuildSources)" />
-      <_BuildSources Include="$(NetSdkSupportingFeedName)"
-                     Condition="'$(AddNetSdkSupportingFeed)' == 'true'" />
-    </ItemGroup>
-
     <RemoveInternetSourcesFromNuGetConfig
       NuGetConfigFile="$(NuGetConfigFile)"
       BuildWithOnlineFeeds="$(DotNetBuildWithOnlineFeeds)"
@@ -255,6 +247,20 @@
                             SourcePath="$(NetSdkSupportingFeed)"
                             Condition="'$(AddNetSdkSupportingFeed)' == 'true'" />
 
+    <ItemGroup>
+      <_BuildSources Include="$(PrebuiltNuGetSourceName);
+                              $(PreviouslySourceBuiltNuGetSourceName);
+                              $(PreviouslySourceBuiltSharedComponentsNuGetSourceName);
+                              $(ReferencePackagesNuGetSourceName)"
+                     Condition="'$(AddPrebuiltFeeds)' == 'true'"/>
+      <_BuildSources Include="@(_CommonBuildSources)" />
+      <_BuildSources Include="$(NetSdkSupportingFeedName)"
+                     Condition="'$(AddNetSdkSupportingFeed)' == 'true'" />
+      <_FallbackSources Include="$(PrebuiltNuGetSourceName);
+                                 $(PreviouslySourceBuiltNuGetSourceName);
+                                 $(PreviouslySourceBuiltSharedComponentsNuGetSourceName)" />
+    </ItemGroup>
+
     <UpdateNuGetConfigPackageSourcesMappings
       NuGetConfigFile="$(NuGetConfigFile)"
       BuildWithOnlineFeeds="$(DotNetBuildWithOnlineFeeds)"
@@ -262,8 +268,7 @@
       SbrpRepoSrcPath="$(SbrpRepoSrcDir)"
       SbrpCacheSourceName="$(SbrpCacheNuGetSourceName)"
       ReferencePackagesSourceName="$(ReferencePackagesNuGetSourceName)"
-      PreviouslySourceBuiltSourceName="$(PreviouslySourceBuiltNuGetSourceName)"
-      PrebuiltSourceName="$(PrebuiltNuGetSourceName)"
+      FallbackSourceNames="@(_FallbackSources)"
       SourceBuiltSourceNamePrefix="$(SourceBuiltSourceNamePrefix)"
       PreviousBuildPassSourceNamePrefix="$(PreviousBuildPassSourceNamePrefix)"
       CustomSources="$(NetSdkSupportingFeedName)"
@@ -333,32 +338,17 @@
     <!-- Get the previously-built-source-built package information from the manifest from that build. -->
     <ItemGroup>
       <_PreviouslySourceBuiltAssetManifests Include="$(PreviouslySourceBuiltPackagesPath)VerticalManifest.xml" />
-      <_PreviouslySourceBuiltSharedComponentAssetManifests Include="$(SharedComponentsArtifactsPath)VerticalManifest.xml" />
     </ItemGroup>
 
     <GetKnownArtifactsFromAssetManifests AssetManifests="@(_PreviouslySourceBuiltAssetManifests)" Condition="Exists(@(_PreviouslySourceBuiltAssetManifests))">
       <Output TaskParameter="KnownPackages" ItemName="_PreviouslyBuiltSourceBuiltPackages" />
     </GetKnownArtifactsFromAssetManifests>
 
-    <GetKnownArtifactsFromAssetManifests
-        AssetManifests="@(_PreviouslySourceBuiltSharedComponentAssetManifests)"
-        Condition="
-          Exists(@(_PreviouslySourceBuiltSharedComponentAssetManifests))
-          and '$(RepositoryName)' != 'source-build-reference-packages'
-          and '$(RepositoryName)' != 'arcade'">
-      <Output TaskParameter="KnownPackages" ItemName="_PreviouslyBuiltSourceBuiltSharedComponentPackages" />
-    </GetKnownArtifactsFromAssetManifests>
-
-    <PropertyGroup>
-      <SharedRepositoryReferenceString>;@(SharedRepositoryReference, ';');</SharedRepositoryReferenceString>
-    </PropertyGroup>
-
-    <!-- Remove tooling components from the shared packages -->
-    <ItemGroup>
-      <_ToolingComponents Include="@(_PreviouslyBuiltSourceBuiltSharedComponentPackages)"
-                          Condition="!$(SharedRepositoryReferenceString.Contains(';%(RepoOrigin);')) or %(RepoOrigin) == 'arcade' or %(RepoOrigin) == 'source-build-reference-packages'" />
-      <_PreviouslyBuiltSourceBuiltSharedComponentPackages Remove="@(_ToolingComponents)" MatchOnMetadata="Version" />
-    </ItemGroup>
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="GetFilteredSharedComponentPackages"
+             Condition="'$(RepositoryName)' != 'source-build-reference-packages' and '$(RepositoryName)' != 'arcade'">
+      <Output TaskParameter="TargetOutputs" ItemName="_PreviouslyBuiltSourceBuiltSharedComponentPackages" />
+    </MSBuild>
 
     <PropertyGroup>
       <_UsePackageVersionPropsAggregation>true</_UsePackageVersionPropsAggregation>


### PR DESCRIPTION
Fixes #1112

This adds source build poisoning support for multi-band SDK scenarios in the VMR. In this scenario, runtime-related packages that are provided as input to a non-1xx branch via a shared components tarball are considered to be acceptable for redistribution by the SDK produced from that branch. That is, of course, the whole intention of providing these packages because they are part of the working product. However, the tooling-related packages that comes from the shared components tarball are not considered acceptable to redistribute because the non-1xx branch is the one that is producing the new tooling-related packages. This means that runtime-related packages are _not_ marked for poisoning but the tooling-related packages are.

Notes on the changes:
* Added extra poisoning checks which validates that at least one package exists to be poisoned from both the previously source built artifacts and the shared component packages.
* Refactored `UpdateNuGetConfigPackageSourcesMappings` so that it can handle an arbitrary number of "fallback" inputs (prebuilts, previously source built, shared components).
* Created a new `GetFilteredSharedComponentPackages` target that can filter the packages from the shared components according to whether they come from runtime- or tooling-related repos. This is shared by both repo-projects (for build input props generation) and poisoning. This is defined in `VmrCommon.targets` and needed to be separately referenced in two different locations because of the need for it to be usable in the case of the `Publish` target. In `Publish`, the `Directory.Build.targets` of the VMR root isn't in scope because the project being built is from Arcade. So it needs to be explicitly imported by the `Publishing.props` file.