### PR TITLE
[release/10.0.1xx] Fix certificate selection for debs and fix signing validation for the new key (and all future new keys)

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.props
@@ -104,9 +104,10 @@
     <AzureLinuxRPM Include="$(ArtifactsPackagesDir)**/*-azl.*-*.rpm" />
     <FileSignInfo Include="@(AzureLinuxRPM->'%(Filename)%(Extension)')" CertificateName="LinuxSignMariner" />
 
-    <!-- Explicitly use the "new" LinuxSign cert. TODO: Update the cert name to the actual name in MicroBuild once it's added. -->
-    <NewKeyLinuxRPM Include="$(ArtifactsPackagesDir)**/*-newkey-*.rpm" />
-    <FileSignInfo Include="@(NewKeyLinuxRPM->'%(Filename)%(Extension)')" CertificateName="LinuxSign500207PGP" />
+    <!-- Explicitly use the "new" LinuxSign cert. -->
+    <NewKeyLinuxPackage Include="$(ArtifactsPackagesDir)**/*-newkey-*.rpm" />
+    <NewKeyLinuxPackage Include="$(ArtifactsPackagesDir)**/*-newkey-*.deb" />
+    <FileSignInfo Include="@(NewKeyLinuxPackage->'%(Filename)%(Extension)')" CertificateName="LinuxSign500207PGP" />
   </ItemGroup>
 
   <!-- The name of the .NET specific certificate, which is a general replacement for Microsoft400

--- a/src/arcade/src/Microsoft.DotNet.SignTool/src/VerifySignatures.cs
+++ b/src/arcade/src/Microsoft.DotNet.SignTool/src/VerifySignatures.cs
@@ -262,7 +262,8 @@ namespace Microsoft.DotNet.SignTool
         {
             string[] keyUrls = new string[]
             {
-                "https://packages.microsoft.com/keys/microsoft.asc", // Microsoft public key
+                "https://packages.microsoft.com/keys/microsoft.asc", // SHA-1 Microsoft public key
+                "https://packages.microsoft.com/keys/microsoft-rolling.asc", // Non-SHA1 Microsoft public keys for non-Azure Linux distributions
                 "https://raw.githubusercontent.com/microsoft/azurelinux/3.0/SPECS/azurelinux-repos/MICROSOFT-RPM-GPG-KEY" // Azure linux public key
             };
             foreach (string keyUrl in keyUrls)

--- a/src/arcade/src/SignCheck/Microsoft.SignCheck/Utils.cs
+++ b/src/arcade/src/SignCheck/Microsoft.SignCheck/Utils.cs
@@ -200,6 +200,7 @@ namespace Microsoft.SignCheck
             string[] keyUrls = new string[]
             {
                 "https://packages.microsoft.com/keys/microsoft.asc", // Microsoft public key
+                "https://packages.microsoft.com/keys/microsoft-rolling.asc", // Non-SHA1 Microsoft public keys for non-Azure Linux distributions
                 "https://raw.githubusercontent.com/microsoft/azurelinux/3.0/SPECS/azurelinux-repos/MICROSOFT-RPM-GPG-KEY" // Azure linux public key
             };
             foreach (string keyUrl in keyUrls)


### PR DESCRIPTION
`-newkey-` deb files weren't being signed with the correct key.

Also, we didn't import the new public key into our list of valid keys for signing validation. Add the new `microsoft-rolling.asc` file (which contains the new key and will contain all future new keys if the keys change again) so we can validate the new signatures forever (no matter when the keys change).