### PR TITLE
Increment PreReleaseVersion for nuget-client

### DIFF
--- a/src/nuget-client/build/config.props
+++ b/src/nuget-client/build/config.props
@@ -47,6 +47,8 @@
   <!--Setting the Pre-release/Build meta-data from CI if Version is set-->
   <PropertyGroup Condition="'$(BuildNumber)' != ''">
     <PreReleaseVersion>$(BuildNumber)</PreReleaseVersion>
+    <!-- Add 100 to the revision number to avoid clashing with the existing msft official build. -->
+    <PreReleaseVersion Condition="'$(DotNetBuildFromVMR)' == 'true'">$([MSBuild]::Add($(BuildNumber), 100))</PreReleaseVersion>
   </PropertyGroup>
 
   <!--Setting the product information for Beta builds-->


### PR DESCRIPTION
This mimics what is done for OfficialBuildId: https://github.com/dotnet/dotnet/blob/642154c2e9842942eba21f488fd092bc6ca7d03e/repo-projects/Directory.Build.props#L83

nuget-client doesn't use OfficialBuildId as it doesn't use the Arcade SDK. Manually increment the PreReleaseVersion.