### PR TITLE
Fix ANCM path for WOW64 support

### DIFF
--- a/src/aspnetcore/src/Installers/Windows/AspNetCoreModule-Setup/ANCMIISExpressV2/ancm_iis_expressv2.wxs
+++ b/src/aspnetcore/src/Installers/Windows/AspNetCoreModule-Setup/ANCMIISExpressV2/ancm_iis_expressv2.wxs
@@ -192,7 +192,7 @@
 
           <!-- WOW64 Support -->
           <?if $(InstallerPlatform) != "x86" ?>
-          <StandardDirectory Id="ProgramFilesFolder">
+          <Directory Id="ProgramFilesFolder">
             <Directory Id="INSTALLDIR32" Name="IIS Express">
               <Directory Id="INSTALLLOCATION32" ShortName="ANCM" Name="$(ProductName)">
                 <Directory Id="VersionDir32" Name="$(ProductVersionString)">
@@ -221,7 +221,7 @@
                 </Directory>
               </Directory>
             </Directory>
-          </StandardDirectory>
+          </Directory>
           <?endif?>
         </DirectoryRef>
 


### PR DESCRIPTION
We always want to install to the 32-bit Program files directory for WOW64 support, rather than relying on Wix to determine the installer architecture.

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2805462&view=results