### PR TITLE
Add --force option to codesign flags for roslyn

### DIFF
--- a/src/sdk/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/sdk/src/Layout/redist/targets/GenerateLayout.targets
@@ -66,7 +66,7 @@
                    IntermediateAssembly="%(_RoslynAppHost.FullPath)"
                    EnableMacOSCodeSign="$(SharedFrameworkRid.StartsWith('osx'))" />
     
-    <Exec Command="codesign --sign - --entitlements '$(MSBuildProjectDirectory)/roslyn-entitlements.plist' %(_RoslynAppHost.RootDir)%(_RoslynAppHost.Directory)%(_RoslynAppHost.Filename)$(ExeExtension)"
+    <Exec Command="codesign --sign - --force --entitlements '$(MSBuildProjectDirectory)/roslyn-entitlements.plist' %(_RoslynAppHost.RootDir)%(_RoslynAppHost.Directory)%(_RoslynAppHost.Filename)$(ExeExtension)"
           Condition="$(SharedFrameworkRid.StartsWith('osx'))" />
   </Target>
 


### PR DESCRIPTION
The build currently fails with:
> /Users/runner/work/1/s/src/sdk/artifacts/bin/redist/Release/net10.0/Roslyn/bincore/csc: is already signed

Follow-up to https://github.com/dotnet/dotnet/pull/3052

This makes the codesign command now match what we do in dotnet/runtime: https://github.com/dotnet/runtime/blob/9bcdd873eb4b93934ae34328845599f63253d32a/eng/native/functions.cmake#L736