### PR TITLE
source-build-toolset-init.sh: fix tempDir no longer defined when EXIT trap is executed.

### DIFF
--- a/eng/source-build-toolset-init.sh
+++ b/eng/source-build-toolset-init.sh
@@ -71,7 +71,7 @@ function source_only_toolset_init() {
     elif [ -f "$sourceBuiltArchive" ]; then
       # Extract safely into a private temporary directory and ensure cleanup.
       tempDir="$(mktemp -d)"
-      trap 'rm -rf "${tempDir}"' EXIT
+      trap "rm -rf '${tempDir}'" EXIT # tempDir is local, use double quotes to expand.
       tar -xzf "$sourceBuiltArchive" -C "$tempDir" PackageVersions.props
       packageVersionsPath="$tempDir/PackageVersions.props"
     fi


### PR DESCRIPTION
Fixes https://github.com/dotnet/source-build/issues/5403.

cc @omajid 