### PR TITLE
Revert SB artifacts cleanup

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -608,14 +608,6 @@ jobs:
           sudo chown -R $(whoami) $(Build.ArtifactStagingDirectory)
         displayName: Update owner of artifacts staging directory
 
-    - script: |
-        if [[ -d "$(Build.ArtifactStagingDirectory)/artifacts/assets/${{ parameters.configuration }}/source-build" ]]; then
-          rm -rf $(Build.ArtifactStagingDirectory)/artifacts/assets/${{ parameters.configuration }}/source-build
-        fi
-      displayName: Clean up unwanted Source Build Artifacts
-      continueOnError: true
-      condition: succeededOrFailed()
-
     # Only run tests if enabled
     - ${{ if eq(parameters.runTests, 'True') }}:
       - ${{ parameters.testInitSteps }}
@@ -756,3 +748,4 @@ jobs:
           PathtoPublish: $(Build.ArtifactStagingDirectory)/artifacts/manifests/${{ parameters.configuration }}/$(Agent.JobName).xml
           ArtifactName: VerticalManifests
         displayName: Publish Vertical Manifest
+


### PR DESCRIPTION
Reverts the changes from https://github.com/dotnet/dotnet/pull/1827.

Fixes https://github.com/dotnet/source-build/issues/5327

Note: git automatically fixed up line endings as there was a mix of Unix and Windows line endings in this file.