### PR TITLE
Exclude Spectre.Console.dll from sn verification

### DIFF
--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -25,6 +25,7 @@ Microsoft.ApplicationInsights.dll;; IGNORE-STRONG-NAME
 Microsoft.Build.Locator.dll;; IGNORE-STRONG-NAME
 Mono.Cecil.*dll;; IGNORE-STRONG-NAME
 Newtonsoft.Json.dll;; IGNORE-STRONG-NAME
+Spectre.Console.dll;; IGNORE-STRONG-NAME
 *.mibc;; IGNORE-STRONG-NAME, .mibc files are not strong-named
 
 ;; ## MACH-O ##


### PR DESCRIPTION
Addresses SignCheck failures related to spectre console: https://dev.azure.com/dnceng/internal/internal%20Team/_build/results?buildId=2862904&view=logs&j=5aa0659d-d34b-5c54-db98-526d154cc18c&t=4d32bbf5-a0c0-546c-5d7a-d95b98fa65f4&l=50