### PR TITLE
Add support for suppressing Wix warnings

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixBuildWixpack.cs
+++ b/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixBuildWixpack.cs
@@ -71,6 +71,8 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
         [Required]
         public ITaskItem[] SourceFiles { get; set; }
 
+        public string[] SuppressSpecificWarnings { get; set; }
+
         [Required]
         public string WixpackWorkingDir { get; set; }
 
@@ -331,6 +333,15 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
                 foreach (var culture in Cultures)
                 {
                     commandLineArgs.Add($"-culture {culture}");
+                }
+            }
+
+            // Add each Warning from SuppressSpecificWarnings array
+            if (SuppressSpecificWarnings != null && SuppressSpecificWarnings.Length > 0)
+            {
+                foreach (var warning in SuppressSpecificWarnings)
+                {
+                    commandLineArgs.Add($"-sw{warning}");
                 }
             }
 

--- a/src/aspnetcore/src/Installers/Windows/Wix.targets
+++ b/src/aspnetcore/src/Installers/Windows/Wix.targets
@@ -129,6 +129,7 @@
       PdbFile="$(IntermediateOutputPath)%(CultureGroup.OutputFolder)$(TargetPdbFileName)"
       PdbType="$(DebugType)"
       SourceFiles="@(Compile)"
+      SuppressSpecificWarnings="$(SuppressSpecificWarnings)"
       LocalizationFiles="@(_WixLocalizationFile)"
       BindPaths="@(BindPath)"
       WixpackWorkingDir="$(WixpackWorkingDir)">


### PR DESCRIPTION
Adds support to `CreateWixBuildWixpack` task for Wix warning suppression.

Currently utilized by some `aspnetcore` projects, i.e. https://github.com/dotnet/dotnet/blob/8ebb400ec2c5327a543f9f5a08f6f7acedd0803c/src/aspnetcore/src/Installers/Windows/AspNetCoreModule-Setup/ANCMIISExpressV2/AncmIISExpressV2.wixproj#L20