### PR TITLE
Rebrand command-line-api to patch 1

### DIFF
--- a/src/command-line-api/eng/Versions.props
+++ b/src/command-line-api/eng/Versions.props
@@ -2,8 +2,8 @@
   <Import Project="Version.Details.props" Condition="Exists('Version.Details.props')" />
   <!-- Repo Version Information -->
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
-    <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
+    <VersionPrefix>2.0.1</VersionPrefix>
+    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <!-- Allowed values: '', 'prerelease', 'release'. Set to 'release' when stabilizing. -->
     <DotNetFinalVersionKind>


### PR DESCRIPTION
Increment patch version 0 -> 1 for command-line-api on release/10.0.1xx

Sets prerelease label to 'servicing' and iteration to empty string.