### PR TITLE
Update api-diff tests

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-diff-tests.yml
+++ b/eng/pipelines/templates/jobs/sdk-diff-tests.yml
@@ -161,6 +161,7 @@ jobs:
       find artifacts/TestResults/ -type f -name "*.binlog" -exec cp {} --parents -t ${targetFolder} \;
       find artifacts/TestResults/ -type f -name "*.log" -exec cp {} --parents -t ${targetFolder} \;
       find artifacts/TestResults/ -type f -name "*.diff" -exec cp {} --parents -t ${targetFolder} \;
+      find artifacts/TestResults/ -type f -name "*.suppression" -exec cp {} --parents -t ${targetFolder} \;
       find artifacts/TestResults/ -type f -name "Updated*.txt" -exec cp {} --parents -t ${targetFolder} \;
     displayName: Prepare BuildLogs staging directory
     continueOnError: true

--- a/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/ApiDiff.suppression
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/ApiDiff.suppression
@@ -212,12 +212,6 @@
     <Right>/sb/sdk/x.y.z/DotnetTools/dotnet-user-jwts/x.y.z/tools/netx.y/any/Microsoft.IdentityModel.Tokens.dll</Right>
   </Suppression>
   <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:System.ComponentModel.Composition.Primitives.ComposablePartException.#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)</Target>
-    <Left>/msft/sdk/x.y.z/System.ComponentModel.Composition.dll</Left>
-    <Right>/sb/sdk/x.y.z/System.ComponentModel.Composition.dll</Right>
-  </Suppression>
-  <Suppression>
     <DiagnosticId>CP0003</DiagnosticId>
     <Target>Humanizer, Version=x.y.z, Culture=neutral, PublicKeyToken=979442b78dfc278e</Target>
     <Left>/msft/sdk/x.y.z/DotnetTools/dotnet-watch/x.y.z/tools/netx.y/any/Humanizer.dll</Left>
@@ -294,11 +288,5 @@
     <Target>T:Newtonsoft.Json.Linq.JTokenWriter</Target>
     <Left>/msft/sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/tools/Newtonsoft.Json.dll</Left>
     <Right>/sb/sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Razor/tools/Newtonsoft.Json.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0008</DiagnosticId>
-    <Target>T:System.ComponentModel.Composition.ReflectionModel.LazyMemberInfo</Target>
-    <Left>/msft/sdk/x.y.z/System.ComponentModel.Composition.dll</Left>
-    <Right>/sb/sdk/x.y.z/System.ComponentModel.Composition.dll</Right>
   </Suppression>
 </Suppressions>


### PR DESCRIPTION
[Failing tests](https://dev.azure.com/dnceng/internal/_build/results?buildId=2812770&view=logs&j=90cfd064-37a8-540a-744d-0d0c64eeec78&t=210c45e3-71fa-588c-6d44-cad928d791ff)

Removing two differences from the baseline to account for a recent fix.

Also updating the file collection step to ensure that updated api-diff baseline gets published.