### PR TITLE
Comment out NuGet command addition in Parser.cs

### DIFF
--- a/src/sdk/src/Cli/dotnet/Parser.cs
+++ b/src/sdk/src/Cli/dotnet/Parser.cs
@@ -165,7 +165,7 @@ public static class Parser
         rootCommand.Arguments.Add(DotnetSubCommand);
 
         // NuGet implements several commands in its own repo. Add them to the .NET SDK via the provided API.
-        NuGet.CommandLine.XPlat.NuGetCommands.Add(rootCommand, CommonOptions.CreateInteractiveOption(acceptArgument: true));
+        //NuGet.CommandLine.XPlat.NuGetCommands.Add(rootCommand, CommonOptions.CreateInteractiveOption(acceptArgument: true));
 
         rootCommand.SetAction(parseResult =>
         {


### PR DESCRIPTION
Comment out the addition of NuGet commands to the root command to test if NuGet command initialization is impacting the output of `dotnet --info`