### PR TITLE
Remove secure@microsoft.com from security reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,9 +10,7 @@ If you believe you have found a security vulnerability in any Microsoft-owned re
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://msrc.microsoft.com/create-report).
-
-If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
+Please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://msrc.microsoft.com/create-report).
 
 You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc).
 


### PR DESCRIPTION
The method of reporting suspected vulnerabilities via secure@microsoft.com has been deprecated, all vulnerabilities must now be reported via the MSRC portal.