### PR TITLE
Package installer test support for non-1xx branches

### DIFF
--- a/test/Microsoft.DotNet.Installer.Tests/Config.cs
+++ b/test/Microsoft.DotNet.Installer.Tests/Config.cs
@@ -40,6 +40,12 @@ public static class Config
     public static bool KeepDockerImages { get; } = TryGetRuntimeConfig(KeepDockerImagesSwitch, out bool value) ? value : false;
     const string KeepDockerImagesSwitch = RuntimeConfigSwitchPrefix + nameof(KeepDockerImages);
 
+    public static bool DotNetBuildSharedComponents { get; } = TryGetRuntimeConfig(DotNetBuildSharedComponentsSwitch, out bool value) ? value : false;
+    const string DotNetBuildSharedComponentsSwitch = RuntimeConfigSwitchPrefix + nameof(DotNetBuildSharedComponents);
+
+    public static string Sdk1xxVersion { get; } = GetRuntimeConfig(Sdk1xxVersionSwitch);
+    const string Sdk1xxVersionSwitch = RuntimeConfigSwitchPrefix + nameof(Sdk1xxVersion);
+
     public const string RuntimeConfigSwitchPrefix = "Microsoft.DotNet.Installer.Tests.";
 
     public static Architecture GetArchitecture(string architecture) => architecture switch

--- a/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
+++ b/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
@@ -44,6 +44,12 @@
       <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).KeepDockerImages">
         <Value>$(KeepDockerImages)</Value>
       </RuntimeHostConfigurationOption>
+      <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).DotNetBuildSharedComponents">
+        <Value>$(DotNetBuildSharedComponents)</Value>
+      </RuntimeHostConfigurationOption>
+      <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).Sdk1xxVersion">
+        <Value>$(MicrosoftNETSdkVersion)</Value>
+      </RuntimeHostConfigurationOption>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Contributes to https://github.com/dotnet/dotnet/issues/1011

The package installer tests in the VMR pipeline require the ability to install the `dotnet-sdk` deb/rpm packages. But these packages are dependent on the runtime packages (e.g. `dotnet-runtime`) which are not produced in a non-1xx branch of the VMR.

To solve this, these dependent packages are downloaded from ci.dot.net where they've been published by Arcade for each VMR build. The version of the 1xx build is determined by the VMR's configuration where it has a `MicrosoftNETSdkVersion` property that indicates this dependency. The condition for knowing whether this is in the context of a 1xx branch or not is determined by the `DotNetBuildSharedComponents` property which is `true` only in the context of a 1xx branch.