### PR TITLE
Add inventory as code for VMR

### DIFF
--- a/src/es-metadata.yml
+++ b/src/es-metadata.yml
@@ -1,0 +1,8 @@
+schemaVersion: 0.0.1
+isProduction: true
+accountableOwners:
+  service: 8d20dc36-68f2-41f9-94fe-c3cd15ce04bd
+routing:
+  defaultAreaPath:
+    org: devdiv
+    path: DevDiv\.NET Shared\VMR


### PR DESCRIPTION
MSBuild has an inventory set up since July 31st, and this may be the cause of a bunch issues assigned to them, even though their es-metadata.yml is in a subdirectory. Update the ownership of the overall VMR.