### PR TITLE
Update poolImage_LinuxArm64 from mariner to azurelinux

### DIFF
--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -262,7 +262,7 @@ variables:
   - name: poolImage_Linux
     value: build.ubuntu.2204.amd64.open
   - name: poolImage_LinuxArm64
-    value: Mariner-2-Docker-ARM64
+    value: azure-linux-3-arm64
   - name: poolName_LinuxArm64
     value: Docker-Linux-Arm-Public
   - name: poolImage_Mac
@@ -281,7 +281,7 @@ variables:
   - name: poolImage_Linux
     value: build.ubuntu.2204.amd64
   - name: poolImage_LinuxArm64
-    value: Mariner-2-Docker-ARM64
+    value: azure-linux-3-arm64
   - name: poolName_LinuxArm64
     value: Docker-Linux-Arm-Internal
   - name: poolImage_Mac


### PR DESCRIPTION
The mariner image is deprecated and shows a warning in AzDO.