### PR TITLE
Fix a usage of a changed DarcLib API

### DIFF
--- a/eng/tools/ChangeValidation/ExclusionFileValidation.cs
+++ b/eng/tools/ChangeValidation/ExclusionFileValidation.cs
@@ -105,7 +105,7 @@ internal class ExclusionFileValidation : IValidationStep
 
     private async Task<List<string>> GetExclusionPatterns()
     {
-        await _dependencyTracker.RefreshMetadata();
+        await _dependencyTracker.RefreshMetadataAsync();
 
         var sourceMappings = _dependencyTracker.Mappings;
 


### PR DESCRIPTION
This didn't show in https://github.com/dotnet/dotnet/pull/2095 because we don't run this job in Maestro PRs.

Causes this: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1131345&view=logs&j=912e8062-b0ba-5930-681b-db020daf9df9&t=9a5472b0-d287-5f30-37b7-302b6e277fb9&l=12