### PR TITLE
Fix PlatformToken value for SDK bundle

### DIFF
--- a/src/sdk/src/Layout/pkg/windows/bundles/sdk/bundle.wixproj
+++ b/src/sdk/src/Layout/pkg/windows/bundles/sdk/bundle.wixproj
@@ -40,7 +40,7 @@
       <DefineConstants>$(DefineConstants);MinimumVSVersion=$(MinimumVSVersion)</DefineConstants>
 
       <!-- PlatformToken is used to generate a generate a WiX variable name using a preprocessor variable so casing matters. -->
-      <DefineConstants>$(DefineConstants);PlatformToken=$(InstallerPlatform.ToUpper())</DefineConstants>
+      <DefineConstants>$(DefineConstants);PlatformToken=$(TargetArchitecture.ToUpper())</DefineConstants>
 
       <!-- Source paths for packages to chain. -->
       <DefineConstants>$(DefineConstants);FinalizerExeSourceFile=$(FinalizerExeSourceFile)</DefineConstants>


### PR DESCRIPTION
## Description

WiX 5 supports native bundles, but we need to retain them as 32-bit. Since the `InstallerPlatform` is always `x86` for bundles, this causes the SDK to always default `DOTNETHOME` to `ProgramFilesFolder` by selecting `DOTNETHOME_X86. It should instead set the variable name based off the `TargetArchitecture`.

## Testing

Manual testing on Sandbox to verify that it now sets the correct directory value. 

Before:
```
[66758:60EA0][2025-08-05T13:12:01]i001: Burn x86 v5.0.2+131262537fc56e24f4ff1afaf35094dc81e2132d, Windows v10.0 x64 (Build 26100: Service Pack 0), path: C:\Users\*****\Downloads\dotnet-sdk-10.0.100-rc.1.25405.103-win-x64.exe
[66758:60EA0][2025-08-05T13:12:01]i000: Initializing formatted variable 'DOTNETHOME' to value '[DOTNETHOME_X86]'
```

After:
```
[191C:1480][2025-08-05T14:26:54]i001: Burn x86 v5.0.2+131262537fc56e24f4ff1afaf35094dc81e2132d, Windows v10.0 x64 (Build 26100: Service Pack 0), path: C:\Users\WDAGUtilityAccount\Documents\dotnet-sdk-10.0.100-dev-win-x64.exe
[191C:1480][2025-08-05T14:26:54]i000: Initializing formatted variable 'DOTNETHOME' to value '[DOTNETHOME_X64]'
```
