### PR TITLE
Fix workload package versioning

### DIFF
--- a/repo-projects/sdk.proj
+++ b/repo-projects/sdk.proj
@@ -21,7 +21,6 @@
     
     <BuildArgs Condition="'$(BuildWorkloads)' == 'true'">$(BuildArgs) /p:BuildWorkloads=true</BuildArgs>
     <BuildArgs Condition="'$(BuildWorkloads)' == 'true' and '$(DotNetBuildSharedComponents)' != 'true'">$(BuildArgs) /p:DownloadWorkloadMsis=true</BuildArgs>
-    <BuildArgs Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(DotNetBuildSharedComponents)' != 'true'">$(BuildArgs) /p:SkipManifestBuild=true</BuildArgs>
     <BuildArgs Condition="'$(DotNetBuildSharedComponents)' != 'true'">$(BuildArgs) /p:DotNet1xxRuntimeVersion=$(MicrosoftNETCoreAppRefVersion) /p:DotNet1xxWorkloadManifestVersion=$(DotNet1xxWorkloadManifestVersion)</BuildArgs>
   </PropertyGroup>
 

--- a/src/sdk/eng/Publishing.props
+++ b/src/sdk/eng/Publishing.props
@@ -49,6 +49,13 @@
     <Artifact Update="$(ArtifactsShippingPackagesDir)*.Msi.*.nupkg" Visibility="Internal" />
   </ItemGroup>
 
+  <!-- In 2xx+ bands, don't publish workload manifest packages since these are versioned the same as the 1xx
+       band and would cause conflicts. -->
+  <ItemGroup Condition="'$(DotNet1xxWorkloadManifestVersion)' != ''">
+    <Artifact Update="$(ArtifactsShippingPackagesDir)Microsoft.NET.Workload.*.Manifest-*.nupkg" Visibility="Internal" />
+    <Artifact Update="$(ArtifactsNonShippingPackagesDir)Microsoft.NET.Workload.*.Manifest-*.nupkg" Visibility="Internal" />
+  </ItemGroup>
+
   <Target Name="GetNonStableProductVersion">
     <!-- Retrieve the non-stable product version. -->
     <MSBuild Projects="$(RepoRoot)src\Layout\redist\redist.csproj"

--- a/src/sdk/src/Workloads/Manifests/Directory.Build.props
+++ b/src/sdk/src/Workloads/Manifests/Directory.Build.props
@@ -12,6 +12,7 @@
     <IsShipping Condition="'$(MSBuildProjectName)' == 'Microsoft.NET.Workload.Emscripten.Current.Transport.Manifest'">false</IsShipping>
     <IsShippingPackage>$(IsShipping)</IsShippingPackage>
     <IncludeSymbols>false</IncludeSymbols>
+    <PackageVersion Condition="'$(DotNet1xxWorkloadManifestVersion)' != ''">$(DotNet1xxWorkloadManifestVersion)</PackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/sdk/src/Workloads/Manifests/manifest-packages.csproj
+++ b/src/sdk/src/Workloads/Manifests/manifest-packages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Build.Traversal" DefaultTargets="Pack">
 
   <ItemGroup>
-    <ProjectReference Include="**\*.Manifest.proj" Condition="'$(SkipManifestBuild)' != 'true'" />
+    <ProjectReference Include="**\*.Manifest.proj" />
   </ItemGroup>
 
   <Target Name="LayoutBuiltinManifests">


### PR DESCRIPTION
Fixes dotnet/sdk#52457

This reverts the changes that were made in https://github.com/dotnet/dotnet/pull/4166 as that was incorrect. It's ok to build the workload manifests in 2xx, just not the MSIs. These will be excluded from publish.