### PR TITLE
Pin the 1xx dependency to RC 2

### DIFF
--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -8,7 +8,7 @@ This file should be imported by eng/Versions.props
     <!-- _git/dotnet-dotnet dependencies -->
     <MicrosoftDotNetArcadeSdkPackageVersion>10.0.0-beta.25502.107</MicrosoftDotNetArcadeSdkPackageVersion>
     <MicrosoftDotNetBuildManifestPackageVersion>10.0.0-beta.25502.107</MicrosoftDotNetBuildManifestPackageVersion>
-    <MicrosoftNETSdkPackageVersion>10.0.100-rtm.25513.102</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>10.0.100-rc.2.25502.107</MicrosoftNETSdkPackageVersion>
   </PropertyGroup>
   <!--Property group for alternate package version names-->
   <PropertyGroup>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -14,7 +14,7 @@
       <Uri>https://github.com/dotnet/arcade-services</Uri>
       <Sha>4aa8e8c35aaf3cbdfc387d28af3366fcd9125bc8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-rtm.25513.102">
+    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-rc.2.25502.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>b502b6eeec0db06720ead7fd9570befa39a6b2f7</Sha>
     </Dependency>


### PR DESCRIPTION
Updates the branch to use the official RC 2 build as its dependency on the shared components from the 1xx branch. The 2xx branch should always be referencing the most recently released version of 1xx to get the runtime.