### PR TITLE
[release/10.0.1xx] Enable VMR validation in unofficial builds

### DIFF
--- a/eng/pipelines/templates/stages/vmr-build.yml
+++ b/eng/pipelines/templates/stages/vmr-build.yml
@@ -131,6 +131,7 @@ stages:
           **/manifests/**/*.xml
           !*Sdk_*_Artifacts/**/VerticalManifest.xml
 
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), in(parameters.scope, 'full')) }}:
   - template: vmr-validation.yml
     parameters:
       desiredSigning: ${{ parameters.desiredSigning }}


### PR DESCRIPTION
Backports the PRs: https://github.com/dotnet/dotnet/pull/3419 and https://github.com/dotnet/dotnet/pull/3474

Enables `VMR Validation` stage in internal, full-scope, builds. This essentially enables the stage in unofficial pipeline.

## Notes

Infra-only change.