### PR TITLE
Revert enabling package pruning for MT scenarios

### DIFF
--- a/src/sdk/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/sdk/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -52,10 +52,9 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
   
   <!-- TODO: https://github.com/dotnet/sdk/issues/49917 Remove the framework based condition when the data for netcoreapp2.1 and below is fixed-->
-  <!-- Package pruning is expected to be enable for all TFMs for multi-targeted projects, so still generate the pruning data when RestoreEnablePackagePruning is '' which implies a multi-targeted project. -->
   <Target Name="AddPrunePackageReferences" BeforeTargets="CollectPrunePackageReferences"
           DependsOnTargets="ProcessFrameworkReferences"
-          Condition="('$(RestoreEnablePackagePruning)' == 'true' OR '$(RestoreEnablePackagePruning)' == '')
+          Condition="'$(RestoreEnablePackagePruning)' == 'true'
           AND (('$(TargetFrameworkIdentifier)' == '.NETCoreApp'
           AND '$(TargetFrameworkVersion)' != ''
           AND $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)', '3.0')))

--- a/src/sdk/test/Microsoft.NET.Build.Tests/GivenThatWeWantToResolveConflicts.cs
+++ b/src/sdk/test/Microsoft.NET.Build.Tests/GivenThatWeWantToResolveConflicts.cs
@@ -331,9 +331,7 @@ namespace Microsoft.NET.Build.Tests
         [InlineData("net451", false)]
         [InlineData("net462")]
         [InlineData("net481")]
-        [InlineData("net9.0", true, "")]
-        [InlineData("netstandard2.1", true, "")]
-        public void PrunePackageDataSucceeds(string targetFramework, bool shouldPrune = true, string enablePackagePruning = "True")
+        public void PrunePackageDataSucceeds(string targetFramework, bool shouldPrune = true)
         {
             var nugetFramework = NuGetFramework.Parse(targetFramework);
 
@@ -344,7 +342,7 @@ namespace Microsoft.NET.Build.Tests
                     TargetFrameworks = targetFramework
                 };
 
-                testProject.AdditionalProperties["RestoreEnablePackagePruning"] = enablePackagePruning;
+                testProject.AdditionalProperties["RestoreEnablePackagePruning"] = "True";
 
                 if (!string.IsNullOrEmpty(frameworkReference))
                 {
@@ -444,49 +442,6 @@ namespace Microsoft.NET.Build.Tests
 
             items2.Should().BeEquivalentTo(items1);
 
-        }
-
-        [CoreMSBuildOnlyTheory]
-        [InlineData("net10.0;net9.0", true)]
-        [InlineData("net10.0;net8.0", true)]
-        [InlineData("net6.0;net7.0", false)]
-        public void WithMultitargetedProjects_PruningsDefaultsAreApplies(string frameworks, bool prunePackages)
-        {
-            var referencedProject = new TestProject("ReferencedProject")
-            {
-                TargetFrameworks = frameworks,
-                IsExe = false
-            };
-            referencedProject.PackageReferences.Add(new TestPackageReference("System.Text.Json", "6.0.0"));
-            referencedProject.AdditionalProperties["RestoreEnablePackagePruning"] = "false";
-
-            var testProject = new TestProject()
-            {
-                TargetFrameworks = frameworks,
-            };
-
-            testProject.ReferencedProjects.Add(referencedProject);
-
-            var testAsset = _testAssetsManager.CreateTestProject(testProject, identifier: prunePackages.ToString());
-
-            var buildCommand = new BuildCommand(testAsset);
-
-            buildCommand.Execute().Should().Pass();
-
-            var assetsFilePath = Path.Combine(buildCommand.GetBaseIntermediateDirectory().FullName, "project.assets.json");
-            var lockFile = LockFileUtilities.GetLockFile(assetsFilePath, new NullLogger());
-
-            foreach(var lockFileTarget in lockFile.Targets)
-            {
-                if (prunePackages)
-                {
-                    lockFileTarget.Libraries.Should().NotContain(library => library.Name.Equals("System.Text.Json", StringComparison.OrdinalIgnoreCase));
-                }
-                else
-                {
-                    lockFileTarget.Libraries.Should().Contain(library => library.Name.Equals("System.Text.Json", StringComparison.OrdinalIgnoreCase));
-                }
-            }
         }
 
         static List<KeyValuePair<string, string>> ParsePrunePackageReferenceJson(string json)


### PR DESCRIPTION
it's causing perf regressions in orchardcore when TargetFrameworks is set to a single value. We believe this is because nuget and the project system aren't handling the default correctly in the project system cache and triggering multiple DTBs.

We found ~83k projects on nuget with a singular TargetFrameworks (279k with multiple values) out of 5M csproj files total.

