### PR TITLE
[release/10.0.1xx] Restore MB install steps to pre-rebootstrap

### DIFF
--- a/eng/common/core-templates/steps/install-microbuild.yml
+++ b/eng/common/core-templates/steps/install-microbuild.yml
@@ -12,6 +12,7 @@ parameters:
   # variable is not available in template expression. _SignType has a very large proliferation across .NET, so replacing it is tough.
   microbuildUseESRP: true
   # Location of the MicroBuild output folder
+  # NOTE: There's something that relies on this being in the "default" source directory for tasks such as Signing to work properly.
   microBuildOutputFolder: '$(Build.SourcesDirectory)'
 
   continueOnError: false
@@ -46,17 +47,19 @@ steps:
       displayName: 'Validate ESRP usage (Non-Windows)'
       condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
 
+    # Two different MB install steps. This is due to not being able to use the agent OS during
+    # YAML expansion, and Windows vs. Linux/Mac uses different service connections. However,
+    # we can avoid including the MB install step if not enabled at all. This avoids a bunch of
+    # extra pipeline authorizations, since most pipelines do not sign on non-Windows.
     - task: MicroBuildSigningPlugin@4
-      displayName: Install MicroBuild plugin
+      displayName: Install MicroBuild plugin (Windows)
       inputs:
         signType: $(_SignType)
         zipSources: false
         feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
         ${{ if eq(parameters.microbuildUseESRP, true) }}:
-          ${{ if eq(parameters.enableMicrobuildForMacAndLinux, 'true') }}:
-            azureSubscription: 'MicroBuild Signing Task (DevDiv)'
-            useEsrpCli: true
-          ${{ elseif eq(variables['System.TeamProject'], 'DevDiv') }}:
+          ConnectedServiceName: 'MicroBuild Signing Task (DevDiv)'
+          ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
             ConnectedPMEServiceName: 6cc74545-d7b9-4050-9dfa-ebefcc8961ea
           ${{ else }}:
             ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
@@ -65,16 +68,24 @@ steps:
         MicroBuildOutputFolderOverride: ${{ parameters.microBuildOutputFolder }}
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       continueOnError: ${{ parameters.continueOnError }}
-      condition: and(
-        succeeded(),
-        or(
-          and(
-            eq(variables['Agent.Os'], 'Windows_NT'),
-            in(variables['_SignType'], 'real', 'test')
-          ),
-          and(
-            ${{ eq(parameters.enableMicrobuildForMacAndLinux, true) }},
-            ne(variables['Agent.Os'], 'Windows_NT'),
-            eq(variables['_SignType'], 'real')
-          )
-        ))
+      condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'), in(variables['_SignType'], 'real', 'test'))
+
+    - ${{ if eq(parameters.enableMicrobuildForMacAndLinux, true) }}:
+      - task: MicroBuildSigningPlugin@4
+        displayName: Install MicroBuild plugin (non-Windows)
+        inputs:
+          signType: $(_SignType)
+          zipSources: false
+          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+          ${{ if eq(parameters.microbuildUseESRP, true) }}:
+            ConnectedServiceName: 'MicroBuild Signing Task (DevDiv)'
+            ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+              ConnectedPMEServiceName: beb8cb23-b303-4c95-ab26-9e44bc958d39
+            ${{ else }}:
+              ConnectedPMEServiceName: c24de2a5-cc7a-493d-95e4-8e5ff5cad2bc
+        env:
+          TeamName: $(_TeamName)
+          MicroBuildOutputFolderOverride: ${{ parameters.microBuildOutputFolder }}
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        continueOnError: ${{ parameters.continueOnError }}
+        condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'),  eq(variables['_SignType'], 'real'))


### PR DESCRIPTION
When the rc1 re-bootstrap happened it reverted to a version of this template that can't be used any longer.