### PR TITLE
[release/10.0.1xx] Add empty PATH component

### DIFF
--- a/src/runtime/src/installer/pkg/sfx/installers/host.wxs
+++ b/src/runtime/src/installer/pkg/sfx/installers/host.wxs
@@ -75,6 +75,12 @@
         </File>
       </Component>
 
+      <!-- Adding the new PATH component in 10.0 (P7 through RC2) and then reverting that change also modified when RemoveExistingProducts
+           was scheduled. To avoid losing the PATH setting when upgrading from P7/RC1/RC2, we need to retain an empty component to ensure
+           reference counts are maintained. -->
+      <Component Id="cmpSetPath" Guid="{0B910ED8-0877-473D-8658-647382324433}" Directory="DOTNETHOME">
+        <CreateFolder />
+      </Component>
     </ComponentGroup>
 
     <Property Id="ProductCPU" Value="$(var.Platform)" />


### PR DESCRIPTION
## Customer Impact

Upgrading .NET 10 rom Preview 7, RC1 or RC2 to 10.0 RTM will result in not having `dotnet.exe` on the system path.

## Description

In Preview7, a change was made to conditionally set the system PATH. Prior to Preview7, the host installer scheduled the removal of the previous MSI at the end after installing the new product. Removing the environment setting from the original component requires modifying the scheduling to run early (removing the older product first before installing the new version). 

This had an unintended impact on SxS installs. Installing .NET 9.0 and 10.0 and removing 10.0 would result in the removal of the new component because it only existed in the 10 host installer. Users would either need to repair previous .NET installations or manually edit the system PATH.

After RC2, the change was reverted. However, adding the environment entry back to the original component was itself a compositional change that required retaining the early removal of older installs. The later removal was a change introduced in ..NET 6.0 to avoid upgrades from swapping the x86 and x64 PATH, so reverting the P7 PR, but keeping the early removal would break this scenario.

This meant that upgrading from P7/RC1/RC2 to RTM would still result in removing the entry from the PATH and require users to repair .NET immediately after updating. By keeping an empty component that match the new component introduced in P7, the reference counts are maintained and the PATH remains set when upgrading.

## Risk

Low/Medium. We're tweaking the components to satisfy the specific upgrade requirements without regressing other requirements that prohibit us from modifying when `RemoveExisitingProducts` are scheduled.

## Testing

* RC2 + Private build with the fix: Path contains `dotnet` 
* RC2 + Latest GA build from staging: Path is missing `dotnet`
* VS 17.12 LTSC (9.0 SDK and runtime) + Private - Private: Path is correct
* 5.0.17 (x64) + 5.0.17 (x86) + 10.0.0-rc.2 (x64) + GA (without fix): Only x86 path is set.
* 5.0.17 (x64) + 5.0.17 (x86) + 10.0.0-rc2 (x64) + Private: `dotnet` under Program Files remains first on the path
