### PR TITLE
Free up disk space by deleting simulator runtimes on Apple jobs

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -225,9 +225,8 @@ jobs:
 
   ### Basic arguments
   - name: cleanArgument
-    # Don't clean-while-building on OSs that have enough disk space to keep
-    # intermediates for compliance scanners.
-    ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(parameters.targetOS, 'osx')) }}:
+    # Don't clean-while-building on internal builds to keep intermediates for compliance scanners.
+    ${{ if eq(variables['System.TeamProject'], 'internal') }}:
       value: ''
     ${{ else }}:
       ${{ if eq(parameters.targetOS, 'windows') }}:
@@ -497,6 +496,10 @@ jobs:
         timeoutInMinutes: ${{ variables.runTestsTimeout }}
 
   - ${{ else }}:
+    - ${{ if or(eq(parameters.targetOS, 'osx'), eq(parameters.targetOS, 'ios'), eq(parameters.targetOS, 'iossimulator'), eq(parameters.targetOS, 'tvos'), eq(parameters.targetOS, 'tvossimulator'), eq(parameters.targetOS, 'maccatalyst')) }}:
+      - script: |
+          xcrun simctl runtime delete all
+        displayName: Reclaim disk space from unused simulator runtimes
     - ${{ if eq(parameters.targetOS, 'osx') }}:
       - script: |
           $(sourcesPath)/eng/common/native/install-dependencies.sh osx

--- a/eng/pipelines/templates/steps/vmr-validate-installers.yml
+++ b/eng/pipelines/templates/steps/vmr-validate-installers.yml
@@ -15,6 +15,11 @@ parameters:
   default: ''
 
 steps:
+- ${{ if eq(parameters.OS, 'Darwin') }}:
+  - script: |
+      xcrun simctl runtime delete all
+    displayName: Reclaim disk space from unused simulator runtimes
+
 - ${{ if ne(parameters.reuseBuildArtifactsFrom,'') }}:
   - ${{ each reuseBuildArtifacts in parameters.reuseBuildArtifactsFrom }}:
     - task: DownloadPipelineArtifact@2

--- a/eng/pipelines/templates/steps/vmr-validate-signing.yml
+++ b/eng/pipelines/templates/steps/vmr-validate-signing.yml
@@ -28,6 +28,11 @@ parameters:
   default: '$(Build.ArtifactStagingDirectory)/SigningValidation'
 
 steps:
+- ${{ if eq(parameters.OS, 'Darwin') }}:
+  - script: |
+      xcrun simctl runtime delete all
+    displayName: Reclaim disk space from unused simulator runtimes
+
 - task: DownloadPipelineArtifact@2
   displayName: Download Vertical Build Artifacts
   continueOnError: ${{ parameters.continueOnError }}


### PR DESCRIPTION
Backport of https://github.com/dotnet/dotnet/pull/2013 and https://github.com/dotnet/dotnet/pull/2038