### PR TITLE
Remove featureBand template parameter

### DIFF
--- a/eng/pipelines/unofficial.yml
+++ b/eng/pipelines/unofficial.yml
@@ -142,7 +142,6 @@ extends:
         desiredFinalVersionKind: ${{ parameters.desiredFinalVersionKind }}
         scope: ${{ parameters.buildScope }}
         isOfficialBuild: false
-        featureBand: ${{ parameters.featureBand }}
         # Exclude runtime dependent jobs for any branch not producing a 1xx version since runtime-related repos aren't built in that context
         # Will exclude runtime-dependent jobs when either of the following are true:
         #   - 'Detect By Branch Name' was selected for the feature band: branch is not main and does not contain '.1xx' but does end with 'xx'.


### PR DESCRIPTION
Attempting to run the unofficial pipeline causes this error:

```
Encountered error(s) while parsing pipeline YAML:
/eng/pipelines/unofficial.yml (Line: 145, Col: 22): Unexpected parameter 'featureBand'
/eng/pipelines/unofficial.yml: Object reference not set to an instance of an object.
```

This was caused by https://github.com/dotnet/dotnet/pull/2021, which removed the `featureBand` parameter from the `vmr-stages.yml` template but didn't update the `unofficial.yml` pipeline to no longer pass in that parameter.