### PR TITLE
Change schedule of public pipeline to 14:00 UTC

### DIFF
--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -15,7 +15,7 @@ pr:
     - release/*
 
 schedules:
-  - cron: "0 14 * * *" # run at 01:00 (UTC)
+  - cron: "0 14 * * *" # run at 14:00 (UTC)
     branches:
       include:
       - main


### PR DESCRIPTION
Updated cron schedule to run at 14:00 (UTC) instead of 01:00.