### PR TITLE
Update baseline for sdk-diff tests

### DIFF
--- a/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/MsftToSbSdkFiles.diff
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/MsftToSbSdkFiles.diff
@@ -45,7 +45,7 @@ index ------------
  ./packs/Microsoft.NETCore.App.Ref/x.y.z/
  ./packs/Microsoft.NETCore.App.Ref/x.y.z/analyzers/
 @@ ------------ @@
- ./packs/NETStandard.Library.Ref/x.y.z/ref/netstandard2.1/System.Xml.XPath.XDocument.dll
+ ./packs/Microsoft.NETCore.App.Ref/x.y.z/ref/netx.y/WindowsBase.dll
  ./sdk-manifests/
  ./sdk-manifests/x.y.z/
 -./sdk-manifests/x.y.z/

--- a/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/SdkFileDiffExclusions.txt
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/SdkFileDiffExclusions.txt
@@ -17,6 +17,7 @@
 # 'folder/' is equivalent to 'folder/**. It matches 'folder/', 'folder/abc', and 'folder/abc/def/'
 
 ./sdk/x.y.z/TestHostNetFramework/|msft   # Intentional - MSFT build includes test-host that targets netcoreapp3.1
+./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/|msft   # Intentional - netfx excluded from source-build
 
 # netfx tooling and tasks, not building in source-build - https://github.com/dotnet/source-build/issues/3514
 ./sdk/x.y.z/Sdks/Microsoft.Build.Tasks.Git/tools/netframework/|msft


### PR DESCRIPTION
Updates the baseline and exclusion files for sdk-diff tests. These files now match what's in `main`.