### PR TITLE
Fix installer tests URL for runtime-deps package

### DIFF
--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -11,6 +11,7 @@ This file should be imported by eng/Versions.props
     <!-- dotnet/dotnet dependencies -->
     <MicrosoftNETSdkPackageVersion>10.0.100-rtm.25523.111</MicrosoftNETSdkPackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>10.0.0</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>10.0.0-rtm.25523.111</MicrosoftNETCorePlatformsPackageVersion>
   </PropertyGroup>
   <!--Property group for alternate package version names-->
   <PropertyGroup>
@@ -20,5 +21,6 @@ This file should be imported by eng/Versions.props
     <!-- dotnet/dotnet dependencies -->
     <MicrosoftNETSdkVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETSdkVersion>
     <MicrosoftNETCoreAppRefVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftNETCoreAppRefVersion>
+    <MicrosoftNETCorePlatformsVersion>$(MicrosoftNETCorePlatformsPackageVersion)</MicrosoftNETCorePlatformsVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -22,5 +22,9 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>b0f34d51fccc69fd334253924abd8d6853fad7aa</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="10.0.0-rtm.25523.111">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>b0f34d51fccc69fd334253924abd8d6853fad7aa</Sha>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/test/Microsoft.DotNet.Installer.Tests/Config.cs
+++ b/test/Microsoft.DotNet.Installer.Tests/Config.cs
@@ -43,8 +43,11 @@ public static class Config
     public static bool DotNetBuildSharedComponents { get; } = TryGetRuntimeConfig(DotNetBuildSharedComponentsSwitch, out bool value) ? value : false;
     const string DotNetBuildSharedComponentsSwitch = RuntimeConfigSwitchPrefix + nameof(DotNetBuildSharedComponents);
 
-    public static string Sdk1xxVersion { get; } = TryGetRuntimeConfig(Sdk1xxVersionSwitch, out string? value) ? value : string.Empty;
-    const string Sdk1xxVersionSwitch = RuntimeConfigSwitchPrefix + nameof(Sdk1xxVersion);
+    public static string MicrosoftNETCoreAppRefVersion1xx { get; } = TryGetRuntimeConfig(MicrosoftNETCoreAppRefVersion1xxSwitch, out string? value) ? value : string.Empty;
+    const string MicrosoftNETCoreAppRefVersion1xxSwitch = RuntimeConfigSwitchPrefix + nameof(MicrosoftNETCoreAppRefVersion1xx);
+
+    public static string MicrosoftNETCorePlatformsVersion1xx { get; } = TryGetRuntimeConfig(MicrosoftNETCorePlatformsVersion1xxSwitch, out string? value) ? value : string.Empty;
+    const string MicrosoftNETCorePlatformsVersion1xxSwitch = RuntimeConfigSwitchPrefix + nameof(MicrosoftNETCorePlatformsVersion1xx);
 
     public static string TargetFrameworkVersion { get; } = TryGetRuntimeConfig(TargetFrameworkVersionSwitch, out string? value) ? value : string.Empty;
     const string TargetFrameworkVersionSwitch = RuntimeConfigSwitchPrefix + nameof(TargetFrameworkVersion);

--- a/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
+++ b/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
@@ -58,14 +58,6 @@ public partial class LinuxInstallerTests : IDisposable
         }
     };
 
-    // Transform patch versions in 100-199 range by removing leading "1"
-    // e.g., 10.0.100-rc.1.25405.108 -> 10.0.0-rc.1.25405.108
-    // e.g., 10.0.112-rc.1.25405.108 -> 10.0.12-rc.1.25405.108
-    // Note: This will transform 108 -> 8, 112 -> 12, etc.
-    [GeneratedRegex(@"^(\d+\.\d+\.)1(0)?(\d+)(-.*)?$")]
-    private static partial Regex SdkVersionToRuntimeVersionRegex { get; }
-    private static readonly string Runtime1xxVersion = SdkVersionToRuntimeVersionRegex.Replace(Config.Sdk1xxVersion, "$1$3$4");
-
     // Extract the package prefix from the package name
     // e.g., dotnet-runtime-10.0.0-rc.2.25418.119-x64 -> dotnet-runtime-
     [GeneratedRegex(@"^(.*?-)(?=\d)")]
@@ -320,7 +312,7 @@ public partial class LinuxInstallerTests : IDisposable
         string runtimeLocation = "Runtime",
         string distroLabel = "")
     {
-        Uri packageUrl = new Uri($"https://ci.dot.net/public/{runtimeLocation}/{Runtime1xxVersion}/{packagePrefix}{Runtime1xxVersion}{distroLabel}-{architecture}.{packageType.ToString().ToLower()}");
+        Uri packageUrl = new Uri($"https://ci.dot.net/public/{runtimeLocation}/{Config.MicrosoftNETCorePlatformsVersion1xx}/{packagePrefix}{Config.MicrosoftNETCoreAppRefVersion1xx}{distroLabel}-{architecture}.{packageType.ToString().ToLower()}");
         downloadsToProcess.Add((packageUrl, packageUrl.Segments.Last()));
     }
 

--- a/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
+++ b/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
@@ -62,8 +62,11 @@
       <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).DotNetBuildSharedComponents">
         <Value>$(DotNetBuildSharedComponents)</Value>
       </RuntimeHostConfigurationOption>
-      <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).Sdk1xxVersion">
-        <Value>$(MicrosoftNETSdkVersion)</Value>
+      <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).MicrosoftNETCorePlatformsVersion1xx">
+        <Value>$(MicrosoftNETCorePlatformsVersion)</Value>
+      </RuntimeHostConfigurationOption>
+      <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).MicrosoftNETCoreAppRefVersion1xx">
+        <Value>$(MicrosoftNETCoreAppRefVersion)</Value>
       </RuntimeHostConfigurationOption>
       <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).TargetFrameworkVersion">
         <Value>$(_TargetFrameworkVersionWithoutV)</Value>


### PR DESCRIPTION
Package installer tests were broken for 10.0.2xx because they were attempting to download package URLs that don't exist (e.g. `https://ci.dot.net/public/Runtime/10.0.0-rtm.25523.111/dotnet-runtime-deps-10.0.0-rtm.25523.111-x64.deb`). This is because the filename should be using the stable version instead of the non-stable version but the directory name should continue to use the non-stable version.

This is resolved by making use of the `MicrosoftNETCoreAppRefVersion` property which will be the stable version in this case.

While working on this, I realized that the logic for computing the directory name is incorrect as well. It relies on the SDK version and then just converts that to a runtime version. But that's an incorrect assumption to make that the runtime version can be derived from the SDK version. It won't produce a correct runtime version in the scenario where we have an SDK-only release. So I've corrected this too by making use of the `MicrosoftNETCorePlatformsVersion` property which represents the non-stable runtime version.