### PR TITLE
`SignType` variables must be lowercase

### DIFF
--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -82,7 +82,7 @@ variables:
   - name: signEnabled
     value: true
   - name: signType
-    value: Real
+    value: real
   - ${{ if and(eq(parameters.isOfficialBuild, true), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))) }}:
     - name: signDacEnabled
       value: true
@@ -93,7 +93,7 @@ variables:
   - name: signEnabled
     value: true
   - name: signType
-    value: Test
+    value: test
   - name: signDacEnabled
     value: false
 - ${{ elseif eq(parameters.desiredSigning, 'Signed (Dry Run)') }}:


### PR DESCRIPTION
Arcade expects these values to be lowercase, when they are not, conditions that check the `DotNetSignType` value evaluate to false.

As explained in https://github.com/dotnet/dotnet/issues/1949, this doesn't affect real signing, but it does affect test signing.