### PR TITLE
[release/10.0.1xx] Enable runtime's bootstrap build in all VMR builds

### DIFF
--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -731,6 +731,9 @@
   <Target Name="MoveDotNetBuildLogs" Condition="'$(IsUtilityProject)' != 'true'">
     <ItemGroup>
       <LogFilesToMove Include="$(RepoArtifactsDir)log\$(Configuration)\**\*" />
+      <LogFilesToMove Include="$(RepoArtifactsDir)log\\**\*"
+                      Exclude="@(LogFilesToMove)"
+                      Condition="'$(MoveNoConfigLogs)' == 'true'" />
     </ItemGroup>
 
     <!-- Move the build logs -->

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -731,9 +731,6 @@
   <Target Name="MoveDotNetBuildLogs" Condition="'$(IsUtilityProject)' != 'true'">
     <ItemGroup>
       <LogFilesToMove Include="$(RepoArtifactsDir)log\$(Configuration)\**\*" />
-      <LogFilesToMove Include="$(RepoArtifactsDir)log\\**\*"
-                      Exclude="@(LogFilesToMove)"
-                      Condition="'$(MoveNoConfigLogs)' == 'true'" />
     </ItemGroup>
 
     <!-- Move the build logs -->

--- a/repo-projects/runtime.proj
+++ b/repo-projects/runtime.proj
@@ -17,9 +17,6 @@
 
     <!-- May stabilize. -->
     <AllowDotNetFinalVersionKindOverride>true</AllowDotNetFinalVersionKindOverride>
-    
-    <!-- The bootstrapping build drops its log in the root artifacts/log folder for the repo build. -->
-    <MoveNoConfigLogs>true</MoveNoConfigLogs>
 
     <!--
       When building a vertical where we explicitly request using the Mono runtime, only build the Mono runtime.

--- a/repo-projects/runtime.proj
+++ b/repo-projects/runtime.proj
@@ -37,7 +37,7 @@
       Some targets don't build any assets that use the LKG bits at from a dev build at runtime. Those platforms
       can skip the bootstrapping build.
     -->
-    <BuildArgs Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi' and '$(TargetsMobile)' != 'true'">$(BuildArgs) --bootstrap</BuildArgs>
+    <BuildArgs Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi' and '$(TargetsMobile)' != 'true'">$(BuildArgs) $(FlagParameterPrefix)bootstrap</BuildArgs>
 
     <!-- If this build is not a "special flavor" build, build everything that can be built for this target. -->
     <BuildArgs Condition="'$(DotNetBuildUseMonoRuntime)' != 'true'">$(BuildArgs) /p:DotNetBuildAllRuntimePacks=true</BuildArgs>

--- a/repo-projects/runtime.proj
+++ b/repo-projects/runtime.proj
@@ -29,8 +29,8 @@
     <TargetsMobile Condition="'$(TargetOS)' == 'ios' or '$(TargetOS)' == 'iossimulator' or '$(TargetOS)' == 'maccatalyst' or '$(TargetOS)' == 'tvos' or '$(TargetOS)' == 'tvossimulator' or '$(TargetOS)' == 'android' or '$(TargetOS)' == 'browser' or '$(TargetOS)' == 'wasi'">true</TargetsMobile>
     <BuildArgs Condition="'$(CrossBuild)' == 'true' or ('$(TargetOS)-$(TargetArchitecture)' != '$(TargetOS)-$(BuildArchitecture)' and '$(TargetsMobile)' != 'true' and '$(TargetOS)' != 'windows' and '$(TargetOS)' != 'linux-bionic')">$(BuildArgs) $(FlagParameterPrefix)cross</BuildArgs>
 
-    <!-- Source-build will use non-portable RIDs. To build for these non-portable RID scenarios, we must do a bootstrapped build. -->
-    <BuildArgs Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(DotNetBuildUseMonoRuntime)' != 'true'">$(BuildArgs) --bootstrap</BuildArgs>
+    <!-- Always bootstrap our build so we are building the shipping product from a cohesive commit (no LKG usage). -->
+    <BuildArgs>$(BuildArgs) --bootstrap</BuildArgs>
 
     <!-- If this build is not a "special flavor" build, build everything that can be built for this target. -->
     <BuildArgs Condition="'$(DotNetBuildUseMonoRuntime)' != 'true'">$(BuildArgs) /p:DotNetBuildAllRuntimePacks=true</BuildArgs>

--- a/repo-projects/runtime.proj
+++ b/repo-projects/runtime.proj
@@ -37,7 +37,7 @@
       Some targets don't build any assets that use the LKG bits at from a dev build at runtime. Those platforms
       can skip the bootstrapping build.
     -->
-    <BuildArgs Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi' and '$(TargetsMobile)' != 'true' and '$(TargetOS)' != 'linux-bionic' and  and '$(DotNetBuildUseMonoRuntime)' != 'true'">$(BuildArgs) $(FlagParameterPrefix)bootstrap</BuildArgs>
+    <BuildArgs Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi' and '$(TargetsMobile)' != 'true' and '$(TargetOS)' != 'linux-bionic' and '$(DotNetBuildUseMonoRuntime)' != 'true'">$(BuildArgs) $(FlagParameterPrefix)bootstrap</BuildArgs>
 
     <!-- If this build is not a "special flavor" build, build everything that can be built for this target. -->
     <BuildArgs Condition="'$(DotNetBuildUseMonoRuntime)' != 'true'">$(BuildArgs) /p:DotNetBuildAllRuntimePacks=true</BuildArgs>

--- a/repo-projects/runtime.proj
+++ b/repo-projects/runtime.proj
@@ -32,8 +32,12 @@
     <TargetsMobile Condition="'$(TargetOS)' == 'ios' or '$(TargetOS)' == 'iossimulator' or '$(TargetOS)' == 'maccatalyst' or '$(TargetOS)' == 'tvos' or '$(TargetOS)' == 'tvossimulator' or '$(TargetOS)' == 'android' or '$(TargetOS)' == 'browser' or '$(TargetOS)' == 'wasi'">true</TargetsMobile>
     <BuildArgs Condition="'$(CrossBuild)' == 'true' or ('$(TargetOS)-$(TargetArchitecture)' != '$(TargetOS)-$(BuildArchitecture)' and '$(TargetsMobile)' != 'true' and '$(TargetOS)' != 'windows' and '$(TargetOS)' != 'linux-bionic')">$(BuildArgs) $(FlagParameterPrefix)cross</BuildArgs>
 
-    <!-- Always bootstrap our build so we are building the shipping product from a cohesive commit (no LKG usage). -->
-    <BuildArgs>$(BuildArgs) --bootstrap</BuildArgs>
+    <!--
+      Always bootstrap our build so we are building the shipping product from a cohesive commit (no LKG usage).
+      Some targets don't build any assets that use the LKG bits at from a dev build at runtime. Those platforms
+      can skip the bootstrapping build.
+    -->
+    <BuildArgs Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi' and '$(TargetsMobile)' != 'true'">$(BuildArgs) --bootstrap</BuildArgs>
 
     <!-- If this build is not a "special flavor" build, build everything that can be built for this target. -->
     <BuildArgs Condition="'$(DotNetBuildUseMonoRuntime)' != 'true'">$(BuildArgs) /p:DotNetBuildAllRuntimePacks=true</BuildArgs>

--- a/repo-projects/runtime.proj
+++ b/repo-projects/runtime.proj
@@ -37,7 +37,7 @@
       Some targets don't build any assets that use the LKG bits at from a dev build at runtime. Those platforms
       can skip the bootstrapping build.
     -->
-    <BuildArgs Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi' and '$(TargetsMobile)' != 'true'">$(BuildArgs) $(FlagParameterPrefix)bootstrap</BuildArgs>
+    <BuildArgs Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi' and '$(TargetsMobile)' != 'true' and '$(TargetOS)' != 'linux-bionic' and  and '$(DotNetBuildUseMonoRuntime)' != 'true'">$(BuildArgs) $(FlagParameterPrefix)bootstrap</BuildArgs>
 
     <!-- If this build is not a "special flavor" build, build everything that can be built for this target. -->
     <BuildArgs Condition="'$(DotNetBuildUseMonoRuntime)' != 'true'">$(BuildArgs) /p:DotNetBuildAllRuntimePacks=true</BuildArgs>

--- a/repo-projects/runtime.proj
+++ b/repo-projects/runtime.proj
@@ -17,6 +17,9 @@
 
     <!-- May stabilize. -->
     <AllowDotNetFinalVersionKindOverride>true</AllowDotNetFinalVersionKindOverride>
+    
+    <!-- The bootstrapping build drops its log in the root artifacts/log folder for the repo build. -->
+    <MoveNoConfigLogs>true</MoveNoConfigLogs>
 
     <!--
       When building a vertical where we explicitly request using the Mono runtime, only build the Mono runtime.

--- a/src/runtime/eng/build.ps1
+++ b/src/runtime/eng/build.ps1
@@ -354,9 +354,9 @@ if ($bootstrap -eq $True) {
 
   if ($actionPassedIn) {
     # Filter out all actions
-    $bootstrapArguments = ($arguments -split ' ') | Where-Object {
+    $bootstrapArguments = $(($arguments -split ' ') | Where-Object {
         $_ -notmatch '^/p:(' + ($actionPassedIn -join '|') + ')=.*'
-    } -join ' '
+    }) -join ' '
 
     # Preserve Restore and Build if they're passed in
     if ($arguments -match "/p:Restore=true") {

--- a/src/runtime/eng/build.ps1
+++ b/src/runtime/eng/build.ps1
@@ -369,7 +369,7 @@ if ($bootstrap -eq $True) {
     $bootstrapArguments = $arguments
   }
 
-  $bootstrapArguments += "/p:Subset=bootstrap /bl:$PSScriptRoot/../artifacts/log/bootstrap.binlog"
+  $bootstrapArguments += " /p:Subset=bootstrap /bl:$PSScriptRoot/../artifacts/log/bootstrap.binlog"
   Invoke-Expression "& `"$PSScriptRoot/common/build.ps1`" $bootstrapArguments"
   
   # Remove artifacts from the bootstrap build so the product build is a "clean" build.

--- a/src/runtime/eng/build.ps1
+++ b/src/runtime/eng/build.ps1
@@ -380,7 +380,7 @@ if ($bootstrap -eq $True) {
   }
 
   $bootstrapArguments += " /p:TargetArchitecture=$($arch[0])"
-  $bootstrapArguments += " -configuration $((Get-Culture).TextInfo.ToTitleCase($config))"
+  $bootstrapArguments += " -configuration $((Get-Culture).TextInfo.ToTitleCase($configuration[0]))"
 
   $bootstrapArguments += " /p:Subset=bootstrap /bl:$PSScriptRoot/../artifacts/log/bootstrap.binlog"
   Invoke-Expression "& `"$PSScriptRoot/common/build.ps1`" $bootstrapArguments"

--- a/src/runtime/eng/build.ps1
+++ b/src/runtime/eng/build.ps1
@@ -25,7 +25,7 @@ Param(
   [switch]$pgoinstrument,
   [string[]]$fsanitize,
   [switch]$bootstrap,
-  [switch]$useBoostrap
+  [switch]$useBoostrap,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 

--- a/src/runtime/eng/build.ps1
+++ b/src/runtime/eng/build.ps1
@@ -24,6 +24,8 @@ Param(
   [string]$cmakeargs,
   [switch]$pgoinstrument,
   [string[]]$fsanitize,
+  [switch]$bootstrap,
+  [switch]$useBoostrap
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
@@ -57,6 +59,8 @@ function Get-Help() {
   Write-Host "  -usemonoruntime                Product a .NET runtime with Mono as the underlying runtime."
   Write-Host "  -verbosity (-v)                MSBuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]."
   Write-Host "                                 [Default: Minimal]"
+  Write-Host "  --useBootstrap                 Use the results of building the bootstrap subset to build published tools on the target machine."
+  Write-Host "  --bootstrap                     Build the bootstrap subset and then build the repo with --use-bootstrap."
   Write-Host "  -vs                            Open the solution with Visual Studio using the locally acquired SDK."
   Write-Host "                                 Path or any project or solution name is accepted."
   Write-Host "                                 (Example: -vs Microsoft.CSharp or -vs CoreCLR.sln)"
@@ -330,6 +334,7 @@ foreach ($argument in $PSBoundParameters.Keys)
     "configuration"          {}
     "arch"                   {}
     "fsanitize"              { $arguments += " /p:EnableNativeSanitizers=$($PSBoundParameters[$argument])"}
+    "useBootstrap"           { $arguments += " /p:UseBootstrap=$($PSBoundParameters[$argument])" }
     default                  { $arguments += " /p:$argument=$($PSBoundParameters[$argument])" }
   }
 }
@@ -344,6 +349,33 @@ $arguments += " /tl:false"
 # Disable targeting pack caching as we reference a partially constructed targeting pack and update it later.
 # The later changes are ignored when using the cache.
 $env:DOTNETSDK_ALLOW_TARGETING_PACK_CACHING=0
+
+if ($bootstrap -eq $True) {
+
+  if ($actionsPassedIn) {
+    # Filter out all actions
+    $bootstrapArguments = ($arguments -split ' ') | Where-Object {
+        $_ -notmatch '^/p:(' + ($actionsPassedIn -join '|') + ')=.*'
+    } -join ' '
+
+    # Preserve Restore and Build if they're passed in
+    if ($arguments -match "/p:Restore=true") {
+      $bootstrapArguments += "/p:Restore=true"
+    }
+    if ($arguments -match "/p:Build=true") {
+      $bootstrapArguments += "/p:Build=true"
+    }
+  }
+
+  $bootstrapArguments += "/p:Subset=bootstrap -bl:$PSScriptRoot/../artifacts/log/bootstrap.binlog"
+  Invoke-Expression "& `"$PSScriptRoot/common/build.ps1`" $bootstrapArguments"
+  
+  # Remove artifacts from the bootstrap build so the product build is a "clean" build.
+  Write-Host "Cleaning up artifacts from bootstrap build..."
+  Remove-Item -Recurse "$PSScriptRoot/../artifacts/bin"
+  Remove-Item -Recurse "$PSScriptRoot/../artifacts/obj"
+  $arguments += " /p:UseBootstrap=true"
+}
 
 $failedBuilds = @()
 

--- a/src/runtime/eng/build.ps1
+++ b/src/runtime/eng/build.ps1
@@ -352,10 +352,10 @@ $env:DOTNETSDK_ALLOW_TARGETING_PACK_CACHING=0
 
 if ($bootstrap -eq $True) {
 
-  if ($actionsPassedIn) {
+  if ($actionPassedIn) {
     # Filter out all actions
     $bootstrapArguments = ($arguments -split ' ') | Where-Object {
-        $_ -notmatch '^/p:(' + ($actionsPassedIn -join '|') + ')=.*'
+        $_ -notmatch '^/p:(' + ($actionPassedIn -join '|') + ')=.*'
     } -join ' '
 
     # Preserve Restore and Build if they're passed in
@@ -365,6 +365,8 @@ if ($bootstrap -eq $True) {
     if ($arguments -match "/p:Build=true") {
       $bootstrapArguments += "/p:Build=true"
     }
+  } else {
+    $bootstrapArguments = $arguments
   }
 
   $bootstrapArguments += "/p:Subset=bootstrap /bl:$PSScriptRoot/../artifacts/log/bootstrap.binlog"

--- a/src/runtime/eng/build.ps1
+++ b/src/runtime/eng/build.ps1
@@ -369,9 +369,22 @@ if ($bootstrap -eq $True) {
     $bootstrapArguments = $arguments
   }
 
+  if ($configuration.Count -gt 1) {
+    Write-Error "Building the bootstrap build does not support multiple configurations. Please specify a single configuration using -configuration."
+    exit 1
+  }
+
+  if ($arch.Count -gt 1) {
+    Write-Error "Building the bootstrap build does not support multiple architectures. Please specify a single architecture using -arch."
+    exit 1
+  }
+
+  $bootstrapArguments += " /p:TargetArchitecture=$($arch[0])"
+  $bootstrapArguments += " -configuration $((Get-Culture).TextInfo.ToTitleCase($config))"
+
   $bootstrapArguments += " /p:Subset=bootstrap /bl:$PSScriptRoot/../artifacts/log/bootstrap.binlog"
   Invoke-Expression "& `"$PSScriptRoot/common/build.ps1`" $bootstrapArguments"
-  
+
   # Remove artifacts from the bootstrap build so the product build is a "clean" build.
   Write-Host "Cleaning up artifacts from bootstrap build..."
   Remove-Item -Recurse "$PSScriptRoot/../artifacts/bin"

--- a/src/runtime/eng/build.ps1
+++ b/src/runtime/eng/build.ps1
@@ -380,9 +380,10 @@ if ($bootstrap -eq $True) {
   }
 
   $bootstrapArguments += " /p:TargetArchitecture=$($arch[0])"
-  $bootstrapArguments += " -configuration $((Get-Culture).TextInfo.ToTitleCase($configuration[0]))"
+  $config = $((Get-Culture).TextInfo.ToTitleCase($configuration[0]))
+  $bootstrapArguments += " -configuration $config"
 
-  $bootstrapArguments += " /p:Subset=bootstrap /bl:$PSScriptRoot/../artifacts/log/bootstrap.binlog"
+  $bootstrapArguments += " /p:Subset=bootstrap /bl:$PSScriptRoot/../artifacts/log/$config/bootstrap.binlog"
   Invoke-Expression "& `"$PSScriptRoot/common/build.ps1`" $bootstrapArguments"
 
   # Remove artifacts from the bootstrap build so the product build is a "clean" build.

--- a/src/runtime/eng/build.ps1
+++ b/src/runtime/eng/build.ps1
@@ -367,7 +367,7 @@ if ($bootstrap -eq $True) {
     }
   }
 
-  $bootstrapArguments += "/p:Subset=bootstrap -bl:$PSScriptRoot/../artifacts/log/bootstrap.binlog"
+  $bootstrapArguments += "/p:Subset=bootstrap /bl:$PSScriptRoot/../artifacts/log/bootstrap.binlog"
   Invoke-Expression "& `"$PSScriptRoot/common/build.ps1`" $bootstrapArguments"
   
   # Remove artifacts from the bootstrap build so the product build is a "clean" build.

--- a/src/runtime/eng/build.sh
+++ b/src/runtime/eng/build.sh
@@ -159,6 +159,7 @@ extraargs=()
 crossBuild=0
 portableBuild=1
 bootstrap=0
+bootstrapConfig='Debug'
 
 source $scriptroot/common/native/init-os-and-arch.sh
 
@@ -241,6 +242,7 @@ while [[ $# > 0 ]]; do
           exit 1
           ;;
       esac
+      bootstrapConfig=$val
       arguments+=("-configuration" "$val")
       shift 2
       ;;
@@ -598,7 +600,7 @@ if [[ "$bootstrap" == "1" ]]; then
       bootstrapArguments+=("$argument")
     fi
   done
-  "$scriptroot/common/build.sh" ${bootstrapArguments[@]+"${bootstrapArguments[@]}"} /p:Subset=bootstrap -bl:$scriptroot/../artifacts/log/bootstrap.binlog
+  "$scriptroot/common/build.sh" ${bootstrapArguments[@]+"${bootstrapArguments[@]}"} /p:Subset=bootstrap -bl:$scriptroot/../artifacts/log/$bootstrapConfig/bootstrap.binlog
 
   # Remove artifacts from the bootstrap build so the product build is a "clean" build.
   echo "Cleaning up artifacts from bootstrap build..."


### PR DESCRIPTION
This will ensure that all outputs from the .NET runtime build will always be built based on the same commit (the commit that's building), ensuring that if/when we fix a CVE, all of our components in the .NET 10 build ship with the fix (nothing in the runtime repo that ships NativeAOT'd uses the N-1 build).