### PR TITLE
Use Ubuntu container tag for package installer tests

### DIFF
--- a/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
+++ b/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
@@ -149,7 +149,7 @@ public partial class LinuxInstallerTests : IDisposable
     }
 
     [ConditionalTheory(typeof(LinuxInstallerTests), nameof(IncludeDebTests))]
-    [InlineData(RuntimeDepsRepo, $"{RuntimeDepsVersion}-trixie-slim")]
+    [InlineData(RuntimeDepsRepo, $"{RuntimeDepsVersion}-noble")]
     public async Task DebScenarioTest(string repo, string tag)
     {
         await InitializeContextAsync(PackageType.Deb);
@@ -167,7 +167,7 @@ public partial class LinuxInstallerTests : IDisposable
     }
 
     [ConditionalTheory(typeof(LinuxInstallerTests), nameof(IncludeDebTests))]
-    [InlineData(RuntimeDepsRepo, $"{RuntimeDepsVersion}-trixie-slim")]
+    [InlineData(RuntimeDepsRepo, $"{RuntimeDepsVersion}-noble")]
     public async Task DebPackageMetadataTest(string repo, string tag)
     {
         await InitializeContextAsync(PackageType.Deb, initializeSharedContext: false);


### PR DESCRIPTION
The changes in https://github.com/dotnet/dotnet/pull/3634 cause an invalid tag to be referenced: `10.0-trixie-slim`. Debian images are [no longer provided](https://learn.microsoft.com/dotnet/core/compatibility/containers/10.0/default-images-use-ubuntu) for .NET 10 container images. Instead, the tag has been updated to use Ubuntu.