### PR TITLE
Rebrand windowsdesktop to patch 1

### DIFF
--- a/src/windowsdesktop/eng/Versions.props
+++ b/src/windowsdesktop/eng/Versions.props
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <MajorVersion>10</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>0</PatchVersion>
-    <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
+    <PatchVersion>1</PatchVersion>
+    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <!-- Enable to remove prerelease label. -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>


### PR DESCRIPTION
Increment patch version 0 -> 1 for windowsdesktop on release/10.0.1xx

Sets prerelease label to 'servicing' and iteration to empty string.