### PR TITLE
Skip building of workload manifests

### DIFF
--- a/repo-projects/sdk.proj
+++ b/repo-projects/sdk.proj
@@ -21,6 +21,7 @@
     
     <BuildArgs Condition="'$(BuildWorkloads)' == 'true'">$(BuildArgs) /p:BuildWorkloads=true</BuildArgs>
     <BuildArgs Condition="'$(BuildWorkloads)' == 'true' and '$(DotNetBuildSharedComponents)' != 'true'">$(BuildArgs) /p:DownloadWorkloadMsis=true</BuildArgs>
+    <BuildArgs Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(DotNetBuildSharedComponents)' != 'true'">$(BuildArgs) /p:SkipManifestBuild=true</BuildArgs>
     <BuildArgs Condition="'$(DotNetBuildSharedComponents)' != 'true'">$(BuildArgs) /p:DotNet1xxRuntimeVersion=$(MicrosoftNETCoreAppRefVersion) /p:DotNet1xxWorkloadManifestVersion=$(DotNet1xxWorkloadManifestVersion)</BuildArgs>
   </PropertyGroup>
 

--- a/src/sdk/src/Workloads/Manifests/manifest-packages.csproj
+++ b/src/sdk/src/Workloads/Manifests/manifest-packages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Build.Traversal" DefaultTargets="Pack">
 
   <ItemGroup>
-    <ProjectReference Include="**\*.Manifest.proj" />
+    <ProjectReference Include="**\*.Manifest.proj" Condition="'$(SkipManifestBuild)' != 'true'" />
   </ItemGroup>
 
   <Target Name="LayoutBuiltinManifests">


### PR DESCRIPTION
Fixes #4155 

The 10.0.2xx build fails during darc publishing because there are multiple workload manifest packages described in `MergedManifest.xml` with duplicate names. For example:

```xml
<Package Id="Microsoft.NET.Workload.Emscripten.Current.Manifest-10.0.100-preview.0" Version="10.0.100" DotNetReleaseShipping="true" PipelineArtifactName="Windows_x64_Artifacts" PipelineArtifactPath="packages/Release/Shipping/sdk/Microsoft.NET.Workload.Emscripten.Current.Manifest-10.0.100-preview.0.10.0.100.nupkg" RepoOrigin="sdk" Visibility="External" />
<Package Id="Microsoft.NET.Workload.Emscripten.Current.Manifest-10.0.100-preview.0" Version="10.0.200-preview.0.26062.102" DotNetReleaseShipping="true" PipelineArtifactName="Windows_x64_Artifacts" PipelineArtifactPath="packages/Release/Shipping/sdk/Microsoft.NET.Workload.Emscripten.Current.Manifest-10.0.100-preview.0.10.0.200-preview.0.26062.102.nupkg" RepoOrigin="sdk" Visibility="External" />
```

In fact, neither of these packages should be output by the build. For 2xx, the intent is to use the downloaded 10.0.100 manifest packages, not build new ones.