### PR TITLE
Support non-1xx feature bands in source-only validation jobs

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,6 +9,7 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
+    <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/eng/init-source-only.proj
+++ b/eng/init-source-only.proj
@@ -64,7 +64,7 @@
   </Target>  
 
   <Target Name="UnpackSharedComponentsPrereqsArchive"
-          Condition="'$(SharedComponentsPrereqsArchiveFile)' != '' and '$(CustomSharedComponentsArtifactsPath)' == ''"
+          Condition="'$(SharedComponentsPrereqsArchiveFile)' != '' and '$(CustomSharedComponentsArtifactsPath)' == '' and '$(DotNetSourceOnlyTestOnly)' != 'true'"
           Inputs="$(SharedComponentsPrereqsArchiveFile)"
           Outputs="$(BaseIntermediateOutputPath)UnpackSharedComponentsPrereqsArchive.complete">
 

--- a/eng/pipelines/templates/stages/source-build-and-validate.yml
+++ b/eng/pipelines/templates/stages/source-build-and-validate.yml
@@ -20,6 +20,11 @@ parameters:
   type: string
   default: ''
 
+# Indicates whether runtime dependent jobs are excluded.
+- name: excludeRuntimeDependentJobs
+  type: boolean
+  default: false
+
 stages:
 - stage: VMR_SourceOnly_Build
   displayName: VMR Source-Only Build
@@ -204,13 +209,14 @@ stages:
                 downloadFilePatterns: packages/Release/Shipping/**
                 copyDestination: $(Pipeline.Workspace)/msft-pkgs
                 flattenDirs: true
-          - template: ../steps/download-artifacts.yml
-            parameters:
-              artifactDescription: Microsoft WASM Packages
-              artifactName: Browser_Shortstack_wasm_Artifacts
-              downloadFilePatterns: packages/Release/Shipping/**
-              copyDestination: $(Pipeline.Workspace)/msft-pkgs
-              flattenDirs: true
+          - ${{ if not(parameters.excludeRuntimeDependentJobs) }}:
+            - template: ../steps/download-artifacts.yml
+              parameters:
+                artifactDescription: Microsoft WASM Packages
+                artifactName: Browser_Shortstack_wasm_Artifacts
+                downloadFilePatterns: packages/Release/Shipping/**
+                copyDestination: $(Pipeline.Workspace)/msft-pkgs
+                flattenDirs: true
           - template: ../steps/download-artifacts.yml
             parameters:
               artifactDescription: Microsoft Windows Packages

--- a/eng/pipelines/templates/stages/source-build-stages.yml
+++ b/eng/pipelines/templates/stages/source-build-stages.yml
@@ -35,6 +35,11 @@ parameters:
   type: object
   default: []
 
+# Indicates whether runtime dependent jobs are excluded.
+- name: excludeRuntimeDependentJobs
+  type: boolean
+  default: false
+
 stages:
 - ${{ if or(in(parameters.scope, 'full') , contains(join(';', parameters.verifications), 'source-build-')) }}:
   - template: source-build-and-validate.yml
@@ -44,6 +49,7 @@ stages:
       useMicrosoftBuildAssetsForTests: ${{ parameters.useMicrosoftBuildAssetsForTests }}
       isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
       desiredFinalVersionKind: ${{ parameters.desiredFinalVersionKind }}
+      excludeRuntimeDependentJobs: ${{ parameters.excludeRuntimeDependentJobs }}
       
       # Description of the source build legs to run.
       # This is described here as a parameter to allow two separate stages to be produced from this list (one for building

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -90,14 +90,11 @@ parameters:
     demands: ImageOverride -equals $(poolImage_Linux)
     os: linux
 
-- name: featureBand
-  displayName: 'Target Feature Band'
-  type: string
-  default: 'Detect by Branch Name'
-  values:
-    - 'Detect by Branch Name'
-    - '1xx'
-    - '>= 2xx'
+# Indicates whether to exclude runtime dependent jobs.
+# This is used to skip building the cross-OS DACs and other runtime dependent jobs in non-1xx branches.
+- name: excludeRuntimeDependentJobs
+  type: boolean
+  default: false
 
 stages:
 - template: vmr-verticals.yml
@@ -109,12 +106,7 @@ stages:
     isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
     scope: ${{ parameters.scope }}
     verifications: ${{ parameters.verifications }}
-    # Exclude runtime dependent jobs for any branch not producing a 1xx version since runtime-related repos aren't built in that context
-    # Will exclude runtime-dependent jobs when either of the following are true:
-    #   - 'Detect By Branch Name' was selected for the feature band: branch is not main and does not contain '.1xx' but does end with 'xx'.
-    #   - '>= 2xx' was selected for the feature band
-    ${{ if or(and(eq(parameters.featureBand, 'Detect by Branch Name'), ne(variables['Build.SourceBranch'], 'refs/heads/main'), not(contains(variables['Build.SourceBranch'], '.1xx')), endsWith(variables['Build.SourceBranch'], 'xx')), eq(parameters.featureBand, '>= 2xx')) }}:
-      excludeRuntimeDependentJobs: true
+    excludeRuntimeDependentJobs: ${{ parameters.excludeRuntimeDependentJobs }}
 
 - ${{ if and(parameters.isBuiltFromVmr, eq(parameters.isOfficialBuild, true)) }}:
   - stage: Publish_Build_Assets
@@ -154,3 +146,4 @@ stages:
         # are available from the subset of jobs that get build in PRs compared to the full build. Instead, we run
         # the tests in the same job as the build and filter out some of the tests that can't be executed in this state.
         useMicrosoftBuildAssetsForTests: false
+      excludeRuntimeDependentJobs: ${{ parameters.excludeRuntimeDependentJobs }}

--- a/eng/pipelines/unofficial.yml
+++ b/eng/pipelines/unofficial.yml
@@ -143,3 +143,9 @@ extends:
         scope: ${{ parameters.buildScope }}
         isOfficialBuild: false
         featureBand: ${{ parameters.featureBand }}
+        # Exclude runtime dependent jobs for any branch not producing a 1xx version since runtime-related repos aren't built in that context
+        # Will exclude runtime-dependent jobs when either of the following are true:
+        #   - 'Detect By Branch Name' was selected for the feature band: branch is not main and does not contain '.1xx' but does end with 'xx'.
+        #   - '>= 2xx' was selected for the feature band
+        ${{ if or(and(eq(parameters.featureBand, 'Detect by Branch Name'), ne(variables['Build.SourceBranch'], 'refs/heads/main'), not(contains(variables['Build.SourceBranch'], '.1xx')), endsWith(variables['Build.SourceBranch'], 'xx')), eq(parameters.featureBand, '>= 2xx')) }}:
+          excludeRuntimeDependentJobs: true

--- a/test/tests.proj
+++ b/test/tests.proj
@@ -41,4 +41,30 @@
     <ProjectReference Include="$(RepoProjectsDir)scenario-tests.proj" Condition="'$(_RunScenarioTests)' == 'true'" BuildInParallel="false" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <_DownloadWasmPackages Condition="'$(DotNetBuildSharedComponents)' != 'true' and '$(DotNetBuildSourceOnly)' == 'true'">true</_DownloadWasmPackages>
+  </PropertyGroup>
+
+  <!-- Download WASM packages for non-1xx source-only builds -->
+  <Target Name="DownloadWasmPackages" BeforeTargets="Test" Condition="'$(_DownloadWasmPackages)' == 'true'">
+
+    <PropertyGroup>
+      <_TmpPackagesRoot>$(ArtifactsTmpDir)wasm-dependencies/</_TmpPackagesRoot>
+    </PropertyGroup>
+    
+    <Exec
+        Command="&quot;$(DOTNET_HOST_PATH)&quot; restore &quot;$(MSBuildThisFileDirectory)wasm-dependencies.proj&quot; -bl:$(ArtifactsLogDir)/wasm-test-dependencies.binlog"
+        EnvironmentVariables="NUGET_PACKAGES=$(_TmpPackagesRoot)"
+    />
+    
+    <!-- Copy the nupkg files to the extra custom restore path for the tests -->
+    <ItemGroup>
+      <_DownloadedNupkgs Include="$(_TmpPackagesRoot)**/*.nupkg" />
+    </ItemGroup>
+    
+    <Copy SourceFiles="@(_DownloadedNupkgs)"
+          DestinationFolder="$(ExtraRestoreSourcePath)" 
+          Condition="@(_DownloadedNupkgs->Count()) > 0" />
+  </Target>
+
 </Project>

--- a/test/wasm-dependencies.proj
+++ b/test/wasm-dependencies.proj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
+    <!-- Calculate runtime version from SDK version (convert from 1xx to 0xx format) -->
+    <_RuntimeVersion1xx>$([System.Text.RegularExpressions.Regex]::Replace('$(MicrosoftNETSdkVersion)', '^(\d+\.\d+\.)1(0)?(\d+)(-.*)?$', '$1$3$4'))</_RuntimeVersion1xx>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageDownload Include="Microsoft.NET.Runtime.WebAssembly.Sdk" Version="[$(_RuntimeVersion1xx)]" />
+    <PackageDownload Include="Microsoft.NET.Runtime.wasm.Sample.Mono" Version="[$(_RuntimeVersion1xx)]" />
+    <PackageDownload Include="Microsoft.NET.Sdk.WebAssembly.Pack" Version="[$(_RuntimeVersion1xx)]" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
In non-1xx feature band branches, there are no runtime-related vertical jobs. This is a problem for the source-only validation jobs which rely on the `Browser_Shortstack_wasm` job to retrieve the various WASM packages needed for testing because that job is not run in those branches.

The solution is to conditionally depend on that job so that we don't depend on it outside 1xx scenarios. But we still need to have the packages. So the test project dynamically downloads the required WASM packages from the related build produced by the 1xx branch.

Contributes to #1011