### PR TITLE
Don't publish Microsoft.NET.Workload.Mono.ToolChain.Current.Manifest from runtime build

### DIFF
--- a/src/runtime/eng/Publishing.props
+++ b/src/runtime/eng/Publishing.props
@@ -5,6 +5,11 @@
     <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages>
   </PropertyGroup>
 
+  <!-- remove the manifest packages, they are built in the SDK repo now -->
+  <ItemGroup>
+    <Artifact Remove="$(ArtifactsShippingPackagesDir)*.Manifest-*.nupkg" />
+  </ItemGroup>
+
   <!-- The PGO runtime should always have External visibility, even if someone changes the default artifact visibility -->
   <ItemGroup>
     <Artifact Update="$(ArtifactsNonShippingPackagesDir)dotnet-runtime-pgo-*" Visibility="External" />


### PR DESCRIPTION
This regressed with https://github.com/dotnet/runtime/commit/e5798b9f08ab6def1848d226512815357e9ccb80 which removed removing the manifest packages from publishing in the runtime build with a runtime version number.

These packages are unused (only the ones with sdk-style version numbers are used) but they are confusing and they also seem to mess with darc dependency tracking.

Fixes https://github.com/dotnet/dotnet/issues/3019