### PR TITLE
MSBuildLocator: add fix for MarshalDirectiveException that gets thrown on Mono.

### DIFF
--- a/src/aspnetcore/src/submodules/MessagePack-CSharp/src/MessagePack.Generator/MessagePack.Generator.csproj
+++ b/src/aspnetcore/src/submodules/MessagePack-CSharp/src/MessagePack.Generator/MessagePack.Generator.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="ConsoleAppFramework" Version="3.3.2" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.10.2" />
     <PackageReference Include="Microsoft.Build.Framework" Version="16.5.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build" Version="16.5.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.1" />

--- a/src/efcore/Directory.Packages.props
+++ b/src/efcore/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
 
     <!-- build dependencies-->
-    <PackageVersion Include="Microsoft.Build.Locator" Version="1.9.1" />
+    <PackageVersion Include="Microsoft.Build.Locator" Version="1.10.2" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />

--- a/src/nuget-client/Directory.Packages.props
+++ b/src/nuget-client/Directory.Packages.props
@@ -39,7 +39,7 @@
     <PackageVersion Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
     <PackageVersion Include="Microsoft.Build.Artifacts" Version="4.2.0" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
-    <PackageVersion Include="Microsoft.Build.Locator" Version="1.5.5" />
+    <PackageVersion Include="Microsoft.Build.Locator" Version="1.10.2" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.3.1" />

--- a/src/razor/Directory.Packages.props
+++ b/src/razor/Directory.Packages.props
@@ -28,7 +28,7 @@
     <PackageVersion Include="MessagePack" Version="2.5.198" />
     <PackageVersion Include="Microsoft.AspNetCore.App.Runtime.$(NetCoreSDKRuntimeIdentifier)" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="$(_MicrosoftBuildPackageVersion)" />
-    <PackageVersion Include="Microsoft.Build.Locator" Version="1.8.1" />
+    <PackageVersion Include="Microsoft.Build.Locator" Version="1.10.2" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="$(_MicrosoftBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="$(_MicrosoftBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="1.1.3-beta1.24423.1" />

--- a/src/roslyn/eng/Packages.props
+++ b/src/roslyn/eng/Packages.props
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Build.Locator" Version="1.8.1" />
+    <PackageVersion Include="Microsoft.Build.Locator" Version="1.10.2" />
 
     <!--
       Visual Studio

--- a/src/sdk/eng/Versions.props
+++ b/src/sdk/eng/Versions.props
@@ -125,7 +125,7 @@
   </PropertyGroup>
   <PropertyGroup Label="Manually updated">
     <!-- Dependencies from https://github.com/microsoft/MSBuildLocator -->
-    <MicrosoftBuildLocatorPackageVersion>1.8.1</MicrosoftBuildLocatorPackageVersion>
+    <MicrosoftBuildLocatorPackageVersion>1.10.2</MicrosoftBuildLocatorPackageVersion>
     <MicrosoftCodeAnalysisCSharpAnalyzerPinnedVersionPackageVersion>4.0.1</MicrosoftCodeAnalysisCSharpAnalyzerPinnedVersionPackageVersion>
   </PropertyGroup>
   <!-- Get .NET Framework reference assemblies from NuGet packages -->


### PR DESCRIPTION
This adds the fix for https://github.com/dotnet/msbuild/issues/12570 to the 10.0.1xx branch.

@rainersigwald @YuliiaKovalova @ViktorHofer ptal.

cc @medhatiwari @giritrivedi

https://github.com/dotnet/dotnet/issues/2716 tracks removing this patch.