### PR TITLE
Revert "Revert temporary ITypeSymbol extension APIs"

### DIFF
--- a/src/roslyn/src/Compilers/CSharp/Portable/Symbols/PublicModel/TypeSymbol.cs
+++ b/src/roslyn/src/Compilers/CSharp/Portable/Symbols/PublicModel/TypeSymbol.cs
@@ -156,6 +156,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
 
         bool ITypeSymbol.IsNativeIntegerType => UnderlyingTypeSymbol.IsNativeIntegerType;
 
+#nullable enable
+        bool ITypeSymbol.IsExtension => UnderlyingTypeSymbol is Symbols.NamedTypeSymbol { IsExtension: true };
+
+        IParameterSymbol? ITypeSymbol.ExtensionParameter
+        {
+            get
+            {
+                return UnderlyingTypeSymbol is Symbols.NamedTypeSymbol namedType
+                    ? namedType.ExtensionParameter?.GetPublicSymbol()
+                    : null;
+            }
+        }
+#nullable disable
+
         string ITypeSymbol.ToDisplayString(CodeAnalysis.NullableFlowState topLevelNullability, SymbolDisplayFormat format)
         {
             return SymbolDisplay.ToDisplayString(this, topLevelNullability, format);

--- a/src/roslyn/src/Compilers/Core/Portable/PublicAPI.Shipped.txt
+++ b/src/roslyn/src/Compilers/Core/Portable/PublicAPI.Shipped.txt
@@ -1695,9 +1695,11 @@ Microsoft.CodeAnalysis.ITypeParameterSymbol.Variance.get -> Microsoft.CodeAnalys
 Microsoft.CodeAnalysis.ITypeSymbol
 Microsoft.CodeAnalysis.ITypeSymbol.AllInterfaces.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.INamedTypeSymbol!>
 Microsoft.CodeAnalysis.ITypeSymbol.BaseType.get -> Microsoft.CodeAnalysis.INamedTypeSymbol?
+Microsoft.CodeAnalysis.ITypeSymbol.ExtensionParameter.get -> Microsoft.CodeAnalysis.IParameterSymbol?
 Microsoft.CodeAnalysis.ITypeSymbol.FindImplementationForInterfaceMember(Microsoft.CodeAnalysis.ISymbol! interfaceMember) -> Microsoft.CodeAnalysis.ISymbol?
 Microsoft.CodeAnalysis.ITypeSymbol.Interfaces.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.INamedTypeSymbol!>
 Microsoft.CodeAnalysis.ITypeSymbol.IsAnonymousType.get -> bool
+Microsoft.CodeAnalysis.ITypeSymbol.IsExtension.get -> bool
 Microsoft.CodeAnalysis.ITypeSymbol.IsNativeIntegerType.get -> bool
 Microsoft.CodeAnalysis.ITypeSymbol.IsReadOnly.get -> bool
 Microsoft.CodeAnalysis.ITypeSymbol.IsRecord.get -> bool

--- a/src/roslyn/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
+++ b/src/roslyn/src/Compilers/Core/Portable/Symbols/INamedTypeSymbol.cs
@@ -202,13 +202,13 @@ namespace Microsoft.CodeAnalysis
         /// Is this a symbol for an extension declaration.
         /// </summary>
         [MemberNotNullWhen(true, nameof(ExtensionGroupingName), nameof(ExtensionMarkerName))]
-        bool IsExtension { get; }
+        new bool IsExtension { get; }
 
         /// <summary>
         /// The extension parameter if this is an extension declaration (<see cref="IsExtension"/> is true).
         /// Note: this may be null even if <see cref="IsExtension"/> is true, in error cases.
         /// </summary>
-        IParameterSymbol? ExtensionParameter { get; }
+        new IParameterSymbol? ExtensionParameter { get; }
 
         /// <summary>
         /// For extensions, returns the synthesized identifier for the grouping type.

--- a/src/roslyn/src/Compilers/Core/Portable/Symbols/ITypeSymbol.cs
+++ b/src/roslyn/src/Compilers/Core/Portable/Symbols/ITypeSymbol.cs
@@ -80,6 +80,12 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         bool IsNativeIntegerType { get; }
 
+        [Obsolete($"This API will be removed in the future. Use {nameof(INamedTypeSymbol)}.{nameof(INamedTypeSymbol.IsExtension)} instead.")]
+        bool IsExtension { get; }
+
+        [Obsolete($"This API will be removed in the future. Use {nameof(INamedTypeSymbol)}.{nameof(INamedTypeSymbol.ExtensionParameter)} instead.")]
+        IParameterSymbol? ExtensionParameter { get; }
+
         /// <summary>
         /// The original definition of this symbol. If this symbol is constructed from another
         /// symbol by type substitution then <see cref="OriginalDefinition"/> gets the original symbol as it was defined in

--- a/src/roslyn/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
+++ b/src/roslyn/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
@@ -782,5 +782,19 @@ Done:
         Private Function ITypeSymbolInternal_GetITypeSymbol() As ITypeSymbol Implements ITypeSymbolInternal.GetITypeSymbol
             Return Me
         End Function
+
+        <Obsolete>
+        Private ReadOnly Property ITypeSymbol_IsExtension As Boolean Implements ITypeSymbol.IsExtension
+            Get
+                Return False
+            End Get
+        End Property
+
+        <Obsolete>
+        Private ReadOnly Property ITypeSymbol_ExtensionParameter As IParameterSymbol Implements ITypeSymbol.ExtensionParameter
+            Get
+                Return Nothing
+            End Get
+        End Property
     End Class
 End Namespace

--- a/src/roslyn/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/Microsoft.CodeAnalysis.txt
+++ b/src/roslyn/src/Tools/SemanticSearch/ReferenceAssemblies/Apis/Microsoft.CodeAnalysis.txt
@@ -1480,8 +1480,10 @@ Microsoft.CodeAnalysis.ITypeSymbol.ToMinimalDisplayString(Microsoft.CodeAnalysis
 Microsoft.CodeAnalysis.ITypeSymbol.WithNullableAnnotation(Microsoft.CodeAnalysis.NullableAnnotation)
 Microsoft.CodeAnalysis.ITypeSymbol.get_AllInterfaces
 Microsoft.CodeAnalysis.ITypeSymbol.get_BaseType
+Microsoft.CodeAnalysis.ITypeSymbol.get_ExtensionParameter
 Microsoft.CodeAnalysis.ITypeSymbol.get_Interfaces
 Microsoft.CodeAnalysis.ITypeSymbol.get_IsAnonymousType
+Microsoft.CodeAnalysis.ITypeSymbol.get_IsExtension
 Microsoft.CodeAnalysis.ITypeSymbol.get_IsNativeIntegerType
 Microsoft.CodeAnalysis.ITypeSymbol.get_IsReadOnly
 Microsoft.CodeAnalysis.ITypeSymbol.get_IsRecord

--- a/src/roslyn/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationTypeSymbol.cs
+++ b/src/roslyn/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/CodeGeneration/Symbols/CodeGenerationTypeSymbol.cs
@@ -42,6 +42,12 @@ internal abstract class CodeGenerationTypeSymbol(
 
     public bool IsNativeIntegerType => false;
 
+#if !ROSLYN_4_12_OR_LOWER
+    bool ITypeSymbol.IsExtension => false;
+
+    IParameterSymbol ITypeSymbol.ExtensionParameter => null;
+#endif
+
     public static ImmutableArray<ITypeSymbol> TupleElementTypes => default;
 
     public static ImmutableArray<string> TupleElementNames => default;


### PR DESCRIPTION
Reverts dotnet/dotnet#2822

To avoid breaking net10.0 projects, we'll need to ship https://github.com/dotnet/runtime/pull/123509 before making this breaking change. @jjonescz @agocke