### PR TITLE
Move code execution after owner permission update

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -606,6 +606,13 @@ jobs:
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
+    - ${{ if ne(parameters.runOnline, 'True' )}}:
+      - script: |
+          set -ex
+          # Update the owner of the staging directory to the current user
+          sudo chown -R $(whoami) $(Build.ArtifactStagingDirectory)
+        displayName: Update owner of artifacts staging directory
+
     - script: |
         if [[ -d "$(Build.ArtifactStagingDirectory)/artifacts/assets/${{ parameters.configuration }}/source-build" ]]; then
           rm -rf $(Build.ArtifactStagingDirectory)/artifacts/assets/${{ parameters.configuration }}/source-build
@@ -613,13 +620,6 @@ jobs:
       displayName: Clean up unwanted Source Build Artifacts
       continueOnError: true
       condition: succeededOrFailed()
-
-    - ${{ if ne(parameters.runOnline, 'True' )}}:
-      - script: |
-          set -ex
-          # Update the owner of the staging directory to the current user
-          sudo chown -R $(whoami) $(Build.ArtifactStagingDirectory)
-        displayName: Update owner of artifacts staging directory
 
     # Only run tests if enabled
     - ${{ if eq(parameters.runTests, 'True') }}:


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/5294

This PR changes the step sequence to execute code after updating owner permissions, addressing the permission denied issue.