### PR TITLE
Add the missing sdl parameter to new unofficial pipelines

### DIFF
--- a/eng/pipelines/source-build-sdk-diff-tests-unofficial.yml
+++ b/eng/pipelines/source-build-sdk-diff-tests-unofficial.yml
@@ -30,6 +30,17 @@ extends:
       name: NetCore1ESPool-Svc-Internal
       image: 1es-ubuntu-2204
       os: linux
+    sdl:
+      sourceAnalysisPool:
+          name: NetCore1ESPool-Svc-Internal
+          image: 1es-windows-2022
+          os: windows
+      binskim:
+        enabled: true
+      policheck:
+        enabled: true
+      tsa:
+        enabled: true
     stages:
     - template: /eng/pipelines/templates/stages/source-build-sdk-diff-tests.yml@self
       parameters:

--- a/eng/pipelines/source-build-sdk-diff-tests-unofficial.yml
+++ b/eng/pipelines/source-build-sdk-diff-tests-unofficial.yml
@@ -35,12 +35,6 @@ extends:
           name: NetCore1ESPool-Svc-Internal
           image: 1es-windows-2022
           os: windows
-      binskim:
-        enabled: true
-      policheck:
-        enabled: true
-      tsa:
-        enabled: true
     stages:
     - template: /eng/pipelines/templates/stages/source-build-sdk-diff-tests.yml@self
       parameters:

--- a/eng/pipelines/vmr-license-scan-unofficial.yml
+++ b/eng/pipelines/vmr-license-scan-unofficial.yml
@@ -28,6 +28,17 @@ extends:
       azurelinuxSourceBuildTestContainer:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-source-build-test-amd64
         options: '--memory=6g'
+    sdl:
+      sourceAnalysisPool:
+          name: NetCore1ESPool-Svc-Internal
+          image: 1es-windows-2022
+          os: windows
+      binskim:
+        enabled: true
+      policheck:
+        enabled: true
+      tsa:
+        enabled: true
     stages:
     - template: /eng/pipelines/templates/stages/vmr-license-scan.yml@self
       parameters:

--- a/eng/pipelines/vmr-license-scan-unofficial.yml
+++ b/eng/pipelines/vmr-license-scan-unofficial.yml
@@ -33,12 +33,6 @@ extends:
           name: NetCore1ESPool-Svc-Internal
           image: 1es-windows-2022
           os: windows
-      binskim:
-        enabled: true
-      policheck:
-        enabled: true
-      tsa:
-        enabled: true
     stages:
     - template: /eng/pipelines/templates/stages/vmr-license-scan.yml@self
       parameters:


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/5290

This is a follow-up to https://github.com/dotnet/dotnet/pull/1745 New pipeline YMLs were created without `sdl` parameter. This caused the pipeline validation failure.

It works fine now - pipeline runs:
https://dev.azure.com/dnceng/internal/_build/results?buildId=2766507&view=results
https://dev.azure.com/dnceng/internal/_build/results?buildId=2766511&view=results
