### PR TITLE
Add KeepNativeSymbols to CommonArgs in build props

### DIFF
--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -119,6 +119,7 @@
     <CommonArgs Condition="'$(OfficialBuilder)' != ''">$(CommonArgs) /p:OfficialBuilder="$(OfficialBuilder)"</CommonArgs>
     <CommonArgs Condition="'$(ForceDryRunSigning)' != ''">$(CommonArgs) /p:ForceDryRunSigning=$(ForceDryRunSigning)</CommonArgs>
     <CommonArgs Condition="'$(DotNetSignType)' != ''">$(CommonArgs) /p:DotNetSignType=$(DotNetSignType)</CommonArgs>
+    <CommonArgs Condition="'$(KeepNativeSymbols)' != ''">$(CommonArgs) /p:KeepNativeSymbols=$(KeepNativeSymbols)</CommonArgs>
 
     <CommonArgs>$(CommonArgs) /p:DotNetPackageVersionPropsPath=$(PackageVersionPropsPath)</CommonArgs>
 


### PR DESCRIPTION
Allowing KeepNativeSymbols to be passed via CommonArgs since it's being enable for source builds by default in the runtime at https://github.com/dotnet/dotnet/blob/cc7f6e84d8dae36ad9ea51a5112627b8235982cc/src/runtime/Directory.Build.props#L276 generating bigger in size artifacts.