### PR TITLE
Propagate file mode when re-packing through more archive kinds

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/src/ArEntry.cs
+++ b/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/src/ArEntry.cs
@@ -7,6 +7,8 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
 {
     public sealed class ArEntry
     {
+        public const uint FilePermissionMask = 0xFFF;
+
         public ArEntry(string name, ulong timestamp, ulong ownerID, ulong groupID, uint mode, Stream dataStream)
         {
             Name = name;

--- a/src/arcade/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
+++ b/src/arcade/src/Microsoft.DotNet.SignTool.Tests/SignToolTests.cs
@@ -420,8 +420,11 @@ namespace Microsoft.DotNet.SignTool.Tests
             Directory.CreateDirectory(controlLayout);
             Directory.CreateDirectory(dataLayout);
 
-            ZipData.ExtractTarballContents(dataArchive, dataLayout, skipSymlinks: false);
-            ZipData.ExtractTarballContents(controlArchive, controlLayout);
+            var fakeBuildEngine = new FakeBuildEngine(_output);
+            var fakeLog = new TaskLoggingHelper(fakeBuildEngine, "TestLog");
+
+            ZipData.ExtractTarballContents(fakeLog, dataArchive, dataLayout, skipSymlinks: false);
+            ZipData.ExtractTarballContents(fakeLog, controlArchive, controlLayout);
 
             string md5sumsContents = File.ReadAllText(Path.Combine(controlLayout, "md5sums"));
 

--- a/src/arcade/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/arcade/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -823,6 +823,7 @@ namespace Microsoft.DotNet.SignTool
                             Directory.CreateDirectory(Path.GetDirectoryName(tempPath));
 
                             entry.WriteToFile(tempPath);
+                            ZipData.SetUnixFileMode(_log, entry, tempPath, _pathToContainerUnpackingDirectory);
 
                             _hashToCollisionIdMap.TryGetValue(fileUniqueKey, out string collisionPriorityId);
                             PathWithHash nestedFile = new PathWithHash(tempPath, entry.ContentHash);

--- a/src/arcade/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/arcade/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -823,7 +823,7 @@ namespace Microsoft.DotNet.SignTool
                             Directory.CreateDirectory(Path.GetDirectoryName(tempPath));
 
                             entry.WriteToFile(tempPath);
-                            ZipData.SetUnixFileMode(_log, entry, tempPath);
+                            ZipData.SetUnixFileMode(_log, entry.UnixFileMode, tempPath);
 
                             _hashToCollisionIdMap.TryGetValue(fileUniqueKey, out string collisionPriorityId);
                             PathWithHash nestedFile = new PathWithHash(tempPath, entry.ContentHash);

--- a/src/arcade/src/Microsoft.DotNet.SignTool/src/Configuration.cs
+++ b/src/arcade/src/Microsoft.DotNet.SignTool/src/Configuration.cs
@@ -823,7 +823,7 @@ namespace Microsoft.DotNet.SignTool
                             Directory.CreateDirectory(Path.GetDirectoryName(tempPath));
 
                             entry.WriteToFile(tempPath);
-                            ZipData.SetUnixFileMode(_log, entry, tempPath, _pathToContainerUnpackingDirectory);
+                            ZipData.SetUnixFileMode(_log, entry, tempPath);
 
                             _hashToCollisionIdMap.TryGetValue(fileUniqueKey, out string collisionPriorityId);
                             PathWithHash nestedFile = new PathWithHash(tempPath, entry.ContentHash);

--- a/src/arcade/src/Microsoft.DotNet.SignTool/src/ZipData.cs
+++ b/src/arcade/src/Microsoft.DotNet.SignTool/src/ZipData.cs
@@ -776,7 +776,7 @@ namespace Microsoft.DotNet.SignTool
 
         private static bool RunExternalProcess(TaskLoggingHelper log, string cmd, string args, out string output, string workingDir = null)
         {
-            log?.LogMessage(MessageImportance.Low, $"Running command: '{cmd}' {args}");
+            log.LogMessage(MessageImportance.Low, $"Running command: '{cmd}' {args}");
 
             ProcessStartInfo psi = new()
             {
@@ -796,12 +796,12 @@ namespace Microsoft.DotNet.SignTool
             string stderr = process.StandardError.ReadToEnd();
             if (!string.IsNullOrWhiteSpace(stderr))
             {
-                log?.LogMessage(MessageImportance.Low, $"  Stderr: {stderr}");
+                log.LogMessage(MessageImportance.Low, $"  Stderr: {stderr}");
             }
 
             if (process.ExitCode != 0)
             {
-                log?.LogMessage(MessageImportance.Low, $"  Exit code: {process.ExitCode}");
+                log.LogMessage(MessageImportance.Low, $"  Exit code: {process.ExitCode}");
             }
 
             return process.ExitCode == 0;

--- a/src/arcade/src/Microsoft.DotNet.SignTool/src/ZipData.cs
+++ b/src/arcade/src/Microsoft.DotNet.SignTool/src/ZipData.cs
@@ -757,15 +757,20 @@ namespace Microsoft.DotNet.SignTool
                 if (entry != null)
                 {
                     entry.WriteToFile(outputPath);
-
-                    // Set file mode if not the default.
-                    if (entry.UnixFileMode is { } mode and not /* 0644 */ 420)
-                    {
-                        RunExternalProcess(log, "bash", $"""
-                            -c "chmod {Convert.ToString(mode, 8)} '{outputPath}'"
-                            """, out string _, layout);
-                    }
+                    SetUnixFileMode(log, entry, outputPath, layout);
                 }
+            }
+        }
+#endif
+
+        internal static void SetUnixFileMode(TaskLoggingHelper log, ZipDataEntry entry, string outputPath, string workingDir)
+        {
+            // Set file mode if not the default.
+            if (entry.UnixFileMode is { } mode and not /* 0644 */ 420)
+            {
+                RunExternalProcess(log, "bash", $"""
+                    -c "chmod {Convert.ToString(mode, 8)} '{outputPath}'"
+                    """, out string _, workingDir);
             }
         }
 
@@ -801,6 +806,5 @@ namespace Microsoft.DotNet.SignTool
 
             return process.ExitCode == 0;
         }
-#endif
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/sdk/issues/50881.
Follow up on https://github.com/dotnet/dotnet/pull/2425.
Related to https://github.com/dotnet/roslyn/issues/80151.
Official build validation run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2797161&view=results

- [x] I've manually verified the `.pkg` artifact contains `csc` with +x mode, so this should fix the linked issue.