### PR TITLE
Fixup NuGet versioning again

### DIFF
--- a/src/nuget-client/build/common.project.props
+++ b/src/nuget-client/build/common.project.props
@@ -147,8 +147,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- Assembly attributes for net core projects -->
-    <AssemblyVersion>$(SemanticVersion).$(PreReleaseVersion)</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetFramework)' == '$(NETFXTargetFramework)'">$(SemanticVersion).$(PreReleaseVersion)</AssemblyVersion>
+    <AssemblyVersion Condition="'$(TargetFramework)' == '$(NETCoreTargetFramework)'">$(SemanticVersion).0</AssemblyVersion>
     <FileVersion>$(SemanticVersion).$(PreReleaseVersion)</FileVersion>
     <InformationalVersion Condition="'$(BUILD_SOURCEVERSION)' == ''">$(SemanticVersion)$(PreReleaseInformationVersion)</InformationalVersion>
     <InformationalVersion Condition="'$(BUILD_SOURCEVERSION)' != ''">$(SemanticVersion)$(PreReleaseInformationVersion)+$(BUILD_SOURCEVERSION)</InformationalVersion>

--- a/src/nuget-client/build/config.props
+++ b/src/nuget-client/build/config.props
@@ -41,14 +41,14 @@
   </PropertyGroup>
 
  <PropertyGroup Condition=" '$(PreReleaseVersion)' == '' ">
-    <PreReleaseVersion>32767</PreReleaseVersion>
+    <!-- This number is chosen to be higher than the assembly versions that the VMR-built NuGet uses, so that a dev build of NuGet can be patched over
+         the VMR build. -->
+    <PreReleaseVersion>65534</PreReleaseVersion>
   </PropertyGroup>
 
   <!--Setting the Pre-release/Build meta-data from CI if Version is set-->
   <PropertyGroup Condition="'$(BuildNumber)' != ''">
     <PreReleaseVersion>$(BuildNumber)</PreReleaseVersion>
-    <!-- Add 500 to the revision number to avoid clashing with the existing msft official build. -->
-    <PreReleaseVersion Condition="'$(DotNetBuildFromVMR)' == 'true'">$([MSBuild]::Add($(BuildNumber), 500))</PreReleaseVersion>
   </PropertyGroup>
 
   <!--Setting the product information for Beta builds-->


### PR DESCRIPTION
- Use 65534 as the build number in dev builds so that it is higher than any of the .NET VMR or NuGet official builds.
- Pin the last quartile (love that word) of the assembly version to .0 for NETCore. This doens't affect assembly loading since there is no SxS.
- Eliminate the +500 for the build number. Not necesssary since we are using the full date based number % 50000.