### PR TITLE
Set `isOfficialBuild` in source-only build legs

### DIFF
--- a/eng/pipelines/templates/stages/source-build-and-validate.yml
+++ b/eng/pipelines/templates/stages/source-build-and-validate.yml
@@ -16,6 +16,11 @@ parameters:
   type: boolean
   default: true
 
+# True when the build is a build run from the production pipeline
+- name: isOfficialBuild
+  type: boolean
+  default: false
+
 - name: desiredSigning
   type: string
   default: ''
@@ -41,6 +46,7 @@ stages:
   - template: ../variables/vmr-build.yml
     parameters:
       buildSourceOnly: true
+      isOfficialBuild: ${{ parameters.isOfficialBuild }}
       desiredSigning: ${{ parameters.desiredSigning }}
       desiredFinalVersionKind: ${{ parameters.desiredFinalVersionKind }}
   jobs:

--- a/eng/pipelines/templates/stages/source-build-stages.yml
+++ b/eng/pipelines/templates/stages/source-build-stages.yml
@@ -28,6 +28,11 @@ parameters:
   type: boolean
   default: true
 
+# True when the build is a build run from the production pipeline
+- name: isOfficialBuild
+  type: boolean
+  default: false
+
 - name: desiredSigning
   type: string
   default: ''
@@ -54,6 +59,7 @@ stages:
       pool_LinuxArm64: ${{ parameters.pool_LinuxArm64 }}
       useMicrosoftBuildAssetsForTests: ${{ parameters.useMicrosoftBuildAssetsForTests }}
       isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+      isOfficialBuild: ${{ parameters.isOfficialBuild }}
       desiredSigning: ${{ parameters.desiredSigning }}
       desiredFinalVersionKind: ${{ parameters.desiredFinalVersionKind }}
       excludeRuntimeDependentJobs: ${{ parameters.excludeRuntimeDependentJobs }}

--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -32,6 +32,7 @@ parameters:
   type: boolean
   default: true
 
+# True when the build is a build run from the production pipeline
 - name: isOfficialBuild
   type: boolean
   default: false
@@ -142,6 +143,7 @@ stages:
       pool_LinuxArm64: ${{ parameters.pool_LinuxArm64 }}
       scope: ${{ parameters.scope }}
       isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}
+      isOfficialBuild: ${{ parameters.isOfficialBuild }}
       desiredSigning: ${{ parameters.desiredSigning }}
       desiredFinalVersionKind: ${{ parameters.desiredFinalVersionKind }}
       verifications: ${{ parameters.verifications }}

--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -41,8 +41,8 @@ variables:
   - name: ibcEnabled
     value: false
 - ${{ elseif or(startsWith(parameters.desiredIBC, 'Default'), eq(parameters.desiredIBC, '')) }}:
-  # Enable IBC on the internal project if the, branch is a release branch
-  - ${{ if and(eq(parameters.isOfficialBuild, true), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))) }}:
+  # Enable IBC on the internal project if this is an official build of a release branch and is not a source-only build.
+  - ${{ if and(eq(parameters.isOfficialBuild, true), ne(parameters.buildSourceOnly, true), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))) }}:
     - name: ibcEnabled
       value: true
   # No IBC otherwise.
@@ -80,7 +80,8 @@ variables:
     value: true
   - name: signType
     value: real
-  - ${{ if and(eq(parameters.isOfficialBuild, true), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))) }}:
+  # Only sign DACs if this is an official build of a release branch and is not a source-only build.
+  - ${{ if and(eq(parameters.isOfficialBuild, true), ne(parameters.buildSourceOnly, true), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))) }}:
     - name: signDacEnabled
       value: true
   - ${{ else }}:
@@ -120,8 +121,13 @@ variables:
       value: true
     - name: signType
       value: real
-    - name: signDacEnabled
-      value: true
+    # Only sign DACs if this is not a source-only build.
+    - ${{ if ne(parameters.buildSourceOnly, true) }}:
+      - name: signDacEnabled
+        value: true
+    - ${{ else }}:
+      - name: signDacEnabled
+        value: false
   # Do not sign otherwise.
   - ${{ else }}:
     - name: signEnabled


### PR DESCRIPTION
Signing was not running in source-only build legs when the `desiredSigning` parameter was set to the default value. This was occurring because the source-only build legs were not passing `isOfficialBuild` to the variables template. This PR fixes that issue by defining and passing the `isOfficialBuild` parameter in the source source-build templates.