### PR TITLE
InstalledSize should be in kilobytes

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateMD5SumsFile.cs
+++ b/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateMD5SumsFile.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
 #endif
             }
 
-            InstalledSize = installedSize.ToString();
+            InstalledSize = (installedSize / 1024).ToString();
 
             return true;
         }


### PR DESCRIPTION
New DEB packaging tooling sets the `Installed-Size` to a value in bytes. 

This is a regression from old tooling which was setting this to the value in kilobytes. Debian packages, unlike RPM ones, require that this be in kilobytes.

## Notes 
The value is calculated in `CreateMD5SumsFile` task and later consumed by https://github.com/dotnet/dotnet/blob/631770038dd6f723225f84446128e779b3c40578/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/installer.build.targets#L217 and https://github.com/dotnet/dotnet/blob/631770038dd6f723225f84446128e779b3c40578/src/arcade/src/Microsoft.DotNet.SignTool/src/ZipData.cs#L618

## Testing

[Verification build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2839170&view=results)