### PR TITLE
Don't publish portable RID packages in SB tarball and enable bootstrapping a new RID from an existing SB SDK

### DIFF
--- a/eng/PublishSourceBuild.props
+++ b/eng/PublishSourceBuild.props
@@ -86,9 +86,14 @@
           Inputs="@(PackageToPublish);$(SourceBuiltVersionInputName);$(AssetManifestFilePath)"
           Outputs="$(SourceBuiltTarballName);$(SourceBuiltVersionName);$(AllPackageVersionsPropsName);$(SourceBuiltMergedAssetManifestName)"
           Condition="'$(IsPublishPass2)' != 'true'">
+    <ItemGroup>
+      <PackageToPublish>
+        <IncludeInSBTarball Condition="'%(PackageToPublish.Visibility)' != 'Vertical'">true</IncludeInSBTarball>
+      </PackageToPublish>
+    </ItemGroup>
     <!-- Copy packages to layout directory. Since there are a large number of files,
           this will use symlinks instead of copying files to make this execute quickly. -->
-    <Copy SourceFiles="@(PackageToPublish)"
+    <Copy SourceFiles="@(PackageToPublish->WithMetadataValue('IncludeInSBTarball','true'))"
           DestinationFolder="$(SourceBuiltLayoutDir)"
           UseSymbolicLinksIfPossible="true" />
 
@@ -103,7 +108,7 @@
           UseSymbolicLinksIfPossible="true" />
 
     <!-- Create a PackageVersions.props file that includes entries for all packages. -->
-    <WritePackageVersionsProps KnownPackages="@(ProducedPackage->Metadata('PackageId'))"
+    <WritePackageVersionsProps KnownPackages="@(ProducedPackage->WithMetadataValue('IncludeInSBTarball','true')->Metadata('PackageId'))"
                                ExtraProperties="@(ExtraPackageVersionPropsPackageInfo)"
                                VersionPropsFlowType="AllPackages"
                                OutputPath="$(AllPackageVersionsPropsName)"

--- a/src/runtime/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/runtime/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -20,9 +20,16 @@
     <_generateRuntimeGraphTask>$([MSBuild]::NormalizePath('$(BaseOutputPath)', $(Configuration), '$(_generateRuntimeGraphTargetFramework)', '$(AssemblyName).dll'))</_generateRuntimeGraphTask>
   </PropertyGroup>
 
-  <ItemGroup>
-    <!-- When building from source, ensure the RID we're building for is part of the RID graph. -->
-    <AdditionalRuntimeIdentifiers Include="$(TargetRid)" Imports="$(PortableTargetRid)" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+    <!--
+      When building from source, ensure the RID we're building for and the RID we're building on are part of the RID graph.
+      The RID we're targeting may not be part of the graph because source-build builds are generally non-portable.
+      The RID we're building on may not be part of the RID graph if we are being built with a source-built SDK.
+      If we're cross-building (for example building source-build for a new version of an existing distro and bootstrapping from an old version)
+      then the RID we're building on would be different than the RID we're targeting.
+    -->
+    <AdditionalRuntimeIdentifiers Include="$(TargetRid)" Imports="$(PortableTargetRid)" />
+    <AdditionalRuntimeIdentifiers Include="$(NETCoreSdkRuntimeIdentifier)" Imports="$(NETCoreSdkPortableRuntimeIdentifier)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/5225

cc: @tmds 