### PR TITLE
Don't build the newkey packages for any packages based on azure linux (even versioned azure linux packages)

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets
+++ b/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets
@@ -354,7 +354,7 @@
 
   <Target Name="_BuildNewKeyLinuxPackage"
           AfterTargets="GenerateRpm;GenerateDeb"
-          Condition="'$(PackageTargetOS)' != 'azl'">
+          Condition="!$(PackageTargetOS.Contains('azl'))">
     <!-- Packages to be signed with the new key -->
     <PropertyGroup>
       <_NewKeyVersionSuffix>newkey</_NewKeyVersionSuffix>


### PR DESCRIPTION
Fixes duplicate sign info for the runtime-deps by removing the package that was causing issues (which shouldn't exist anyway)