### PR TITLE
Bump public macOS image to 14

### DIFF
--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -266,7 +266,7 @@ variables:
   - name: poolName_LinuxArm64
     value: Docker-Linux-Arm-Public
   - name: poolImage_Mac
-    value: macos-14-arm64
+    value: macos-14
   - ${{ if eq(parameters.isScoutingJob, true) }}:
     - name: poolImage_Windows
       value: windows.vs2022preview.scout.amd64.open
@@ -288,4 +288,5 @@ variables:
     value: macos-latest-internal
   - name: poolImage_Windows
     value: windows.vs2022preview.amd64
+
 


### PR DESCRIPTION
The macos-13 image is deprecated on AzDO.