### PR TITLE
Publish source-built SDK tarball

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -113,6 +113,7 @@
 
     <ItemGroup Condition="'$(IsPublishPass2)' == 'true' and '$(DotNetBuildSourceOnly)' == 'true'">
       <SourceBuildArtifact Include="$(ArtifactsAssetsDir)/$(SourceBuiltArtifactsTarballName).*$(ArchiveExtension)" />
+      <SourceBuildArtifact Include="$(ArtifactsAssetsDir)/**/dotnet-sdk-*$(ArchiveExtension)" />
       <Artifact Include="@(SourceBuildArtifact)">
         <IsShipping>true</IsShipping>
         <Kind>Blob</Kind>


### PR DESCRIPTION
Contributes to dotnet/source-build#5318

Updates the VMR build to include the source-built SDK in its publishing.