### PR TITLE
[runtime] Remove remnant LinuxTracepoints references

### DIFF
--- a/eng/allowed-vmr-binaries.txt
+++ b/eng/allowed-vmr-binaries.txt
@@ -103,7 +103,6 @@ src/runtime/src/mono/mono/eglib/test/*.txt
 src/runtime/src/mono/mono/tests/exiting/*.out
 src/runtime/src/mono/wasm/testassets/**/*.dat
 src/runtime/src/mono/wasm/testassets/**/*.o
-src/runtime/src/native/external/LinuxTracepoints/TestOutput/EventHeaderInterceptorLE64.dat
 src/runtime/src/tests/FunctionalTests/Android/Device_Emulator/AOT_PROFILED/*.mibc
 src/runtime/src/tests/FunctionalTests/Android/Device_Emulator/AOT_PROFILED/*.nettrace
 src/runtime/src/tests/FunctionalTests/Android/Device_Emulator/gRPC/grpc-dotnet/testassets/Certs/InteropTests/server1.pfx

--- a/repo-projects/runtime.proj
+++ b/repo-projects/runtime.proj
@@ -56,7 +56,6 @@
     <BuildArgs Condition="$(UseSystemLibs.Contains('+brotli')) or $(UseSystemLibs.Contains('+all'))">$(BuildArgs) --cmakeargs -DCLR_CMAKE_USE_SYSTEM_BROTLI=true</BuildArgs>
     <BuildArgs Condition="$(UseSystemLibs.Contains('+libunwind')) or $(UseSystemLibs.Contains('+all'))">$(BuildArgs) --cmakeargs -DCLR_CMAKE_USE_SYSTEM_LIBUNWIND=true</BuildArgs>
     <!-- TODO: llvm-libunwind -->
-    <!-- TODO: LinuxTracepoints -->
     <BuildArgs Condition="$(UseSystemLibs.Contains('+rapidjson')) or $(UseSystemLibs.Contains('+all'))">$(BuildArgs) --cmakeargs -DCLR_CMAKE_USE_SYSTEM_RAPIDJSON=true</BuildArgs>
     <BuildArgs Condition="$(UseSystemLibs.Contains('+zlib')) or $(UseSystemLibs.Contains('+all'))">$(BuildArgs) --cmakeargs -DCLR_CMAKE_USE_SYSTEM_ZLIB=true</BuildArgs>
     <BuildArgs Condition="$(UseSystemLibs.Contains('-lttng'))">$(BuildArgs) /p:FeatureXplatEventSource=false</BuildArgs>


### PR DESCRIPTION
In dotnet/runtime, LinuxTracepoints references may be completely removed through https://github.com/dotnet/runtime/pull/120720. Once that is merged and flowed into this repo, there are some more dangling references to LinuxTracepoints that should no longer be needed.