### PR TITLE
[release/10.0.2xx] Allow default branding to be set by the VMR orchestrator

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,12 @@ usage()
   echo "  --rid, --target-rid <value>       Overrides the rid that is produced by the build. e.g. alpine.3.18-arm64, fedora.37-x64, freebsd.13-arm64, ubuntu.19.10-x64"
   echo "  --os, --target-os <value>         Target operating system: e.g. linux, osx, freebsd. Note: this is the base OS name, not the distro"
   echo "  --arch, --target-arch <value>     Target architecture: e.g. x64, x86, arm64, arm, riscv64"
-  echo "  --branding <preview|rtm|default>  Specify versioning for shipping packages/assets. 'preview' will produce assets suffixed with '.final', 'rtm' will not contain a pre-release suffix. Default or unspecified will use VMR repo defaults."
+  echo "  --branding                        Specify the branding suffix for shipping packages/assets. By default uses VMR branding defaults (RepoDotNetFinalVersionKind property in eng/Versions.props)"
+  echo "                                    for release branch builds or otherwise repo branding defaults."
+  echo "    <repodefault>                   'repodefault' uses the repo branding defaults."
+  echo "    <unstable>                      'unstable' produces assets with the repo specified branding suffix."
+  echo "    <preview>                       'preview' produces assets with a '.final' branding suffix."
+  echo "    <release>                       'release' produces assets without a branding suffix."
   echo "  --verbosity <value>               Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
   echo "  --with-system-libs <libs>         Use system versions of these libraries. Combine with a plus. 'all' will use all supported libraries. e.g. brotli+libunwind+rapidjson+zlib"
   echo "  --official-build-id <YYYYMMDD.X>  Official build ID to use for the build. This is used to set the OfficialBuildId MSBuild property."
@@ -59,23 +64,6 @@ usage()
   echo "Arguments can also be passed in with a single hyphen."
 }
 
-function SetBranding()
-{
-  local brandingValue="$1"
-  
-  if [[ "$brandingValue" == "preview" ]]; then
-    properties+=( "/p:DotNetFinalVersionKind=prerelease" )
-  elif [[ "$brandingValue" == "rtm" ]]; then
-    properties+=( "/p:DotNetFinalVersionKind=release" )
-  elif [[ "$brandingValue" == "default" ]]; then
-    # default branding; no extra property needed
-    :
-  else
-    echo "ERROR: Invalid branding '$brandingValue'. Allowed values are 'preview', 'rtm', or 'default'."
-    exit 1
-  fi
-}
-
 function SetOfficialBuildId()
 {
   local officialBuildIdValue="$1"
@@ -103,7 +91,6 @@ binary_log=''
 configuration='Release'
 verbosity='minimal'
 officialBuildId=''
-branding=''
 
 # Actions
 clean=false
@@ -156,8 +143,23 @@ while [[ $# > 0 ]]; do
       shift
       ;;
     -branding)
-      branding="$2"
-      SetBranding "$branding"
+      if [ -z ${2+x} ]; then
+        echo "No branding type supplied. See help (--help) for supported values." 1>&2
+        exit 1
+      fi
+      passedBrandingType="$(echo "$2" | tr "[:upper:]" "[:lower:]")"
+      case "$passedBrandingType" in
+        repodefault|unstable|preview|release)
+          ;;
+        *)
+          echo "Unsupported branding type '$2'."
+          echo "The allowed values are repodefault, unstable, preview or release."
+          echo ""
+          echo "IMPORTANT: If you previously passed in the '-branding rtm' argument for .NET 10, remove it entirely. The default is now set correctly (VMR branding defaults for release branch builds or otherwise repo branding defaults)."
+          exit 1
+          ;;
+      esac
+      properties+=( "/p:RepoDotNetFinalVersionKind=$passedBrandingType" )
       shift
       ;;
     -with-system-libs)

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,12 +1,26 @@
-﻿<Project>
-  <Import Project="Version.Details.props" Condition="Exists('Version.Details.props')" />
-  <!-- Repo Version Information -->
+<Project>
+
+  <Import Project="Version.Details.props" />
+
   <PropertyGroup>
-    <VersionPrefix>0.1.0</VersionPrefix>
-    <PreReleaseVersionLabel>alpha.1</PreReleaseVersionLabel>
-    <UseVSTestRunner>true</UseVSTestRunner>
     <VersionSDKMinor>2</VersionSDKMinor>
+    <VersionPrefix>11.0.$(VersionSDKMinor)00</VersionPrefix>
+    <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration></PreReleaseVersionIteration>
+
+    <!-- 
+      Allowed values: 'repodefault', 'unstable', 'preview', 'release'
+      'repodefault' uses the repo branding defaults.
+      'unstable' produces assets with the repo specified branding suffix.
+      'preview' produces assets with a '.final' branding suffix.
+      'release' produces assets without a branding suffix.
+    -->
+    <RepoDotNetFinalVersionKind>repodefault</RepoDotNetFinalVersionKind>
+
+    <!-- Arcade features -->
+    <UseVSTestRunner>true</UseVSTestRunner>
   </PropertyGroup>
+
   <PropertyGroup>
     <!--
       Building .NET from source depends on several archives, depending on the branch's current
@@ -42,4 +56,5 @@
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <OctokitVersion>10.0.0</OctokitVersion>
   </PropertyGroup>
+
 </Project>

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -7,8 +7,8 @@ Param(
   [string][Alias('os')]$targetOS,
   [string][Alias('arch')]$targetArch,
   [string][Alias('v')]$verbosity = "minimal",
-  [Parameter()][ValidateSet("preview", "rtm", "default")]
-  [string]$branding = "default",
+  [Parameter()][ValidateSet("repodefault", "unstable", "preview", "release")]
+  [string]$branding,
   [Parameter()][ValidatePattern("^\d{8}\.\d{1,3}$")]
   [string][Alias('obid')]$officialBuildId,
 
@@ -39,7 +39,12 @@ function Get-Usage() {
   Write-Host "  -os, -targetOS <value>           Target operating system: e.g. windows."
   Write-Host "  -arch, -targetArch <value>       Target architecture: e.g. x64, x86, arm64, arm, riscv64"
   Write-Host "  -verbosity <value>               Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
-  Write-Host "  -branding <preview|rtm|default>  Specify versioning for shipping packages/assets. 'preview' will produce assets suffixed with '.final', 'rtm' will not contain a pre-release suffix. Default or unspecified will use VMR repo defaults."
+  Write-Host "  -branding                        Specify the branding suffix for shipping packages/assets. By default uses VMR branding defaults (RepoDotNetFinalVersionKind property in eng/Versions.props)"
+  Write-Host "                                   for release branch builds or otherwise repo branding defaults."
+  Write-Host "    <repodefault>                  'repodefault' uses the repo branding defaults."
+  Write-Host "    <unstable>                     'unstable' produces assets with the repo specified branding suffix."
+  Write-Host "    <preview>                      'preview' produces assets with a '.final' branding suffix."
+  Write-Host "    <release>                      'release' produces assets without a branding suffix."
   Write-Host "  -officialBuildId <YYYYMMDD.X>    Official build ID to use for the build. This is used to set the OfficialBuildId MSBuild property."
   Write-Host ""
 
@@ -91,13 +96,7 @@ if ($targetArch) { $arguments += "/p:TargetArchitecture=$targetArch" }
 if ($sign) { $arguments += "/p:DotNetBuildSign=true" }
 if ($buildRepoTests) { $arguments += "/p:DotNetBuildTests=true" }
 if ($cleanWhileBuilding) { $arguments += "/p:CleanWhileBuilding=true" }
-if ($branding) {
-    switch ($branding) {
-        "preview" { $arguments += "/p:DotNetFinalVersionKind=prerelease" }
-        "rtm"     { $arguments += "/p:DotNetFinalVersionKind=release" }
-        "default" { $arguments += "" }
-    }
-}
+if ($branding) { $arguments += "/p:RepoDotNetFinalVersionKind=$branding" }
 if ($officialBuildId) { $arguments += "/p:OfficialBuildId=$officialBuildId" }
 
 function Build {

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -42,11 +42,13 @@ parameters:
 - name: desiredFinalVersionKind
   displayName: 'Final version kind'
   type: string
-  default: 'Default (repo specifies)'
+  default: 'Default (uses VMR branding defaults for release branch builds or otherwise repo branding defaults)'
   values:
-    - Default (repo specifies)
-    - Stable Preview
-    - Stable Final
+    - Default (uses VMR branding defaults for release branch builds or otherwise repo branding defaults)
+    - Repo default (uses the repo branding defaults)
+    - Unstable (produces assets with the repo specified branding suffix)
+    - Preview (produces assets with a '.final' branding suffix)
+    - Release (produces assets without a branding suffix)
 
 variables:
 - name: isScheduleTrigger

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -249,7 +249,10 @@ jobs:
         value: $(commandPrefix)clean-while-building
 
   - name: brandingArgument
-    value: $(commandPrefix)branding $(brandingType)
+    ${{ if ne(variables['brandingType'], '') }}:
+      value: $(commandPrefix)branding $(brandingType)
+    ${{ else }}:
+      value: ''
 
   - ${{ if and(eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - name: officialBuildArgument

--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -53,18 +53,21 @@ variables:
   - name: ibcEnabled
     value: false
 
-- ${{ if eq(parameters.desiredFinalVersionKind, 'Default (repo specifies)') }}:
+- ${{ if eq(parameters.desiredFinalVersionKind, 'Repo default (uses the repo branding defaults)') }}:
   - name: brandingType
-    value: 'default'
-- ${{ elseif eq(parameters.desiredFinalVersionKind, 'Stable Preview') }}:
+    value: 'repodefault'
+- ${{ elseif eq(parameters.desiredFinalVersionKind, 'Unstable (produces assets with the repo specified branding suffix)') }}:
+  - name: brandingType
+    value: 'unstable'
+- ${{ elseif eq(parameters.desiredFinalVersionKind, 'Preview (produces assets with a .final branding suffix)') }}:
   - name: brandingType
     value: 'preview'
-- ${{ elseif eq(parameters.desiredFinalVersionKind, 'Stable Final') }}:
+- ${{ elseif eq(parameters.desiredFinalVersionKind, 'Release (produces assets without a branding suffix)') }}:
   - name: brandingType
-    value: 'rtm'
+    value: 'release'
 - ${{ else }}:
   - name: brandingType
-    value: 'default'
+    value: ''
 
 ## Do not set this when building source only to avoid including telemetry in the bootstrap artifacts
 ## handed off to distro partners.

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -28,7 +28,13 @@
     <CommonArgs>$(CommonArgs) /p:PortableBuild=$(PortableBuild)</CommonArgs>
     <CommonArgs>$(CommonArgs) /p:PortableTargetRid=$(PortableTargetRid)</CommonArgs>
     <CommonArgs Condition="'$(DefaultArtifactVisibility)' != ''">$(CommonArgs) /p:DefaultArtifactVisibility=$(DefaultArtifactVisibility)</CommonArgs>
-    <CommonArgs Condition="'$(DotNetFinalVersionKind)' != '' and '$(AllowDotNetFinalVersionKindOverride)' == 'true'">$(CommonArgs) /p:DotNetFinalVersionKind=$(DotNetFinalVersionKind)</CommonArgs>
+
+    <!-- Branding -->
+    <RepoDotNetFinalVersionKindArg Condition="'$(RepoDotNetFinalVersionKind)' == 'repodefault' or '$(RepoDotNetFinalVersionKind)' == ''"></RepoDotNetFinalVersionKindArg>
+    <RepoDotNetFinalVersionKindArg Condition="'$(RepoDotNetFinalVersionKind)' == 'unstable'">/p:DotNetFinalVersionKind=""</RepoDotNetFinalVersionKindArg>
+    <RepoDotNetFinalVersionKindArg Condition="'$(RepoDotNetFinalVersionKind)' == 'preview'">/p:DotNetFinalVersionKind=prerelease</RepoDotNetFinalVersionKindArg>
+    <RepoDotNetFinalVersionKindArg Condition="'$(RepoDotNetFinalVersionKind)' == 'release'">/p:DotNetFinalVersionKind=release</RepoDotNetFinalVersionKindArg>
+    <CommonArgs Condition="'$(AllowDotNetFinalVersionKindOverride)' == 'true'">$(CommonArgs) $(RepoDotNetFinalVersionKindArg)</CommonArgs>
 
     <!-- Only pass these properites through when necessary to reduce command line noise. -->
     <CommonArgs Condition="'$(DotNetBuildTests)' == 'true' and '$(DotNetBuildTestsOptOut)' != 'true'">$(CommonArgs) /p:DotNetBuildTests=true</CommonArgs>
@@ -36,7 +42,6 @@
     <BuildArgs Condition="'$(EnableDefaultRidSpecificArtifacts)' != ''">$(BuildArgs) /p:EnableDefaultRidSpecificArtifacts=$(EnableDefaultRidSpecificArtifacts)</BuildArgs>
     <!-- If a repo has no RID-specific artifacts, then we expect the repo to not have any artifacts when only publishing RID-specific artifacts. -->
     <BuildArgs Condition="'$(EnableDefaultRidSpecificArtifacts)' == 'true'">$(BuildArgs) /p:AllowEmptySignList=true</BuildArgs>
-
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Manual backport of https://github.com/dotnet/dotnet/commit/f59b33bfb1617ae94b4c4f3fbb1e9733cde4b7e2