### PR TITLE
Fix offline build for 2xx source-only

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -70,8 +70,7 @@
     <PropertyGroup>
       <_PreviouslySourceBuiltSharedComponentAssetManifests>$(SharedComponentsArtifactsPath)VerticalManifest.xml</_PreviouslySourceBuiltSharedComponentAssetManifests>
       <SharedRepositoryReferenceString>;@(SharedRepositoryReference);</SharedRepositoryReferenceString>
-      <!-- Property to control filtering mode: true = include only tooling components, false = exclude tooling components (default) -->
-      <IncludeOnlyToolingComponents Condition="'$(IncludeOnlyToolingComponents)' == ''">false</IncludeOnlyToolingComponents>
+      <SharedComponentFilterMode Condition="'$(SharedComponentFilterMode)' == ''">NonToolingAndBootstrapOnly</SharedComponentFilterMode>
     </PropertyGroup>
 
     <GetKnownArtifactsFromAssetManifests AssetManifests="$(_PreviouslySourceBuiltSharedComponentAssetManifests)"
@@ -79,17 +78,22 @@
       <Output TaskParameter="KnownPackages" ItemName="_SharedComponentFilteredPackages" />
     </GetKnownArtifactsFromAssetManifests>
 
-    <!-- Filter tooling components based on the mode -->
-    <ItemGroup Condition="'$(IncludeOnlyToolingComponents)' == 'false'">
-      <!-- Default mode: Remove tooling components from the shared packages -->
+    <!-- Non-tooling-and-bootstrap mode: Keep non-tooling components and bootstrap arcade repos -->
+    <ItemGroup Condition="'$(SharedComponentFilterMode)' == 'NonToolingAndBootstrapOnly'">
       <_ItemsToRemove Include="@(_SharedComponentFilteredPackages)"
                       Condition="!$(SharedRepositoryReferenceString.Contains(';%(RepoOrigin);')) or $([System.String]::new(';$(BootstrapArcadeRepos);').Contains(';%(RepoOrigin);'))" />
     </ItemGroup>
-
-    <ItemGroup Condition="'$(IncludeOnlyToolingComponents)' == 'true'">
-      <!-- Alternate mode: Keep only tooling components, remove everything else -->
+    
+    <!-- Tooling-only mode: Keep only tooling components that are not bootstrap arcade repos -->
+    <ItemGroup Condition="'$(SharedComponentFilterMode)' == 'ToolingOnly'">
       <_ItemsToRemove Include="@(_SharedComponentFilteredPackages)"
                       Condition="$(SharedRepositoryReferenceString.Contains(';%(RepoOrigin);')) and !$([System.String]::new(';$(BootstrapArcadeRepos);').Contains(';%(RepoOrigin);'))" />
+    </ItemGroup>
+    
+    <!-- Bootstrap-only mode: Keep only packages from bootstrap arcade repos -->
+    <ItemGroup Condition="'$(SharedComponentFilterMode)' == 'BootstrapOnly'">
+      <_ItemsToRemove Include="@(_SharedComponentFilteredPackages)"
+                      Condition="!$([System.String]::new(';$(BootstrapArcadeRepos);').Contains(';%(RepoOrigin);'))" />
     </ItemGroup>
 
     <!-- Create a lookup string of items to remove -->

--- a/build.proj
+++ b/build.proj
@@ -19,6 +19,8 @@
     <ProjectReference Include="$(RepositoryEngineeringDir)init-detect-binaries.proj"
                       Condition="'$(BuildOS)' != 'windows' and '$(SkipDetectBinaries)' != 'true'"
                       BuildInParallel="true" />
+    <ProjectReference Include="$(RepositoryEngineeringDir)prebuild.proj"
+                      BuildInParallel="true" />
 
     <ProjectReference Include="$(RepoProjectsDir)dotnet.proj" />
 

--- a/eng/init-poison.proj
+++ b/eng/init-poison.proj
@@ -32,7 +32,7 @@
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="GetFilteredSharedComponentPackages"
              Condition="Exists('$(SharedComponentsArtifactsPath)') and !$([System.String]::new(';$(BootstrapArcadeRepos);').Contains(';$(RepositoryName);'))"
-             Properties="IncludeOnlyToolingComponents=true">
+             Properties="SharedComponentFilterMode=ToolingOnly">
       <Output TaskParameter="TargetOutputs" ItemName="_FilteredSharedComponentPackages" />
     </MSBuild>
 

--- a/eng/prebuild.proj
+++ b/eng/prebuild.proj
@@ -1,0 +1,47 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(TasksDir)Microsoft.DotNet.UnifiedBuild.Tasks\Microsoft.DotNet.UnifiedBuild.Tasks.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <SharedComponentsPrereqsArchivePathItem Include="$(ExternalTarballsDir)$(SourceBuiltSharedComponentsTarballName).*$(ArchiveExtension)" />
+  </ItemGroup>
+  <PropertyGroup>
+    <SharedComponentsPrereqsArchiveFile>@(SharedComponentsPrereqsArchivePathItem)</SharedComponentsPrereqsArchiveFile>
+    <HasSharedComponents>false</HasSharedComponents>
+    <HasSharedComponents Condition="'$(SharedComponentsPrereqsArchiveFile)' != '' or '$(CustomSharedComponentsArtifactsPath)' != ''">true</HasSharedComponents>
+  </PropertyGroup>
+
+  <Target Name="UpdateSharedComponentsArtifacts"
+          BeforeTargets="Build"
+          Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(HasSharedComponents)' == 'true'"
+          Outputs="$(BaseIntermediateOutputPath)UpdateNuGetConfig.complete">
+
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="GetFilteredSharedComponentPackages"
+             Properties="SharedComponentFilterMode=BootstrapOnly">
+      <Output TaskParameter="TargetOutputs" ItemName="_BootstrapPackages" />
+    </MSBuild>
+
+    <ItemGroup>
+      <_BootstrapPackagesFilenames Include="@(_BootstrapPackages)">
+        <PackagePath>$(SharedComponentsArtifactsPath)$([System.IO.Path]::GetFileName('%(PipelineArtifactPath)'))</PackagePath>
+      </_BootstrapPackagesFilenames>
+      <_BootstrapPackagesToDelete Include="@(_BootstrapPackagesFilenames->'%(PackagePath)')" />
+    </ItemGroup>
+    <!-- Delete bootstrap packages that shouldn't be included. For example, the Microsoft.NETCore.Platforms package can
+        exist in the shared components from two different origins: SBRP and runtime. Since non-1xx branches have their
+        own SBRP repo, it can create indeterminism from the NuGet.config as to which package should be loaded since
+        source mappings of that package would need to exist for both the current (non-1xx version) of SBRP and
+        shared-components sources.
+     -->
+    <Delete Files="@(_BootstrapPackagesToDelete)" Condition="'@(_BootstrapPackagesToDelete)' != ''" />
+
+  </Target>
+
+</Project>


### PR DESCRIPTION
Offline source-only builds will fail in a non-1xx branch with the following error:

```
  /__w/1/s/src/sdk/src/Layout/redist/redist.csproj : error NU1102: Unable to find package Microsoft.NETCore.Platforms with version (= 10.0.0-preview.7.25377.103) [/__w/1/s/src/sdk/source-build.slnf]
```

The version that's referenced here is the "live" version of `Microsoft.NETCore.Platforms` that comes from the shared components (1xx build artifacts). The problem is that there's no package source mapping defined for `Microsoft.NETCore.Platforms` from the shared components source. There's only a mapping defined for it from SBRP.

This behavior is due to the logic in the `UpdateNuGetConfigPackageSourcesMappings` task. To understand what's happening we first need to look at the package versions that exist in from the shared components:

* 1.1.0
* 5.0.0
* 10.0.0-preview.7.25377.103

And the SBRP repo has these versions:

* 1.1.0
* 5.0.0

Since SBRP is being built in the non-1xx branch, the `UpdateNuGetConfigPackageSourcesMappings` task will classify those package versions as "current" and give them priority. This means that it will not create a mapping for any of the other sources if a package exists in the "current" source. Since one of the versions of `Microsoft.NETCore.Platforms` from the shared components matches the same version that exists in SBRP, it omits out the mapping of `Microsoft.NETCore.Platforms` for the shared component source (a mapping is done on just a package name basis, not version basis). So we miss out on having access to the version of `Microsoft.NETCore.Platforms` that was produced by the 1xx build.

The solution is to strip out the SBRP packages from the shared components feed. They are not needed because the non-1xx branch builds its own SBRP. This is done in a general manner by stripping out all bootstrapped repos which includes arcade and SBRP.