### PR TITLE
Remove sourcelink SharedRepositoryReference

### DIFF
--- a/eng/VmrLayout.props
+++ b/eng/VmrLayout.props
@@ -108,7 +108,6 @@
     <SharedRepositoryReference Include="efcore" />
     <SharedRepositoryReference Include="emsdk" />
     <SharedRepositoryReference Include="runtime" />
-    <SharedRepositoryReference Include="sourcelink" />
     <SharedRepositoryReference Include="symreader" />
     <SharedRepositoryReference Include="windowsdesktop" />
     <SharedRepositoryReference Include="winforms" />


### PR DESCRIPTION
Sourcelink follows the feature band model and will have release/10.0.xxx branches.

This will need a backport into at least release/10.0.2xx.