### PR TITLE
[release/10.0.1xx] Update repacking of control archive

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.SignTool/src/ZipData.cs
+++ b/src/arcade/src/Microsoft.DotNet.SignTool/src/ZipData.cs
@@ -647,7 +647,9 @@ namespace Microsoft.DotNet.SignTool
                 File.WriteAllText(controlFile, fileContents);
             }
 
-            // Update the control tarball contents
+            // Update the control tarball contents. We update the contents of the control entry streams
+            // rather than recreating from the unpacked directory layout to ensure that
+            // the original entry field metadata and tar format is preserved.
             using MemoryStream streamToCompress = new();
             using (TarWriter writer = new(streamToCompress, leaveOpen: true))
             {


### PR DESCRIPTION
Fixes the TAR warning issue from https://github.com/dotnet/runtime/issues/121715

## Issue

We were using `TarFile.CreateFromDirectory` for repacking of the updated `control` archive - https://github.com/dotnet/dotnet/blob/50a911f75148cda6c24e8b7d866a2c5ab5f78129/src/arcade/src/Microsoft.DotNet.SignTool/src/ZipData.cs#L626

This method always uses PAX format - https://github.com/dotnet/dotnet/blob/50a911f75148cda6c24e8b7d866a2c5ab5f78129/src/runtime/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarFile.cs#L330

## Fix

Creating the archive and `TarEntry` fields from scratch does not set all the entry fields to values that were in original archive.

The solution is to repack using original `TarEntry` elements, but update the content. This is very similar to tar.gz repacking code in the same class.

## Verification

[Build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2843729&view=results)
