### PR TITLE
Rebrand efcore to patch 1

### DIFF
--- a/src/efcore/eng/Versions.props
+++ b/src/efcore/eng/Versions.props
@@ -1,8 +1,8 @@
 <Project>
   <Import Project="Version.Details.props" Condition="Exists('Version.Details.props')" />
   <PropertyGroup Label="Version settings">
-    <VersionPrefix>10.0.0</VersionPrefix>
-    <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
+    <VersionPrefix>10.0.1</VersionPrefix>
+    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>
     <IsServicingBuild Condition="'$(PreReleaseVersionLabel)' == 'servicing'">true</IsServicingBuild>


### PR DESCRIPTION
Increment patch version 0 -> 1 for efcore on release/10.0.1xx

Sets prerelease label to 'servicing' and iteration to empty string.