### PR TITLE
[10.0.1xx] Disable bootstrap on BuildPass >=2 builds

### DIFF
--- a/repo-projects/runtime.proj
+++ b/repo-projects/runtime.proj
@@ -34,7 +34,10 @@
       Some targets don't build any assets that use the LKG bits at from a dev build at runtime. Those platforms
       can skip the bootstrapping build.
     -->
-    <BuildArgs Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi' and '$(TargetsMobile)' != 'true' and '$(TargetOS)' != 'linux-bionic' and '$(DotNetBuildUseMonoRuntime)' != 'true'">$(BuildArgs) $(FlagParameterPrefix)bootstrap</BuildArgs>
+    <BuildBootstrap Condition="'$(TargetOS)' != 'browser' and '$(TargetOS)' != 'wasi' and '$(TargetsMobile)' != 'true' and '$(TargetOS)' != 'linux-bionic'">true</BuildBootstrap>
+    <BuildBootstrap Condition="'$(DotNetBuildUseMonoRuntime)' == 'true'">false</BuildBootstrap>
+    <BuildBootstrap Condition="'$(DotNetBuildPass)' != '' and '$(DotNetBuildPass)' != '1'">false</BuildBootstrap>
+    <BuildArgs Condition="'$(BuildBootstrap)' == 'true'">$(BuildArgs) $(FlagParameterPrefix)bootstrap</BuildArgs>
 
     <!-- If this build is not a "special flavor" build, build everything that can be built for this target. -->
     <BuildArgs Condition="'$(DotNetBuildUseMonoRuntime)' != 'true'">$(BuildArgs) /p:DotNetBuildAllRuntimePacks=true</BuildArgs>


### PR DESCRIPTION
Fixes a regression in the official build