### PR TITLE
[release/10.0.1xx] Add Winforms PackageOverrides to WindowsDesktop

### DIFF
--- a/src/windowsdesktop/src/windowsdesktop/src/sfx/Directory.Build.targets
+++ b/src/windowsdesktop/src/windowsdesktop/src/sfx/Directory.Build.targets
@@ -56,10 +56,13 @@
       <!-- Add the RuntimeWindowsDesktopPackageLibrary item information from the Microsoft.Internal.Runtime.WindowsDesktop.Transport package. -->
       <RuntimeWindowsDesktopPackageLibraries>@(RuntimeWindowsDesktopPackageLibrary->'%(PackageId)|%(PackageVersion)', '
 ')</RuntimeWindowsDesktopPackageLibraries>
+      <WinformsWindowsDesktopPackageLibraries>@(WinformsWindowsDesktopPackageLibrary->'%(PackageId)|%(PackageVersion)', '
+')</WinformsWindowsDesktopPackageLibraries>
     </PropertyGroup>
 
     <ItemGroup>
       <CreatePackageOverridesTemplateProperty Include="RuntimeWindowsDesktopPackageLibraries=$(RuntimeWindowsDesktopPackageLibraries)" />
+      <CreatePackageOverridesTemplateProperty Include="WinformsWindowsDesktopPackageLibraries=$(WinformsWindowsDesktopPackageLibraries)" />
     </ItemGroup>
 
     <GenerateFileFromTemplate

--- a/src/windowsdesktop/src/windowsdesktop/src/sfx/PackageOverrides.txt
+++ b/src/windowsdesktop/src/windowsdesktop/src/sfx/PackageOverrides.txt
@@ -1,1 +1,2 @@
 ${RuntimeWindowsDesktopPackageLibraries}
+${WinformsWindowsDesktopPackageLibraries}

--- a/src/winforms/Directory.Packages.props
+++ b/src/winforms/Directory.Packages.props
@@ -27,6 +27,7 @@
     <PackageVersion Include="System.Windows.Forms.DataVisualization" Version="1.0.0-prerelease.20110.1" />
 
     <!-- Arcade -->
+    <PackageVersion Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingPackageVersion)" />
     <PackageVersion Include="Microsoft.DotNet.GenFacades" Version="$(MicrosoftDotNetGenFacadesPackageVersion)" />
 
     <!-- Test related -->

--- a/src/winforms/eng/Version.Details.props
+++ b/src/winforms/eng/Version.Details.props
@@ -7,6 +7,7 @@ This file should be imported by eng/Versions.props
   <PropertyGroup>
     <!-- dotnet/dotnet dependencies -->
     <MicrosoftDotNetArcadeSdkPackageVersion>10.0.0-beta.25454.107</MicrosoftDotNetArcadeSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksTemplatingPackageVersion>10.0.0-beta.25454.107</MicrosoftDotNetBuildTasksTemplatingPackageVersion>
     <MicrosoftDotNetCMakeSdkPackageVersion>10.0.0-beta.25454.107</MicrosoftDotNetCMakeSdkPackageVersion>
     <MicrosoftDotNetGenFacadesPackageVersion>10.0.0-beta.25454.107</MicrosoftDotNetGenFacadesPackageVersion>
     <MicrosoftDotNetHelixSdkPackageVersion>10.0.0-beta.25454.107</MicrosoftDotNetHelixSdkPackageVersion>
@@ -35,6 +36,7 @@ This file should be imported by eng/Versions.props
   <PropertyGroup>
     <!-- dotnet/dotnet dependencies -->
     <MicrosoftDotNetArcadeSdkVersion>$(MicrosoftDotNetArcadeSdkPackageVersion)</MicrosoftDotNetArcadeSdkVersion>
+    <MicrosoftDotNetBuildTasksTemplatingVersion>$(MicrosoftDotNetBuildTasksTemplatingPackageVersion)</MicrosoftDotNetBuildTasksTemplatingVersion>
     <MicrosoftDotNetCMakeSdkVersion>$(MicrosoftDotNetCMakeSdkPackageVersion)</MicrosoftDotNetCMakeSdkVersion>
     <MicrosoftDotNetGenFacadesVersion>$(MicrosoftDotNetGenFacadesPackageVersion)</MicrosoftDotNetGenFacadesVersion>
     <MicrosoftDotNetHelixSdkVersion>$(MicrosoftDotNetHelixSdkPackageVersion)</MicrosoftDotNetHelixSdkVersion>

--- a/src/winforms/eng/Version.Details.xml
+++ b/src/winforms/eng/Version.Details.xml
@@ -87,6 +87,10 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>96384f46287cd0b6ae49f3885676e3d1635c7894</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="10.0.0-beta.25454.107">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>96384f46287cd0b6ae49f3885676e3d1635c7894</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.GenFacades" Version="10.0.0-beta.25454.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>96384f46287cd0b6ae49f3885676e3d1635c7894</Sha>

--- a/src/winforms/eng/packageContent.targets
+++ b/src/winforms/eng/packageContent.targets
@@ -65,7 +65,7 @@
     />
 
     <ItemGroup>
-      <PackageFile Include="$(TargetPath)" PackagePath="$(PackagePath)" />
+      <PackageFile Include="$(TargetPath)" PackagePath="$(PackagePath)" IsPackable="$(IsPackable)" PackageId="$(PackageId)" PackageVersion="$(PackageVersion)" />
       <PackageFile Condition="'$(IncludePdbInPackage)' == 'true'" Include="$(TargetDir)$(TargetName).pdb" PackagePath="$(PackagePath)" />
       <PackageFile Condition="'$(ProduceReferenceAssembly)' == 'true'" Include="$(TargetRefPath)" PackagePath="$(RefPackagePath)" />
       <PackageFile Condition="'$(ProduceReferenceAssembly)' == 'true' Or '$(PackageAsRefAndLib)' == 'true'"

--- a/src/winforms/pkg/Microsoft.Private.Winforms/Microsoft.Private.Winforms.csproj
+++ b/src/winforms/pkg/Microsoft.Private.Winforms/Microsoft.Private.Winforms.csproj
@@ -114,6 +114,7 @@
     <ProjectReference Include="..\..\src\System.Windows.Forms.Analyzers.CodeFixes.CSharp\System.Windows.Forms.Analyzers.CodeFixes.CSharp.csproj" />
     <ProjectReference Include="..\..\src\System.Windows.Forms.Analyzers.CodeFixes.VisualBasic\System.Windows.Forms.Analyzers.CodeFixes.VisualBasic.vbproj" />
 
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Templating" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- Force the output item type for all project references to "TfmSpecificPackageFile", which makes them get packed -->
@@ -127,9 +128,43 @@
     </ItemGroup>
   </Target>
 
-  <!-- Call custom targets (defined below) when creating the package -->
   <PropertyGroup>
+    <!-- Call custom targets (defined below) when creating the package -->
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificBuildOutput);ResolveReferences</TargetsForTfmSpecificContentInPackage>
+    <BeforePack>$(BeforePack);GenerateTransportPropsFile</BeforePack>
+
+    <TransportPropsFileInputPath>$(MSBuildThisFileDirectory)build\$(MSBuildProjectName).props</TransportPropsFileInputPath>
+    <TransportPropsFileOutputPath>$(IntermediateOutputPath)$(MSBuildProjectName).props</TransportPropsFileOutputPath>
   </PropertyGroup>
+
+  <Target Name="GenerateTransportPropsFile"
+          DependsOnTargets="BuildOnlySettings;ResolveReferences"
+          Inputs="$(MSBuildThisFileFullPath);$(TransportPropsFileInputPath)"
+          Outputs="$(TransportPropsFileOutputPath)">
+    <ItemGroup>
+      <WinformsWindowsDesktopPackageLibrary Include="@(TfmSpecificPackageFile->WithMetadataValue('Extension', '.dll')->WithMetadataValue('IsPackable', 'true'))" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <WinformsWindowsDesktopPackageLibraries>@(WinformsWindowsDesktopPackageLibrary->'&lt;WinformsWindowsDesktopPackageLibrary Include=&quot;%(Filename)%(Extension)&quot; PackageId=&quot;%(PackageId)&quot; PackageVersion=&quot;%(PackageVersion)&quot; /&gt;', '
+    ')</WinformsWindowsDesktopPackageLibraries>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <TransportPropsTemplateProperty Include="WinformsWindowsDesktopPackageLibraries=$(WinformsWindowsDesktopPackageLibraries)" />
+    </ItemGroup>
+
+    <Error Condition="'@(WinformsWindowsDesktopPackageLibrary)' == ''"
+           Text="Unexpected build error: No packable references were found." />
+
+    <GenerateFileFromTemplate
+      TemplateFile="$(TransportPropsFileInputPath)"
+      Properties="@(TransportPropsTemplateProperty)"
+      OutputPath="$(TransportPropsFileOutputPath)" />
+
+    <ItemGroup>
+      <None Include="$(TransportPropsFileOutputPath)" Pack="true" PackagePath="build/" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/winforms/pkg/Microsoft.Private.Winforms/Microsoft.Private.Winforms.csproj
+++ b/src/winforms/pkg/Microsoft.Private.Winforms/Microsoft.Private.Winforms.csproj
@@ -138,6 +138,7 @@
   </PropertyGroup>
 
   <Target Name="GenerateTransportPropsFile"
+          Condition="'@(ProjectReference)' != ''"
           DependsOnTargets="BuildOnlySettings;ResolveReferences"
           Inputs="$(MSBuildThisFileFullPath);$(TransportPropsFileInputPath)"
           Outputs="$(TransportPropsFileOutputPath)">

--- a/src/winforms/pkg/Microsoft.Private.Winforms/build/Microsoft.Private.Winforms.props
+++ b/src/winforms/pkg/Microsoft.Private.Winforms/build/Microsoft.Private.Winforms.props
@@ -1,0 +1,10 @@
+<Project>
+
+  <!-- The list of redistributed assemblies that also ship via out-of-band packages.
+       Includes the AssemblyName, PackageId and the PackageVersion:
+       <WinformsWindowsDesktopPackageLibrary Include="" PackageId="" PackageVersion="" /> -->
+  <ItemGroup>
+    ${WinformsWindowsDesktopPackageLibraries}
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Backporting https://github.com/dotnet/dotnet/pull/2297

## Customer Impact
-	Internally found
System.Drawing.Common is part of WindowsDesktop shared framework but is not trimmed.  The package will be downloaded even though it will not be used on .NET 10.0

## Regression
No, missing functionality in a feature new to 10.0

## Testing
Discovered this as part of comprehensive testing of https://github.com/dotnet/dotnet/pull/2254
Manually verified that this one addition fixes the remaining missing packages from pruning data for net10.

## Risk
Low.  Functionally this will not change anything since the package was removed by conflict resolution in build.  
This change adds to pruning.  There is a small chance that folks who don’t multitarget and have a direct reference to the package on net10.0 will see a pruning warning, but this is an actionable warning and consistent with all other packages that are part of shared framework (and introduced in .NET 10).  
For those moving from a previous framework this will not be a new warning but will be part of the rest of the warnings they see.
