### PR TITLE
Temporarily disable hard linking on sdk installer layout creation

### DIFF
--- a/src/sdk/src/Layout/redist/targets/GenerateInstallerLayout.targets
+++ b/src/sdk/src/Layout/redist/targets/GenerateInstallerLayout.targets
@@ -112,7 +112,6 @@
 
     <Copy SourceFiles="@(SdkOutputFile)"
           DestinationFiles="@(SdkOutputFile -> '$(IntermediateSdkInstallerOutputPath)sdk\$(Version)\%(RecursiveDir)%(Filename)%(Extension)')"
-          UseHardLinksIfPossible="true"
           SkipUnchangedFiles="true" />
 
     <!-- Copy dnx script to root dotnet folder (which will map to DOTNETHOME) -->


### PR DESCRIPTION
This hard linking is a problem because the original source for the hard link gets written to by the testing overlay update. Depending on timing, the bundled versions files may get updated, leading to incorrect implicit versions.