### PR TITLE
Clean existing .dotnet dir

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -526,6 +526,7 @@ jobs:
 
           if [[ "$prepSdk" == "false" ]]; then
             customPrepArgs="${customPrepArgs} --no-sdk"
+            rm -rf $(sourcesPath)/.dotnet
             mkdir $(sourcesPath)/.dotnet
             previousSdkPath="$(sourcesPath)/prereqs/packages/archive/dotnet-sdk-*.tar.gz"
             eval tar -ozxf "$previousSdkPath" -C "$(sourcesPath)/.dotnet"


### PR DESCRIPTION
Signed builds in the 10.0.2xx branch fail in the `SB_CentOSStream10_Offline_MsftSdk_x64` job with the following error in the Prep Source Build step:

```
mkdir: cannot create directory '/__w/1/s/.dotnet': File exists
```

This happens because the "Install .NET 8.0 SDK for MicroBuild Plugin" step has already installed an SDK at that location.

This is resolved by ensuring the `.dotnet` directory is removed. The SDK installed for MicroBuild is no longer needed at this point in the build.