### PR TITLE
Add tests for verification of expected set of Linux packages

### DIFF
--- a/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
+++ b/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
@@ -734,16 +734,9 @@ public partial class LinuxInstallerTests : IDisposable
         string extension = packageType == PackageType.Rpm ? "*.rpm" : "*.deb";
         string[] expectedPatterns = GetExpectedPackagePatterns(packageType);
 
-        // Find all packages of the specified type
-        List<string> actualPackages = Directory.GetFiles(Config.AssetsDirectory, extension, SearchOption.AllDirectories)
-            .Select(Path.GetFileName)
-            .Where(name => name != null)
-            .Cast<string>()
-            .ToList();
-
-        // Normalize package names by removing version numbers
-        List<string> normalizedActual = actualPackages
-            .Select(name => RemoveVersionFromPackageNameRegex.Replace(name, "*"))
+        // Find all packages of the specified type and normalize by removing version numbers
+        List<string> normalizedActual = Directory.GetFiles(Config.AssetsDirectory, extension, SearchOption.AllDirectories)
+            .Select(path => RemoveVersionFromPackageNameRegex.Replace(Path.GetFileName(path), "*"))
             .Distinct()
             .OrderBy(name => name)
             .ToList();

--- a/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
+++ b/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
@@ -741,47 +741,10 @@ public partial class LinuxInstallerTests : IDisposable
             .OrderBy(name => name)
             .ToList();
 
-        // Compare the lists
-        var missing = expectedPatterns.Except(normalizedActual).ToList();
-        var extra = normalizedActual.Except(expectedPatterns).ToList();
-
-        if (missing.Any() || extra.Any())
-        {
-            _outputHelper.WriteLine($"Expected {packageType} packages:");
-            foreach (string pattern in expectedPatterns)
-            {
-                _outputHelper.WriteLine($"  {pattern}");
-            }
-
-            _outputHelper.WriteLine($"\nActual {packageType} packages (normalized):");
-            foreach (string package in normalizedActual)
-            {
-                _outputHelper.WriteLine($"  {package}");
-            }
-
-            var errorMessage = new StringBuilder();
-            errorMessage.AppendLine($"Package list validation failed for {packageType}:");
-
-            if (missing.Any())
-            {
-                errorMessage.AppendLine("Missing packages:");
-                foreach (string pkg in missing)
-                {
-                    errorMessage.AppendLine($"  - {pkg}");
-                }
-            }
-
-            if (extra.Any())
-            {
-                errorMessage.AppendLine("Unexpected packages:");
-                foreach (string pkg in extra)
-                {
-                    errorMessage.AppendLine($"  + {pkg}");
-                }
-            }
-
-            Assert.Fail(errorMessage.ToString());
-        }
+        Assert.True(
+            expectedPatterns.SequenceEqual(normalizedActual),
+            $"Package list validation failed for {packageType}:\nExpected:\n{string.Join("\n", expectedPatterns)}\nActual:\n{string.Join("\n", normalizedActual)}"
+        );
     }
 
     private List<string> GetExpectedPackagePatterns(PackageType packageType)

--- a/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
+++ b/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
@@ -732,7 +732,7 @@ public partial class LinuxInstallerTests : IDisposable
     private void ValidatePackageList(PackageType packageType)
     {
         string extension = packageType == PackageType.Rpm ? "*.rpm" : "*.deb";
-        string[] expectedPatterns = GetExpectedPackagePatterns(packageType);
+        List<string> expectedPatterns = GetExpectedPackagePatterns(packageType).OrderBy(p => p).ToList();
 
         // Find all packages of the specified type and normalize by removing version numbers
         List<string> normalizedActual = Directory.GetFiles(Config.AssetsDirectory, extension, SearchOption.AllDirectories)
@@ -741,26 +741,24 @@ public partial class LinuxInstallerTests : IDisposable
             .OrderBy(name => name)
             .ToList();
 
-        List<string> expectedPatterns_sorted = expectedPatterns.OrderBy(p => p).ToList();
-
-        _outputHelper.WriteLine($"Expected {packageType} packages:");
-        foreach (string pattern in expectedPatterns_sorted)
-        {
-            _outputHelper.WriteLine($"  {pattern}");
-        }
-
-        _outputHelper.WriteLine($"\nActual {packageType} packages (normalized):");
-        foreach (string package in normalizedActual)
-        {
-            _outputHelper.WriteLine($"  {package}");
-        }
-
         // Compare the lists
-        var missing = expectedPatterns_sorted.Except(normalizedActual).ToList();
-        var extra = normalizedActual.Except(expectedPatterns_sorted).ToList();
+        var missing = expectedPatterns.Except(normalizedActual).ToList();
+        var extra = normalizedActual.Except(expectedPatterns).ToList();
 
         if (missing.Any() || extra.Any())
         {
+            _outputHelper.WriteLine($"Expected {packageType} packages:");
+            foreach (string pattern in expectedPatterns)
+            {
+                _outputHelper.WriteLine($"  {pattern}");
+            }
+
+            _outputHelper.WriteLine($"\nActual {packageType} packages (normalized):");
+            foreach (string package in normalizedActual)
+            {
+                _outputHelper.WriteLine($"  {package}");
+            }
+
             var errorMessage = new StringBuilder();
             errorMessage.AppendLine($"Package list validation failed for {packageType}:");
 
@@ -786,7 +784,7 @@ public partial class LinuxInstallerTests : IDisposable
         }
     }
 
-    private string[] GetExpectedPackagePatterns(PackageType packageType)
+    private List<string> GetExpectedPackagePatterns(PackageType packageType)
     {
         string extension = packageType == PackageType.Rpm ? ".rpm" : ".deb";
         string arch = Config.Architecture == Architecture.X64 ? "x64" :
@@ -836,6 +834,6 @@ public partial class LinuxInstallerTests : IDisposable
             }
         }
 
-        return patterns.ToArray();
+        return patterns;
     }
 }

--- a/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
+++ b/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
@@ -82,7 +82,7 @@ public partial class LinuxInstallerTests : IDisposable
     private static partial Regex RemoveVersionConstraintRegex { get; }
 
     // Remove version numbers from package names: "dotnet-runtime-10.0.0-rc.1.25480.112-x64.rpm" -> "dotnet-runtime-*-x64.rpm"
-    [GeneratedRegex(@"\d+\.\d+\.\d+(?:-(?:rc\.\d+(?:\.\d+)*|rtm|preview\.\d+(?:\.\d+)*))?", RegexOptions.CultureInvariant)]
+    [GeneratedRegex(@"\d+\.\d+\.\d+(?:-(?:rc|rtm|preview)(?:\.\d+)*)?", RegexOptions.CultureInvariant)]
     private static partial Regex RemoveVersionFromPackageNameRegex { get; }
 
     private const string RuntimeDepsRepo = "mcr.microsoft.com/dotnet/runtime-deps";


### PR DESCRIPTION
Fixes: https://github.com/dotnet/sdk/issues/51086

New tests will ensure that we are producing all the expected Linux packages. This will catch any issues early, way before the packages would need to be consumed, i.e. during product release.