### PR TITLE
Stop packing ilmerged pack

### DIFF
--- a/src/nuget-client/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/nuget-client/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -213,19 +213,14 @@
 
   <Target Name="CreatePackNupkg">
     <PropertyGroup>
-      <!-- Build from source can't use ILMerge and XPLat builds don't run the ILmerge targets. -->
-      <ILMergeSubpath Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(IsXPlat)' != 'true'">ilmerge\</ILMergeSubpath>
       <PackagePathDir Condition="'$(TargetFramework)' == '$(NETFXTargetFramework)'">Desktop/</PackagePathDir>
       <PackagePathDir Condition="'$(TargetFramework)' == '$(NetStandardVersion)'">CoreCLR/</PackagePathDir>
     </PropertyGroup>
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)NuGet.Build.Tasks.Pack.dll" Condition="'$(DotNetBuildSourceOnly)' != 'true'">
-        <PackagePath>$(PackagePathDir)</PackagePath>
-      </TfmSpecificPackageFile>
       <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)**\NuGet*.resources.dll" Exclude="$(OutputPath)\$(ILMergeSubpath)publish\**\NuGet*.resources.dll">
         <PackagePath>$(PackagePathDir)</PackagePath>
       </TfmSpecificPackageFile>
-      <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)NuGet*.dll" Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+      <TfmSpecificPackageFile Include="$(OutputPath)\$(ILMergeSubpath)NuGet*.dll">
         <PackagePath>$(PackagePathDir)</PackagePath>
       </TfmSpecificPackageFile>
     </ItemGroup>

--- a/src/nuget-client/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/nuget-client/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -66,7 +66,7 @@
   <Target
     Name="PublishAndMergePackNupkg"
     AfterTargets="AfterBuild"
-    Condition="'$(TargetFramework)' != '' AND '$(IsXPlat)' != 'true' AND '$(DotNetBuildSourceOnly)' != 'true' AND '$(BuildingInsideVisualStudio)' != 'true'">
+    Condition="'$(TargetFramework)' != '' AND '$(IsXPlat)' != 'true' AND '$(DotNetBuildSourceOnly)' != 'true' AND '$(DotNetBuildFromVMR)' != 'true' AND '$(BuildingInsideVisualStudio)' != 'true'">
     <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish;ILMergeNuGetPack;ILMergeNuGetPackResourcesPerCulture" />
   </Target>
 
@@ -105,7 +105,7 @@
           DependsOnTargets="GetILMergePlatformArg;DetermineILMergeNuGetPackInputsOutputs"
           Inputs="$(PathToBuiltNuGetPack);@(BuildArtifacts)"
           Outputs="$(PathToMergedNuGetPack)"
-          Condition="'$(TargetFramework)' != '' AND '$(DotNetBuildSourceOnly)' != 'true' ">
+          Condition="'$(TargetFramework)' != '' AND '$(DotNetBuildSourceOnly)' != 'true' AND '$(DotNetBuildFromVMR)' != 'true' ">
     <PropertyGroup>
       <ILMergeResultDir>$([System.IO.Path]::GetDirectoryName($(PathToMergedNuGetPack)))</ILMergeResultDir>
     </PropertyGroup>


### PR DESCRIPTION
An attempt to unblock https://github.com/dotnet/sdk/pull/50073. 

For simplicity, I'm just fixing up pack but not stopping the ilmerge. I'll do that in a follow-up PR on the NuGet side that has tests. 

This is just the faster way to flow the changes.