### PR TITLE
[release/10.0.1xx] Add System.Private.Windows.GdiPlus to WPF

### DIFF
--- a/src/winforms/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/System.Windows.Forms.FileClassification.props
+++ b/src/winforms/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/System.Windows.Forms.FileClassification.props
@@ -13,7 +13,7 @@
     <FrameworkListFileClass Include="System.Drawing.dll" Profile="WindowsForms" />
     <!-- System.Private.Windows.Core is now used by both WPF and Windows Forms -->
     <FrameworkListFileClass Include="System.Private.Windows.Core.dll" Profile="WindowsForms;WPF" />
-    <FrameworkListFileClass Include="System.Private.Windows.GdiPlus.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.Private.Windows.GdiPlus.dll" Profile="WindowsForms;WPF" />
     <FrameworkListFileClass Include="System.Windows.Forms.Design.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.Design.Editors.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.dll" Profile="WindowsForms" />


### PR DESCRIPTION
## Customer Impact

- [x] Customer reported
- [x] Found internally

When applying a using statement or casting any of the following types to an interface in a WPF project, a compiler error is emitted: Bitmap, Image, MetaFile, Icon, Graphics.
```c#
using var bitmap = new Bitmap(100, 100);
```

```
error CS0012: The type 'IImage' is defined in an assembly that is not referenced. You must add a reference to assembly 'System.Private.Windows.GdiPlus, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'
```

## Background

Due to https://github.com/dotnet/roslyn/issues/80921 my fix https://github.com/dotnet/dotnet/pull/2839 for https://github.com/dotnet/sdk/issues/51173 was incomplete.  When any interface cast or using statement is applied to Bitmap or any other type that implements internal interfaces from System.Private.Windows.GdiPlus the compiler will fail with CS0012 error, even though it does not need to call those interfaces.

To workaround this, the reference can be added to the project, in the same way as before - see https://github.com/dotnet/sdk/issues/51173#issuecomment-3392609295

We missed this in the first fix as we didn't test a user scenario involving a cast or a using statement on one of the impacted types. This fix does not omit any other private dependencies of System.Drawing.Common.

## Regression

- [x] Yes
- [ ] No

Regressed in .NET 10.0 when enabling pruning for WindowsDesktop shared framework, fix in GA was not complete.

## Testing

Verified customer repro is fixed.  Verified closure of System.Drawing.Common is exposed for reference -- no other assembly private or otherwise is omitted.

## Risk

Low - this is essentially just extending the previous fix.  The added assembly contains entirely internal API.
