### PR TITLE
Adjust non-portable RID handling for tool packs to handle cross builds between non-portable RIDs

### DIFF
--- a/src/sdk/src/Layout/redist/targets/GenerateBundledVersions.targets
+++ b/src/sdk/src/Layout/redist/targets/GenerateBundledVersions.targets
@@ -268,18 +268,6 @@
         Condition="'$(BundleRuntimePacks)' == 'true'"
         Include="$(ProductMonikerRid)" />
 
-      <ILCompilerSupportedPortableRids Include="@(ILCompilerSupportedRids)" />
-
-      <ILCompilerSupportedRids
-        Condition="'$(BundleNativeAotCompiler)' == 'true'"
-        Include="$(ProductMonikerRid)" />
-
-      <Crossgen2SupportedPortableRids Include="@(Crossgen2SupportedRids)" />
-
-      <Crossgen2SupportedRids
-        Condition="'$(BundleCrossgen2)' == 'true'"
-        Include="$(ProductMonikerRid)" />
-
       <Net60MonoRuntimePackRids Include="
         @(Net60RuntimePackRids);
         browser-wasm;
@@ -372,6 +360,12 @@
 
       <Crossgen2SupportedRids Include="@(Net90Crossgen2SupportedRids);" />
 
+      <Crossgen2SupportedPortableRids Include="@(Crossgen2SupportedRids)" />
+
+      <Crossgen2SupportedRids
+        Condition="'$(BundleCrossgen2)' == 'true'"
+        Include="$(ProductMonikerRid)" />
+
       <Net70ILCompilerSupportedRids Include="
         linux-arm64;
         linux-musl-arm64;
@@ -405,6 +399,12 @@
         linux-riscv64;
         linux-musl-riscv64;
         " />
+
+      <ILCompilerSupportedPortableRids Include="@(ILCompilerSupportedRids)" />
+
+      <ILCompilerSupportedRids
+        Condition="'$(BundleNativeAotCompiler)' == 'true'"
+        Include="$(ProductMonikerRid)" />
 
       <Net80NativeAOTRuntimePackRids Include="
         ios-arm64;

--- a/src/sdk/src/Layout/redist/targets/GenerateBundledVersions.targets
+++ b/src/sdk/src/Layout/redist/targets/GenerateBundledVersions.targets
@@ -268,9 +268,13 @@
         Condition="'$(BundleRuntimePacks)' == 'true'"
         Include="$(ProductMonikerRid)" />
 
+      <ILCompilerSupportedPortableRids Include="@(ILCompilerSupportedRids)" />
+
       <ILCompilerSupportedRids
         Condition="'$(BundleNativeAotCompiler)' == 'true'"
         Include="$(ProductMonikerRid)" />
+
+      <Crossgen2SupportedPortableRids Include="@(Crossgen2SupportedRids)" />
 
       <Crossgen2SupportedRids
         Condition="'$(BundleCrossgen2)' == 'true'"
@@ -580,6 +584,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                         TargetFramework="net10.0"
                         Crossgen2PackNamePattern="Microsoft.NETCore.App.Crossgen2.**RID**"
                         Crossgen2PackVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)"
+                        Crossgen2PortableRuntimeIdentifiers="@(Crossgen2SupportedPortableRids, '%3B')"
                         Crossgen2RuntimeIdentifiers="@(Crossgen2SupportedRids, '%3B')"
                         />
 
@@ -588,6 +593,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                          ILCompilerPackNamePattern="runtime.**RID**.Microsoft.DotNet.ILCompiler"
                          ILCompilerRuntimePackNamePattern="Microsoft.NETCore.App.Runtime.NativeAOT.**RID**"
                          ILCompilerPackVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)"
+                         ILCompilerPortableRuntimeIdentifiers="@(ILCompilerSupportedPortableRids, '%3B')"
                          ILCompilerRuntimeIdentifiers="@(ILCompilerSupportedRids, '%3B')"
                          />
 

--- a/src/sdk/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/sdk/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -813,12 +813,20 @@ namespace Microsoft.NET.Build.Tasks
 
                 var runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
 
-                // If the provided RID is compatible with a non-portable RID in the support list, then it's considered non-portable.
-                NuGetUtils.GetBestMatchingRidWithExclusion(runtimeGraph, RuntimeIdentifier, packSupportedPortableRuntimeIdentifiers, packSupportedRuntimeIdentifiers, out bool targetsNonPortableSdkRid);
+                // Prefer portable when the "supported RID" for the tool pack is the same RID as the "supported portable RID".
+                // This makes non-portable SDKs behave the same as portable SDKs except for the specific cases added to "supported", such as targeting the non-portable RID.
+                // This also ensures that targeting common RIDs doesn't require any non-portable assets that aren't packaged in the SDK by default.
+                // Due to size concerns, the non-portable ILCompiler and Crossgen2 aren't included by default in non-portable SDK distributions.
+                string supportedTargetRid = NuGetUtils.GetBestMatchingRid(runtimeGraph, RuntimeIdentifier, packSupportedRuntimeIdentifiers, out _);
+                string supportedPortableTargetRid = NuGetUtils.GetBestMatchingRid(runtimeGraph, RuntimeIdentifier, packSupportedPortableRuntimeIdentifiers, out _);
 
-                string hostRuntimeIdentifier = targetsNonPortableSdkRid ? NETCoreSdkRuntimeIdentifier : portableSdkRid;
+                bool usePortable = !string.IsNullOrEmpty(NETCoreSdkPortableRuntimeIdentifier) && supportedTargetRid == supportedPortableTargetRid;
+
                 // Get the best RID for the host machine, which will be used to validate that we can run crossgen for the target platform and architecture
-                hostRuntimeIdentifier = NuGetUtils.GetBestMatchingRid(runtimeGraph, hostRuntimeIdentifier, packSupportedRuntimeIdentifiers, out bool wasInGraph);
+                string hostRuntimeIdentifier = usePortable
+                    ? NuGetUtils.GetBestMatchingRid(runtimeGraph, NETCoreSdkPortableRuntimeIdentifier, packSupportedPortableRuntimeIdentifiers, out _)
+                    : NuGetUtils.GetBestMatchingRid(runtimeGraph, NETCoreSdkRuntimeIdentifier, packSupportedRuntimeIdentifiers, out _);
+
                 if (hostRuntimeIdentifier == null)
                 {
                     return ToolPackSupport.UnsupportedForHostRuntimeIdentifier;

--- a/src/sdk/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/sdk/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -802,17 +802,22 @@ namespace Microsoft.NET.Build.Tasks
             {
                 var packNamePattern = knownPack.GetMetadata(packName + "PackNamePattern");
                 var packSupportedRuntimeIdentifiers = knownPack.GetMetadata(packName + "RuntimeIdentifiers").Split(';');
+                var packSupportedPortableRuntimeIdentifiers = knownPack.GetMetadata(packName + "PortableRuntimeIdentifiers").Split(';');
 
-                // When publishing for the non-portable RID that matches NETCoreSdkRuntimeIdentifier, prefer NETCoreSdkRuntimeIdentifier for the host.
+                // When publishing for a non-portable RID, prefer NETCoreSdkRuntimeIdentifier for the host.
                 // Otherwise prefer the NETCoreSdkPortableRuntimeIdentifier.
-                // This makes non-portable SDKs behave the same as portable SDKs except for the specific case of targetting the non-portable RID.
-                // It also enables the non-portable ILCompiler to be packaged separately from the SDK and
-                // only required when publishing for the non-portable SDK RID.
+                // This makes non-portable SDKs behave the same as portable SDKs except for the specific case of targetting a non-portable RID.
+                // This ensures that targeting portable RIDs doesn't require any non-portable assets that aren't packaged in the SDK.
+                // Due to size concerns, the non-portable ILCompiler and Crossgen2 aren't included by default in non-portable SDK distributions.
                 string portableSdkRid = !string.IsNullOrEmpty(NETCoreSdkPortableRuntimeIdentifier) ? NETCoreSdkPortableRuntimeIdentifier : NETCoreSdkRuntimeIdentifier;
-                bool targetsNonPortableSdkRid = RuntimeIdentifier == NETCoreSdkRuntimeIdentifier && NETCoreSdkRuntimeIdentifier != portableSdkRid;
+
+                var runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
+
+                // If the provided RID is compatible with a non-portable RID in the support list, then it's considered non-portable.
+                NuGetUtils.GetBestMatchingRidWithExclusion(runtimeGraph, RuntimeIdentifier, packSupportedPortableRuntimeIdentifiers, packSupportedRuntimeIdentifiers, out bool targetsNonPortableSdkRid);
+
                 string hostRuntimeIdentifier = targetsNonPortableSdkRid ? NETCoreSdkRuntimeIdentifier : portableSdkRid;
                 // Get the best RID for the host machine, which will be used to validate that we can run crossgen for the target platform and architecture
-                var runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
                 hostRuntimeIdentifier = NuGetUtils.GetBestMatchingRid(runtimeGraph, hostRuntimeIdentifier, packSupportedRuntimeIdentifiers, out bool wasInGraph);
                 if (hostRuntimeIdentifier == null)
                 {


### PR DESCRIPTION
Try using the non-portable cg2/ilc when targeting any non-portable RID, not just the non-portable RID matching the SDK RID.

Fixes dotnet/source-build#5225