### PR TITLE
Azure Linux DEPS packages do not have a newkey variant

### DIFF
--- a/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
+++ b/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
@@ -793,7 +793,12 @@ public partial class LinuxInstallerTests : IDisposable
             foreach (string distro in distros)
             {
                 patterns.Add($"dotnet-runtime-deps-*-{distro}-{arch}{extension}");
-                patterns.Add($"dotnet-runtime-deps-*-{distro}-newkey-{arch}{extension}");
+
+                // `azl` deps packages do not have a -newkey- variant
+                if (distro != "azl.3")
+                {
+                    patterns.Add($"dotnet-runtime-deps-*-{distro}-newkey-{arch}{extension}");
+                }
             }
         }
 


### PR DESCRIPTION
Follow up on https://github.com/dotnet/dotnet/pull/2720

Updates the test based on recent change in packages produced: https://github.com/dotnet/dotnet/pull/2694