### PR TITLE
Exclude package assets in SB manifest

### DIFF
--- a/eng/PublishSourceBuild.props
+++ b/eng/PublishSourceBuild.props
@@ -173,7 +173,8 @@
 
   <Target Name="IncludeSharedComponentsAsArtifacts"
           AfterTargets="DiscoverArtifacts"
-          DependsOnTargets="GetFilteredSharedComponentPackages">
+          DependsOnTargets="GetFilteredSharedComponentPackages"
+          Condition="'$(IsPublishPass2)' != 'true'">
 
     <ItemGroup>
       <Artifact Include="@(SharedComponentFilteredPackages->'%(PackagePath)')">


### PR DESCRIPTION
Fixes https://github.com/dotnet/dotnet/issues/3077

Darc publishing in the `release/10.0.2xx` branch is failing due to duplicate package entries in the `MergedManifest.xml` files. This stems from the SB legs. Example snippet from the manifest that illustrates duplicate package IDs:

```xml
  <Package Id="dotnet-dev-certs" Version="10.0.0-rc.2.25502.107" PipelineArtifactName="SB_AlmaLinux8_Offline_MsftSdk_x64_Artifacts" PipelineArtifactPath="packages/Release/Shipping/aspnetcore/dotnet-dev-certs.10.0.0-rc.2.25502.107.nupkg" RepoOrigin="aspnetcore" Visibility="External" />
  <Package Id="dotnet-dev-certs" Version="10.0.0-rc.2.25502.107" PipelineArtifactName="SB_Alpine321_Offline_MsftSdk_x64_Artifacts" PipelineArtifactPath="packages/Release/Shipping/aspnetcore/dotnet-dev-certs.10.0.0-rc.2.25502.107.nupkg" RepoOrigin="aspnetcore" Visibility="External" />
  <Package Id="dotnet-dev-certs" Version="10.0.0-rc.2.25502.107" PipelineArtifactName="SB_CentOSStream10_Offline_MsftSdk_x64_Artifacts" PipelineArtifactPath="packages/Release/Shipping/aspnetcore/dotnet-dev-certs.10.0.0-rc.2.25502.107.nupkg" RepoOrigin="aspnetcore" Visibility="External" />
  <Package Id="dotnet-dev-certs" Version="10.0.0-rc.2.25502.107" PipelineArtifactName="SB_Fedora41_Offline_MsftSdk_x64_Artifacts" PipelineArtifactPath="packages/Release/Shipping/aspnetcore/dotnet-dev-certs.10.0.0-rc.2.25502.107.nupkg" RepoOrigin="aspnetcore" Visibility="External" />
  <Package Id="dotnet-dev-certs" Version="10.0.0-rc.2.25502.107" PipelineArtifactName="SB_Ubuntu2404Arm64_Offline_MsftSdk_arm64_Artifacts" PipelineArtifactPath="packages/Release/Shipping/aspnetcore/dotnet-dev-certs.10.0.0-rc.2.25502.107.nupkg" RepoOrigin="aspnetcore" Visibility="External" />
  <Package Id="dotnet-dev-certs" Version="10.0.0-rc.2.25502.107" PipelineArtifactName="SB_Ubuntu2404_Offline_MsftSdk_x64_Artifacts" PipelineArtifactPath="packages/Release/Shipping/aspnetcore/dotnet-dev-certs.10.0.0-rc.2.25502.107.nupkg" RepoOrigin="aspnetcore" Visibility="External" />
```

This happens because of the special logic that gets triggered in non-1xx branches where shared component packages get added to the manifest explicitly. The problem is that this logic is also running in the 2nd publish pass which is specifically meant for the SB blob assets (SDK tarball, artifacts tarball) -- it is not meant to contain packages. It is this publish pass which produces the manifest that ends up going to darc for publishing.

The fix is to just ensure that we don't include the shared component packages as part of this 2nd publish pass. That allows the SB manifest to only contain the blob assets, not packages.