### PR TITLE
Include shared component packages in SB artifacts

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,7 @@
 <Project>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" Condition="'$(SkipArcadeSdkImport)' != 'true'" />
+  <Import Project="$(RepositoryEngineeringDir)shared-source-only.targets" />
 
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.GetKnownArtifactsFromAssetManifests" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
 
@@ -52,49 +53,4 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="GetFilteredSharedComponentPackages"
-          Outputs="@(SharedComponentFilteredPackages)">
-
-    <PropertyGroup>
-      <_PreviouslySourceBuiltSharedComponentAssetManifests>$(SharedComponentsArtifactsPath)VerticalManifest.xml</_PreviouslySourceBuiltSharedComponentAssetManifests>
-      <SharedRepositoryReferenceString>;@(SharedRepositoryReference);</SharedRepositoryReferenceString>
-      <SharedComponentFilterMode Condition="'$(SharedComponentFilterMode)' == ''">NonToolingAndBootstrapOnly</SharedComponentFilterMode>
-    </PropertyGroup>
-
-    <GetKnownArtifactsFromAssetManifests AssetManifests="$(_PreviouslySourceBuiltSharedComponentAssetManifests)"
-                                         Condition="Exists($(_PreviouslySourceBuiltSharedComponentAssetManifests))">
-      <Output TaskParameter="KnownPackages" ItemName="SharedComponentFilteredPackages" />
-    </GetKnownArtifactsFromAssetManifests>
-
-    <!-- Non-tooling-and-bootstrap mode: Keep non-tooling components and bootstrap arcade repos -->
-    <ItemGroup Condition="'$(SharedComponentFilterMode)' == 'NonToolingAndBootstrapOnly'">
-      <_ItemsToRemove Include="@(SharedComponentFilteredPackages)"
-                      Condition="!$(SharedRepositoryReferenceString.Contains(';%(RepoOrigin);')) and !$([System.String]::new(';$(BootstrapArcadeRepos);').Contains(';%(RepoOrigin);'))" />
-    </ItemGroup>
-    
-    <!-- Tooling-only mode: Keep only tooling components that are not bootstrap arcade repos -->
-    <ItemGroup Condition="'$(SharedComponentFilterMode)' == 'ToolingOnly'">
-      <_ItemsToRemove Include="@(SharedComponentFilteredPackages)"
-                      Condition="$(SharedRepositoryReferenceString.Contains(';%(RepoOrigin);')) or $([System.String]::new(';$(BootstrapArcadeRepos);').Contains(';%(RepoOrigin);'))" />
-    </ItemGroup>
-    
-    <!-- Bootstrap-only mode: Keep only packages from bootstrap arcade repos -->
-    <ItemGroup Condition="'$(SharedComponentFilterMode)' == 'BootstrapOnly'">
-      <_ItemsToRemove Include="@(SharedComponentFilteredPackages)"
-                      Condition="!$([System.String]::new(';$(BootstrapArcadeRepos);').Contains(';%(RepoOrigin);'))" />
-    </ItemGroup>
-
-    <!-- Create a lookup string of items to remove -->
-    <PropertyGroup>
-      <_ItemsToRemoveString>@(_ItemsToRemove->'%(Identity)::%(Version)', ';')</_ItemsToRemoveString>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <SharedComponentFilteredPackages Remove="@(SharedComponentFilteredPackages)" 
-                                        Condition="'@(_ItemsToRemove)' != '' and 
-                                                   '$(_ItemsToRemoveString)' != '' and
-                                                   $(_ItemsToRemoveString.Contains($([System.String]::Concat('%(Identity)', '::', '%(Version)'))))" />
-    </ItemGroup>
-
-  </Target>
 </Project>

--- a/eng/PublishSourceBuild.props
+++ b/eng/PublishSourceBuild.props
@@ -1,4 +1,6 @@
 <Project>
+  <Import Project="$(RepositoryEngineeringDir)shared-source-only.targets" />
+
   <!-- Add targets here that run logic that depends on the merged asset manifest and published packages. -->
   <UsingTask TaskName="Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.CheckForPoison" AssemblyFile="$(MicrosoftDotNetSourceBuildTasksLeakDetectionAssembly)" TaskFactory="TaskHostFactory" Condition="'$(EnablePoison)' == 'true'" />
   <Target Name="ReportPoisonUsage"
@@ -80,14 +82,21 @@
     </PropertyGroup>
   </Target>
 
+  <PropertyGroup>
+    <SharedComponentFilterMode>NonToolingOnly</SharedComponentFilterMode>
+    <CreatePrivateSourceBuiltArtifactsArchiveDependsOn>DiscoverArtifacts;GetOutputsForCreatePrivateSourceBuiltArtifactsArchive</CreatePrivateSourceBuiltArtifactsArchiveDependsOn>
+    <CreatePrivateSourceBuiltArtifactsArchiveDependsOn Condition="Exists('$(SharedComponentsArtifactsPath)')">
+      $(CreatePrivateSourceBuiltArtifactsArchiveDependsOn);GetFilteredSharedComponentPackages
+    </CreatePrivateSourceBuiltArtifactsArchiveDependsOn>
+  </PropertyGroup>
+
   <!-- Create the SourceBuilt.Private.Artifacts archive when building source-only. -->
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.WritePackageVersionsProps" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
   <Target Name="CreatePrivateSourceBuiltArtifactsArchive"
           AfterTargets="Publish"
-          DependsOnTargets="DiscoverArtifacts;GetOutputsForCreatePrivateSourceBuiltArtifactsArchive"
+          DependsOnTargets="$(CreatePrivateSourceBuiltArtifactsArchiveDependsOn)"
           Inputs="@(PackageToPublish);$(SourceBuiltVersionInputName);$(AssetManifestFilePath)"
-          Outputs="$(SourceBuiltTarballName);$(SourceBuiltVersionName);$(AllPackageVersionsPropsName);$(SourceBuiltMergedAssetManifestName)"
-          Condition="'$(IsPublishPass2)' != 'true'">
+          Outputs="$(SourceBuiltTarballName);$(SourceBuiltVersionName);$(AllPackageVersionsPropsName);$(SourceBuiltMergedAssetManifestName)">
     <ItemGroup>
       <PackageToPublish>
         <IncludeInSBTarball Condition="'%(PackageToPublish.Visibility)' != 'Vertical'">true</IncludeInSBTarball>
@@ -96,9 +105,10 @@
         <IncludeInSBTarball Condition="'%(ProducedPackage.Visibility)' != 'Vertical'">true</IncludeInSBTarball>
       </ProducedPackage>
     </ItemGroup>
+    
     <!-- Copy packages to layout directory. Since there are a large number of files,
           this will use symlinks instead of copying files to make this execute quickly. -->
-    <Copy SourceFiles="@(PackageToPublish->WithMetadataValue('IncludeInSBTarball','true'))"
+    <Copy SourceFiles="@(PackageToPublish->WithMetadataValue('IncludeInSBTarball','true'));@(SharedComponentFilteredPackages->'%(PackagePath)')"
           DestinationFolder="$(SourceBuiltLayoutDir)"
           UseSymbolicLinksIfPossible="true" />
 
@@ -125,7 +135,7 @@
           UseSymbolicLinksIfPossible="true" />
 
     <!-- Create a PackageVersions.props file that includes entries for all packages. -->
-    <WritePackageVersionsProps KnownPackages="@(ProducedPackage->WithMetadataValue('IncludeInSBTarball','true')->Metadata('PackageId'))"
+    <WritePackageVersionsProps KnownPackages="@(ProducedPackage->WithMetadataValue('IncludeInSBTarball','true')->Metadata('PackageId'));@(SharedComponentFilteredPackages)"
                                ExtraProperties="@(ExtraPackageVersionPropsPackageInfo)"
                                VersionPropsFlowType="AllPackages"
                                OutputPath="$(AllPackageVersionsPropsName)"
@@ -159,6 +169,17 @@
           SkipUnchangedFiles="true">
       <Output TaskParameter="CopiedFiles" ItemName="FileWrites" />
     </Copy>
+  </Target>
+
+  <Target Name="IncludeSharedComponentsAsArtifacts"
+          AfterTargets="DiscoverArtifacts"
+          DependsOnTargets="GetFilteredSharedComponentPackages">
+
+    <ItemGroup>
+      <Artifact Include="@(SharedComponentFilteredPackages->'%(PackagePath)')">
+        <Kind>Package</Kind>
+      </Artifact>
+    </ItemGroup>
   </Target>
 
 </Project>

--- a/eng/clean-shared-components.proj
+++ b/eng/clean-shared-components.proj
@@ -25,10 +25,7 @@
           Outputs="$(BaseIntermediateOutputPath)UpdateSharedComponentsArtifacts.complete">
 
     <ItemGroup>
-      <_BootstrapPackagesFilenames Include="@(SharedComponentFilteredPackages)">
-        <PackagePath>$(SharedComponentsArtifactsPath)$([System.IO.Path]::GetFileName('%(PipelineArtifactPath)'))</PackagePath>
-      </_BootstrapPackagesFilenames>
-      <_BootstrapPackagesToDelete Include="@(_BootstrapPackagesFilenames->'%(PackagePath)')" />
+      <_BootstrapPackagesToDelete Include="@(SharedComponentFilteredPackages->'%(PackagePath)')" />
     </ItemGroup>
     <!-- Delete bootstrap packages that shouldn't be included. For example, the Microsoft.NETCore.Platforms package can
         exist in the shared components from two different origins: SBRP and runtime. Since non-1xx branches have their

--- a/eng/init-poison.proj
+++ b/eng/init-poison.proj
@@ -45,10 +45,7 @@
            Text="Expected NuGet packages to be present from shared components artifacts." />
 
     <ItemGroup>
-      <_SharedToolingComponentFilenames Include="@(_FilteredSharedComponentPackages)">
-        <PackagePath>$(SharedComponentsArtifactsPath)$([System.IO.Path]::GetFileName('%(PipelineArtifactPath)'))</PackagePath>
-      </_SharedToolingComponentFilenames>
-      <SharedComponentPackagesToPoison Include="@(_SharedToolingComponentFilenames->'%(PackagePath)')" />
+      <SharedComponentPackagesToPoison Include="@(_FilteredSharedComponentPackages->'%(PackagePath)')" />
     </ItemGroup>
 
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Poisoning existing packages for leak detection." />

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -517,7 +517,11 @@ jobs:
             customPrepArgs="${customPrepArgs} --no-sdk --no-bootstrap"
             prepSdk=false
           elif [[ '${{ length(parameters.reuseBuildArtifactsFrom) }}' -gt '0' ]]; then
-            customPrepArgs="${customPrepArgs} --no-sdk --no-artifacts"
+            # Don't use --no-artifacts because it will prevent the shared components archive from being
+            # downloaded in non-1xx branches. It's ok to not provide this option since the downloading
+            # of the PSB artifacts will be skipped anyway because we've already manually copied the file
+            # to use at the expected location.
+            customPrepArgs="${customPrepArgs} --no-sdk"
             prepSdk=false
           fi
 

--- a/eng/shared-source-only.targets
+++ b/eng/shared-source-only.targets
@@ -1,0 +1,60 @@
+<Project>
+
+  <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.GetKnownArtifactsFromAssetManifests" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
+
+  <Target Name="GetFilteredSharedComponentPackages"
+          Outputs="@(SharedComponentFilteredPackages)">
+
+    <PropertyGroup>
+      <SharedRepositoryReferenceString>;@(SharedRepositoryReference);</SharedRepositoryReferenceString>
+      <SharedComponentFilterMode Condition="'$(SharedComponentFilterMode)' == ''">NonToolingAndBootstrapOnly</SharedComponentFilterMode>
+    </PropertyGroup>
+
+    <GetKnownArtifactsFromAssetManifests AssetManifests="$(SharedComponentAssetManifests)"
+                                         Condition="Exists($(SharedComponentAssetManifests))">
+      <Output TaskParameter="KnownPackages" ItemName="SharedComponentFilteredPackages" />
+    </GetKnownArtifactsFromAssetManifests>
+
+    <!-- Non-tooling-and-bootstrap mode: Keep non-tooling components and bootstrap arcade repos -->
+    <ItemGroup Condition="'$(SharedComponentFilterMode)' == 'NonToolingAndBootstrapOnly'">
+      <_ItemsToRemove Include="@(SharedComponentFilteredPackages)"
+                      Condition="!$(SharedRepositoryReferenceString.Contains(';%(RepoOrigin);')) and !$([System.String]::new(';$(BootstrapArcadeRepos);').Contains(';%(RepoOrigin);'))" />
+    </ItemGroup>
+
+    <!-- Non-tooling-only mode: Keep only non-tooling components that are not bootstrap arcade repos -->
+    <ItemGroup Condition="'$(SharedComponentFilterMode)' == 'NonToolingOnly'">
+      <_ItemsToRemove Include="@(SharedComponentFilteredPackages)"
+                      Condition="!$(SharedRepositoryReferenceString.Contains(';%(RepoOrigin);'))" />
+    </ItemGroup>
+    
+    <!-- Tooling-only mode: Keep only tooling components that are not bootstrap arcade repos -->
+    <ItemGroup Condition="'$(SharedComponentFilterMode)' == 'ToolingOnly'">
+      <_ItemsToRemove Include="@(SharedComponentFilteredPackages)"
+                      Condition="$(SharedRepositoryReferenceString.Contains(';%(RepoOrigin);')) or $([System.String]::new(';$(BootstrapArcadeRepos);').Contains(';%(RepoOrigin);'))" />
+    </ItemGroup>
+    
+    <!-- Bootstrap-only mode: Keep only packages from bootstrap arcade repos -->
+    <ItemGroup Condition="'$(SharedComponentFilterMode)' == 'BootstrapOnly'">
+      <_ItemsToRemove Include="@(SharedComponentFilteredPackages)"
+                      Condition="!$([System.String]::new(';$(BootstrapArcadeRepos);').Contains(';%(RepoOrigin);'))" />
+    </ItemGroup>
+
+    <!-- Create a lookup string of items to remove -->
+    <PropertyGroup>
+      <_ItemsToRemoveString>@(_ItemsToRemove->'%(Identity)::%(Version)', ';')</_ItemsToRemoveString>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <SharedComponentFilteredPackages Remove="@(SharedComponentFilteredPackages)" 
+                                        Condition="'@(_ItemsToRemove)' != '' and 
+                                                   '$(_ItemsToRemoveString)' != '' and
+                                                   $(_ItemsToRemoveString.Contains($([System.String]::Concat('%(Identity)', '::', '%(Version)'))))" />
+
+      <SharedComponentFilteredPackages Update="@(SharedComponentFilteredPackages)">
+        <PackagePath>$(SharedComponentsArtifactsPath)$([System.IO.Path]::GetFileName('%(PipelineArtifactPath)'))</PackagePath>
+      </SharedComponentFilteredPackages>
+    </ItemGroup>
+
+  </Target>
+
+</Project>

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -345,6 +345,7 @@
 
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="GetFilteredSharedComponentPackages"
+             Properties="SharedComponentFilterMode=NonToolingOnly"
              Condition="!$([System.String]::new(';$(BootstrapArcadeRepos);').Contains(';$(RepositoryName);'))">
       <Output TaskParameter="TargetOutputs" ItemName="_PreviouslyBuiltSourceBuiltSharedComponentPackages" />
     </MSBuild>


### PR DESCRIPTION
Contributes to #1011

In a non-1xx build, the stage 2 source-only build fails in the build of `source-build-reference-packages` with errors like the following:
`/__w/1/s/src/source-build-reference-packages/src/targetPacks/ILsrc/microsoft.netcore.app.ref/6.0.0/Microsoft.NETCore.App.Ref.6.0.0.csproj error NU1603: Microsoft.NETCore.App.Ref.6.0.0 depends on runtime.centos.10-x64.Microsoft.NETCore.ILAsm (>= 10.0.0-preview.7.25377.103) but runtime.centos.10-x64.Microsoft.NETCore.ILAsm 10.0.0-preview.7.25377.103 was not found. runtime.centos.10-x64.Microsoft.NETCore.ILAsm 10.0.0-rc.1.25405.108 was resolved instead. [/__w/1/s/.dotnet/sdk/10.0.200-rc.1.25408.102/NuGet.targets]`

The issue here is that a dependency to `runtime.centos.10-x64.Microsoft.NETCore.ILAsm` is being defined targeting the version that is defined directly in the repo's [`MicrosoftNETCoreILAsmVersion` property](https://github.com/dotnet/source-build-reference-packages/blob/299471506deb40dc03945ecc920932f95027fec8/eng/Version.Details.props#L14) (in this case `10.0.0-preview.7.25377.103`. It's not being overridden with the version that was produced by the stage 1 build (in this case `10.0.0-rc.1.25405.108`). It doesn't get overridden because that package is not listed in the versions props file that exists in the SB artifacts tarball produced by the stage 1 build. In fact, _none_ of the packages which originate from the shared components are listed in there.

The fix is to ensure that those properties are written. This also applies to the VersionManifest.xml file which also needs to accurately reflect this state as there are dependencies on that file as well.