### PR TITLE
Cleanup PreviouslySourceBuiltPreferencePackageDir

### DIFF
--- a/eng/VmrLayout.props
+++ b/eng/VmrLayout.props
@@ -41,8 +41,6 @@
 
     <SbrpRepoSrcDir>$([MSBuild]::NormalizeDirectory('$(SrcDir)', 'source-build-reference-packages', 'src'))</SbrpRepoSrcDir>
     <ReferencePackagesDir>$([MSBuild]::NormalizeDirectory('$(PrereqsPackagesDir)', 'reference'))</ReferencePackagesDir>
-    <PreviouslySourceBuiltReferencePackagesDirName>SourceBuildReferencePackages</PreviouslySourceBuiltReferencePackagesDirName>
-    <PreviouslySourceBuiltReferencePackagesDir>$([MSBuild]::NormalizeDirectory('$(PreviouslySourceBuiltPackagesPath)', '$(PreviouslySourceBuiltReferencePackagesDirName)'))</PreviouslySourceBuiltReferencePackagesDir>
     <SourceBuiltArtifactsTarballName>Private.SourceBuilt.Artifacts</SourceBuiltArtifactsTarballName>
     <SourceBuiltSharedComponentsTarballName>Private.SourceBuilt.SharedComponents</SourceBuiltSharedComponentsTarballName>
     <SourceBuiltPrebuiltsTarballName>Private.SourceBuilt.Prebuilts</SourceBuiltPrebuiltsTarballName>

--- a/eng/init-source-only.proj
+++ b/eng/init-source-only.proj
@@ -172,24 +172,8 @@
   <Target Name="ExtractToolsetPackages" DependsOnTargets="UnpackTarballs">
     <ItemGroup>
       <ToolsetPackage Include="Microsoft.DotNet.Arcade.Sdk" SourceFolder="$(PreviouslySourceBuiltPackagesPath)" Version="$(ARCADE_BOOTSTRAP_VERSION)" />
-
-      <!-- Remove the entries referencing PreviouslySourceBuiltReferencePackagesDir after rebootstrapping to pick up https://github.com/dotnet/dotnet/pull/1132 -->
-      <ToolsetPackage Include="Microsoft.Build.NoTargets" 
-                      SourceFolder="$(PreviouslySourceBuiltPackagesPath)"
-                      Version="$(NOTARGETS_BOOTSTRAP_VERSION)"
-                      Condition="!Exists('$(PreviouslySourceBuiltReferencePackagesDir)')" />
-      <ToolsetPackage Include="Microsoft.Build.Traversal"
-                      SourceFolder="$(PreviouslySourceBuiltPackagesPath)"
-                      Version="$(TRAVERSAL_BOOTSTRAP_VERSION)"
-                      Condition="!Exists('$(PreviouslySourceBuiltReferencePackagesDir)')" />
-      <ToolsetPackage Include="Microsoft.Build.NoTargets"
-                      SourceFolder="$(PreviouslySourceBuiltReferencePackagesDir)"
-                      Version="$(NOTARGETS_BOOTSTRAP_VERSION)"
-                      Condition="Exists('$(PreviouslySourceBuiltReferencePackagesDir)')" />
-      <ToolsetPackage Include="Microsoft.Build.Traversal"
-                      SourceFolder="$(PreviouslySourceBuiltReferencePackagesDir)"
-                      Version="$(TRAVERSAL_BOOTSTRAP_VERSION)"
-                      Condition="Exists('$(PreviouslySourceBuiltReferencePackagesDir)')" />
+      <ToolsetPackage Include="Microsoft.Build.NoTargets" SourceFolder="$(PreviouslySourceBuiltPackagesPath)" Version="$(NOTARGETS_BOOTSTRAP_VERSION)"  />
+      <ToolsetPackage Include="Microsoft.Build.Traversal" SourceFolder="$(PreviouslySourceBuiltPackagesPath)" Version="$(TRAVERSAL_BOOTSTRAP_VERSION)" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This is a follow-up to https://github.com/dotnet/dotnet/pull/1132 now that reference packages are no longer in the previous artifacts for source-build.