### PR TITLE
Rebrand wpf to patch 1

### DIFF
--- a/src/wpf/eng/Versions.props
+++ b/src/wpf/eng/Versions.props
@@ -4,8 +4,8 @@
   <PropertyGroup>
     <MajorVersion>10</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>0</PatchVersion>
-    <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
+    <PatchVersion>1</PatchVersion>
+    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <!--


### PR DESCRIPTION
Increment patch version 0 -> 1 for wpf on release/10.0.1xx

Sets prerelease label to 'servicing' and iteration to empty string.