### PR TITLE
Revert distro upgrade until latest release/10.0.1xx flows in

### DIFF
--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -151,7 +151,7 @@ variables:
 - name: alpineContainerName
   value: alpineContainer
 - name: alpineContainerImage
-  value: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.23-amd64
+  value: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.21-amd64
 
 - name: centOSStreamContainerName
   value: centOSStreamContainer
@@ -226,7 +226,7 @@ variables:
 - name: almaLinuxName
   value: AlmaLinux8
 - name: alpineName
-  value: Alpine323
+  value: Alpine321
 - name: centOSStreamName
   value: CentOSStream10
 - name: fedoraName
@@ -247,7 +247,7 @@ variables:
 - name: linuxMuslArm64Rid
   value: linux-musl-arm64
 - name: alpineX64Rid
-  value: alpine.3.23-x64
+  value: alpine.3.21-x64
 - name: centOSStreamX64Rid
   value: centos.10-x64
 - name: fedoraX64Rid


### PR DESCRIPTION
Reverts https://github.com/dotnet/dotnet/pull/3851 and https://github.com/dotnet/dotnet/pull/3848

These must be coordinated with a build of 1xx flowing in with the corresponding changes.

Related to https://github.com/dotnet/source-build/issues/5448