### PR TITLE
Enable error logging in source-build and other tests

### DIFF
--- a/test/TestUtilities/ExecuteHelper.cs
+++ b/test/TestUtilities/ExecuteHelper.cs
@@ -99,7 +99,7 @@ public static class ExecuteHelper
                 outputHelper.WriteLine(output);
             }
 
-            if (string.IsNullOrWhiteSpace(error))
+            if (!string.IsNullOrWhiteSpace(error))
             {
                 outputHelper.WriteLine(error);
             }


### PR DESCRIPTION
This fixes the issue with logging of process errors. `ExecuteHelper` is used by source-build and other tests.

For some reason the condition was incorrect, so errors were never logged. Found this by accident while investigating https://github.com/dotnet/dotnet/issues/3144