### PR TITLE
Allow NU5104 in MSBuild

### DIFF
--- a/src/msbuild/Directory.Build.props
+++ b/src/msbuild/Directory.Build.props
@@ -66,7 +66,7 @@ ates https://learn.microsoft.com/en-gb/dotnet/fundamentals/syslib-diagnostics/sy
          That means the .NET 10 packages referenced by the MSBuild packages will have unstable
          version numbers. This is ok in that context, since VMR-produced MSBuild packages won't
          be published. -->
-    <NoWarn Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(NoWarn);NU5104;</NoWarn>
+    <NoWarn Condition="'$(DotNetBuild)' == 'true'">$(NoWarn);NU5104;</NoWarn>
   </PropertyGroup>
 
   <!-- Configuration MSBuild for portable (xcopy-install) toolsets: works on WinNT and linux/mac via Mono, isolates from machine environment:


### PR DESCRIPTION
Fixes dotnet/source-build#5376.

When MSBuild exposes a stable version, but dotnet/runtime does not, VMR
builds can fail with a warning-as-error like

    .../NuGet.Build.Tasks.Pack.targets(221,5): error NU5104: Warning As Error: A stable release of a package should not have a prerelease dependency. Either modify the version spec of dependency "System.Formats.Nrbf [10.0.0-rtm.25514.101, )" or update the version field in the nuspec. [/home/tester/workdir/dotnet/src/msbuild/src/Tasks/Microsoft.Build.Tasks.csproj]

This is an error we want to keep in the MSBuild repo’s standalone build,
so that the official NuGet packages we ship don't violate the rule, but
it is not helpful in a unified build where the packages won't be
published and we always want to have a consistent, unified set of
references to what is building.

Avoid this by suppressing the warning for any project in the MSBuild
repo, conditional on whether we're in a source-build scenario.
