### PR TITLE
[release/10.0.1xx] Ensure that signed SB artifacts are published

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -9,6 +9,7 @@
     <ArtifactsStagingDir Condition="'$(ArtifactsStagingDir)' == ''">$(ArtifactsDir)/staging/</ArtifactsStagingDir>
     <ArtifactsPublishStagingDir>$(ArtifactsStagingDir)/artifacts</ArtifactsPublishStagingDir>
     <SourceBuiltAssetsDir>$(ArtifactsPublishStagingDir)/assets/$(Configuration)</SourceBuiltAssetsDir>
+    <SourceBuiltPublishAssetsDir>$(SourceBuiltAssetsDir)/source-build</SourceBuiltPublishAssetsDir>
     <SourceBuiltShippingPackagesDir>$(ArtifactsPublishStagingDir)/packages/$(Configuration)/Shipping</SourceBuiltShippingPackagesDir>
     <SourceBuiltNonShippingPackagesDir>$(ArtifactsPublishStagingDir)/packages/$(Configuration)/NonShipping</SourceBuiltNonShippingPackagesDir>
     <SourceBuiltAssetManifestsDir>$(ArtifactsPublishStagingDir)/manifests/$(Configuration)</SourceBuiltAssetManifestsDir>
@@ -122,8 +123,9 @@
       <SourceBuildArtifact Include="$(ArtifactsAssetsDir)/$(SourceBuiltSourceArtifactName)-*" />
       <Artifact Include="@(SourceBuildArtifact)">
         <IsShipping>true</IsShipping>
+        <DotNetReleaseShipping Condition="'$(DotNetSourceOnlyPostBuildSign)' == 'true'">true</DotNetReleaseShipping>
         <Kind>Blob</Kind>
-        <RelativeBlobPath>source-build/%(Filename)%(Extension)</RelativeBlobPath>
+        <RelativeBlobPath>$([System.IO.Path]::GetFileName($(SourceBuiltPublishAssetsDir)))/%(Filename)%(Extension)</RelativeBlobPath>
       </Artifact>
     </ItemGroup>
 

--- a/eng/init-source-only.proj
+++ b/eng/init-source-only.proj
@@ -19,6 +19,7 @@
 
   <Target Name="Build"
           DependsOnTargets="
+      ValidateSourceOnlySigning;
       UnpackTarballs;
       BuildMSBuildSdkResolver;
       ExtractToolsetPackages" />
@@ -39,6 +40,11 @@
   <PropertyGroup>
     <SharedComponentsPrereqsArchiveFile>@(SharedComponentsPrereqsArchivePathItem)</SharedComponentsPrereqsArchiveFile>
   </PropertyGroup>
+
+  <Target Name="ValidateSourceOnlySigning">
+    <Error Condition="'$(DotNetSourceOnlyPostBuildSign)' == 'true' and '$(DotNetSourceOnlyPublishArtifacts)' != 'true'" 
+           Text="Source-only signing requires publishing artifacts through Arcade. Please set 'DotNetSourceOnlyPublishArtifacts' to 'true', or disable signing by setting 'DotNetSourceOnlyPostBuildSign' to 'false'." />
+  </Target>
 
   <Target Name="ValidateSharedComponents">
     <Error Condition="'$(DotNetBuildSharedComponents)' == 'true' and ('$(CustomSharedComponentsArtifactsPath)' != '' or '$(SharedComponentsPrereqsArchiveFile)' != '')"

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -557,11 +557,18 @@ jobs:
           customBuildArgs="$(baseArguments)"
           extraBuildProperties="$(baseProperties) /p:ArtifactsStagingDir=$(Build.ArtifactStagingDirectory) $(targetProperties) $(buildPassProperties) ${{ parameters.extraProperties }}"
 
-          # We shouldn't pass signing arguments to the build script when building source-only
-          # because signing source-built artifacts happens post-build.
           if [[ '${{ parameters.buildSourceOnly }}' != 'True' ]]; then
+            # We shouldn't pass signing arguments to the build script when building source-only
+            # because signing source-built artifacts happens post-build.
             customBuildArgs="$customBuildArgs $(signArguments) $(_SignDiagnosticFilesArgs)"
             extraBuildProperties="$extraBuildProperties $(signProperties)"
+          else
+            customBuildArgs="$customBuildArgs --source-only"
+            extraBuildProperties="$extraBuildProperties /p:ReportSbrpUsage=true"
+            if [[ '${{ parameters.sign }}' == 'True' ]]; then
+              # Set up for signing source-built artifacts post-build.
+              extraBuildProperties="$extraBuildProperties /p:DotNetSourceOnlyPostBuildSign=true"
+            fi
           fi
 
           if [[ '${{ parameters.runOnline }}' == 'True' ]]; then
@@ -588,11 +595,6 @@ jobs:
           
           if [[ '${{ parameters.createSourceArtifacts }}' == 'True' ]]; then
             extraBuildProperties="$extraBuildProperties /p:CreateSourceArtifacts=true"
-          fi
-
-          if [[ '${{ parameters.buildSourceOnly }}' == 'True' ]]; then
-            customBuildArgs="$customBuildArgs --source-only"
-            extraBuildProperties="$extraBuildProperties /p:ReportSbrpUsage=true"
           fi
 
           if [[ '${{ parameters.useMonoRuntime }}' == 'True' ]]; then
@@ -683,15 +685,23 @@ jobs:
   - ${{ if eq(parameters.sign, 'True') }}:
     - ${{ if eq(parameters.buildSourceOnly, 'true') }}:
       - script: |
-          . eng/common/tools.sh
-
           sign_properties="$(signProperties) $(_SignDiagnosticFilesArgs)"
 
-          MSBuild -restore eng/sign-source-built-artifacts.proj \
-            /p:SignProperties=$sign_properties \
-            /p:ArtifactsStagingDir=$(Build.ArtifactStagingDirectory) \
-            /p:OfficialBuildId=$(Build.BuildNumber) \
-            /bl:artifacts/log/outer-sign-source-built-artifacts.binlog
+          customPreBuildArgs=""
+          if [[ '${{ parameters.runOnline }}' == 'False' ]]; then
+            customPreBuildArgs="sudo -E"
+            export MICROBUILDOUTPUTFOLDEROVERRIDE
+          fi
+
+          $customPreBuildArgs bash -c '
+            set -euo pipefail
+            . eng/common/tools.sh
+            MSBuild eng/sign-source-built-artifacts.proj -restore \
+              "/p:SignProperties='"$sign_properties"'" \
+              "/p:ArtifactsStagingDir=$(Build.ArtifactStagingDirectory)" \
+              "/p:OfficialBuildId=$(Build.BuildNumber)" \
+              "/bl:artifacts/log/outer-sign-source-built-artifacts.binlog"
+          '
         displayName: Sign Source-Built Artifacts
         workingDirectory: $(Build.SourcesDirectory)
         env:

--- a/eng/pipelines/templates/stages/source-build-stages.yml
+++ b/eng/pipelines/templates/stages/source-build-stages.yml
@@ -111,8 +111,8 @@ stages:
             useMonoRuntime: false              # 🚫
             useSystemLibraries: false          # 🚫
             withPreviousSDK: false             # 🚫
-            disableSigning: false              # 🚫
-            createSourceArtifacts: true        # ✅
+            disableSigning: true               # ✅
+            createSourceArtifacts: false       # 🚫
 
           - ${{ if containsValue(parameters.verifications, 'source-build-stage2') }}:
 
@@ -184,14 +184,14 @@ stages:
             - buildNameFormat: 'SB_{0}_Offline_MsftSdk'
               distro: centos
               targetArchitecture: x64
-              buildFromArchive: true             # ✅
+              buildFromArchive: false            # 🚫
               enablePoison: false                # 🚫
               runOnline: false                   # 🚫
               useMonoRuntime: false              # 🚫
               useSystemLibraries: false          # 🚫
               withPreviousSDK: false             # 🚫
-              disableSigning: true               # ✅
-              createSourceArtifacts: false       # 🚫
+              disableSigning: false              # 🚫
+              createSourceArtifacts: true        # ✅
 
             - buildNameFormat: 'SB_{0}_Online_PreviousSourceBuiltSdk'
               distro: centos

--- a/eng/pipelines/templates/steps/vmr-validate-signing.yml
+++ b/eng/pipelines/templates/steps/vmr-validate-signing.yml
@@ -33,7 +33,7 @@ steps:
       xcrun simctl runtime delete all
     displayName: Reclaim disk space from unused simulator runtimes
 
-# Include "**SB_CentOSStream*_Online_MsftSdk_x64_Artifacts/**/Release/dotnet-source-*"
+# Include "**SB_CentOSStream*_Offline_MsftSdk_x64_Artifacts/**/Release/source-build/dotnet-source-*"
 # once https://github.com/dotnet/arcade/issues/16034 has been resolved.
 - task: DownloadPipelineArtifact@2
   displayName: Download Vertical Build Artifacts
@@ -45,8 +45,8 @@ steps:
       **AzureLinux*_Artifacts/**
       **OSX_*_Artifacts/**
       **Windows_*_Artifacts/**
-      **SB_CentOSStream*_Online_MsftSdk_x64_Artifacts/**/Release/dotnet-sdk-*.tar.gz
-      **SB_CentOSStream*_Online_MsftSdk_x64_Artifacts/**/Release/Private.SourceBuilt.Artifacts.*.tar.gz
+      **SB_CentOSStream*_Offline_MsftSdk_x64_Artifacts/**/Release/source-build/dotnet-sdk-*.tar.gz
+      **SB_CentOSStream*_Offline_MsftSdk_x64_Artifacts/**/Release/source-build/Private.SourceBuilt.Artifacts.*.tar.gz
     downloadPath: '${{ parameters.signCheckFilesDirectory }}'
 
 # This is necessary whenever we want to publish/restore to an AzDO private feed

--- a/eng/sign-source-built-artifacts.proj
+++ b/eng/sign-source-built-artifacts.proj
@@ -32,6 +32,7 @@
       <ArtifactsStagingDir Condition="'$(ArtifactsStagingDir)' == ''">$(ArtifactsDir)/staging/</ArtifactsStagingDir>
       <ArtifactsPublishStagingDir>$(ArtifactsStagingDir)/artifacts</ArtifactsPublishStagingDir>
       <SourceBuiltAssetsDir>$(ArtifactsPublishStagingDir)/assets/$(Configuration)</SourceBuiltAssetsDir>
+      <SourceBuiltPublishAssetsDir>$(SourceBuiltAssetsDir)/source-build</SourceBuiltPublishAssetsDir>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -40,16 +41,16 @@
 
     <ItemGroup>
       <!-- Sdk tarball -->
-      <SignableSourceBuiltSdkTarball Include="$(SourceBuiltAssetsDir)/$(SourceBuiltSdkTarballName)-*$(ArchiveExtension)" />
+      <SignableSourceBuiltSdkTarball Include="$(SourceBuiltPublishAssetsDir)/$(SourceBuiltSdkTarballName)-*$(ArchiveExtension)" />
       <SignableSourceBuiltAsset Include="@(SignableSourceBuiltSdkTarball)" />
 
       <!-- PSB artifacts -->
-      <SignableSourceBuiltArtifactsTarball Include="$(SourceBuiltAssetsDir)/$(SourceBuiltArtifactsTarballName).*$(ArchiveExtension)" />
+      <SignableSourceBuiltArtifactsTarball Include="$(SourceBuiltPublishAssetsDir)/$(SourceBuiltArtifactsTarballName).*$(ArchiveExtension)" />
       <SignableSourceBuiltAsset Include="@(SignableSourceBuiltArtifactsTarball)" />
 
       <!-- Source tarball and zipball -->
       <!-- Uncomment once https://github.com/dotnet/arcade/issues/16034 has been resolved. -->
-      <!-- <SignableSourceBuiltSourceArtifact Include="$(SourceBuiltAssetsDir)/$(SourceBuiltSourceArtifactName)-*" />
+      <!-- <SignableSourceBuiltSourceArtifact Include="$(SourceBuiltPublishAssetsDir)/$(SourceBuiltSourceArtifactName)-*" />
       <SignableSourceBuiltAsset Include="@(SignableSourceBuiltSourceArtifact)" /> -->
     </ItemGroup>
 


### PR DESCRIPTION
Backport of https://github.com/dotnet/dotnet/pull/2295

[Test pipeline run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2792116&view=logs&j=514c02f0-737b-56ba-c340-bc19bd9edf9b)