### PR TITLE
Fix x64 runtime installer on x86/arm64

### DIFF
--- a/src/runtime/src/installer/pkg/sfx/installers/host.wxs
+++ b/src/runtime/src/installer/pkg/sfx/installers/host.wxs
@@ -126,6 +126,6 @@
   
   <Fragment>
     <!-- Unlike DOTNETHOME which gives precedence to a user specified value over an x64 suffix, here we always want the suffixed path -->
-    <SetProperty Action="Set_PROGRAMFILES_DOTNET_NON_NATIVE_ARCHITECTURE" Id="PROGRAMFILES_DOTNET" Value="[ProgramFiles6432Folder]dotnet\x64\" After="Set_NON_NATIVE_ARCHITECTURE" Condition="NON_NATIVE_ARCHITECTURE" />
+    <SetProperty Action="Set_PROGRAMFILES_DOTNET_NON_NATIVE_ARCHITECTURE" Id="PROGRAMFILES_DOTNET" Value="[ProgramFiles64Folder]dotnet\x64\" After="Set_NON_NATIVE_ARCHITECTURE" Condition="NON_NATIVE_ARCHITECTURE" />
   </Fragment>
 </Wix>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/120108

When installing using an x64 installer on arm64, the PROGRAMFILES_DOTNET (used to place the host) is not correctly computed because WiX has not resolved `ProgramFiles6432Folder` yet. This change makes it use `ProgramFiles64Folder` instead which is valid because this code only applies to x64 installers on x86/arm64 machines.