### PR TITLE
Add WindowsDesktop SDK override back until a new SDK is used

### DIFF
--- a/eng/tools/EmptySdk/Sdk/Sdk.props
+++ b/eng/tools/EmptySdk/Sdk/Sdk.props
@@ -1,0 +1,14 @@
+<Project>
+
+  <PropertyGroup>
+    <RepoRoot Condition="'$(RepoRoot)' == ''">$([MSBuild]::NormalizeDirectory('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'global.json'))'))</RepoRoot>
+    <RepositoryEngineeringDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'eng'))</RepositoryEngineeringDir>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Skip importing NuGet Pack targets which are imported from the Microsoft.NET.Sdk targets -->
+    <ImportNuGetBuildTasksPackTargetsFromSdk>false</ImportNuGetBuildTasksPackTargetsFromSdk>
+  </PropertyGroup>
+
+</Project>
+

--- a/eng/tools/EmptySdk/Sdk/Sdk.targets
+++ b/eng/tools/EmptySdk/Sdk/Sdk.targets
@@ -1,0 +1,9 @@
+<Project>
+  <Target Name="_IsProjectRestoreSupported"/>
+  <Target Name="Restore"/>
+  <Target Name="Build"/>
+  <Target Name="Test"/>
+  <Target Name="Pack"/>
+  <Target Name="Publish"/>
+</Project>
+

--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -219,6 +219,8 @@
                                 Group="ARCADE"
                                 Version="$(ArcadeBootstrapVersion)"
                                 Location="$(BootstrapPackagesDir)microsoft.dotnet.arcade.sdk/$(ArcadeBootstrapVersion)" />
+    <!-- Make the WindowsDesktop SDK override opt-in for repos that need it. Keep this line until the VMR updates to a new SDK. -->
+    <WindowsDesktopSdkOverride Include="Microsoft.Net.Sdk.WindowsDesktop" Group="WINDOWS_DESKTOP" Location="$(ToolsDir)EmptySdk" Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Partial revert of https://github.com/dotnet/dotnet/commit/ee8b9094a435891d3ee8c40624cb467c51463b9c to unblock the official build