### PR TITLE
Clean shared components for Microsoft build

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -14,8 +14,7 @@
     <ProjectReference Include="$(RepositoryEngineeringDir)init-detect-binaries.proj"
                       Condition="'$(BuildOS)' != 'windows' and '$(SkipDetectBinaries)' != 'true'" />
     
-    <ProjectReference Include="$(RepositoryEngineeringDir)clean-shared-components.proj"
-                      Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
+    <ProjectReference Include="$(RepositoryEngineeringDir)clean-shared-components.proj" />
     
     <!-- Pre-build: Init tools-->
     <ProjectReference Include="$(RepositoryEngineeringDir)init-cross-build.proj"

--- a/eng/clean-shared-components.proj
+++ b/eng/clean-shared-components.proj
@@ -37,4 +37,61 @@
 
   </Target>
 
+  <Target Name="DownloadMergedManifest"
+          BeforeTargets="Build"
+          Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(DotNetBuildSharedComponents)' != 'true'"
+          Inputs="$(RepositoryEngineeringDir)Versions.props"
+          Outputs="$(SharedMergedManifest)">
+
+    <!-- 
+      Extract official build ID from package version that represents the SDK version of the 1xx build.
+      Input: package version (e.g., "10.0.100-preview.7.25377.103")
+      Output: official build ID (e.g., "20250727.3")
+      
+      The package version format includes VersionSuffixDateStamp and VersionSuffixBuildOfTheDay in the prerelease suffix.
+      We extract these values and reverse the date calculation to get the original official build ID.
+    -->
+    <PropertyGroup Condition="'$(MicrosoftNETSdkVersion)' != ''">
+      <!-- Split the package version to get the prerelease part after the dash -->
+      <_PrereleasePart>$(MicrosoftNETSdkVersion.Split('-')[1])</_PrereleasePart>
+      
+      <!-- Split the prerelease part by dots to get individual segments -->
+      <!-- Example: "preview.7.25377.103" -> ["preview", "7", "25377", "103"] -->
+      <!-- We want the last two segments: "25377" (VersionSuffixDateStamp) and "103" (VersionSuffixBuildOfTheDay) -->
+      
+      <!-- Use LastIndexOf to find the last two dot-separated segments -->
+      <_LastDotIndex>$(_PrereleasePart.LastIndexOf('.'))</_LastDotIndex>
+      <_ExtractedVersionSuffixBuildOfTheDay>$(_PrereleasePart.Substring($([MSBuild]::Add($(_LastDotIndex), 1))))</_ExtractedVersionSuffixBuildOfTheDay>
+      
+      <!-- Get the part before the last dot, then find the second-to-last segment -->
+      <_BeforeLastDot>$(_PrereleasePart.Substring(0, $(_LastDotIndex)))</_BeforeLastDot>
+      <_SecondLastDotIndex>$(_BeforeLastDot.LastIndexOf('.'))</_SecondLastDotIndex>
+      <_ExtractedVersionSuffixDateStamp>$(_BeforeLastDot.Substring($([MSBuild]::Add($(_SecondLastDotIndex), 1))))</_ExtractedVersionSuffixDateStamp>
+      
+      <!-- Reverse the SHORT_DATE calculation: yy * 1000 + mm * 50 + dd = VersionSuffixDateStamp -->
+      <_ReversedYY>$([MSBuild]::Divide($(_ExtractedVersionSuffixDateStamp), 1000))</_ReversedYY>
+      <_Remainder1>$([MSBuild]::Subtract($(_ExtractedVersionSuffixDateStamp), $([MSBuild]::Multiply($(_ReversedYY), 1000))))</_Remainder1>
+      <_ReversedMM>$([MSBuild]::Divide($(_Remainder1), 50))</_ReversedMM>
+      <_ReversedDD>$([MSBuild]::Subtract($(_Remainder1), $([MSBuild]::Multiply($(_ReversedMM), 50))))</_ReversedDD>
+      
+      <!-- Format components with leading zeros -->
+      <_FormattedYY>$(_ReversedYY.PadLeft(2, $([System.Convert]::ToChar(`0`))))</_FormattedYY>
+      <_FormattedMM>$(_ReversedMM.PadLeft(2, $([System.Convert]::ToChar(`0`))))</_FormattedMM>
+      <_FormattedDD>$(_ReversedDD.PadLeft(2, $([System.Convert]::ToChar(`0`))))</_FormattedDD>
+      
+      <!-- The revision is the VersionSuffixBuildOfTheDay modulo 100 -->
+      <_RevisionFromBuildOfDay>$([MSBuild]::Modulo($(_ExtractedVersionSuffixBuildOfTheDay), 100))</_RevisionFromBuildOfDay>
+      
+      <!-- Reconstruct OfficialBuildId in format 20yymmdd.r -->
+      <_CalculatedOfficialBuildId>20$(_FormattedYY)$(_FormattedMM)$(_FormattedDD).$(_RevisionFromBuildOfDay)</_CalculatedOfficialBuildId>
+    </PropertyGroup>
+
+    <Error Text="Unable to calculate official build ID of 1xx build for SDK version '$(MicrosoftNETSdkVersion)'."
+           Condition="'$(_CalculatedOfficialBuildId)' == ''" />
+
+    <DownloadFile SourceUrl="https://dotnetbuilds.blob.core.windows.net/public/assets/manifests/dotnet-dotnet/$(_CalculatedOfficialBuildId)/MergedManifest.xml"
+                  DestinationFolder="$([System.IO.Path]::GetDirectoryName($(SharedMergedManifest)))"
+                  DestinationFileName="$([System.IO.Path]::GetFileName($(SharedMergedManifest)))"
+                  Retries="3" />
+  </Target>
 </Project>


### PR DESCRIPTION
Running 2xx builds for Microsoft vertical legs results in the following error:

```
D:\a\_work\1\s\repo-projects\Directory.Build.targets(689,5): error MSB4018: The "GetKnownArtifactsFromAssetManifests" task failed unexpectedly. [D:\a\_work\1\s\repo-projects\diagnostics.proj]
D:\a\_work\1\s\repo-projects\Directory.Build.targets(689,5): error MSB4018: System.IO.FileNotFoundException->Microsoft.Build.Framework.BuildException.GenericBuildTransferredException: Could not find file 'D:\a\_work\1\s\artifacts\obj\SharedMergedManifest.xml'. [D:\a\_work\1\s\repo-projects\diagnostics.proj]
D:\a\_work\1\s\repo-projects\Directory.Build.targets(689,5): error MSB4018:    at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options) [D:\a\_work\1\s\repo-projects\diagnostics.proj]
D:\a\_work\1\s\repo-projects\Directory.Build.targets(689,5): error MSB4018:    at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode) [D:\a\_work\1\s\repo-projects\diagnostics.proj]
D:\a\_work\1\s\repo-projects\Directory.Build.targets(689,5): error MSB4018:    at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode) [D:\a\_work\1\s\repo-projects\diagnostics.proj]
D:\a\_work\1\s\repo-projects\Directory.Build.targets(689,5): error MSB4018:    at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode) [D:\a\_work\1\s\repo-projects\diagnostics.proj]
D:\a\_work\1\s\repo-projects\Directory.Build.targets(689,5): error MSB4018:    at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize) [D:\a\_work\1\s\repo-projects\diagnostics.proj]
D:\a\_work\1\s\repo-projects\Directory.Build.targets(689,5): error MSB4018:    at System.Xml.XmlDownloadManager.GetStream(Uri uri, ICredentials credentials, IWebProxy proxy) [D:\a\_work\1\s\repo-projects\diagnostics.proj]
D:\a\_work\1\s\repo-projects\Directory.Build.targets(689,5): error MSB4018:    at System.Xml.XmlTextReaderImpl.FinishInitUriString() [D:\a\_work\1\s\repo-projects\diagnostics.proj]
D:\a\_work\1\s\repo-projects\Directory.Build.targets(689,5): error MSB4018:    at System.Xml.XmlReaderSettings.CreateReader(String inputUri, XmlParserContext inputContext) [D:\a\_work\1\s\repo-projects\diagnostics.proj]
D:\a\_work\1\s\repo-projects\Directory.Build.targets(689,5): error MSB4018:    at System.Xml.Linq.XDocument.Load(String uri, LoadOptions options) [D:\a\_work\1\s\repo-projects\diagnostics.proj]
D:\a\_work\1\s\repo-projects\Directory.Build.targets(689,5): error MSB4018:    at Microsoft.DotNet.UnifiedBuild.Tasks.GetKnownArtifactsFromAssetManifests.<>c.<Execute>b__25_0(ITaskItem manifest) in /_/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/GetKnownArtifactsFromAssetManifests.cs:line 60 [D:\a\_work\1\s\repo-projects\diagnostics.proj]
D:\a\_work\1\s\repo-projects\Directory.Build.targets(689,5): error MSB4018:    at System.Linq.Enumerable.ArraySelectIterator`2.Fill(ReadOnlySpan`1 source, Span`1 destination, Func`2 func) [D:\a\_work\1\s\repo-projects\diagnostics.proj]
D:\a\_work\1\s\repo-projects\Directory.Build.targets(689,5): error MSB4018:    at System.Linq.Enumerable.ArraySelectIterator`2.ToArray() [D:\a\_work\1\s\repo-projects\diagnostics.proj]
D:\a\_work\1\s\repo-projects\Directory.Build.targets(689,5): error MSB4018:    at Microsoft.DotNet.UnifiedBuild.Tasks.GetKnownArtifactsFromAssetManifests.Execute() in /_/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/GetKnownArtifactsFromAssetManifests.cs:line 59 [D:\a\_work\1\s\repo-projects\diagnostics.proj]
D:\a\_work\1\s\repo-projects\Directory.Build.targets(689,5): error MSB4018:    at Microsoft.Build.CommandLine.OutOfProcTaskAppDomainWrapperBase.InstantiateAndExecuteTask(IBuildEngine oopTaskHostNode, LoadedType taskType, String taskName, String taskLocation, String taskFile, Int32 taskLine, Int32 taskColumn, IDictionary`2 taskParams) [D:\a\_work\1\s\repo-projects\diagnostics.proj]
##[error]repo-projects\Directory.Build.targets(689,5): error MSB4018: (NETCORE_ENGINEERING_TELEMETRY=Build) The "GetKnownArtifactsFromAssetManifests" task failed unexpectedly.
```

This is because the build is attempting to gather a SharedMergedManifest.xml file for a shared component repo which never gets built, as intended, in the 2xx branch.

The fix for this is to download the merged manifest from the 1xx build which will include all the manifest info for the shared component repos. This will prevent the build from attempting to look for it in the local build.