### PR TITLE
Fix interp thread context offset for x64 apple platforms

### DIFF
--- a/src/runtime/src/coreclr/vm/amd64/asmconstants.h
+++ b/src/runtime/src/coreclr/vm/amd64/asmconstants.h
@@ -569,7 +569,11 @@ ASMCONSTANTS_C_ASSERT(OFFSETOF__ThreadLocalInfo__m_pThread == offsetof(ThreadLoc
 ASMCONSTANTS_C_ASSERT(OFFSETOF__InterpMethod__pCallStub == offsetof(InterpMethod, pCallStub))
 
 #ifdef TARGET_UNIX
+#ifdef _DEBUG
 #define OFFSETOF__Thread__m_pInterpThreadContext 0xb08
+#else // _DEBUG
+#define OFFSETOF__Thread__m_pInterpThreadContext 0x2a0
+#endif // _DEBUG
 #else // TARGET_UNIX
 #define OFFSETOF__Thread__m_pInterpThreadContext 0xb60
 #endif // TARGET_UNIX


### PR DESCRIPTION
Should unblock official builds.