### PR TITLE
Run cg detection in container

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -110,6 +110,8 @@ extends:
         enabled: true
       credscan:
         suppressionsFile: $(Build.SourcesDirectory)/.config/CredScanSuppressions.json
+      componentgovernance:
+        useExecutionTargetAsUserSteps: true
 
     containers:
       ${{ variables.almaLinuxContainerName }}:


### PR DESCRIPTION
Avoids issue where CG detects the container host's components that are not used in the build.