### PR TITLE
Update 1xx SDK download location

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -415,13 +415,13 @@ jobs:
     - script: |
         source "$(sourcesPath)/eng/download-source-built-archive.sh"
         # Download the 1xx source-built SDK
-        DownloadArchive "1xx source-built SDK" "MicrosoftNETSdkPackageVersion" false "${{ parameters.artifactsRid }}" "$(sourcesPath)/prereqs/packages/archive/" "" "dotnet-sdk"
+        DownloadArchive "1xx source-built SDK" "PrivateSourceBuiltSdkVersion" false "${{ parameters.artifactsRid }}" "$(sourcesPath)/prereqs/packages/archive/" "" "" true
       displayName: Download 1xx SDK
 
   - ${{ if parameters.excludeRuntimeDependentJobs }}:
     - script: |
         source "$(sourcesPath)/eng/download-source-built-archive.sh"
-        DownloadArchive "shared component artifacts" "MicrosoftNETSdkPackageVersion" false "${{ parameters.artifactsRid }}" "$(sourcesPath)/prereqs/packages/archive/" "Private.SourceBuilt.SharedComponents"
+        DownloadArchive "shared component artifacts" "PrivateSourceBuiltArtifactsVersion" false "${{ parameters.artifactsRid }}" "$(sourcesPath)/prereqs/packages/archive/" "Private.SourceBuilt.SharedComponents" "MicrosoftNETSdkPackageVersion" true
       displayName: Download Shared Component Artifacts
 
   # https://github.com/dotnet/dotnet/issues/1758


### PR DESCRIPTION
## Fix: Update 1xx SDK download location for feature bands

Fixes https://github.com/dotnet/source-build/issues/5370

### Problem
Feature band branches (2xx+) were consuming the SDK from the current in-development 1xx build instead of the released 1xx SDK. For example, 10.0.200 should use the 10.0 RC2 SDK, not the current 10.0 GA SDK being developed.

The issue was that the build was using `MicrosoftNETSdkPackageVersion` (which points to the current in-development SDK) instead of `PrivateSourceBuiltSdkVersion` (which points to the released SDK).

### Changes

#### download-source-built-archive.sh
Refactored the `DownloadArchive` function to support downloading from different locations:

- **Added `versionPropertyOverride` parameter (position 7)**: Allows specifying a different property to look up the version number than the `propertyName` parameter. This decouples version lookup from archive type determination. For example, this enables downloading shared component artifacts (archive type determined by `PrivateSourceBuiltArtifactsVersion`) while getting the version number from a different property (`MicrosoftNETSdkPackageVersion`).

- **Added `useCILocation` parameter (position 8)**: Controls whether to download from `ci.dot.net` (CI builds) or `builds.dotnet.microsoft.com` (official builds). Defaults to `false` for official builds. Note: The script automatically overrides this to `false` for assets with the default RID (`centos.10-x64`), as those are always hosted on the official builds location.

- **Removed `archiveBaseFileNameOverride` parameter**: This was replaced by the more flexible combination of `versionPropertyOverride` and `useCILocation`, which better separates concerns between archive type identification, version lookup, and download location.

- **Updated URL logic**: Now determines the base URL (`builds.dotnet.microsoft.com` vs `ci.dot.net`) based on the `useCILocation` flag, and automatically uses the official location for default RID assets.

#### vmr-build.yml
Updated the download calls to use the correct version properties:

- **1xx SDK download**: Changed from `MicrosoftNETSdkPackageVersion` to `PrivateSourceBuiltSdkVersion` with `useCILocation=true`. This downloads the released SDK from the CI location for non-default RIDs, or from the official builds location for the default RID.

- **Shared component artifacts**: Changed to use `PrivateSourceBuiltArtifactsVersion` as the property name (to identify it as an artifacts-type archive) with `versionPropertyOverride=MicrosoftNETSdkPackageVersion` (to get the version number from the SDK property) and `useCILocation=true`. This downloads from the appropriate location based on the RID.

### Why the function signature changed
The original `archiveBaseFileNameOverride` parameter only allowed overriding the filename but couldn't:
1. Control the download location (CI vs official builds)
2. Separate version lookup from archive type determination

The new design uses two focused parameters:
- `versionPropertyOverride`: Separates "which property determines the archive type and URL pattern" from "which property contains the version number to download"
- `useCILocation`: Explicitly controls the download source location (subject to the default RID override)

This provides better separation of concerns and makes the function calls more explicit about their intent, while enabling scenarios like downloading shared component artifacts versioned by the SDK version.