### PR TITLE
Add Re-Bootstrapping Doc to the VMR

### DIFF
--- a/docs/VMR-re-bootstrapping.md
+++ b/docs/VMR-re-bootstrapping.md
@@ -33,6 +33,11 @@ released.
 > Eligible builds must have published artifacts to a public channel.
 > For this reason, re-bootstrapping is only allowed with official builds
 > from the main branch and non-internal release branches.
+>
+> Additionally, re-bootstrapping should only be done with signed builds.
+> In exceptional cases (e.g., during early development), re-bootstrapping
+> with an unsigned build may be necessary, but this should be avoided
+> unless absolutely required.
 
 ### Automated
 


### PR DESCRIPTION
Related to https://github.com/dotnet/release/issues/1564

Moves and updates the doc from https://github.com/dotnet/source-build/blob/main/Documentation/VMR-re-bootstrapping.md