### PR TITLE
Do not run VMR validation in public

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -131,7 +131,7 @@ stages:
           **/manifests/**/*.xml
           !*Sdk_*_Artifacts/**/VerticalManifest.xml
 
-- ${{ if in(parameters.scope, 'full') }}:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), in(parameters.scope, 'full')) }}:
   - template: vmr-validation.yml
     parameters:
       desiredSigning: ${{ parameters.desiredSigning }}


### PR DESCRIPTION
Fixes the issue encountered in https://dev.azure.com/dnceng-public/public/_build/results?buildId=1208608

VMR Validation stage runs installer tests and uses 1ES step to publish the test results.

This PR reverts to previous, working, set of stages for public pipeline.

## Verification

[Public](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1208772&view=results)
[Internal](https://dev.azure.com/dnceng/internal/_build/results?buildId=2843754&view=results)