### PR TITLE
[release/10.0.1xx] Add tests for verification of expected set of Linux packages

### DIFF
--- a/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
+++ b/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
@@ -793,7 +793,12 @@ public partial class LinuxInstallerTests : IDisposable
             foreach (string distro in distros)
             {
                 patterns.Add($"dotnet-runtime-deps-*-{distro}-{arch}{extension}");
-                patterns.Add($"dotnet-runtime-deps-*-{distro}-newkey-{arch}{extension}");
+
+                // `azl` deps packages do not have a -newkey- variant
+                if (distro != "azl.3")
+                {
+                    patterns.Add($"dotnet-runtime-deps-*-{distro}-newkey-{arch}{extension}");
+                }
             }
         }
 

--- a/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
+++ b/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
@@ -81,6 +81,10 @@ public partial class LinuxInstallerTests : IDisposable
     [GeneratedRegex(@"\s*\([^)]*\)", RegexOptions.CultureInvariant)]
     private static partial Regex RemoveVersionConstraintRegex { get; }
 
+    // Remove version numbers from package names: "dotnet-runtime-10.0.0-rc.1.25480.112-x64.rpm" -> "dotnet-runtime-*-x64.rpm"
+    [GeneratedRegex(@"\d+\.\d+\.\d+(?:-(?:rc|rtm|preview)(?:\.\d+)*)?", RegexOptions.CultureInvariant)]
+    private static partial Regex RemoveVersionFromPackageNameRegex { get; }
+
     private const string RuntimeDepsRepo = "mcr.microsoft.com/dotnet/runtime-deps";
     private const string RuntimeDepsVersion = "10.0-preview";
     private const string DotnetRuntimeDepsPrefix = "dotnet-runtime-deps-";
@@ -168,6 +172,18 @@ public partial class LinuxInstallerTests : IDisposable
         await InitializeContextAsync(PackageType.Deb, initializeSharedContext: false);
 
         ValidatePackageMetadata($"{repo}:{tag}", PackageType.Deb);
+    }
+
+    [ConditionalFact(typeof(LinuxInstallerTests), nameof(IncludeRpmTests))]
+    public void ValidateRpmPackageList()
+    {
+        ValidatePackageList(PackageType.Rpm);
+    }
+
+    [ConditionalFact(typeof(LinuxInstallerTests), nameof(IncludeDebTests))]
+    public void ValidateDebPackageList()
+    {
+        ValidatePackageList(PackageType.Deb);
     }
 
     private async Task InitializeContextAsync(PackageType packageType, bool initializeSharedContext = true)
@@ -711,5 +727,76 @@ public partial class LinuxInstallerTests : IDisposable
         }
 
         return results;
+    }
+
+    private void ValidatePackageList(PackageType packageType)
+    {
+        string extension = packageType == PackageType.Rpm ? "*.rpm" : "*.deb";
+        List<string> expectedPatterns = GetExpectedPackagePatterns(packageType).OrderBy(p => p).ToList();
+
+        // Find all packages of the specified type and normalize by removing version numbers
+        List<string> normalizedActual = Directory.GetFiles(Config.AssetsDirectory, extension, SearchOption.AllDirectories)
+            .Select(path => RemoveVersionFromPackageNameRegex.Replace(Path.GetFileName(path), "*"))
+            .Distinct()
+            .OrderBy(name => name)
+            .ToList();
+
+        Assert.True(
+            expectedPatterns.SequenceEqual(normalizedActual),
+            $"Package list validation failed for {packageType}:\nExpected:\n{string.Join("\n", expectedPatterns)}\nActual:\n{string.Join("\n", normalizedActual)}"
+        );
+    }
+
+    private List<string> GetExpectedPackagePatterns(PackageType packageType)
+    {
+        string extension = packageType == PackageType.Rpm ? ".rpm" : ".deb";
+        string arch = Config.Architecture == Architecture.X64 ? "x64" :
+                     (packageType == PackageType.Rpm ? "aarch64" : "arm64");
+
+        var patterns = new List<string>();
+
+        // Base package prefixes (common to both RPM and DEB)
+        var basePackages = new List<string>
+        {
+            "aspnetcore-runtime", "aspnetcore-targeting-pack", "dotnet-apphost-pack",
+            "dotnet-host", "dotnet-hostfxr", "dotnet-runtime", "dotnet-sdk", "dotnet-targeting-pack"
+        };
+
+        // Add runtime-deps for DEB only (RPM only has distro-specific variants)
+        if (packageType == PackageType.Deb)
+        {
+            basePackages.Add("dotnet-runtime-deps");
+        }
+
+        // Standard variants
+        foreach (string package in basePackages)
+        {
+            patterns.Add($"{package}-*-{arch}{extension}");
+        }
+
+        // New key variants
+        foreach (string package in basePackages)
+        {
+            patterns.Add($"{package}-*-newkey-{arch}{extension}");
+        }
+
+        if (packageType == PackageType.Rpm)
+        {
+            // Azure Linux variants
+            foreach (string package in basePackages)
+            {
+                patterns.Add($"{package}-*-azl-{arch}{extension}");
+            }
+
+            // Runtime deps distro variants (RPM only)
+            string[] distros = new[] { "azl.3", "opensuse.15", "sles.15" };
+            foreach (string distro in distros)
+            {
+                patterns.Add($"dotnet-runtime-deps-*-{distro}-{arch}{extension}");
+                patterns.Add($"dotnet-runtime-deps-*-{distro}-newkey-{arch}{extension}");
+            }
+        }
+
+        return patterns;
     }
 }


### PR DESCRIPTION
Backport of https://github.com/dotnet/dotnet/pull/2720 and https://github.com/dotnet/dotnet/pull/2722

New tests will ensure that we are producing all the expected Linux packages. This will catch any issues early, way before the packages would need to be consumed, i.e. during product release.

The tests were enabled in main. This backport ensures that we have the same tests in 10.

## Notes

**Infra change**