### PR TITLE
Restore bundle.wixproj in BP3

### DIFF
--- a/src/sdk/src/Layout/redist/redist.csproj
+++ b/src/sdk/src/Layout/redist/redist.csproj
@@ -73,8 +73,9 @@
     <ProjectReference Include="$(RepoRoot)template_feed\*\*.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Private="false" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\finalizer\finalizer.csproj" Condition="'$(OS)' == 'Windows_NT'" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Private="false" />
+  <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
+    <ProjectReference Include="windows\bundles\sdk\bundle.wixproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Condition="'$(MSBuildRestoreSessionId)' != ''" />
+    <ProjectReference Include="..\finalizer\finalizer.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Private="false" />
   </ItemGroup>
 
   <!-- In .NET product build mode, explicitly build workloads in build pass 2.

--- a/src/sdk/src/Layout/redist/redist.csproj
+++ b/src/sdk/src/Layout/redist/redist.csproj
@@ -74,7 +74,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
-    <ProjectReference Include="windows\bundles\sdk\bundle.wixproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Condition="'$(MSBuildRestoreSessionId)' != ''" />
+    <ProjectReference Include="..\pkg\windows\bundles\sdk\bundle.wixproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Condition="'$(MSBuildRestoreSessionId)' != ''" />
     <ProjectReference Include="..\finalizer\finalizer.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Private="false" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes the official build BP3 windows legs by making sure that the bundle.wixproj gets restored.