### PR TITLE
Remove auditSources from NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -15,8 +15,4 @@
   <disabledPackageSources>
     <clear />
   </disabledPackageSources>
-  <auditSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </auditSources>
 </configuration>


### PR DESCRIPTION
AzDO now already has auditSource support so we don't need to fetch from nuget.org directly anymore.