### PR TITLE
Use SB artifacts RID

### DIFF
--- a/eng/pipelines/templates/stages/source-build-and-validate.yml
+++ b/eng/pipelines/templates/stages/source-build-and-validate.yml
@@ -39,17 +39,17 @@ stages:
           container:
             name: ${{ variables.centOSStreamContainerName }}
             image: ${{ variables.centOSStreamContainerImage }}
+          artifactsRid: ${{ variables.centOSStreamX64Rid }}
           ${{ if ne(leg.reuseBuildArtifactsFrom, '') }}:
             reuseBuildArtifactsFrom:
             - ${{ format(leg.reuseBuildArtifactsFrom, variables.centOSStreamName) }}
-          ${{ if and(contains(leg.buildNameFormat, 'Previous'), eq(leg.targetArchitecture, 'x64')) }}:
-            artifactsRid: ${{ variables.centOSStreamX64Rid }}
         # Fedora
         ${{ elseif eq(leg.distro, 'fedora') }}:
           buildName: ${{ format(leg.buildNameFormat, variables.fedoraName) }}
           container:
             name: ${{ variables.fedoraContainerName }}
             image: ${{ variables.fedoraContainerImage }}
+          artifactsRid: ${{ variables.fedoraX64Rid }}
           ${{ if ne(leg.reuseBuildArtifactsFrom, '') }}:
             reuseBuildArtifactsFrom:
             - ${{ format(leg.reuseBuildArtifactsFrom, variables.fedoraName) }}
@@ -65,6 +65,10 @@ stages:
             container:
               name: ${{ variables.ubuntuContainerName }}
               image: ${{ variables.ubuntuContainerImage }}
+          ${{ if eq(leg.targetArchitecture, 'arm64') }}:
+            artifactsRid: ${{ variables.ubuntuArm64Rid }}
+          ${{ else }}:
+            artifactsRid: ${{ variables.ubuntuX64Rid }}
           ${{ if ne(leg.reuseBuildArtifactsFrom, '') }}:
             reuseBuildArtifactsFrom:
             - ${{ format(leg.reuseBuildArtifactsFrom, variables.centOSStreamName) }}
@@ -74,20 +78,22 @@ stages:
           container:
             name: ${{ variables.almaLinuxContainerName }}
             image: ${{ variables.almaLinuxContainerImage }}
+          artifactsRid: ${{ variables.almaLinuxX64Rid }}
+          targetRid: ${{ variables.almaLinuxX64Rid }}
           ${{ if ne(leg.reuseBuildArtifactsFrom, '') }}:
             reuseBuildArtifactsFrom:
             - ${{ format(leg.reuseBuildArtifactsFrom, variables.centOSStreamName) }}
-          targetRid: ${{ variables.almaLinuxX64Rid }}
         # Alpine
         ${{ elseif eq(leg.distro, 'alpine') }}:
           buildName: ${{ format(leg.buildNameFormat, variables.alpineName) }}
           container:
             name: ${{ variables.alpineContainerName }}
             image: ${{ variables.alpineContainerImage }}
+          artifactsRid: ${{ variables.alpineX64Rid }}
+          targetRid: ${{ variables.alpineX64Rid }}
           ${{ if ne(leg.reuseBuildArtifactsFrom, '') }}:
             reuseBuildArtifactsFrom:
             - ${{ format(leg.reuseBuildArtifactsFrom, variables.centOSStreamName) }}
-          targetRid: ${{ variables.alpineX64Rid }}
         
         targetArchitecture: ${{ leg.targetArchitecture }}
         isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}

--- a/prep-source-build.sh
+++ b/prep-source-build.sh
@@ -230,12 +230,10 @@ function DownloadArchive {
   fi
 
   local archiveUrl
-  if [[ "$propertyName" == "MicrosoftNETSdkVersion" ]]; then
+  if [[ "$propertyName" == "MicrosoftNETSdkVersion" || "$propertyName" == *Artifacts* ]]; then
     archiveUrl="https://ci.dot.net/public/source-build/$artifactsBaseFileName.$archiveVersion.$artifactsRid.tar.gz"
   elif [[ "$propertyName" == *Prebuilts* ]]; then
     archiveUrl="https://builds.dotnet.microsoft.com/source-built-artifacts/assets/$prebuiltsBaseFileName.$archiveVersion.$defaultArtifactsRid.tar.gz"
-  elif [[ "$propertyName" == *Artifacts* ]]; then
-    archiveUrl="https://builds.dotnet.microsoft.com/source-built-artifacts/assets/$artifactsBaseFileName.$archiveVersion.$artifactsRid.tar.gz"
   else
     echo "  ERROR: Unknown archive property name: $propertyName"
     exit 1
@@ -312,11 +310,7 @@ if [ "$downloadPsbArtifacts" == true ]; then
 fi
 
 if [ "$downloadSharedComponentsArtifacts" == true ]; then
-  source $REPO_ROOT/eng/common/native/init-os-and-arch.sh
-  source $REPO_ROOT/eng/common/native/init-distro-rid.sh
-  initDistroRidGlobal "$os" "$arch" ""
-
-  DownloadArchive "shared component artifacts" "MicrosoftNETSdkVersion" false "$__DistroRid" "$packagesArchiveDir" "$sharedComponentsBaseFileName"
+  DownloadArchive "shared component artifacts" "MicrosoftNETSdkVersion" false "$artifactsRid" "$packagesArchiveDir" "$sharedComponentsBaseFileName"
 fi
 
 if [ "$downloadPrebuilts" == true ]; then


### PR DESCRIPTION
Contributes to https://github.com/dotnet/dotnet/issues/1011

To support non-1xx feature bands for source-only builds, the prep script downloads the SB artifacts that came were produced from the corresponding 1xx build. This is known as the shared components artifacts tarball.

However, the logic to determine the URL from which to download this tarball is incorrect. The filename contains the RID value. The script is using Arcade scripts to get the RID but that RID doesn't align with the RID defined in the tarball. The RID for the tarball is actually defined by the pipeline ([example](https://github.com/dotnet/dotnet/blob/a7b5a075945764f5e1775604300e3a8b7c12b24e/eng/pipelines/templates/stages/source-build-and-validate.yml#L90)). To fix this, we need to align with the RID being used by the pipeline.

The prep script already happens to have an `artifactsRid` option. But that applies to the downloading of the PSB artifacts, which today is only ever valid to use the `centos.<version>-x64` RID since that is the only artifacts tarball we publish from where this downloads from. So, without any other changes, setting `artifactsRid` wouldn't work in cases like `almalinux.8-x64`.

Instead, we can consolidate the manner in which we retrieve SB artifacts between PSB and shared components. Today these are referenced in different ways. PSB artifacts get published as part of the SB release process and referenced from `https://builds.dotnet.microsoft.com/source-built-artifacts/assets`. And shared components artifacts are published via Arcade from VMR builds and are referenced from `https://ci.dot.net/public/source-build`.

These changes align the reference of the artifacts so that we always consume the artifacts published by Arcade at `https://ci.dot.net/public/source-build`. This allows `artifactsRid` to be set in all cases and be able to retrieve the corresponding tarball for both PSB and shared components.

Furthermore, this means that SB artifact publishing can be removed from the SB release process as these won't be consumed anymore.