### PR TITLE
[release/10.0.1xx] Remove FPM tooling support from SDK

### DIFF
--- a/src/sdk/src/Layout/pkg/dotnet-sdk.proj
+++ b/src/sdk/src/Layout/pkg/dotnet-sdk.proj
@@ -8,7 +8,6 @@
     <GenerateInstallers Condition="'$(DotNetBuildSourceOnly)' != 'true'">true</GenerateInstallers>
     <BuildDebPackage Condition="'$(BuildSdkDeb)' == 'true'">true</BuildDebPackage>
     <BuildRpmPackage Condition="'$(BuildSdkRpm)' == 'true'">true</BuildRpmPackage>
-    <UseArcadeRpmTooling>true</UseArcadeRpmTooling>
     <ProductBrandPrefix>Microsoft .NET</ProductBrandPrefix>
     <LicenseFile>$(RepoRoot)LICENSE.TXT</LicenseFile>
     <InstallerName>dotnet-sdk</InstallerName>
@@ -111,7 +110,7 @@
   </Target>
 
   <Target Name="AddLinuxPackageInformation"
-      BeforeTargets="GetDebInstallerJsonProperties;GetRpmInstallerJsonProperties"
+      BeforeTargets="GetAdditionalLinuxInstallerProperties"
       DependsOnTargets="CalculateLinuxNativeInstallerDependencyVersions">
 
     <PropertyGroup>


### PR DESCRIPTION
Cherry pick of https://github.com/dotnet/dotnet/commit/544d4310bec510b8472a773ea3ceb74af499dc7d which got reverted amidst the SDK codeflow misconfiguration