### PR TITLE
[infra] Custom packages path for test scenario

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -402,11 +402,7 @@ if [[ "$sourceOnly" == "true" ]]; then
 
   # Support custom source built package locations
   if [ "$customPackagesDir" != "" ]; then
-    if [ "$test" == "true" ]; then
-      properties+=( "/p:CustomSourceBuiltPackagesPath=$customPackagesDir" )
-    else
-      properties+=( "/p:CustomPreviouslySourceBuiltPackagesPath=$customPackagesDir" )
-    fi
+    properties+=( "/p:CustomPreviouslySourceBuiltPackagesPath=$customPackagesDir" )
   fi
 
   if [ ! -d "$scriptroot/.git" ]; then


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/5359

Fixing this by setting the `CustomPreviouslySourceBuiltPackagesPath` property in both test and non-test scenarios.

The failure was due to https://github.com/dotnet/dotnet/blob/0a70a71d470911840ad38a1452d6ad7a9bab12e5/eng/init-source-only.proj#L27-L29

We were only setting `CustomPreviouslySourceBuiltPackagesPath` for non-test runs. For tests we were setting a different property: https://github.com/dotnet/dotnet/blob/0a70a71d470911840ad38a1452d6ad7a9bab12e5/build.sh#L412-L419

However, `CustomSourceBuiltPackagesPath` isn't used anywhere.

We do have a custom property with a similar name, that is used for tests to provide custom packages feed. I don't think we should set that property automatically - it doesn't seem that was the original intent - https://github.com/dotnet/dotnet/blob/0a70a71d470911840ad38a1452d6ad7a9bab12e5/test/Microsoft.DotNet.SourceBuild.Tests/README.md?plain=1#L19-L21