### PR TITLE
Enable VMR validation in unofficial builds

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -131,12 +131,13 @@ stages:
           **/manifests/**/*.xml
           !*Sdk_*_Artifacts/**/VerticalManifest.xml
 
-- ${{ if notin(parameters.scope, 'scout') }}:
+- ${{ if in(parameters.scope, 'full') }}:
   - template: vmr-validation.yml
     parameters:
       desiredSigning: ${{ parameters.desiredSigning }}
       isOfficialBuild: ${{ parameters.isOfficialBuild }}
 
+- ${{ if notin(parameters.scope, 'scout') }}:
   - template: source-build-stages.yml
     parameters:
       pool_Linux: ${{ parameters.pool_Linux }}


### PR DESCRIPTION
`dotnet-unified-build-unofficial` pipeline had `VMR Validation` stage conditioned to run in `official` pipeline only. This might have been by accident.

This PR enables the stage in `unofficial` pipeline as well. It will only run in `full` scope as that's when required dependent jobs are built.

Some minor whitespace changes produced by Copilot edits.

[Verification build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2841431&view=results)