### PR TITLE
Fix stable versioning

### DIFF
--- a/src/aspnetcore/eng/targets/Wix.Common.targets
+++ b/src/aspnetcore/eng/targets/Wix.Common.targets
@@ -22,7 +22,7 @@
     <!-- Everything built in those projects _except_ the final package & MSI are shipping assets. -->
     <_GeneratedPackageVersion>$(PackageVersion)</_GeneratedPackageVersion>
     <_GeneratedPackageVersion
-        Condition="! $(PackageVersion.Contains('$(_PreReleaseLabel)'))">$(PackageVersion)-$(_PreReleaseLabel)$(_BuildNumberLabels)</_GeneratedPackageVersion>
+        Condition="! $(PackageVersion.Contains('$(_BuildNumberLabels)'))">$(VersionPrefix)-$(_PreReleaseLabel)$(_BuildNumberLabels)</_GeneratedPackageVersion>
     <!-- Insert PackageVersion into OutputName for SharedFx & TargetingPack -->
     <OutputName Condition="'$(OutputNamePrefix)' != '' AND '$(OutputNameSuffix)' != ''">$(OutputNamePrefix)$(_GeneratedPackageVersion)$(OutputNameSuffix)</OutputName>
 


### PR DESCRIPTION
Issue in Preview 7 where a couple non-shipping VS redist packages were getting 10.0.0-preview.N versions.