### PR TITLE
Create and publish source tarball and zipball

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -99,6 +99,11 @@
         <Kind>Blob</Kind>
         <IsShipping>true</IsShipping>
       </SourceBuildArtifact>
+      <!-- Add the source artifacts to the publishing output. -->
+      <SourceBuildArtifact Include="$(ArtifactsAssetsDir)$(SourceBuiltSourceArtifactName)-*">
+        <Kind>Blob</Kind>
+        <IsShipping>true</IsShipping>
+      </SourceBuildArtifact>
       <!-- Include the prebuilts tarball in the publishing output as well. -->
       <SourceBuildArtifact Include="$(ArtifactsAssetsDir)$(SourceBuiltPrebuiltsTarballName).*$(ArchiveExtension)">
         <Kind>Blob</Kind>
@@ -114,6 +119,7 @@
     <ItemGroup Condition="'$(IsPublishPass2)' == 'true' and '$(DotNetBuildSourceOnly)' == 'true'">
       <SourceBuildArtifact Include="$(ArtifactsAssetsDir)/$(SourceBuiltArtifactsTarballName).*$(ArchiveExtension)" />
       <SourceBuildArtifact Include="$(ArtifactsAssetsDir)/**/dotnet-sdk-*$(ArchiveExtension)" />
+      <SourceBuildArtifact Include="$(ArtifactsAssetsDir)/$(SourceBuiltSourceArtifactName)-*" />
       <Artifact Include="@(SourceBuildArtifact)">
         <IsShipping>true</IsShipping>
         <Kind>Blob</Kind>

--- a/eng/VmrLayout.props
+++ b/eng/VmrLayout.props
@@ -44,6 +44,7 @@
     <SourceBuiltArtifactsTarballName>Private.SourceBuilt.Artifacts</SourceBuiltArtifactsTarballName>
     <SourceBuiltSharedComponentsTarballName>Private.SourceBuilt.SharedComponents</SourceBuiltSharedComponentsTarballName>
     <SourceBuiltPrebuiltsTarballName>Private.SourceBuilt.Prebuilts</SourceBuiltPrebuiltsTarballName>
+    <SourceBuiltSourceArtifactName>dotnet-source</SourceBuiltSourceArtifactName>
     <SourceBuiltSymbolsAllTarballName>dotnet-symbols-all</SourceBuiltSymbolsAllTarballName>
     <SourceBuiltSymbolsSdkTarballName>dotnet-symbols-sdk</SourceBuiltSymbolsSdkTarballName>
 

--- a/eng/finish-source-only.proj
+++ b/eng/finish-source-only.proj
@@ -253,6 +253,21 @@
     <RemoveDir Directories="$(IntermediateSdkSymbolsLayout)" />
   </Target>
 
+  <!-- After building, generate the source tarball and zipball -->
+  <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.CreateSourceArtifacts" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
+  <Target Name="CreateSourceArtifacts"
+          BeforeTargets="Build"
+          DependsOnTargets="WriteSourceBuiltSdkVersionFile"
+          Condition="'$(CreateSourceArtifacts)' == 'true'" >
+
+    <CreateSourceArtifacts
+        SourceCommit="$(RepositoryCommit)"
+        ArtifactName="$(SourceBuiltSourceArtifactName)"
+        ArtifactVersion="$(SourceBuiltSdkNonStableVersion)"
+        RepoRoot="$(RepoRoot)"
+        OutputDirectory="$(ArtifactsAssetsDir)" />
+  </Target>
+
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.UsageReport.WriteUsageBurndownData" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
   <Target Name="GeneratePrebuiltBurndownData"
           Inputs="$(MSBuildProjectFullPath)"

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -114,6 +114,11 @@ parameters:
   type: boolean
   default: false
 
+# Create and publish the source artifacts
+- name: createSourceArtifacts
+  type: boolean
+  default: false
+
 # Skip the build step (this would be used when wanting to run tests only)
 - name: skipBuild
   type: boolean
@@ -565,10 +570,16 @@ jobs:
           if [[ '${{ parameters.buildFromArchive }}' == 'True' ]]; then
             customBuildArgs="$customBuildArgs --source-repository https://github.com/dotnet/dotnet"
             customBuildArgs="$customBuildArgs --source-version $(git -C "$(vmrPath)" rev-parse HEAD)"
-          else
-            # Enable source artifact creation only when building from a git repo.
-            # We strip the .git/ directory when building from archive,
-            # so it's not possible to create the artifacts in that mode.
+            if [[ '${{ parameters.createSourceArtifacts }}' == 'True' ]]; then
+              # Do not enable source artifact creation when not building from a git repo.
+              # We strip the .git/ directory when building from archive,
+              # so it's not possible to create the artifacts in that mode.
+              echo "Cannot create source artifacts when building from archive."
+              exit 1
+            fi
+          fi
+          
+          if [[ '${{ parameters.createSourceArtifacts }}' == 'True' ]]; then
             extraBuildProperties="$extraBuildProperties /p:CreateSourceArtifacts=true"
           fi
 

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -565,6 +565,11 @@ jobs:
           if [[ '${{ parameters.buildFromArchive }}' == 'True' ]]; then
             customBuildArgs="$customBuildArgs --source-repository https://github.com/dotnet/dotnet"
             customBuildArgs="$customBuildArgs --source-version $(git -C "$(vmrPath)" rev-parse HEAD)"
+          else
+            # Enable source artifact creation only when building from a git repo.
+            # We strip the .git/ directory when building from archive,
+            # so it's not possible to create the artifacts in that mode.
+            extraBuildProperties="$extraBuildProperties /p:CreateSourceArtifacts=true"
           fi
 
           if [[ '${{ parameters.buildSourceOnly }}' == 'True' ]]; then

--- a/eng/pipelines/templates/stages/source-build-and-validate.yml
+++ b/eng/pipelines/templates/stages/source-build-and-validate.yml
@@ -114,7 +114,8 @@ stages:
         useMonoRuntime: ${{ leg.useMonoRuntime }}
         useSystemLibraries: ${{ leg.useSystemLibraries }}
         withPreviousSDK: ${{ leg.withPreviousSDK }}
-        
+        createSourceArtifacts: ${{ leg.createSourceArtifacts }}
+
         # We only want to publish SB artifacts for each distinct distro/version/arch combination
         ${{ if and(endsWith(leg.buildNameFormat, 'Offline_MsftSdk'), not(contains(leg.buildNameFormat, '_Mono_'))) }}:
           extraProperties: /p:DotNetSourceOnlyPublishArtifacts=true

--- a/eng/pipelines/templates/stages/source-build-stages.yml
+++ b/eng/pipelines/templates/stages/source-build-stages.yml
@@ -73,6 +73,7 @@ stages:
           useMonoRuntime: false              # 🚫
           useSystemLibraries: false          # 🚫
           withPreviousSDK: false             # 🚫
+          createSourceArtifacts: true        # ✅
 
         - ${{ if containsValue(parameters.verifications, 'source-build-stage2') }}:
 
@@ -85,6 +86,7 @@ stages:
             useMonoRuntime: false              # 🚫
             useSystemLibraries: false          # 🚫
             withPreviousSDK: false             # 🚫
+            createSourceArtifacts: false       # 🚫
             reuseBuildArtifactsFrom: 'SB_{0}_Online_MsftSdk_x64'
 
         ### Additional legs for full build ###
@@ -100,6 +102,7 @@ stages:
             useMonoRuntime: false              # 🚫
             useSystemLibraries: false          # 🚫
             withPreviousSDK: false             # 🚫
+            createSourceArtifacts: false       # 🚫
 
           - buildNameFormat: 'SB_{0}_Offline_PreviousSourceBuiltSdk'
             distro: centos
@@ -110,6 +113,7 @@ stages:
             useMonoRuntime: false              # 🚫
             useSystemLibraries: false          # 🚫
             withPreviousSDK: true              # ✅
+            createSourceArtifacts: false       # 🚫
 
           - buildNameFormat: 'SB_{0}_Offline_MsftSdk'
             distro: almalinux
@@ -120,6 +124,7 @@ stages:
             useMonoRuntime: false              # 🚫
             useSystemLibraries: false          # 🚫
             withPreviousSDK: false             # 🚫
+            createSourceArtifacts: false       # 🚫
 
           - buildNameFormat: 'SB_{0}_Offline_MsftSdk'
             distro: alpine
@@ -130,6 +135,7 @@ stages:
             useMonoRuntime: false              # 🚫
             useSystemLibraries: false          # 🚫
             withPreviousSDK: false             # 🚫
+            createSourceArtifacts: false       # 🚫
 
           - buildNameFormat: 'SB_{0}_Offline_MsftSdk'
             distro: centos
@@ -140,6 +146,7 @@ stages:
             useMonoRuntime: false              # 🚫
             useSystemLibraries: false          # 🚫
             withPreviousSDK: false             # 🚫
+            createSourceArtifacts: false       # 🚫
 
           - buildNameFormat: 'SB_{0}_Online_PreviousSourceBuiltSdk'
             distro: centos
@@ -150,6 +157,7 @@ stages:
             useMonoRuntime: false              # 🚫
             useSystemLibraries: false          # 🚫
             withPreviousSDK: true              # ✅
+            createSourceArtifacts: false       # 🚫
 
           - buildNameFormat: 'SB_{0}_Mono_Offline_MsftSdk'
             distro: centos
@@ -160,6 +168,7 @@ stages:
             useMonoRuntime: true               # ✅
             useSystemLibraries: false          # 🚫
             withPreviousSDK: false             # 🚫
+            createSourceArtifacts: false       # 🚫
 
           - buildNameFormat: 'SB_{0}_Offline_MsftSdk'
             distro: fedora
@@ -170,6 +179,7 @@ stages:
             useMonoRuntime: false              # 🚫
             useSystemLibraries: true           # ✅
             withPreviousSDK: false             # 🚫
+            createSourceArtifacts: false       # 🚫
 
           - buildNameFormat: 'SB_{0}Arm64_Offline_MsftSdk'
             distro: ubuntu
@@ -180,6 +190,7 @@ stages:
             useMonoRuntime: false              # 🚫
             useSystemLibraries: false          # 🚫
             withPreviousSDK: false             # 🚫
+            createSourceArtifacts: false       # 🚫
 
           - buildNameFormat: 'SB_{0}_Offline_CurrentSourceBuiltSdk'
             distro: fedora
@@ -190,6 +201,7 @@ stages:
             useMonoRuntime: false              # 🚫
             useSystemLibraries: false          # 🚫
             withPreviousSDK: false             # 🚫
+            createSourceArtifacts: false       # 🚫
             reuseBuildArtifactsFrom: 'SB_{0}_Offline_MsftSdk_x64'
 
           - buildNameFormat: 'SB_{0}_Mono_Offline_CurrentSourceBuiltSdk'
@@ -201,4 +213,5 @@ stages:
             useMonoRuntime: true               # ✅
             useSystemLibraries: false          # 🚫
             withPreviousSDK: false             # 🚫
+            createSourceArtifacts: false       # 🚫
             reuseBuildArtifactsFrom: 'SB_{0}_Mono_Offline_MsftSdk_x64'

--- a/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/CreateSourceArtifacts.cs
+++ b/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/CreateSourceArtifacts.cs
@@ -1,0 +1,99 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.DotNet.UnifiedBuild.Tasks.Models;
+using Microsoft.DotNet.UnifiedBuild.Tasks.Services;
+using BuildTask = Microsoft.Build.Utilities.Task;
+
+namespace Microsoft.DotNet.UnifiedBuild.Tasks;
+
+public class CreateSourceArtifacts : BuildTask
+{
+    /// <summary>
+    /// Commit SHA of the VMR source to download
+    /// </summary>
+    [Required]
+    public required string SourceCommit { get; init; }
+
+    /// <summary>
+    /// Name of the artifact to generate
+    /// </summary>
+    [Required]
+    public required string ArtifactName { get; init; }
+
+    /// <summary>
+    /// Version of the artifact to generate
+    /// </summary>
+    [Required]
+    public required string ArtifactVersion { get; init; }
+
+    /// <summary>
+    /// Path to the root of the repo
+    /// </summary>
+    [Required]
+    public required string RepoRoot { get; init; }
+
+    /// <summary>
+    /// Path to the directory to place the source artifacts in
+    /// </summary>
+    [Required]
+    public required string OutputDirectory { get; init; }
+
+    private const int GitArchiveTimeout = 5 * 60 * 1000; // 5 minutes
+
+    public override bool Execute() => ExecuteAsync().GetAwaiter().GetResult();
+
+    private async Task<bool> ExecuteAsync()
+    {
+        var processService = new ProcessService(Log, GitArchiveTimeout);
+        var errors = new ConcurrentQueue<string>();
+
+        await Parallel.ForEachAsync(Enum.GetValues<ArtifactType>(), async (artifactType, _) =>
+        {
+            await CreateArtifactAsync(artifactType, processService, errors);
+        });
+
+        if (errors.IsEmpty)
+        {
+            Log.LogMessage(MessageImportance.High, "Source artifact creation succeeded.");
+            return true;
+        }
+
+        Log.LogError($"Source artifact creation failed with the following errors:");
+        foreach (var error in errors)
+        {
+            Log.LogError($" - {error}");
+        }
+        return false;
+    }
+
+    private async Task CreateArtifactAsync(ArtifactType artifactType, ProcessService processService, ConcurrentQueue<string> errors)
+    {
+        string artifactFileName = $"{ArtifactName}-{ArtifactVersion}{artifactType.GetArtifactExtension()}";
+        string artifactFilePath = Path.Combine(OutputDirectory, artifactFileName);
+
+        Log.LogMessage(MessageImportance.High, $"Creating {artifactType} source artifact at: {artifactFilePath}");
+
+        try
+        {
+            ProcessResult result = await processService.RunProcessAsync(
+                "git",
+                $"archive -o {artifactFilePath} {SourceCommit}",
+                workingDirectory: RepoRoot);
+
+            if (result.ExitCode != 0)
+            {
+                errors.Enqueue($"[{artifactType}] Git exited with code {result.ExitCode}: {result.Error}");
+            }
+        }
+        catch (Exception ex)
+        {
+            errors.Enqueue($"[{artifactType}] Exception during artifact creation: {ex.Message}");
+        }
+    }
+}

--- a/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/Models/ArtifactType.cs
+++ b/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/Models/ArtifactType.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.DotNet.UnifiedBuild.Tasks.Models;
+
+public enum ArtifactType
+{
+    Tarball,
+    Zipball
+}
+
+public static class Extensions
+{
+    public static string GetArtifactExtension(this ArtifactType artifactType)
+    {
+        return artifactType switch
+        {
+            ArtifactType.Tarball => ".tar.gz",
+            ArtifactType.Zipball => ".zip",
+            _ => throw new ArgumentOutOfRangeException(nameof(artifactType), artifactType, null)
+        };
+    }
+}

--- a/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/Services/ProcessService.cs
+++ b/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/Services/ProcessService.cs
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.DotNet.UnifiedBuild.Tasks.Services;
+
+public record ProcessResult(string Output, string Error, int ExitCode);
+
+public class ProcessService(TaskLoggingHelper log, int timeout = 10 * 1000)
+{
+    private TaskLoggingHelper Log { get; } = log;
+    private TimeSpan Timeout { get; } = TimeSpan.FromMilliseconds(timeout);
+
+    public async Task<ProcessResult> RunProcessAsync(string command, string arguments, string workingDirectory = "", bool printOutput = false)
+    {
+        var processInfo = new ProcessStartInfo
+        {
+            FileName = command,
+            Arguments = arguments,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = workingDirectory
+        };
+
+        using var process = new Process { StartInfo = processInfo, EnableRaisingEvents = true };
+
+        var outputBuilder = new StringBuilder();
+        var errorBuilder = new StringBuilder();
+
+        var outputTcs = new TaskCompletionSource();
+        var errorTcs = new TaskCompletionSource();
+
+        process.OutputDataReceived += (s, e) =>
+        {
+            if (e.Data == null)
+            {
+                outputTcs.TrySetResult();
+                return;
+            }
+
+            outputBuilder.AppendLine(e.Data);
+            if (printOutput)
+            {
+                Log.LogMessage(e.Data);
+            }
+        };
+
+        process.ErrorDataReceived += (s, e) =>
+        {
+            if (e.Data == null)
+            {
+                errorTcs.TrySetResult();
+                return;
+            }
+
+            errorBuilder.AppendLine(e.Data);
+            if (printOutput)
+            {
+                Log.LogMessage(MessageImportance.High, e.Data);
+            }
+        };
+
+        if (!process.Start())
+        {
+            throw new InvalidOperationException($"Failed to start process: {command} {arguments}");
+        }
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        using var timeoutCts = new CancellationTokenSource(Timeout);
+
+        var exitedTask = Task.Run(() => process.WaitForExit(), timeoutCts.Token);
+
+        try
+        {
+            await exitedTask;
+            await Task.WhenAll(outputTcs.Task, errorTcs.Task);
+        }
+        catch (OperationCanceledException)
+        {
+            try { process.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException($"Process timed out after {Timeout.TotalMilliseconds} ms");
+        }
+
+        return new ProcessResult(
+            Output: outputBuilder.ToString(),
+            Error: errorBuilder.ToString(),
+            ExitCode: process.ExitCode
+        );
+    }
+}


### PR DESCRIPTION
Reverts https://github.com/dotnet/dotnet/pull/2202 (https://github.com/dotnet/dotnet/commit/c8c785c5af00422e94edf6818847f63e7a8c499d) and fixes the publishing issue by only publishing the source artifacts from a single VMR build leg (https://github.com/dotnet/dotnet/commit/111862893175a50adcced67c3cb4448760137356). The selected build leg is the one that creates the SB artifacts we publish during a release.