### PR TITLE
Use macos-14-arm64 image in internal builds to workaround linker bug

### DIFF
--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -282,7 +282,7 @@ variables:
   - name: poolName_LinuxArm64
     value: Docker-Linux-Arm-Internal
   - name: poolImage_Mac
-    value: macos-latest-internal
+    value: macos-14
   - name: poolImage_Windows
     value: windows.vs2022preview.amd64
 

--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -282,7 +282,6 @@ variables:
   - name: poolName_LinuxArm64
     value: Docker-Linux-Arm-Internal
   - name: poolImage_Mac
-    value: macos-14
+    value: macos-14-arm64
   - name: poolImage_Windows
     value: windows.vs2022preview.amd64
-


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/119174