### PR TITLE
Add native signing auth config from runtime repo

### DIFF
--- a/eng/native/signing/auth.json
+++ b/eng/native/signing/auth.json
@@ -1,0 +1,20 @@
+{
+    "Version" : "1.0.0",
+    "AuthenticationType" : "AAD_MSI_WIF",
+    "TenantId" : "975f013f-7f24-47e8-a7d3-abc4752bf346",
+    "ClientId" : "22346933-af99-4e94-97d5-7fa1dcf4bba6",
+    "EsrpClientId": "22346933-af99-4e94-97d5-7fa1dcf4bba6",
+    "RequestSigningCert" :
+    {
+        "GetCertFromKeyVault" : true,
+        "KeyVaultName": "clrdiag-esrp-pme",
+        "KeyVaultCertName": "dac-dnceng-esrpclient-cert",
+        "SendX5c": false,
+        "WithAzureRegion": false,
+        "StoreLocation": null,
+        "StoreName": null,
+        "SubjectName": null
+    },
+    "OAuthToken": null,
+    "FederatedTokenData": {}
+}

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -460,7 +460,6 @@ jobs:
           isOfficialBuild: true
           serviceConnectionGuid: 0a3b81f8-02bd-434b-960a-1e45cfcca801
           serviceConnectionName: 'diagnostics-esrp-kvcertuser-pme'
-          scriptRoot: '${{ variables.sourcesPath }}/src/runtime/eng/native/signing'
 
 
     - script: build.cmd


### PR DESCRIPTION
Signed builds in the 10.0.2xx branch fail for Windows legs with the following error in the `Setup WIF auth for ESRP client` step:

```
Get-Content : Cannot find path 'D:\a\_work\1\s\src\runtime\eng\native\signing\auth.json' because it does not exist.
```

Resolved by copying the auth.json file from the runtime repo into the VMR `eng` directory. Updated the pipeline to reference this (the new path is referenced by default so it's resolved by removing the overridden path).