### PR TITLE
Add FSharp versioning overrides for 10.0.3xx

### DIFF
--- a/src/fsharp/eng/Versions.props
+++ b/src/fsharp/eng/Versions.props
@@ -22,6 +22,18 @@
     <FSBuildVersion>100</FSBuildVersion>
     <FSRevisionVersion>0</FSRevisionVersion>
     <!-- -->
+
+
+    <!-- BEGIN - SPECIFIC OVERRIDES for 10.0.3xx. Those are overrides instead of updates to reduce risk of git conflicts in codeflow -->
+    <FSharpPreReleaseIteration></FSharpPreReleaseIteration>
+    <PreReleaseVersionLabel>servicing$(FSharpPreReleaseIteration)</PreReleaseVersionLabel>
+    <FSMajorVersion>10</FSMajorVersion>
+    <FSMinorVersion>0</FSMinorVersion>
+    <FSBuildVersion>300</FSBuildVersion>
+    <FSRevisionVersion>0</FSRevisionVersion>    
+    <!-- END - SPECIFIC OVERRIDES for 10.0.3xx -->
+
+
     <!-- F# Language version -->
     <FSLanguageVersion>$(FSMajorVersion).$(FSMinorVersion)</FSLanguageVersion>
     <!-- -->
@@ -34,7 +46,7 @@
     <!-- -->
     <!-- FSharp.Compiler.Service version -->
     <FCSMajorVersion>43</FCSMajorVersion>
-    <FCSMinorVersion>12</FCSMinorVersion>
+    <FCSMinorVersion>11</FCSMinorVersion>
     <FCSBuildVersion>$(FSBuildVersion)</FCSBuildVersion>
     <FCSRevisionVersion>$(FSRevisionVersion)</FCSRevisionVersion>
     <FSharpCompilerServicePackageVersion>$(FCSMajorVersion).$(FCSMinorVersion).$(FCSBuildVersion)</FSharpCompilerServicePackageVersion>


### PR DESCRIPTION
dotnet/fsharp main now flows to:
main
10.0.2xx
10.0.3xx

The version numbering overrides will allow to customize package and product branding without raising git flow conflicts.