### PR TITLE
Comment out global.json telemetry to prevent errant stdout writing

### DIFF
--- a/src/sdk/src/Cli/dotnet/Program.cs
+++ b/src/sdk/src/Cli/dotnet/Program.cs
@@ -237,7 +237,7 @@ public class Program
             // Get the global.json state to report in telemetry along with this command invocation.
             // We don't care about the actual SDK resolution, just the global.json information,
             // so just pass empty string as executable directory for resolution.
-            NativeWrapper.SdkResolutionResult result = NativeWrapper.NETCoreSdkResolverNativeWrapper.ResolveSdk(string.Empty, Environment.CurrentDirectory);
+            // NativeWrapper.SdkResolutionResult result = NativeWrapper.NETCoreSdkResolverNativeWrapper.ResolveSdk(string.Empty, Environment.CurrentDirectory);
             globalJsonState = result.GlobalJsonState;
         }
 


### PR DESCRIPTION
This is breaking Aspire and other downstream users, so we'll quickly comment it out now, and wait for a fix to https://github.com/dotnet/sdk/issues/50632 to come from the runtime/SDK side.