### PR TITLE
Introduce more version properties

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,8 +6,7 @@
     <VersionSDKMinor>1</VersionSDKMinor>
     <MajorVersion>11</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <MajorMinorVersion>$(MajorVersion).$(MinorVersion)</MajorMinorVersion>
-    <VersionPrefix>$(MajorMinorVersion).$(VersionSDKMinor)00</VersionPrefix>
+    <VersionPrefix>$(MajorVersion).$(MinorVersion).$(VersionSDKMinor)00</VersionPrefix>
     <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
 

--- a/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
+++ b/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
@@ -69,7 +69,7 @@
         <Value>$(MicrosoftNETCoreAppRefVersion)</Value>
       </RuntimeHostConfigurationOption>
       <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).TargetProductVersion">
-        <Value>$(MajorMinorVersion)</Value>
+        <Value>$(MajorVersion).$(MinorVersion)</Value>
       </RuntimeHostConfigurationOption>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
This also fixes the hard-coded product version in Installer tests: https://github.com/dotnet/dotnet/blob/3e4f63732a2e61ad7ae1d567e820f70b2a55c2f1/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj#L71-L75