### PR TITLE
Add System.Threading.AccessControl to PackageOverrides.txt

### DIFF
--- a/src/runtime/src/installer/pkg/sfx/Microsoft.NETCore.App/PackageOverrides.txt
+++ b/src/runtime/src/installer/pkg/sfx/Microsoft.NETCore.App/PackageOverrides.txt
@@ -253,6 +253,7 @@ System.Text.Encodings.Web|${ProductVersion}
 System.Text.Json|${ProductVersion}
 System.Text.RegularExpressions|4.3.1
 System.Threading|4.3.0
+System.Threading.AccessControl|${ProductVersion}
 System.Threading.Channels|${ProductVersion}
 System.Threading.Overlapped|4.3.0
 System.Threading.Tasks|4.3.0


### PR DESCRIPTION
@ViktorHofer 

It looks like we still maintain this list separately and don't have validation that it's complete.

Making this change in VMR to see if it will introduce any warnings elsewhere in the product.