### PR TITLE
Rebrand fsharp to patch 101

### DIFF
--- a/src/fsharp/eng/Versions.props
+++ b/src/fsharp/eng/Versions.props
@@ -12,13 +12,13 @@
   <PropertyGroup>
     <!-- Don't use the built in support for pre-release iteration. The nuget repack task doesn't support
          the iteration format at the moment. https://github.com/dotnet/arcade/issues/15919 -->
-    <FSharpPreReleaseIteration>2</FSharpPreReleaseIteration>
-    <PreReleaseVersionLabel>rc$(FSharpPreReleaseIteration)</PreReleaseVersionLabel>
+    <FSharpPreReleaseIteration></FSharpPreReleaseIteration>
+    <PreReleaseVersionLabel>servicing$(FSharpPreReleaseIteration)</PreReleaseVersionLabel>
     <!-- These have to be in sync with latest release branch -->
     <!-- F# Version components -->
     <FSMajorVersion>10</FSMajorVersion>
     <FSMinorVersion>0</FSMinorVersion>
-    <FSBuildVersion>100</FSBuildVersion>
+    <FSBuildVersion>101</FSBuildVersion>
     <FSRevisionVersion>0</FSRevisionVersion>
     <!-- -->
     <!-- F# Language version -->


### PR DESCRIPTION
Increment patch version 100 -> 101 for fsharp on release/10.0.1xx

Sets prerelease label to 'servicing' and iteration to empty string.