### PR TITLE
lazy initialize NuGet's instance of AnsiConsole

### DIFF
--- a/src/nuget-client/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommand.cs
+++ b/src/nuget-client/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/Why/WhyCommand.cs
@@ -42,6 +42,8 @@ namespace NuGet.CommandLine.XPlat.Commands.Why
                 WhyCommandRunner.ExecuteCommand);
         }
 
+        // console must be lazy, because Spectre.Console's AnsiConsole will send VT sequences to the output
+        // as soon as it's created, which causes problems with the dotnet CLI's C++ output, like dotnet --info
         internal static void Register(Command rootCommand, Lazy<IAnsiConsole> console, Func<WhyCommandArgs, Task<int>> action)
         {
             var whyCommand = new DocumentedCommand("why", Strings.WhyCommand_Description, "https://aka.ms/dotnet/nuget/why");

--- a/src/nuget-client/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/nuget-client/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -115,10 +115,12 @@ namespace NuGet.CommandLine.XPlat
                     var nugetCommand = new Command("nuget");
                     rootCommand.Subcommands.Add(nugetCommand);
 
+                    var lazyConsole = new Lazy<Spectre.Console.IAnsiConsole>(() => Spectre.Console.AnsiConsole.Console);
+
                     ConfigCommand.Register(nugetCommand, getHidePrefixLogger);
                     ConfigCommand.Register(rootCommand, getHidePrefixLogger);
-                    Commands.Why.WhyCommand.Register(nugetCommand, Spectre.Console.AnsiConsole.Console);
-                    Commands.Why.WhyCommand.Register(rootCommand, Spectre.Console.AnsiConsole.Console);
+                    Commands.Why.WhyCommand.Register(nugetCommand, lazyConsole);
+                    Commands.Why.WhyCommand.Register(rootCommand, lazyConsole);
                 }
 
                 CancellationTokenSource tokenSource = new CancellationTokenSource();

--- a/src/nuget-client/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Why/WhyCommandLineParsingTests.cs
+++ b/src/nuget-client/test/NuGet.Core.Tests/NuGet.CommandLine.Xplat.Tests/Commands/Why/WhyCommandLineParsingTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using NuGet.CommandLine.XPlat.Commands;
 using NuGet.CommandLine.XPlat.Commands.Why;
+using Spectre.Console;
 using Spectre.Console.Testing;
 using Xunit;
 


### PR DESCRIPTION
fixes: https://github.com/dotnet/sdk/issues/52278

Apparently using Spectre.Console's `AnsiConsole.Console` sends VT control codes on initialize, not first API usage, and this is messing up some of the dotnet CLI's C++ output, like `dotnet --info`

So, NuGet should not call `AnsiConsole.Console` until it actually needs it. Lazy<T> should do it.