### PR TITLE
Specify the list of repos that BuildComparer should analyze

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /prereqs/packages
 /src/nuget-client/NuGet.config
 *.binlog
+
+# Visual Studio
+.vs/

--- a/eng/tools/BuildComparer/BuildComparer.csproj
+++ b/eng/tools/BuildComparer/BuildComparer.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  
 	<PropertyGroup>
-		<OutputType>Exe</OutputType>
 		<TargetFramework>$(NetCurrent)</TargetFramework>
+		<OutputType>Exe</OutputType>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>disable</Nullable>
 	</PropertyGroup>
@@ -10,4 +11,5 @@
 		<PackageReference Include="Microsoft.DotNet.Build.Manifest" />
 		<PackageReference Include="System.CommandLine" />
 	</ItemGroup>
+
 </Project>


### PR DESCRIPTION
This fixes the currently failing builds in the pipeline.