### PR TITLE
Create binlogs and use ProcessService

### DIFF
--- a/eng/pipelines/templates/steps/vmr-validate-signing.yml
+++ b/eng/pipelines/templates/steps/vmr-validate-signing.yml
@@ -67,7 +67,8 @@ steps:
         /p:ArtifactDownloadDirectory=${{ parameters.signCheckFilesDirectory }} `
         /p:SourceBranch='$(Build.SourceBranch)' `
         /p:DotNetRootDirectory=$(Build.SourcesDirectory) `
-        /p:OutputLogsDirectory=${{ parameters.outputDirectory }}
+        /p:OutputLogsDirectory=${{ parameters.outputDirectory }} `
+        /bl:${{ parameters.outputDirectory }}/outer-signing-validation.binlog
 
     displayName: Validate Signing
     continueOnError: ${{ parameters.continueOnError }}
@@ -84,7 +85,8 @@ steps:
         /p:ArtifactDownloadDirectory=${{ parameters.signCheckFilesDirectory }} \
         /p:SourceBranch='$(Build.SourceBranch)' \
         /p:DotNetRootDirectory=$(Build.SourcesDirectory) \
-        /p:OutputLogsDirectory=${{ parameters.outputDirectory }}
+        /p:OutputLogsDirectory=${{ parameters.outputDirectory }} \
+        /bl:${{ parameters.outputDirectory }}/outer-signing-validation.binlog
 
     displayName: Validate Signing
     continueOnError: ${{ parameters.continueOnError }}


### PR DESCRIPTION
Some updates to signing validation:
- Creates inner and outer binlogs for the task. Signing validation recently failed due to https://github.com/dotnet/dotnet/pull/2395. Having these binlogs would have helped to diagnose the problem.
- Uses the ProcessService introduced in https://github.com/dotnet/dotnet/pull/2232