### PR TITLE
[release/10.0.1xx] arcade: Pass Platform variable as WiX input

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/variables.wxi
+++ b/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/variables.wxi
@@ -13,14 +13,11 @@
   <?define LCID  = "$(var.ProductLanguage)"?>
   <?define DowngradeErrorMessage  = "A newer version is already installed; please uninstall it and re-run setup."?>
 
-  <?define Platform   =   "$(sys.BUILDARCH)" ?>
-
-  <?if $(var.Platform)!=x86?>
-    <?if $(var.Platform)!=x64?>
-      <?if $(var.Platform)!=arm64?>
-        <?error Invalid Platform ($(var.Platform))?>
-      <?endif?>
-    <?endif?>
+  <?if $(var.Platform)~=x86?>
+  <?elseif $(var.Platform)~=x64?>
+  <?elseif $(var.Platform)~=arm64?>
+  <?else?>
+    <?error Invalid Platform ($(var.Platform))?>
   <?endif?>
 
   <?ifndef DependencyKey?>

--- a/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/wix.targets
+++ b/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/wix.targets
@@ -340,6 +340,7 @@
       <CandleVariables Include="BuildVersion" Value="$(MsiVersionString)" />
       <CandleVariables Include="NugetVersion" Value="$(Version)" />
       <CandleVariables Include="InstallerPlatform" Value="$(MsiArch)" />
+      <CandleVariables Include="Platform" Value="$(MsiArch)" />
       <CandleVariables Include="TargetArchitectureDescription" Value="$(InstallerTargetArchitecture)$(CrossArchContentsBuildPart)" />
       <CandleVariables Include="UpgradeCode" Value="$(UpgradeCode)" />
       <CandleVariables Include="MajorUpgradeSchedule" Value="$(MajorUpgradeSchedule)" Condition="'$(MajorUpgradeSchedule)' != ''" />
@@ -379,7 +380,6 @@
       IgnoreStandardErrorWarningFormat="true"
       RetryDelayBase="2" />
 
-    <!-- TODO this fails on preprocessor directives -->
     <CreateWixBuildWixpack
       Cultures="en-us"
       DefineConstants="@(CandleVariables->'%(Identity)=%(Value)')"


### PR DESCRIPTION
The Platform variable was not being correctly assigned during wixpack creation. This PR just moves it outside to be an input to wix instead of creating a variable in wxi.