### PR TITLE
Revert "[main] Use macos-14-arm64 image in internal builds to workaround linker bug"

### DIFF
--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -285,6 +285,7 @@ variables:
   - name: poolName_LinuxArm64
     value: Docker-Linux-Arm-Internal
   - name: poolImage_Mac
-    value: macos-14-arm64
+    value: macos-latest-internal
   - name: poolImage_Windows
     value: windows.vs2022preview.amd64
+


### PR DESCRIPTION
Reverts dotnet/dotnet#2350

Now that https://github.com/dotnet/runtime/issues/119174 was fixed we should move back to the recommended macOS agent pool (which currently uses macOS 15).