### PR TITLE
Utilize CredScan suppressions file

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -106,6 +106,8 @@ extends:
         enabled: true
       tsa:
         enabled: true
+      credscan:
+        suppressionsFile: $(Build.SourcesDirectory)/.config/CredScanSuppressions.json
 
     containers:
       ${{ variables.almaLinuxContainerName }}:


### PR DESCRIPTION
CredScan suppressions file was checked in, but wasn't referenced in YML. This should fix issues in `source-build-reference-packages`, `aspnetcore` and `msbuild`

@wtgodbe @rainersigwald 