### PR TITLE
[source build] cloak the spectre-console/docs folder

### DIFF
--- a/src/source-mappings.json
+++ b/src/source-mappings.json
@@ -89,7 +89,7 @@
             "name": "source-build-reference-packages",
             "defaultRemote": "https://github.com/dotnet/source-build-reference-packages",
             "exclude": [
-                // Contains undesired binaries
+                // Contains disallowed binaries
                 "src/source-build-reference-packages/src/externalPackages/spectre-console/docs/**/*"
             ]
         },


### PR DESCRIPTION
Context: https://github.com/dotnet/source-build-reference-packages/pull/1447
Context: https://github.com/dotnet/source-build-reference-packages/pull/1287#issuecomment-3046537869

The docs folder contains binary files, that are not needed for building from source.