### PR TITLE
Use random file name for temp file path

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixBuildWixpack.cs
+++ b/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateWixBuildWixpack.cs
@@ -196,7 +196,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
             // We want to keep original files in wixpack, and only preprocess
             // them for wixpack creation. This ensures that repacking process would not be
             // affected by some unintentional change, or a bug in preprocessor.
-            var tempFilePath = Path.Combine(Path.GetTempPath(), Path.GetFileName(includeFile));
+            var tempFilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             File.Copy(includeFile, tempFilePath, overwrite: true);
 
             // We're processing a Wix include file, which contains preprocessor


### PR DESCRIPTION
Change temporary file name generation to use a random file name instead of the original file name. Previously was causing file handle issues when building wix projects in parallel.