### PR TITLE
Remove whitespace from property name

### DIFF
--- a/src/sdk/src/Layout/Directory.Build.props
+++ b/src/sdk/src/Layout/Directory.Build.props
@@ -57,7 +57,7 @@
          because it is large (100MB+). -->
     <_IsCommunityPlatform Condition="'$(OSName)' != 'win' and '$(OSName)' != 'osx' 
       and !('$(OSName)' == 'linux' and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'x86' or '$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'arm64'))">true</_IsCommunityPlatform>
-    <BundleCrossgen2 Condition="'$(BundleCrossgen2)' == '' and '$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetBuildUseMonoRuntime)' != 'true' and '$( _IsCommunityPlatform )' == 'true'">true</BundleCrossgen2>
+    <BundleCrossgen2 Condition="'$(BundleCrossgen2)' == '' and '$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetBuildUseMonoRuntime)' != 'true' and '$(_IsCommunityPlatform)' == 'true'">true</BundleCrossgen2>
 
     <!-- Use the portable "linux-x64" Rid when downloading Linux shared framework compressed file. -->
     <UsePortableLinuxSharedFramework Condition="'$(UsePortableLinuxSharedFramework)' == '' and '$(IsLinux)' == 'true' and !$(TargetRid.StartsWith('linux-musl'))">true</UsePortableLinuxSharedFramework>


### PR DESCRIPTION
Apparently, msbuild evaluates it with whitespaces as a different property.