### PR TITLE
[release/10.0.1xx] Sign sourcelink shim

### DIFF
--- a/src/sourcelink/eng/Signing.props
+++ b/src/sourcelink/eng/Signing.props
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <!-- Ensure that MacOS sourcelink shims get signed properly -->
+    <FileSignInfo Include="sourcelink" CertificateName="MacDeveloperHarden" ExecutableType="MachO" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/dotnet/issues/3979

### Description

The Macho shims in the sourcelink package are being reported as unsigned. Sign them.

### Customer impact

Likely none. Until .NET 10, we haven't signed MacOS shims.

### How found

Signcheck

### Regression

None

### Risk

Very low. We sign other shims (e.g. dotnet-suggest) and this was just missed.