### PR TITLE
Free up disk space by deleting simulator runtimes on macOS

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -224,17 +224,6 @@ jobs:
       value: '--'
 
   ### Basic arguments
-  - name: cleanArgument
-    # Don't clean-while-building on OSs that have enough disk space to keep
-    # intermediates for compliance scanners.
-    ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(parameters.targetOS, 'osx')) }}:
-      value: ''
-    ${{ else }}:
-      ${{ if eq(parameters.targetOS, 'windows') }}:
-        value: $(commandPrefix)cleanWhileBuilding
-      ${{ else }}:
-        value: $(commandPrefix)clean-while-building
-
   - name: brandingArgument
     value: $(commandPrefix)branding $(brandingType)
 
@@ -256,7 +245,7 @@ jobs:
       value: ''
 
   - name: baseArguments
-    value: $(commandPrefix)ci $(cleanArgument) $(commandPrefix)prepareMachine -c ${{ parameters.configuration }} $(brandingArgument) $(useSystemLibrariesArgument) $(officialBuildArgument)
+    value: $(commandPrefix)ci $(commandPrefix)prepareMachine -c ${{ parameters.configuration }} $(brandingArgument) $(useSystemLibrariesArgument) $(officialBuildArgument)
 
   - name: baseProperties
     value: $(officialBuildProperties) /p:VerticalName=$(Agent.JobName)
@@ -498,6 +487,9 @@ jobs:
 
   - ${{ else }}:
     - ${{ if eq(parameters.targetOS, 'osx') }}:
+      - script: |
+          xcrun simctl runtime delete all
+        displayName: Reclaim disk space from unused simulator runtimes
       - script: |
           $(sourcesPath)/eng/common/native/install-dependencies.sh osx
         displayName: Install dependencies

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -225,14 +225,14 @@ jobs:
 
   ### Basic arguments
   - name: cleanArgument
-  # Don't clean-while-building on internal builds to keep intermediates for compliance scanners.
-  ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-    value: ''
-  ${{ else }}:
-    ${{ if eq(parameters.targetOS, 'windows') }}:
-      value: $(commandPrefix)cleanWhileBuilding
+    # Don't clean-while-building on internal builds to keep intermediates for compliance scanners.
+    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      value: ''
     ${{ else }}:
-      value: $(commandPrefix)clean-while-building
+      ${{ if eq(parameters.targetOS, 'windows') }}:
+        value: $(commandPrefix)cleanWhileBuilding
+      ${{ else }}:
+        value: $(commandPrefix)clean-while-building
 
   - name: brandingArgument
     value: $(commandPrefix)branding $(brandingType)
@@ -743,4 +743,5 @@ jobs:
           PathtoPublish: $(Build.ArtifactStagingDirectory)/artifacts/manifests/${{ parameters.configuration }}/$(Agent.JobName).xml
           ArtifactName: VerticalManifests
         displayName: Publish Vertical Manifest
+
 

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -224,6 +224,16 @@ jobs:
       value: '--'
 
   ### Basic arguments
+  - name: cleanArgument
+  # Don't clean-while-building on internal builds to keep intermediates for compliance scanners.
+  ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+    value: ''
+  ${{ else }}:
+    ${{ if eq(parameters.targetOS, 'windows') }}:
+      value: $(commandPrefix)cleanWhileBuilding
+    ${{ else }}:
+      value: $(commandPrefix)clean-while-building
+
   - name: brandingArgument
     value: $(commandPrefix)branding $(brandingType)
 
@@ -245,7 +255,7 @@ jobs:
       value: ''
 
   - name: baseArguments
-    value: $(commandPrefix)ci $(commandPrefix)prepareMachine -c ${{ parameters.configuration }} $(brandingArgument) $(useSystemLibrariesArgument) $(officialBuildArgument)
+    value: $(commandPrefix)ci $(cleanArgument) $(commandPrefix)prepareMachine -c ${{ parameters.configuration }} $(brandingArgument) $(useSystemLibrariesArgument) $(officialBuildArgument)
 
   - name: baseProperties
     value: $(officialBuildProperties) /p:VerticalName=$(Agent.JobName)
@@ -733,3 +743,4 @@ jobs:
           PathtoPublish: $(Build.ArtifactStagingDirectory)/artifacts/manifests/${{ parameters.configuration }}/$(Agent.JobName).xml
           ArtifactName: VerticalManifests
         displayName: Publish Vertical Manifest
+

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -743,5 +743,3 @@ jobs:
           PathtoPublish: $(Build.ArtifactStagingDirectory)/artifacts/manifests/${{ parameters.configuration }}/$(Agent.JobName).xml
           ArtifactName: VerticalManifests
         displayName: Publish Vertical Manifest
-
-

--- a/eng/pipelines/templates/steps/vmr-validate-installers.yml
+++ b/eng/pipelines/templates/steps/vmr-validate-installers.yml
@@ -15,6 +15,11 @@ parameters:
   default: ''
 
 steps:
+- ${{ if eq(parameters.OS, 'Darwin') }}:
+  - script: |
+      xcrun simctl runtime delete all
+    displayName: Reclaim disk space from unused simulator runtimes
+
 - ${{ if ne(parameters.reuseBuildArtifactsFrom,'') }}:
   - ${{ each reuseBuildArtifacts in parameters.reuseBuildArtifactsFrom }}:
     - task: DownloadPipelineArtifact@2

--- a/eng/pipelines/templates/steps/vmr-validate-signing.yml
+++ b/eng/pipelines/templates/steps/vmr-validate-signing.yml
@@ -28,6 +28,11 @@ parameters:
   default: '$(Build.ArtifactStagingDirectory)/SigningValidation'
 
 steps:
+- ${{ if eq(parameters.OS, 'Darwin') }}:
+  - script: |
+      xcrun simctl runtime delete all
+    displayName: Reclaim disk space from unused simulator runtimes
+
 - task: DownloadPipelineArtifact@2
   displayName: Download Vertical Build Artifacts
   continueOnError: ${{ parameters.continueOnError }}


### PR DESCRIPTION
We don't use these iOS/tvOS simulators in the VMR build and they take up a significant amount of disk space.

Available disk space increased from 44GB to 160GB and allows us to turn off clean-while-building for macOS jobs as well.