### PR TITLE
Update Ubuntu image used by Tag & Scan stage

### DIFF
--- a/eng/pipelines/templates/stages/vmr-scan.yml
+++ b/eng/pipelines/templates/stages/vmr-scan.yml
@@ -7,7 +7,7 @@ stages:
     displayName: Tag & Scan
     pool:
       name: $(DncEngInternalBuildPool)
-      image: 1es-ubuntu-2004
+      image: 1es-ubuntu-2204
       os: linux
 
     steps:


### PR DESCRIPTION
Removing the last use case of Ubuntu 20.04 image in VMR builds.