### PR TITLE
Opt out of Guardian Roslyn analyzers

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -74,6 +74,7 @@ extends:
   parameters:
     featureFlags:
       incrementalSDLBinaryAnalysis: true
+      autoEnableRoslynWithNewRuleset: false
     sdl:
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)


### PR DESCRIPTION
We hit a bug: "ErrorLog property didn't match expected pattern"