### PR TITLE
Sync emscripten workload version with common runtime version

### DIFF
--- a/repo-projects/sdk.proj
+++ b/repo-projects/sdk.proj
@@ -58,4 +58,8 @@
     <KeepFeedPrefixes Include="darc-int-dotnet-aspnetcore-" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+    <ExtraPackageVersionPropsPackageInfo Include="EmscriptenWorkloadsVersion" Version="%24(SystemTextJsonVersion)" />
+  </ItemGroup>
+
 </Project>

--- a/src/sdk/eng/Versions.props
+++ b/src/sdk/eng/Versions.props
@@ -268,6 +268,7 @@
     <MicrosoftNETRuntimeEmscriptenSdkInternalVersion>10.0.0-preview.7.25373.105</MicrosoftNETRuntimeEmscriptenSdkInternalVersion>
     <MicrosoftNETRuntimeEmscripten3156Cachewinx64Version>10.0.0-preview.7.25373.105</MicrosoftNETRuntimeEmscripten3156Cachewinx64Version>
     <!-- emscripten versions, these are are included in package IDs and need to be kept in sync with emsdk -->
+    <EmscriptenWorkloadsVersion>$(MicrosoftNETRuntimeEmscripten3156Cachewinx64Version)</EmscriptenWorkloadsVersion>
     <EmscriptenVersionCurrent>3.1.56</EmscriptenVersionCurrent>
     <EmscriptenVersionNet9>3.1.56</EmscriptenVersionNet9>
     <EmscriptenVersionNet8>3.1.34</EmscriptenVersionNet8>

--- a/src/sdk/src/Workloads/VSInsertion/workloads.csproj
+++ b/src/sdk/src/Workloads/VSInsertion/workloads.csproj
@@ -96,13 +96,13 @@
 
   <ItemGroup Condition="'$(BuildWorkloads)' == 'true'">
     <PackageDownload Include="@(RuntimeWorkloadPacksToDownload)" Version="[$(MicrosoftNETCoreAppRuntimePackageVersion)]" />
-    <PackageDownload Include="@(EmsdkWorkloadPacksToDownload)" Version="[$(MicrosoftNETRuntimeEmscripten3156Cachewinx64Version)]" />
+    <PackageDownload Include="@(EmsdkWorkloadPacksToDownload)" Version="[$(EmscriptenWorkloadsVersion)]" />
   </ItemGroup>
 
   <Target Name="_CollectDownloadedWorkloadPacks">
     <ItemGroup>
       <DownloadedWorkloadPacks Include="$(NuGetPackageRoot)\%(RuntimeWorkloadPacksToDownload.Identity)\$(MicrosoftNETCoreAppRuntimePackageVersion)\*.nupkg" />
-      <DownloadedWorkloadPacks Include="$(NuGetPackageRoot)\%(EmsdkWorkloadPacksToDownload.Identity)\$(MicrosoftNETRuntimeEmscripten3156Cachewinx64Version)\*.nupkg" />
+      <DownloadedWorkloadPacks Include="$(NuGetPackageRoot)\%(EmsdkWorkloadPacksToDownload.Identity)\$(EmscriptenWorkloadsVersion)\*.nupkg" />
     </ItemGroup>
 
     <Copy SourceFiles="@(DownloadedWorkloadPacks)"


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/5298

Allows source-build to override the Emscripten package version. Since all package versions are based off the `OfficialBuildId`, we know that the Emscripten packages will match the package versions of the runtime which are correctly lifted in the `sdk` repo. So I've chosen STJ as the one to match since that is likely to always exist as a dependency of the repo.