### PR TITLE
Set custom PSB dir for SB prep

### DIFF
--- a/prep-source-build.sh
+++ b/prep-source-build.sh
@@ -246,10 +246,15 @@ if [ "$removeBinaries" == true ]; then
     tar -xzf "$sourceBuiltArchive" -C "$workingDir"
 
     psbDir=$workingDir
+  else
+    echo "  Using previously source-built packages from $psbDir"
+    toolsetInitProperties+=( "/p:CustomPreviouslySourceBuiltPackagesPath=$psbDir" )
   fi
 
+  toolsetInitProperties+=( "/p:DotNetBuildSourceOnly=true" )
+
   # Initialize source-only toolset for binary detection (includes custom SDK setup, MSBuild resolver, and source-built resolver)
-  source_only_toolset_init "$customSdkDir" "$psbDir" "true" "" "/p:DotNetBuildSourceOnly=true"
+  source_only_toolset_init "$customSdkDir" "$psbDir" "true" "" "${toolsetInitProperties[@]}"
 
   "$_InitializeBuildTool" build \
     "$REPO_ROOT/eng/init-detect-binaries.proj" \


### PR DESCRIPTION
Fixes the source build prep script to set the `CustomPreviouslySourceBuiltPackagesPath` MSBuild property to the directory passed via the `--with-packages` arg.

Fixes dotnet/source-build#5410