### PR TITLE
Make the new SdkResolver set the proper DOTNET_HOST_PATH env var instead of the non-functional DOTNET_HOST env var

### DIFF
--- a/src/sdk/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
+++ b/src/sdk/src/Resolvers/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
         private readonly Func<string, string, string?> _getMsbuildRuntime;
         private readonly NETCoreSdkResolver _netCoreSdkResolver;
 
-        private const string DOTNET_HOST = nameof(DOTNET_HOST);
+        private const string DOTNET_HOST_PATH = nameof(DOTNET_HOST_PATH);
         private const string DotnetHostExperimentalKey = "DOTNET_EXPERIMENTAL_HOST_PATH";
         private const string MSBuildTaskHostRuntimeVersion = "SdkResolverMSBuildTaskHostRuntimeVersion";
         private const string SdkResolverHonoredGlobalJson = "SdkResolverHonoredGlobalJson";
@@ -245,12 +245,12 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
                     // this is the future-facing implementation.
                     environmentVariablesToAdd ??= new Dictionary<string, string?>(1)
                     {
-                        [DOTNET_HOST] = fullPathToMuxer
+                        [DOTNET_HOST_PATH] = fullPathToMuxer
                     };
                 }
                 else
                 {
-                    logger?.LogMessage($"Could not set '{DOTNET_HOST}' environment variable because dotnet executable '{fullPathToMuxer}' does not exist.");
+                    logger?.LogMessage($"Could not set '{DOTNET_HOST_PATH}' environment variable because dotnet executable '{fullPathToMuxer}' does not exist.");
                 }
 
                 string? runtimeVersion = dotnetRoot != null ?


### PR DESCRIPTION
## Customer Impact

There isn't any observable customer impact to this change. This fixes an implementation issue in the previous MSBuild decoupling work that was being hidden by separate MSBuild engine compatibility shims that we added to enable testing the end-to-end of the feature before dev18 was available. If we don't take this change then the net impact is that we aren't able to remove our compat shim in the future and test/rely on the actual designed feature.

If we don't take this for RC2 we wouldn't push for this change, or the compat shim removal, for GA at all. We'd wait until a later feature band/VS release to coordinate that removal more safely.

## Description

The SdkResolver is intended to set DOTNET_HOST_PATH to signal to MSBuild Tasks that need a .NET binary/runtime where to look for that binary. Instead it was setting DOTNET_HOST. This has no impact at all - we should have been setting DOTNET_HOST_PATH the whole time (once we added env var support at all in https://github.com/dotnet/sdk/pull/50091).

This was masked because we put a compat shim in the MSBuild engine that looked for the `DOTNET_EXPERIMENTAL_HOST_PATH` Property set by an SdkResolver and transparently 'promoted' it to the DOTNET_HOST_PATH env var.

After this change, both the experimental property and the correct env var will be set, but the engine [prefers the env var](https://github.com/dotnet/msbuild/blob/5480b47bbc592c6feedca7c57c9863ba01e0c52c/src/Build/Definition/Project.cs#L4455-L4460) if it is present.

## Risk

**Low** - even with this change we will continue to set the back-compat property, this just enables us to remove the compat code some time in the future without breaking the world. 

## Testing

It's hard to test the env-var setting right now because the automated tests run in a CI-driven VS environment where the SdkResolver doesn't have the ability to set environment variables (which is why we made the compatibility shim in the first place). We're waiting on dev18 images to be available before we can truly pin this behavior through testing. @rainersigwald has done some end-to-end testing as well.
