### PR TITLE
Bump timeout for internal CodeQL and public OSX runs

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -327,8 +327,10 @@ jobs:
     timeoutInMinutes: 720
   ## Currently, CodeQL slows the build down too much
   ## https://github.com/dotnet/source-build/issues/4276
-  ${{ elseif and(parameters.isBuiltFromVmr, startswith(parameters.buildName, 'Windows'), eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+  ${{ elseif and(parameters.isBuiltFromVmr, eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
     timeoutInMinutes: 720
+  ${{ elseif and(startswith(parameters.buildName, 'OSX'), ne(variables['System.TeamProject'], 'internal')) }}:
+    timeoutInMinutes: 360
   ${{ else }}:
     timeoutInMinutes: 240
 
@@ -775,4 +777,3 @@ jobs:
           PathtoPublish: $(Build.ArtifactStagingDirectory)/artifacts/manifests/${{ parameters.configuration }}/$(Agent.JobName).xml
           ArtifactName: VerticalManifests
         displayName: Publish Vertical Manifest
-


### PR DESCRIPTION
I noticed that internally when CodeQL is active the AzureLinux jobs timed out after 4hours, extend the current increased timeout from Windows to all jobs.

Also increase the timeout for public OSX runs since we use older macOS hardware there which is slower and finishes in just under 4 hours (we only build OSX in dotnet-unified-build-full so we don't see it all the time)