### PR TITLE
Get rid of net9.0 TFM in roslyn

### DIFF
--- a/src/roslyn/.vscode/launch.json
+++ b/src/roslyn/.vscode/launch.json
@@ -10,9 +10,9 @@
       "request": "launch",
       "preLaunchTask": "build",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/artifacts/bin/BuildValidator/Debug/net9.0/BuildValidator.dll",
+      "program": "${workspaceFolder}/artifacts/bin/BuildValidator/Debug/net10.0/BuildValidator.dll",
       "args": [
-        "--assembliesPath", "./artifacts/obj/csc/Debug/net9.0",
+        "--assembliesPath", "./artifacts/obj/csc/Debug/net10.0",
         "--referencesPath", "./artifacts/bin",
         "--referencesPath", "C:/Program Files/dotnet/packs/Microsoft.AspNetCore.App.Ref",
         "--referencesPath", "C:/Program Files/dotnet/packs/Microsoft.NETCore.App.Ref",
@@ -29,7 +29,7 @@
       "request": "launch",
       "preLaunchTask": "build",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/artifacts/bin/RunTests/Debug/net9.0/RunTests.dll",
+      "program": "${workspaceFolder}/artifacts/bin/RunTests/Debug/net10.0/RunTests.dll",
       "args": ["--runtime", "both", "--artifactspath", "${workspaceFolder}/artifacts/testPayload/artifacts"],
       "cwd": "${workspaceFolder}/artifacts/bin/RunTests",
       "stopAtEntry": false,
@@ -41,7 +41,7 @@
       "request": "launch",
       "preLaunchTask": "build",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/artifacts/bin/PrepareTests/Debug/net9.0/PrepareTests.dll",
+      "program": "${workspaceFolder}/artifacts/bin/PrepareTests/Debug/net10.0/PrepareTests.dll",
       "args": [
         "--source", "${workspaceFolder}",
         "--destination", "${workspaceFolder}/artifacts/testPayload"
@@ -56,7 +56,7 @@
       "request": "launch",
       "preLaunchTask": "build current project",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/artifacts/bin/Replay/Debug/net9.0/Replay.dll",
+      "program": "${workspaceFolder}/artifacts/bin/Replay/Debug/net10.0/Replay.dll",
       "args": [],
       "cwd": "${workspaceFolder}/artifacts/bin/Replay",
       "stopAtEntry": false,
@@ -137,7 +137,7 @@
       "request": "launch",
       "preLaunchTask": "build",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/artifacts/bin/csc/Debug/net9.0/csc.dll",
+      "program": "${workspaceFolder}/artifacts/bin/csc/Debug/net10.0/csc.dll",
       "args": [],
       "cwd": "${workspaceFolder}/src/Compilers/CSharp/csc",
       // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console

--- a/src/roslyn/.vscode/tasks.json
+++ b/src/roslyn/.vscode/tasks.json
@@ -171,7 +171,7 @@
       "type": "process",
       "options": {
         "env": {
-          "DOTNET_ROSLYN_SERVER_PATH": "${workspaceRoot}/artifacts/bin/Microsoft.CodeAnalysis.LanguageServer/Debug/net9.0/Microsoft.CodeAnalysis.LanguageServer.dll"
+          "DOTNET_ROSLYN_SERVER_PATH": "${workspaceRoot}/artifacts/bin/Microsoft.CodeAnalysis.LanguageServer/Debug/net10.0/Microsoft.CodeAnalysis.LanguageServer.dll"
         }
       },
       "dependsOn": [ "build language server" ]

--- a/src/roslyn/docs/contributing/bootstrap-builds.md
+++ b/src/roslyn/docs/contributing/bootstrap-builds.md
@@ -101,14 +101,14 @@ Locally reproducing and attaching a debugger to a bootstrap build failure is fai
 
 ```powershell
 .\build.ps1 -bl
-dotnet run --framework net9.0 src\Tools\Replay\ artifacts\log\Debug\Build.binlog -w
+dotnet run --framework net10.0 --project src\Tools\Replay\ artifacts\log\Debug\Build.binlog -w
 ```
 
 **Linux**
 
 ```sh
 ./build.sh -bl
-dotnet run --framework net9.0 src/Tools/Replay/ artifacts/log/Debug/Build.binlog -w
+dotnet run --framework net10.0 --project src/Tools/Replay/ artifacts/log/Debug/Build.binlog -w
 ```
 
 The `-w` flag will cause replay to print the process ID of the compiler and wait until you hit a key, so that you can attach a debugger to the process and set breakpoints for exceptions you are interested in.

--- a/src/roslyn/eng/build.ps1
+++ b/src/roslyn/eng/build.ps1
@@ -401,7 +401,7 @@ function TestUsingRunTests() {
     $env:DOTNET_RuntimeAsync = 1
   }
 
-  $runTests = GetProjectOutputBinary "RunTests.dll" -tfm "net9.0"
+  $runTests = GetProjectOutputBinary "RunTests.dll" -tfm "net10.0"
 
   if (!(Test-Path $runTests)) {
     Write-Host "Test runner not found: '$runTests'. Run Build.cmd first." -ForegroundColor Red

--- a/src/roslyn/eng/build.sh
+++ b/src/roslyn/eng/build.sh
@@ -402,6 +402,6 @@ if [[ "$test_core_clr" == true ]]; then
   if [[ "$ci" != true ]]; then
     runtests_args="$runtests_args --html"
   fi
-  dotnet exec "$scriptroot/../artifacts/bin/RunTests/${configuration}/net9.0/RunTests.dll" --runtime core --configuration ${configuration} --logs ${log_dir} --dotnet ${_InitializeDotNetCli}/dotnet $runtests_args
+  dotnet exec "$scriptroot/../artifacts/bin/RunTests/${configuration}/net10.0/RunTests.dll" --runtime core --configuration ${configuration} --logs ${log_dir} --dotnet ${_InitializeDotNetCli}/dotnet $runtests_args
 fi
 ExitWithExitCode 0

--- a/src/roslyn/eng/pipelines/test-integration-helix.yml
+++ b/src/roslyn/eng/pipelines/test-integration-helix.yml
@@ -55,7 +55,7 @@ stages:
       - task: BatchScript@1
         displayName: Rehydrate RunTests
         inputs:
-          filename: ./artifacts/bin/RunTests/${{ parameters.configuration }}/net9.0/rehydrate.cmd
+          filename: ./artifacts/bin/RunTests/${{ parameters.configuration }}/net10.0/rehydrate.cmd
         env:
           HELIX_CORRELATION_PAYLOAD: '$(Build.SourcesDirectory)\.duplicate'
       
@@ -69,9 +69,9 @@ stages:
 
       # This is a temporary step until the actual test run moves to helix (then we would need to rehydrate the tests there instead)
       - task: BatchScript@1
-        displayName: Rehydrate Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests (net9.0)
+        displayName: Rehydrate Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests (net10.0)
         inputs:
-          filename: ./artifacts\bin\Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests/${{ parameters.configuration }}/net9.0/rehydrate.cmd
+          filename: ./artifacts\bin\Microsoft.CodeAnalysis.Workspaces.MSBuild.UnitTests/${{ parameters.configuration }}/net10.0/rehydrate.cmd
         env:
           HELIX_CORRELATION_PAYLOAD: '$(Build.SourcesDirectory)\.duplicate'
 

--- a/src/roslyn/eng/pipelines/test-unix-job.yml
+++ b/src/roslyn/eng/pipelines/test-unix-job.yml
@@ -39,7 +39,7 @@ jobs:
     - task: ShellScript@2
       displayName: Rehydrate RunTests
       inputs:
-        scriptPath: ./artifacts/bin/RunTests/${{ parameters.configuration }}/net9.0/rehydrate.sh
+        scriptPath: ./artifacts/bin/RunTests/${{ parameters.configuration }}/net10.0/rehydrate.sh
       env:
         HELIX_CORRELATION_PAYLOAD: '$(Build.SourcesDirectory)/.duplicate'
 

--- a/src/roslyn/eng/pipelines/test-windows-job-single-machine.yml
+++ b/src/roslyn/eng/pipelines/test-windows-job-single-machine.yml
@@ -28,12 +28,12 @@ jobs:
   steps:
     - checkout: none
 
-    # A .NET 9 runtime is needed since our unit tests target net9.0
+    # A .NET 10 runtime is needed since our unit tests target net10.0
     - task: UseDotNet@2
-      displayName: 'Install .NET 9 Runtime'
+      displayName: 'Install .NET 10 Runtime'
       inputs:
         packageType: runtime
-        version: '9.0.0'
+        version: '10.0.0'
         includePreviewVersions: true
         installationPath: '$(Build.SourcesDirectory)/.dotnet'
 

--- a/src/roslyn/eng/pipelines/test-windows-job.yml
+++ b/src/roslyn/eng/pipelines/test-windows-job.yml
@@ -39,7 +39,7 @@ jobs:
     - task: BatchScript@1
       displayName: Rehydrate RunTests
       inputs:
-        filename: ./artifacts/bin/RunTests/${{ parameters.configuration }}/net9.0/rehydrate.cmd
+        filename: ./artifacts/bin/RunTests/${{ parameters.configuration }}/net10.0/rehydrate.cmd
       env:
         HELIX_CORRELATION_PAYLOAD: '$(Build.SourcesDirectory)\.duplicate'
 

--- a/src/roslyn/eng/prepare-tests.ps1
+++ b/src/roslyn/eng/prepare-tests.ps1
@@ -11,7 +11,7 @@ try {
   # permissions issues make this a pain to do in PrepareTests itself.
   Remove-Item -Recurse -Force "$RepoRoot\artifacts\testPayload" -ErrorAction SilentlyContinue
   $dotnet = Ensure-DotNetSdk
-  Exec-Command $dotnet "exec $RepoRoot\artifacts\bin\PrepareTests\$configuration\net9.0\PrepareTests.dll --source $RepoRoot --destination $RepoRoot\artifacts\testPayload --dotnetPath `"$dotnet`""
+  Exec-Command $dotnet "exec $RepoRoot\artifacts\bin\PrepareTests\$configuration\net10.0\PrepareTests.dll --source $RepoRoot --destination $RepoRoot\artifacts\testPayload --dotnetPath `"$dotnet`""
   exit 0
 }
 catch {

--- a/src/roslyn/eng/prepare-tests.sh
+++ b/src/roslyn/eng/prepare-tests.sh
@@ -28,4 +28,4 @@ InitializeDotNetCli true
 # permissions issues make this a pain to do in PrepareTests itself.
 rm -rf "$repo_root/artifacts/testPayload"
 
-dotnet "$repo_root/artifacts/bin/PrepareTests/Debug/net9.0/PrepareTests.dll" --source "$repo_root" --destination "$repo_root/artifacts/testPayload" --unix --dotnetPath ${_InitializeDotNetCli}/dotnet
+dotnet "$repo_root/artifacts/bin/PrepareTests/Debug/net10.0/PrepareTests.dll" --source "$repo_root" --destination "$repo_root/artifacts/testPayload" --unix --dotnetPath ${_InitializeDotNetCli}/dotnet

--- a/src/roslyn/eng/targets/TargetFrameworks.props
+++ b/src/roslyn/eng/targets/TargetFrameworks.props
@@ -12,8 +12,8 @@
       - NetRoslynAll must include all .NET Core TFMS in any property below
   -->
   <PropertyGroup>
-    <NetRoslyn>net9.0</NetRoslyn>
-    <NetRoslynAll>net8.0;net9.0;net10.0</NetRoslynAll>
+    <NetRoslyn>net10.0</NetRoslyn>
+    <NetRoslynAll>net8.0;net10.0</NetRoslynAll>
     <NetVS>net8.0</NetVS>
     <NetVSCode>net10.0</NetVSCode>
     <NetVSShared>net8.0</NetVSShared>

--- a/src/roslyn/eng/test-rebuild.ps1
+++ b/src/roslyn/eng/test-rebuild.ps1
@@ -56,10 +56,9 @@ try {
 # Rebuilds with missing references
 # Rebuilds with other issues
   " --exclude net472\Microsoft.CodeAnalysis.EditorFeatures2.UnitTests.dll" +
-  " --exclude net9.0\Microsoft.CodeAnalysis.Collections.Package.dll" +
+  " --exclude net10.0\Microsoft.CodeAnalysis.Collections.Package.dll" +
   " --exclude netstandard2.0\Microsoft.CodeAnalysis.Contracts.Package.dll" +
   " --exclude net8.0\Microsoft.CodeAnalysis.Contracts.Package.dll" +
-  " --exclude net9.0\Microsoft.CodeAnalysis.Contracts.Package.dll" +
   " --exclude net10.0\Microsoft.CodeAnalysis.Contracts.Package.dll" +
   " --exclude netcoreapp3.1\Microsoft.CodeAnalysis.Collections.Package.dll" +
   " --exclude netstandard2.0\Microsoft.CodeAnalysis.Collections.Package.dll" +
@@ -67,7 +66,7 @@ try {
   " --exclude netstandard2.0\Microsoft.CodeAnalysis.PooledObjects.Package.dll" +
   " --exclude netstandard2.0\Microsoft.CodeAnalysis.Threading.Package.dll" +
   " --exclude net8.0\Microsoft.CodeAnalysis.Threading.Package.dll" +
-  " --exclude net9.0\Microsoft.CodeAnalysis.Threading.Package.dll" +
+  " --exclude net10.0\Microsoft.CodeAnalysis.Threading.Package.dll" +
   " --exclude netstandard2.0\Microsoft.CodeAnalysis.Extensions.Package.dll" +
   " --exclude netcoreapp3.1\Microsoft.CodeAnalysis.Workspaces.UnitTests.dll" +
 

--- a/src/roslyn/src/Compilers/Core/MSBuildTaskTests/SdkIntegrationTests.cs
+++ b/src/roslyn/src/Compilers/Core/MSBuildTaskTests/SdkIntegrationTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests;
 
 public sealed class SdkIntegrationTests : IDisposable
 {
-    public const string NetCoreTfm = "net9.0";
+    public const string NetCoreTfm = "net10.0";
 
     public ITestOutputHelper TestOutputHelper { get; }
     public TempRoot Temp { get; }

--- a/src/roslyn/src/EditorFeatures/Test/EditAndContinue/EditAndContinueLanguageServiceTests.cs
+++ b/src/roslyn/src/EditorFeatures/Test/EditAndContinue/EditAndContinueLanguageServiceTests.cs
@@ -218,7 +218,7 @@ public sealed class EditAndContinueLanguageServiceTests : EditAndContinueWorkspa
 
         var runningProjectInfo = new DebuggerContracts.RunningProjectInfo()
         {
-            ProjectInstanceId = new DebuggerContracts.ProjectInstanceId(project.FilePath, "net9.0"),
+            ProjectInstanceId = new DebuggerContracts.ProjectInstanceId(project.FilePath, "net10.0"),
             RestartAutomatically = false,
         };
 

--- a/src/roslyn/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
+++ b/src/roslyn/src/Tools/BuildBoss/CompilerNuGetCheckerUtil.cs
@@ -189,10 +189,10 @@ namespace BuildBoss
                 (@"tasks\net472", GetProjectOutputDirectory("csi", "net472")),
                 (@"tasks\net472", GetProjectOutputDirectory("VBCSCompiler", "net472")),
                 (@"tasks\net472", GetProjectOutputDirectory("Microsoft.Build.Tasks.CodeAnalysis", "net472")),
-                (@"tasks\netcore\bincore", GetProjectPublishDirectory("csc", "net9.0")),
-                (@"tasks\netcore\bincore", GetProjectPublishDirectory("vbc", "net9.0")),
-                (@"tasks\netcore\bincore", GetProjectPublishDirectory("VBCSCompiler", "net9.0")),
-                (@"tasks\netcore", GetProjectPublishDirectory("Microsoft.Build.Tasks.CodeAnalysis", "net9.0")),
+                (@"tasks\netcore\bincore", GetProjectPublishDirectory("csc", "net10.0")),
+                (@"tasks\netcore\bincore", GetProjectPublishDirectory("vbc", "net10.0")),
+                (@"tasks\netcore\bincore", GetProjectPublishDirectory("VBCSCompiler", "net10.0")),
+                (@"tasks\netcore", GetProjectPublishDirectory("Microsoft.Build.Tasks.CodeAnalysis", "net10.0")),
                 (@"tasks\netcore\binfx", GetProjectOutputDirectory("Microsoft.Build.Tasks.CodeAnalysis.Sdk", "net472")));
 
             foreach (var arch in new[] { "x86", "x64", "arm64" })

--- a/src/roslyn/src/Tools/Replay/README.md
+++ b/src/roslyn/src/Tools/Replay/README.md
@@ -34,9 +34,9 @@ To profile with `dotnet trace` first run with the `-w` option to get the PID of 
 Console 1
 
 ```cmd
-e:\code\roslyn\src\Tools\Replay> dotnet run --framework net9.0 --configuration Release e:\code\example\msbuild.binlog -w
+e:\code\roslyn\src\Tools\Replay> dotnet run --framework net10.0 --configuration Release e:\code\example\msbuild.binlog -w
 Binary Log: E:\code\example\msbuild.binlog
-Client Directory: E:\code\roslyn\artifacts\bin\Replay\Release\net9.0\
+Client Directory: E:\code\roslyn\artifacts\bin\Replay\Release\net10.0\
 Output Directory: E:\code\roslyn\src\Tools\Replay\output
 Pipe Name: 0254ccf8-294e-4b8f-a606-70f105b9e4a1
 Parallel: 6

--- a/src/roslyn/src/Tools/TestDiscoveryWorker/README.md
+++ b/src/roslyn/src/Tools/TestDiscoveryWorker/README.md
@@ -3,5 +3,5 @@
 This program runs xUnit discovery on an assembly and writes the results to a file. 
 
 ```cmd
-> dotnet exec TestDiscoveryWorker.dll --assembly artifacts\bin\Microsoft.CodeAnalysis.UnitTests\Debug\net9.0\Microsoft.CodeAnalysis.UnitTests.dll --out testlist.json
+> dotnet exec TestDiscoveryWorker.dll --assembly artifacts\bin\Microsoft.CodeAnalysis.UnitTests\Debug\net10.0\Microsoft.CodeAnalysis.UnitTests.dll --out testlist.json
 ```


### PR DESCRIPTION
Trying out https://github.com/dotnet/roslyn/pull/81946 here.