### PR TITLE
Migrate VMR pipeline and orchestration fixes from 10.0.2xx

### DIFF
--- a/eng/VmrLayout.props
+++ b/eng/VmrLayout.props
@@ -38,6 +38,8 @@
     <PreviouslySourceBuiltPackageVersionsPropsFile>$(PreviouslySourceBuiltPackagesPath)PackageVersions.props</PreviouslySourceBuiltPackageVersionsPropsFile>
     <SharedComponentsArtifactsPath>$([MSBuild]::NormalizeDirectory('$(PrereqsPackagesDir)', 'shared-components'))</SharedComponentsArtifactsPath>
     <SharedComponentsArtifactsPath Condition="'$(CustomSharedComponentsArtifactsPath)' != ''">$([MSBuild]::EnsureTrailingSlash('$(CustomSharedComponentsArtifactsPath)'))</SharedComponentsArtifactsPath>
+    <SharedComponentAssetManifests>$(SharedComponentsArtifactsPath)VerticalManifest.xml</SharedComponentAssetManifests>
+    <ExtraTestDependenciesRestoreSourcePath>$([MSBuild]::NormalizeDirectory('$(PrereqsPackagesDir)', 'extra-test-dependencies'))</ExtraTestDependenciesRestoreSourcePath>
 
     <SbrpRepoSrcDir>$([MSBuild]::NormalizeDirectory('$(SrcDir)', 'source-build-reference-packages', 'src'))</SbrpRepoSrcDir>
     <ReferencePackagesDir>$([MSBuild]::NormalizeDirectory('$(PrereqsPackagesDir)', 'reference'))</ReferencePackagesDir>

--- a/eng/download-source-built-archive.sh
+++ b/eng/download-source-built-archive.sh
@@ -5,8 +5,8 @@
 # Get the repository root directory
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# Define the path to Versions.props once
 PACKAGE_VERSIONS_PATH="$REPO_ROOT/eng/Versions.props"
+PACKAGE_VERSION_DETAILS_PATH="$REPO_ROOT/eng/Version.Details.props"
 
 # Helper to extract a property value from an XML file
 function GetXmlPropertyValue {
@@ -53,12 +53,20 @@ function DownloadArchive {
   local isRequired="$3"
   local artifactsRid="$4"
   local outputDir="$5"
-  local destinationFilenamePrefix="${6:-}"
+  local destinationFileNamePrefix="${6:-}"
+  local archiveBaseFileNameOverride="${7:-}"
 
   local notFoundMessage="No $label found to download..."
+  local sdkVersionProperty="MicrosoftNETSdkPackageVersion"
 
   local archiveVersion
-  archiveVersion=$(GetXmlPropertyValue "$propertyName" "$PACKAGE_VERSIONS_PATH")
+  local versionsPath
+  if [[ "$propertyName" == "$sdkVersionProperty" ]]; then
+    versionsPath="$PACKAGE_VERSION_DETAILS_PATH"
+  else
+    versionsPath="$PACKAGE_VERSIONS_PATH"
+  fi
+  archiveVersion=$(GetXmlPropertyValue "$propertyName" "$versionsPath")
   if [[ -z "$archiveVersion" ]]; then
     if [ "$isRequired" == true ]; then
       echo "  ERROR: $notFoundMessage"
@@ -72,16 +80,31 @@ function DownloadArchive {
   local archiveUrl
   local artifactsBaseFileName="Private.SourceBuilt.Artifacts"
   local prebuiltsBaseFileName="Private.SourceBuilt.Prebuilts"
+  local sdkBaseFileName="dotnet-sdk-"
   local defaultArtifactsRid='centos.10-x64'
 
-  if [[ "$propertyName" == "MicrosoftNETSdkVersion" ]]; then
-    archiveUrl="https://ci.dot.net/public/source-build/$artifactsBaseFileName.$archiveVersion.$artifactsRid.tar.gz"
-  elif [[ "$propertyName" == *Prebuilts* ]]; then
-    archiveUrl="https://builds.dotnet.microsoft.com/source-built-artifacts/assets/$prebuiltsBaseFileName.$archiveVersion.$defaultArtifactsRid.tar.gz"
-  elif [[ "$propertyName" == *Artifacts* ]]; then
-    archiveUrl="https://builds.dotnet.microsoft.com/source-built-artifacts/assets/$artifactsBaseFileName.$archiveVersion.$artifactsRid.tar.gz"
-  elif [[ "$propertyName" == *Sdk* ]]; then
-    archiveUrl="https://builds.dotnet.microsoft.com/source-built-artifacts/sdks/dotnet-sdk-$archiveVersion-$artifactsRid.tar.gz"
+  # Use override base filename if provided
+  if [[ -n "$archiveBaseFileNameOverride" ]]; then
+    artifactsBaseFileName="$archiveBaseFileNameOverride"
+    prebuiltsBaseFileName="$archiveBaseFileNameOverride"
+    sdkBaseFileName="$archiveBaseFileNameOverride"
+  fi
+
+  local versionDelimiter="."
+  if [[ "$propertyName" == "PrivateSourceBuiltSdkVersion" ]] || [[ "$archiveBaseFileNameOverride" == *sdk* ]]; then
+    versionDelimiter="-"
+  fi
+
+  archiveVersion="${versionDelimiter}${archiveVersion}${versionDelimiter}"
+
+  if [[ "$propertyName" == "$sdkVersionProperty" ]]; then
+    archiveUrl="https://ci.dot.net/public/source-build/${artifactsBaseFileName}${archiveVersion}${artifactsRid}.tar.gz"
+  elif [[ "$propertyName" == "PrivateSourceBuiltPrebuiltsVersion" ]]; then
+    archiveUrl="https://builds.dotnet.microsoft.com/source-built-artifacts/assets/${prebuiltsBaseFileName}${archiveVersion}${defaultArtifactsRid}.tar.gz"
+  elif [[ "$propertyName" == "PrivateSourceBuiltArtifactsVersion" ]]; then
+    archiveUrl="https://builds.dotnet.microsoft.com/source-built-artifacts/assets/${artifactsBaseFileName}${archiveVersion}${artifactsRid}.tar.gz"
+  elif [[ "$propertyName" == "PrivateSourceBuiltSdkVersion" ]]; then
+    archiveUrl="https://builds.dotnet.microsoft.com/source-built-artifacts/sdks/${sdkBaseFileName}${archiveVersion}${artifactsRid}.tar.gz"
   else
     echo "  ERROR: Unknown archive property name: $propertyName"
     return 1
@@ -94,12 +117,16 @@ function DownloadArchive {
   fi
 
   # Rename the file if a destination filename prefix is provided
-  if [[ -n "$destinationFilenamePrefix" ]]; then
+  if [[ -n "$destinationFileNamePrefix" ]]; then
     local downloadedFilename
     downloadedFilename=$(basename "$archiveUrl")
-    # Extract the suffix from the downloaded filename
-    local suffix="${downloadedFilename#$artifactsBaseFileName}"
-    local newFilename="$destinationFilenamePrefix$suffix"
+    # Extract the suffix from the downloaded filename using the appropriate base filename
+    local baseFilenameForSuffix="$artifactsBaseFileName"
+    if [[ "$propertyName" == *Prebuilts* ]]; then
+      baseFilenameForSuffix="$prebuiltsBaseFileName"
+    fi
+    local suffix="${downloadedFilename#$baseFilenameForSuffix}"
+    local newFilename="$destinationFileNamePrefix$suffix"
     mv "$outputDir/$downloadedFilename" "$outputDir/$newFilename"
     echo "  Renamed $downloadedFilename to $newFilename"
   fi

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -169,3 +169,6 @@ extends:
         desiredFinalVersionKind: ${{ parameters.desiredFinalVersionKind }}
         isOfficialBuild: true
         scope: full
+        # Exclude runtime dependent jobs for any branch not producing a 1xx version since runtime-related repos aren't built in that context
+        # This is enabled for all branches except main and 1xx
+        excludeRuntimeDependentJobs: false

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -21,6 +21,25 @@ schedules:
       - main
     always: false # run only if there were changes since the last successful scheduled run.
 
+parameters:
+- name: buildScope
+  displayName: 'Build Scope'
+  type: string
+  default: 'auto'
+  values:
+    - auto
+    - lite
+    - full
+
+- name: featureBand
+  displayName: 'Target Feature Band'
+  type: string
+  default: 'Detect by Branch Name'
+  values:
+    - 'Detect by Branch Name'
+    - '1xx'
+    - '>= 2xx'
+
 variables:
 - name: isScheduleTrigger
   value: ${{ eq(variables['Build.Reason'], 'Schedule') }}
@@ -40,9 +59,15 @@ variables:
 stages:
 - template: /eng/pipelines/templates/stages/vmr-build.yml
   parameters:
-    ${{ if or(eq(variables.isScheduleTrigger, 'true'), contains(variables['Build.DefinitionName'], '-full')) }}:
-      scope: full
-    ${{ elseif eq(variables.isPRTrigger, 'true') }}:
-      scope: lite
+    ${{ if eq(parameters.buildScope, 'auto') }}:
+      ${{ if or(eq(variables.isScheduleTrigger, 'true'), contains(variables['Build.DefinitionName'], '-full')) }}:
+        scope: full
+      ${{ elseif eq(variables.isPRTrigger, 'true') }}:
+        scope: lite
+      ${{ else }}:
+        scope: full
     ${{ else }}:
-      scope: full
+      scope: ${{ parameters.buildScope }}
+    # Exclude runtime dependent jobs for any branch not producing a 1xx version since runtime-related repos aren't built in that context
+    # This is enabled for all branches except main and 1xx
+    excludeRuntimeDependentJobs: false

--- a/eng/pipelines/scout-build.yml
+++ b/eng/pipelines/scout-build.yml
@@ -32,3 +32,6 @@ stages:
 - template: /eng/pipelines/templates/stages/vmr-build.yml
   parameters:
     scope: scout
+    # Exclude runtime dependent jobs for any branch not producing a 1xx version since runtime-related repos aren't built in that context
+    # This is enabled for all branches except main and 1xx
+    excludeRuntimeDependentJobs: false

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -411,10 +411,17 @@ jobs:
         DownloadArchive "source-built SDK" "PrivateSourceBuiltSdkVersion" false "${{ parameters.artifactsRid }}" "$(sourcesPath)/prereqs/packages/archive/"
       displayName: Download Previously Source-Built SDK
 
-  - ${{ if eq(parameters.excludeRuntimeDependentJobs, 'true') }}:
+  - ${{ if and(parameters.excludeRuntimeDependentJobs, eq(parameters.reuseBuildArtifactsFrom, ''), not(parameters.withPreviousSDK)) }}:
     - script: |
         source "$(sourcesPath)/eng/download-source-built-archive.sh"
-        DownloadArchive "shared component artifacts" "MicrosoftNETSdkVersion" false "${{ parameters.artifactsRid }}" "$(sourcesPath)/prereqs/packages/archive/" "Private.SourceBuilt.SharedComponents"
+        # Download the 1xx source-built SDK
+        DownloadArchive "1xx source-built SDK" "MicrosoftNETSdkPackageVersion" false "${{ parameters.artifactsRid }}" "$(sourcesPath)/prereqs/packages/archive/" "" "dotnet-sdk"
+      displayName: Download 1xx SDK
+
+  - ${{ if parameters.excludeRuntimeDependentJobs }}:
+    - script: |
+        source "$(sourcesPath)/eng/download-source-built-archive.sh"
+        DownloadArchive "shared component artifacts" "MicrosoftNETSdkPackageVersion" false "${{ parameters.artifactsRid }}" "$(sourcesPath)/prereqs/packages/archive/" "Private.SourceBuilt.SharedComponents"
       displayName: Download Shared Component Artifacts
 
   # https://github.com/dotnet/dotnet/issues/1758
@@ -504,8 +511,8 @@ jobs:
           customPrepArgs=""
           prepSdk=true
 
-          if [[ '${{ parameters.withPreviousSDK }}' == 'True' ]]; then
-            # Using previous SDK implies we do not want to bootstrap.
+          if [[ '${{ parameters.withPreviousSDK }}' == 'True' ]] || [[ '${{ parameters.excludeRuntimeDependentJobs }}' == 'True' ]]; then
+            # Using source-built SDK implies we do not want to bootstrap.
             customPrepArgs="${customPrepArgs} --no-sdk --no-bootstrap"
             prepSdk=false
           elif [[ '${{ length(parameters.reuseBuildArtifactsFrom) }}' -gt '0' ]]; then

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -174,6 +174,7 @@
       <PreviouslySourceBuiltNuGetSourceName>previously-source-built</PreviouslySourceBuiltNuGetSourceName>
       <PreviouslySourceBuiltSharedComponentsNuGetSourceName>shared-components</PreviouslySourceBuiltSharedComponentsNuGetSourceName>
       <ReferencePackagesNuGetSourceName>reference-packages</ReferencePackagesNuGetSourceName>
+      <ExtraTestDependenciesNuGetSourceName>extra-test-dependencies</ExtraTestDependenciesNuGetSourceName>
       
       <AddPrebuiltFeeds>true</AddPrebuiltFeeds>
       <AddPrebuiltFeeds Condition="'$(DotNetSourceOnlyTestOnly)' == 'true' or '$(DotNetBuildSourceOnly)' != 'true'">false</AddPrebuiltFeeds>
@@ -182,6 +183,7 @@
     <ItemGroup>
       <_CommonBuildSources Include="@(DependentRepoSourceName)" />
       <_CommonBuildSources Include="$(ExtraSourcesNuGetSourceName)" Condition="'$(ExtraRestoreSourcePath)' != ''" />
+      <_CommonBuildSources Include="$(ExtraTestDependenciesNuGetSourceName)" Condition="Exists('$(ExtraTestDependenciesRestoreSourcePath)')" />
     </ItemGroup>
 
     <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
@@ -240,6 +242,11 @@
                             SourceName="$(ExtraSourcesNuGetSourceName)"
                             SourcePath="$(ExtraRestoreSourcePath)"
                             Condition="'$(ExtraRestoreSourcePath)' != ''" />
+
+    <AddSourceToNuGetConfig NuGetConfigFile="$(NuGetConfigFile)"
+                            SourceName="$(ExtraTestDependenciesNuGetSourceName)"
+                            SourcePath="$(ExtraTestDependenciesRestoreSourcePath)"
+                            Condition="Exists('$(ExtraTestDependenciesRestoreSourcePath)')" />
 
     <!-- See root Directory.Build.props for value. -->
     <AddSourceToNuGetConfig NuGetConfigFile="$(NuGetConfigFile)"

--- a/test/tests.proj
+++ b/test/tests.proj
@@ -63,7 +63,7 @@
     </ItemGroup>
     
     <Copy SourceFiles="@(_DownloadedNupkgs)"
-          DestinationFolder="$(ExtraRestoreSourcePath)" 
+          DestinationFolder="$(ExtraTestDependenciesRestoreSourcePath)" 
           Condition="@(_DownloadedNupkgs->Count()) > 0" />
   </Target>
 


### PR DESCRIPTION
There were a number of VMR pipeline and orchestration fixes that were made in https://github.com/dotnet/dotnet/pull/2632. Migrating these back to 10.0.1xx.