### PR TITLE
[release/10.0.1xx] Fix localization of links in runtime bundle

### DIFF
--- a/src/runtime/src/installer/pkg/sfx/bundle/bundle.thm
+++ b/src/runtime/src/installer/pkg/sfx/bundle/bundle.thm
@@ -44,8 +44,8 @@
       <Label Name="LicenseAssent" X="148" Y="288" Width="-12" Height="32" FontId="DefaultFont" HexStyle="000000">#(loc.LicenseAssent)</Label>
 
       <!-- These controls have larger vertical spacing to improve readability (20 instead of 16). -->
-      <Hypertext Name="PrivacyStatementLink" X="172" Y="320" Width="-12" Height="16" FontId="DefaultFont" TabStop="yes" HexStyle="000000" HideWhenDisabled="yes">&lt;A HREF=&quot;https://aka.ms/dev-privacy&quot;&gt;Privacy Statement&lt;/A&gt;</Hypertext>
-      <Hypertext Name="EulaLink" X="172" Y="340" Width="-12" Height="16" FontId="DefaultFont" TabStop="yes" HexStyle="000000" HideWhenDisabled="yes">&lt;A HREF=&quot;https://aka.ms/dotnet-license-windows&quot;&gt;Licensing Information for .NET&lt;/A&gt;</Hypertext>
+      <Hypertext Name="PrivacyStatementLink" X="172" Y="320" Width="-12" Height="16" FontId="DefaultFont" TabStop="yes" HexStyle="000000" HideWhenDisabled="yes">#(loc.PrivacyStatementLink)</Hypertext>
+      <Hypertext Name="EulaLink" X="172" Y="340" Width="-12" Height="16" FontId="DefaultFont" TabStop="yes" HexStyle="000000" HideWhenDisabled="yes">#(loc.EulaLink)</Hypertext>
 
       <Button Name="InstallButton" X="-124" Y="-12" Width="100" Height="24" TabStop="yes" FontId="DefaultFont">#(loc.InstallInstallButton)</Button>
       <Button Name="InstallCancelButton" X="-12" Y="-12" Width="100" Height="24" TabStop="yes" FontId="DefaultFont">


### PR DESCRIPTION
New localization strings were checked in but they weren't being picked up since the value was hardcoded. This PR fixes that by point to the localized string instead.

Kind of a regression:
- RC1: used WiX 3 and had everything localized
- RC2: WiX 5 was introduced unlocalized (technically this was the regression)

Discovered by CTI.

Tested locally by running the installer using `/lang 3082` and verifying that the link is localized.

Fixes https://github.com/dotnet/runtime/issues/120109