### PR TITLE
Add missing nullable modifier for installer test config

### DIFF
--- a/test/Microsoft.DotNet.Installer.Tests/Config.cs
+++ b/test/Microsoft.DotNet.Installer.Tests/Config.cs
@@ -43,7 +43,7 @@ public static class Config
     public static bool DotNetBuildSharedComponents { get; } = TryGetRuntimeConfig(DotNetBuildSharedComponentsSwitch, out bool value) ? value : false;
     const string DotNetBuildSharedComponentsSwitch = RuntimeConfigSwitchPrefix + nameof(DotNetBuildSharedComponents);
 
-    public static string Sdk1xxVersion { get; } = TryGetRuntimeConfig(Sdk1xxVersionSwitch, out string value) ? value : string.Empty;
+    public static string Sdk1xxVersion { get; } = TryGetRuntimeConfig(Sdk1xxVersionSwitch, out string? value) ? value : string.Empty;
     const string Sdk1xxVersionSwitch = RuntimeConfigSwitchPrefix + nameof(Sdk1xxVersion);
 
     public const string RuntimeConfigSwitchPrefix = "Microsoft.DotNet.Installer.Tests.";


### PR DESCRIPTION
Fixes this error in the installer tests:
`/mnt/vss/_work/1/s/test/Microsoft.DotNet.Installer.Tests/Config.cs(46,96): error CS8600: Converting null literal or possible null value to non-nullable type. [/mnt/vss/_work/1/s/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj]`