### PR TITLE
Fix BuildOS when cross-building from linux-musl

### DIFF
--- a/eng/RuntimeIdentifier.props
+++ b/eng/RuntimeIdentifier.props
@@ -2,6 +2,7 @@
   <!-- TargetRid calculations should go in this file. -->
   <PropertyGroup Label="CalculateTargetOS">
     <BuildOS>linux</BuildOS>
+    <BuildOS Condition="$(NETCoreSdkPortableRuntimeIdentifier.StartsWith('linux-musl'))">linux-musl</BuildOS>
     <BuildOS Condition="$([MSBuild]::IsOSPlatform('OSX'))">osx</BuildOS>
     <BuildOS Condition="$([MSBuild]::IsOSPlatform('FREEBSD'))">freebsd</BuildOS>
     <BuildOS Condition="$([MSBuild]::IsOSPlatform('NETBSD'))">netbsd</BuildOS>


### PR DESCRIPTION
Noticed this while looking at https://github.com/dotnet/dotnet/pull/3701