### PR TITLE
Fix SignCheck failing due to bug in sdk-task script

### DIFF
--- a/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/SigningValidation.cs
+++ b/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/SigningValidation.cs
@@ -309,7 +309,9 @@ public class SigningValidation : Microsoft.Build.Utilities.Task
     /// </summary>
     private (string command, string arguments) GetSignCheckCommandAndArguments()
     {
-        string sdkTaskScript = Path.Combine(DotNetRootDirectory, "eng", "common", "sdk-task");
+        // Target sdk-task scripts from Arcade to catch and fix issues with the scripts between releases
+        // This reduces our exposure to known issues in the local VMR copy and improves build reliability during the VMR bootstrap window.
+        string sdkTaskScript = Path.Combine(DotNetRootDirectory, "src", "arcade", "eng", "common", "sdk-task");
 
         string argumentsTemplate =
             $"'{sdkTaskScript}.$scriptExtension$' " +


### PR DESCRIPTION
SignCheck is failing in the 10.0 branch due to a missing `"` in [the sdk-task.sh script](https://github.com/dotnet/dotnet/commit/df1de840916a9afea4625beee3a6a2e489255adf#diff-97c1a310b55e5fdb2c17c4bbefb25d537304919618595a1dc93bdf29411f7f3cR13). This issue with the script was fixed in [Fix small typo on sdk-task.sh (#16074) · dotnet/arcade@0646172](https://github.com/dotnet/arcade/commit/0646172696c86219507f3f9cfd28a251ddd86dba), but the change didn't make it into RC1 so it surfaced after we rebootstrapped the VMR the other day.

The fix is to target the sdk-task script in Arcade. Had we been targeting the script in Arcade in the RC1 branch, we would've caught this regression in the script before it was included in the release and introduced by the RC 1 rebootstrap PR.

[Test run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2792381&view=results)