### PR TITLE
Fix stable publishing issue

### DIFF
--- a/src/winforms/eng/Publishing.props
+++ b/src/winforms/eng/Publishing.props
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
    <PropertyGroup>
-      <PublishingVersion>3</PublishingVersion>
       <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
    </PropertyGroup>
 </Project>

--- a/src/wpf/eng/Publishing.props
+++ b/src/wpf/eng/Publishing.props
@@ -17,8 +17,4 @@
   <Import Project="WpfArcadeSdk\tools\Publishing.targets"
         Condition="'$(MicrosoftDotNetArcadeWpfSdkVersion)' == '' And 
                       Exists('WpfArcadeSdk\Sdk\Sdk.props') And Exists('WpfArcadeSdk\Sdk\Sdk.targets')"/>
-
-  <PropertyGroup>
-    <PublishingVersion>3</PublishingVersion>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
When https://github.com/dotnet/dotnet/pull/3668 went it, it removed DotNetFinalVersionKind from being set at the root level of the VMR. This unintentionally was causing the VMR publishing process to mark all shipping assets as CouldBeStable=true when DotNetFinalVersionKind=release, rather than using the values that were coming from the repos. The fix here is to not set PublishingVersion at the repo level. This will cause VMR builds to use V4 publishing for the repo builds, which will set CouldBeStable appropriately. Only winforms and wpf were manually setting this.