### PR TITLE
Update source-build sdk diff

### DIFF
--- a/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/MsftToSbSdkFiles.diff
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/MsftToSbSdkFiles.diff
@@ -45,7 +45,7 @@ index ------------
  ./packs/Microsoft.NETCore.App.Ref/x.y.z/
  ./packs/Microsoft.NETCore.App.Ref/x.y.z/analyzers/
 @@ ------------ @@
- ./packs/NETStandard.Library.Ref/x.y.z/ref/netstandard2.1/System.Xml.XPath.XDocument.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/WindowsBase.dll
  ./sdk-manifests/
  ./sdk-manifests/x.y.z/
 -./sdk-manifests/x.y.z/


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/5343

Updates the sdk-diff as there were expected changes in file sets.