### PR TITLE
Refactor logging and error handling in build targets

### DIFF
--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -4,6 +4,7 @@ Param(
   [string]$platform = $null,
   [string] $projects,
   [string][Alias('v')]$verbosity = "minimal",
+  [string]$loggerParameters = "Summary",
   [string] $msbuildEngine = $null,
   [bool] $warnAsError = $true,
   [bool] $nodeReuse = $true,
@@ -41,11 +42,12 @@ if($env:Platform) {
 }
 function Print-Usage() {
   Write-Host "Common settings:"
-  Write-Host "  -configuration <value>  Build configuration: 'Debug' or 'Release' (short: -c)"
-  Write-Host "  -platform <value>       Platform configuration: 'x86', 'x64' or any valid Platform value to pass to msbuild"
-  Write-Host "  -verbosity <value>      Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
-  Write-Host "  -binaryLog              Output binary log (short: -bl)"
-  Write-Host "  -help                   Print help and exit"
+  Write-Host "  -configuration <value>     Build configuration: 'Debug' or 'Release' (short: -c)"
+  Write-Host "  -platform <value>          Platform configuration: 'x86', 'x64' or any valid Platform value to pass to msbuild"
+  Write-Host "  -verbosity <value>         Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
+  Write-Host "  -loggerParameters <value>  Msbuild console logger parameters. Defaults to 'Summary'"
+  Write-Host "  -binaryLog                 Output binary log (short: -bl)"
+  Write-Host "  -help                      Print help and exit"
   Write-Host ""
 
   Write-Host "Actions:"

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -10,10 +10,11 @@ set -e
 usage()
 {
   echo "Common settings:"
-  echo "  --configuration <value>    Build configuration: 'Debug' or 'Release' (short: -c)"
-  echo "  --verbosity <value>        Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
-  echo "  --binaryLog                Create MSBuild binary log (short: -bl)"
-  echo "  --help                     Print help and exit (short: -h)"
+  echo "  --configuration <value>     Build configuration: 'Debug' or 'Release' (short: -c)"
+  echo "  --verbosity <value>         Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
+  echo "  --loggerParameters <value>  Msbuild console logger parameters. Defaults to 'Summary'"
+  echo "  --binaryLog                 Create MSBuild binary log (short: -bl)"
+  echo "  --help                      Print help and exit (short: -h)"
   echo ""
 
   echo "Actions:"
@@ -88,6 +89,7 @@ projects=''
 configuration=''
 prepare_machine=false
 verbosity='minimal'
+logger_parameters='Summary'
 runtime_source_feed=''
 runtime_source_feed_key=''
 
@@ -108,6 +110,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     -verbosity|-v)
       verbosity=$2
+      shift
+      ;;
+    -loggerparameters)
+      logger_parameters=$2
       shift
       ;;
     -binarylog|-bl)

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -28,6 +28,9 @@
 # Adjusts msbuild verbosity level.
 [string]$verbosity = if (Test-Path variable:verbosity) { $verbosity } else { 'minimal' }
 
+# Parameters to pass to the msbuild console logger.
+[string]$loggerParameters = if (Test-Path variable:loggerParameters) { $loggerParameters } else { 'Summary' }
+
 # Set to true to reuse msbuild nodes. Recommended to not reuse on CI.
 [bool]$nodeReuse = if (Test-Path variable:nodeReuse) { $nodeReuse } else { !$ci }
 
@@ -818,7 +821,7 @@ function MSBuild-Core() {
 
   $buildTool = InitializeBuildTool
 
-  $cmdArgs = "$($buildTool.Command) /m /nologo /clp:Summary /v:$verbosity /nr:$nodeReuse /p:ContinuousIntegrationBuild=$ci"
+  $cmdArgs = "$($buildTool.Command) /m /nologo /clp:$loggerParameters /v:$verbosity /nr:$nodeReuse /p:ContinuousIntegrationBuild=$ci"
 
   if ($warnAsError) {
     $cmdArgs += ' /warnaserror /p:TreatWarningsAsErrors=true'

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -42,6 +42,9 @@ restore=${restore:-true}
 # Adjusts msbuild verbosity level.
 verbosity=${verbosity:-'minimal'}
 
+# Parameters to pass to the msbuild console logger.
+logger_parameters=${logger_parameters:-'Summary'}
+
 # Set to true to reuse msbuild nodes. Recommended to not reuse on CI.
 if [[ "$ci" == true ]]; then
   node_reuse=${node_reuse:-false}
@@ -522,7 +525,7 @@ function MSBuild-Core {
     }
   }
 
-  RunBuildTool "$_InitializeBuildToolCommand" /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch /p:TreatWarningsAsErrors=$warn_as_error /p:ContinuousIntegrationBuild=$ci "$@"
+  RunBuildTool "$_InitializeBuildToolCommand" /m /nologo /clp:$logger_parameters /v:$verbosity /nr:$node_reuse $warnaserror_switch /p:TreatWarningsAsErrors=$warn_as_error /p:ContinuousIntegrationBuild=$ci "$@"
 }
 
 function GetDarc {

--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -107,6 +107,7 @@
     <!-- Pass down configuration properties -->
     <CommonArgs>$(CommonArgs) $(FlagParameterPrefix)configuration $(Configuration)</CommonArgs>
     <CommonArgs>$(CommonArgs) $(FlagParameterPrefix)verbosity $(LogVerbosity)</CommonArgs>
+    <CommonArgs>$(CommonArgs) $(FlagParameterPrefix)loggerParameters NoSummary</CommonArgs>
     <CommonArgs>$(CommonArgs) /p:TargetRid=$(TargetRid)</CommonArgs>
 
     <!-- Pass through DotNetBuildPass for join point vertical support. -->

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -47,10 +47,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- MinimalConsoleLogOutput determines if the repository build should be logged to a separate file or directly to the console.
-         Enable it by default as with prallel repository builds the log becomes non-readable. -->
     <RepoConsoleLogFile>$(ArtifactsLogRepoDir)$(RepositoryName).log</RepoConsoleLogFile>
-    <MinimalConsoleLogOutput Condition="'$(MinimalConsoleLogOutput)' == ''">$(BuildInParallel)</MinimalConsoleLogOutput>
   </PropertyGroup>
 
   <!-- Exclude shared repositories from the build, unless shared component building is explicitly enabled. -->
@@ -589,7 +586,7 @@
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Building $(RepositoryName)" />
     <Message Importance="High" Text="Running command:" />
     <Message Importance="High" Text="  $(BuildCommand)" />
-    <Message Importance="High" Text="  Log: $(RepoConsoleLogFile)" Condition="'$(MinimalConsoleLogOutput)' == 'true'" />
+    <Message Importance="High" Text="  Log: $(RepoConsoleLogFile)" />
     <Message Importance="High" Text="  With Environment Variables:"/>
     <Message Importance="High" Text="    %(EnvironmentVariables.Identity)" />
     <Message Importance="High" Text="    %(BuildEnvironmentVariable.Identity)" Condition="'@(BuildEnvironmentVariable)' != ''" />
@@ -599,7 +596,9 @@
 
     <PropertyGroup>
       <FullCommand>$(BuildCommand)</FullCommand>
-      <FullCommand Condition="'$(MinimalConsoleLogOutput)' == 'true'">$(FullCommand) &gt; $(RepoConsoleLogFile) 2&gt;&amp;1</FullCommand>
+      <FullCommand Condition="'$(BuildOS)' == 'windows'">powershell -NoProfile -Command "&amp; { $(BuildCommand) 2&gt;&amp;1 | Tee-Object -FilePath "$(RepoConsoleLogFile)"%3B exit %24LASTEXITCODE }"</FullCommand>
+      <FullCommand Condition="'$(BuildOS)' != 'windows'">rcf=%24(mktemp); { $(BuildCommand); printf %s "%24?" &gt;"%24rcf"; } 2&gt;&amp;1 | tee "$(RepoConsoleLogFile)"; rc=%24(cat "%24rcf"); rm -f "%24rcf"; exit "%24rc"</FullCommand> <!-- POSIX compliant -->
+      <RepoStandardOutputImportance Condition="'$(RepoStandardOutputImportance)' == ''">low</RepoStandardOutputImportance> <!-- low, normal, high -->
     </PropertyGroup>
 
     <MakeDir Directories="$([System.IO.Path]::GetDirectoryName('$(RepoConsoleLogFile)'));
@@ -615,7 +614,8 @@
           WorkingDirectory="$(ProjectDirectory)"
           EnvironmentVariables="@(EnvironmentVariables);@(BuildEnvironmentVariable)"
           IgnoreStandardErrorWarningFormat="true"
-          YieldDuringToolExecution="true">
+          YieldDuringToolExecution="true"
+          StandardOutputImportance="$(RepoStandardOutputImportance)">
       <Output TaskParameter="ExitCode" PropertyName="RepoBuildExitCode" />
     </Exec>
 
@@ -626,14 +626,7 @@
       <Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
     </Touch>
 
-    <OnError ExecuteTargets="MoveDotNetBuildLogs;LogRepoBuildError" />
-  </Target>
-
-  <!-- Propagate errors to the output when using the minimal console log feature. -->
-  <Target Name="LogRepoBuildError" Condition="'$(MinimalConsoleLogOutput)' == 'true'">
-    <Message Importance="High" Text="$([System.IO.File]::ReadAllText('$(RepoConsoleLogFile)'))" Condition="Exists('$(RepoConsoleLogFile)')" />
-    <Message Importance="High" Text="'$(RepositoryName)' failed during build." />
-    <Message Importance="High" Text="See '$(RepoConsoleLogFile)' for more information." Condition="Exists('$(RepoConsoleLogFile)')" />
+    <OnError ExecuteTargets="MoveDotNetBuildLogs" />
   </Target>
 
   <!-- Log the new repo artifacts -->
@@ -682,7 +675,6 @@
       <LogManifestNotFoundError Condition="('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1') and '@(RepoAssetManifest)' == ''">true</LogManifestNotFoundError>
     </PropertyGroup>
 
-    <Message Importance="High" Text="$([System.IO.File]::ReadAllText('$(RepoConsoleLogFile)'))" Condition="'$(LogManifestNotFoundError)' == 'true' and '$(MinimalConsoleLogOutput)' == 'true' and Exists('$(RepoConsoleLogFile)')" />
     <Error Text="No repository asset manifest files found at '$(RepoAssetManifestsDir)*.xml'. This often means the build failed but did not log an error." Condition="'$(LogManifestNotFoundError)' == 'true'" />
 
     <GetKnownArtifactsFromAssetManifests AssetManifests="@(RepoAssetManifest)">

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -905,7 +905,6 @@
 
     <PropertyGroup>
       <FullTestCommand>$(TestCommand)</FullTestCommand>
-      <FullTestCommand Condition="'$(LogVerbosityOptOut)' != 'true'">$(FullTestCommand) /v:$(LogVerbosity)</FullTestCommand>
     </PropertyGroup>
 
     <Exec Command="$(FullTestCommand)"

--- a/src/arcade/eng/common/build.ps1
+++ b/src/arcade/eng/common/build.ps1
@@ -4,6 +4,7 @@ Param(
   [string]$platform = $null,
   [string] $projects,
   [string][Alias('v')]$verbosity = "minimal",
+  [string]$loggerParameters = "Summary",
   [string] $msbuildEngine = $null,
   [bool] $warnAsError = $true,
   [bool] $nodeReuse = $true,
@@ -41,11 +42,12 @@ if($env:Platform) {
 }
 function Print-Usage() {
   Write-Host "Common settings:"
-  Write-Host "  -configuration <value>  Build configuration: 'Debug' or 'Release' (short: -c)"
-  Write-Host "  -platform <value>       Platform configuration: 'x86', 'x64' or any valid Platform value to pass to msbuild"
-  Write-Host "  -verbosity <value>      Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
-  Write-Host "  -binaryLog              Output binary log (short: -bl)"
-  Write-Host "  -help                   Print help and exit"
+  Write-Host "  -configuration <value>     Build configuration: 'Debug' or 'Release' (short: -c)"
+  Write-Host "  -platform <value>          Platform configuration: 'x86', 'x64' or any valid Platform value to pass to msbuild"
+  Write-Host "  -verbosity <value>         Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
+  Write-Host "  -loggerParameters <value>  Msbuild console logger parameters. Defaults to 'Summary'"
+  Write-Host "  -binaryLog                 Output binary log (short: -bl)"
+  Write-Host "  -help                      Print help and exit"
   Write-Host ""
 
   Write-Host "Actions:"

--- a/src/arcade/eng/common/build.sh
+++ b/src/arcade/eng/common/build.sh
@@ -10,10 +10,11 @@ set -e
 usage()
 {
   echo "Common settings:"
-  echo "  --configuration <value>    Build configuration: 'Debug' or 'Release' (short: -c)"
-  echo "  --verbosity <value>        Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
-  echo "  --binaryLog                Create MSBuild binary log (short: -bl)"
-  echo "  --help                     Print help and exit (short: -h)"
+  echo "  --configuration <value>     Build configuration: 'Debug' or 'Release' (short: -c)"
+  echo "  --verbosity <value>         Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
+  echo "  --loggerParameters <value>  Msbuild console logger parameters. Defaults to 'Summary'"
+  echo "  --binaryLog                 Create MSBuild binary log (short: -bl)"
+  echo "  --help                      Print help and exit (short: -h)"
   echo ""
 
   echo "Actions:"
@@ -88,6 +89,7 @@ projects=''
 configuration=''
 prepare_machine=false
 verbosity='minimal'
+logger_parameters='Summary'
 runtime_source_feed=''
 runtime_source_feed_key=''
 
@@ -108,6 +110,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     -verbosity|-v)
       verbosity=$2
+      shift
+      ;;
+    -loggerparameters)
+      logger_parameters=$2
       shift
       ;;
     -binarylog|-bl)

--- a/src/arcade/eng/common/tools.ps1
+++ b/src/arcade/eng/common/tools.ps1
@@ -28,6 +28,9 @@
 # Adjusts msbuild verbosity level.
 [string]$verbosity = if (Test-Path variable:verbosity) { $verbosity } else { 'minimal' }
 
+# Parameters to pass to the msbuild console logger.
+[string]$loggerParameters = if (Test-Path variable:loggerParameters) { $loggerParameters } else { 'Summary' }
+
 # Set to true to reuse msbuild nodes. Recommended to not reuse on CI.
 [bool]$nodeReuse = if (Test-Path variable:nodeReuse) { $nodeReuse } else { !$ci }
 
@@ -818,7 +821,7 @@ function MSBuild-Core() {
 
   $buildTool = InitializeBuildTool
 
-  $cmdArgs = "$($buildTool.Command) /m /nologo /clp:Summary /v:$verbosity /nr:$nodeReuse /p:ContinuousIntegrationBuild=$ci"
+  $cmdArgs = "$($buildTool.Command) /m /nologo /clp:$loggerParameters /v:$verbosity /nr:$nodeReuse /p:ContinuousIntegrationBuild=$ci"
 
   if ($warnAsError) {
     $cmdArgs += ' /warnaserror /p:TreatWarningsAsErrors=true'

--- a/src/arcade/eng/common/tools.sh
+++ b/src/arcade/eng/common/tools.sh
@@ -42,6 +42,9 @@ restore=${restore:-true}
 # Adjusts msbuild verbosity level.
 verbosity=${verbosity:-'minimal'}
 
+# Parameters to pass to the msbuild console logger.
+logger_parameters=${logger_parameters:-'Summary'}
+
 # Set to true to reuse msbuild nodes. Recommended to not reuse on CI.
 if [[ "$ci" == true ]]; then
   node_reuse=${node_reuse:-false}
@@ -522,7 +525,7 @@ function MSBuild-Core {
     }
   }
 
-  RunBuildTool "$_InitializeBuildToolCommand" /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch /p:TreatWarningsAsErrors=$warn_as_error /p:ContinuousIntegrationBuild=$ci "$@"
+  RunBuildTool "$_InitializeBuildToolCommand" /m /nologo /clp:$logger_parameters /v:$verbosity /nr:$node_reuse $warnaserror_switch /p:TreatWarningsAsErrors=$warn_as_error /p:ContinuousIntegrationBuild=$ci "$@"
 }
 
 function GetDarc {

--- a/src/aspnetcore/eng/build.ps1
+++ b/src/aspnetcore/eng/build.ps1
@@ -84,6 +84,9 @@ Don't output binary log by default in CI builds (short: -nobl).
 .PARAMETER Verbosity
 MSBuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]
 
+.PARAMETER LoggerParameters
+MSbuild console logger parameters. Defaults to 'Summary'
+
 .PARAMETER MSBuildArguments
 Additional MSBuild arguments to be passed through.
 
@@ -180,6 +183,7 @@ param(
     [switch]$ExcludeCIBinarylog,
     [Alias('v')]
     [string]$Verbosity = 'minimal',
+    [string]$loggerParameters = 'Summary',
     [switch]$DumpProcesses, # Capture all running processes and dump them to a file.
     [string]$msbuildEngine = 'dotnet',
 

--- a/src/aspnetcore/eng/build.sh
+++ b/src/aspnetcore/eng/build.sh
@@ -15,6 +15,7 @@ ci=false
 binary_log=false
 exclude_ci_binary_log=false
 verbosity='minimal'
+logger_parameters='Summary'
 run_restore=''
 run_build=true
 run_pack=false
@@ -85,6 +86,7 @@ Options:
     --binarylog|-bl                   Use a binary logger
     --excludeCIBinarylog              Don't output binary log by default in CI builds (short: -nobl).
     --verbosity|-v                    MSBuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]
+    --loggerParameters <value>        MSBuild console logger parameters. Defaults to 'Summary'
     --warnAsError                     Sets warnaserror msbuild parameter: 'true' or 'false'
 
     --runtime-source-feed             Additional feed that can be used when downloading .NET runtimes and SDKs
@@ -229,13 +231,18 @@ while [[ $# -gt 0 ]]; do
         -binarylog|-bl)
             binary_log=true
             ;;
-        -excludeCIBinarylog|-nobl)
+        -excludecibinarylog|-nobl)
             exclude_ci_binary_log=true
             ;;
         -verbosity|-v)
             shift
             [ -z "${1:-}" ] && __error "Missing value for parameter --verbosity" && __usage
             verbosity="${1:-}"
+            ;;
+        -loggerparameters)
+            shift
+            [ -z "${1:-}" ] && __error "Missing value for parameter --loggerParameters" && __usage
+            logger_parameters="${1:-}"
             ;;
         -dotnet-runtime-source-feed|-dotnetruntimesourcefeed|-runtime-source-feed|-runtimesourcefeed)
             shift

--- a/src/fsharp/eng/Build.ps1
+++ b/src/fsharp/eng/Build.ps1
@@ -18,6 +18,7 @@
 param (
     [string][Alias('c')]$configuration = "Debug",
     [string][Alias('v')]$verbosity = "m",
+    [string]$loggerParameters = "Summary",
     [string]$msbuildEngine = "vs",
 
     # Actions
@@ -89,6 +90,7 @@ function Print-Usage() {
     Write-Host "Common settings:"
     Write-Host "  -configuration <value>        Build configuration: 'Debug' or 'Release' (short: -c)"
     Write-Host "  -verbosity <value>            Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]"
+    Write-Host "  -loggerParameters <value>     Msbuild console logger parameters. Defaults to 'Summary'"
     Write-Host "  -deployExtensions             Deploy built vsixes"
     Write-Host "  -binaryLog                    Create MSBuild binary log (short: -bl)"
     Write-Host "  -noLog                        Turn off logging (short: -nolog)"
@@ -317,7 +319,6 @@ function BuildSolution([string] $solutionName, $packSolution) {
         /p:TestTargetFrameworks=$testTargetFrameworks `
         /p:CompressAllMetadata=$CompressAllMetadata `
         /p:BuildNoRealsig=$buildnorealsig `
-        /v:$verbosity `
         $suppressExtensionDeployment `
         @properties
 

--- a/src/fsharp/eng/build.sh
+++ b/src/fsharp/eng/build.sh
@@ -10,6 +10,7 @@ usage()
   echo "Common settings:"
   echo "  --configuration <value>        Build configuration: 'Debug' or 'Release' (short: -c)"
   echo "  --verbosity <value>            Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
+  echo "  --loggerParameters <value>     Msbuild console logger parameters. Defaults to 'Summary'"
   echo "  --binaryLog                    Create MSBuild binary log (short: -bl)"
   echo ""
   echo "Actions:"
@@ -68,6 +69,7 @@ test_benchmarks=false
 test_scripting=false
 configuration="Debug"
 verbosity='minimal'
+logger_parameters='Summary'
 binary_log=false
 force_bootstrap=false
 ci=false
@@ -113,6 +115,11 @@ while [[ $# > 0 ]]; do
       ;;
     --verbosity|-v)
       verbosity=$2
+      args="$args $1"
+      shift
+      ;;
+    --loggerparameters)
+      logger_parameters=$2
       args="$args $1"
       shift
       ;;

--- a/src/nuget-client/eng/dotnet-build/build.ps1
+++ b/src/nuget-client/eng/dotnet-build/build.ps1
@@ -2,6 +2,7 @@
 param (
   [string][Alias('c')]$configuration = "Release",
   [string][Alias('v')]$verbosity = "minimal",
+  [string]$loggerParameters = "Summary",
   [switch]$ci,
   [switch]$prepareMachine,
   [string]$msbuildEngine = $null,

--- a/src/nuget-client/eng/dotnet-build/build.sh
+++ b/src/nuget-client/eng/dotnet-build/build.sh
@@ -10,6 +10,7 @@ args=()
 
 configuration='Release'
 verbosity='minimal'
+logger_parameters='Summary'
 source_build=false
 product_build=false
 from_vmr=false
@@ -35,6 +36,10 @@ while [[ $# > 0 ]]; do
   case $lowerI in
     --verbosity|-v)
       verbosity=$2
+      shift
+      ;;
+    --loggerparameters|-v)
+      logger_parameters=$2
       shift
       ;;
     --binarylog|-bl)
@@ -128,4 +133,4 @@ if [[ "$ci" == true ]]; then
   node_reuse=false
 fi
 
-"$DOTNET" msbuild /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse /p:ContinuousIntegrationBuild=$ci $bl ${dotnetArguments[@]+"${dotnetArguments[@]}"} ${args[@]+"${args[@]}"}
+"$DOTNET" msbuild /m /nologo /clp:$logger_parameters /v:$verbosity /nr:$node_reuse /p:ContinuousIntegrationBuild=$ci $bl ${dotnetArguments[@]+"${dotnetArguments[@]}"} ${args[@]+"${args[@]}"}

--- a/src/nuget-client/src/NuGet.Core/NuGet.Commands/NuGet.Commands.csproj
+++ b/src/nuget-client/src/NuGet.Core/NuGet.Commands/NuGet.Commands.csproj
@@ -10,7 +10,6 @@
     <Shipping>true</Shipping>
     <XPLATProject>true</XPLATProject>
     <UsePublicApiAnalyzer>perTfm</UsePublicApiAnalyzer>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);IDE0055</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/nuget-client/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
+++ b/src/nuget-client/src/NuGet.Core/NuGet.Commands/RestoreCommand/DependencyGraphResolver.cs
@@ -941,25 +941,25 @@ namespace NuGet.Commands
             // Used when logging package id specific messages, we need to know the target graph name
             string targetGraphName = pair.Name;
 
-        // Used to start over when a dependency has multiple descendants of an item to be evicted.
-        //
-        // Project
-        // ├── A 1.0.0
-        // │   └── B 1.0.0
-        // │       └── C 1.0.0
-        // │           └── D 1.0.0
-        // └── X 2.0.0
-        //     └── Y 2.0.0
-        //         └── G 2.0.0
-        //             └── B 2.0.0
-        // The items are processed in the following order:
-        // Chose A 1.0.0 and X 1.0.0
-        // Chose B 1.0.0 and Y 2.0.0
-        // Chose C 1.0.0 and G 2.0.0
-        // Chose D 1.0.0 and B 2.0.0, but B 2.0.0 should evict C 1.0.0 and D 1.0.0
-        //
-        // In this case, the entire walk is started over and B 1.0.0 is left out of the graph, leading to C 1.0.0 and D 1.0.0 also being left out.
-        //
+            // Used to start over when a dependency has multiple descendants of an item to be evicted.
+            //
+            // Project
+            // ├── A 1.0.0
+            // │   └── B 1.0.0
+            // │       └── C 1.0.0
+            // │           └── D 1.0.0
+            // └── X 2.0.0
+            //     └── Y 2.0.0
+            //         └── G 2.0.0
+            //             └── B 2.0.0
+            // The items are processed in the following order:
+            // Chose A 1.0.0 and X 1.0.0
+            // Chose B 1.0.0 and Y 2.0.0
+            // Chose C 1.0.0 and G 2.0.0
+            // Chose D 1.0.0 and B 2.0.0, but B 2.0.0 should evict C 1.0.0 and D 1.0.0
+            //
+            // In this case, the entire walk is started over and B 1.0.0 is left out of the graph, leading to C 1.0.0 and D 1.0.0 also being left out.
+            //
         StartOver:
             restartCount++;
 

--- a/src/roslyn/eng/build.ps1
+++ b/src/roslyn/eng/build.ps1
@@ -18,6 +18,7 @@
 param (
   [string][Alias('c')]$configuration = "Debug",
   [string][Alias('v')]$verbosity = "m",
+  [string]$loggerParameters = "Summary",
   [string]$msbuildEngine = "vs",
 
   # Actions
@@ -78,11 +79,12 @@ $ErrorActionPreference = "Stop"
 
 function Print-Usage() {
   Write-Host "Common settings:"
-  Write-Host "  -configuration <value>    Build configuration: 'Debug' or 'Release' (short: -c)"
-  Write-Host "  -verbosity <value>        Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]"
-  Write-Host "  -deployExtensions         Deploy built vsixes (short: -d)"
-  Write-Host "  -binaryLog                Create MSBuild binary log (short: -bl)"
-  Write-Host "  -binaryLogName            Name of the binary log (default Build.binlog)"
+  Write-Host "  -configuration <value>      Build configuration: 'Debug' or 'Release' (short: -c)"
+  Write-Host "  -verbosity <value>          Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
+  Write-Host "  -loggerParameters <value>   Msbuild console logger parameters. Defaults to 'Summary'"
+  Write-Host "  -deployExtensions           Deploy built vsixes (short: -d)"
+  Write-Host "  -binaryLog                  Create MSBuild binary log (short: -bl)"
+  Write-Host "  -binaryLogName              Name of the binary log (default Build.binlog)"
   Write-Host ""
   Write-Host "Actions:"
   Write-Host "  -restore                  Restore packages (short: -r)"

--- a/src/roslyn/eng/build.sh
+++ b/src/roslyn/eng/build.sh
@@ -11,9 +11,10 @@ set -e
 usage()
 {
   echo "Common settings:"
-  echo "  --configuration <value>    Build configuration: 'Debug' or 'Release' (short: -c)"
-  echo "  --verbosity <value>        Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
-  echo "  --binaryLog                Create MSBuild binary log (short: -bl)"
+  echo "  --configuration <value>      Build configuration: 'Debug' or 'Release' (short: -c)"
+  echo "  --verbosity <value>          Msbuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic] (short: -v)"
+  echo "  --loggerParameters <value>   Msbuild console logger parameters. Defaults to 'Summary'"
+  echo "  --binaryLog                  Create MSBuild binary log (short: -bl)"
   echo ""
   echo "Actions:"
   echo "  --restore                  Restore projects required to build (short: -r)"
@@ -72,6 +73,7 @@ test_compiler_only=false
 
 configuration="Debug"
 verbosity='minimal'
+logger_parameters='Summary'
 binary_log=false
 ci=false
 helix=false
@@ -110,6 +112,11 @@ while [[ $# > 0 ]]; do
       ;;
     --verbosity|-v)
       verbosity=$2
+      args="$args $1"
+      shift
+      ;;
+    --loggerparameters)
+      logger_parameters=$2
       args="$args $1"
       shift
       ;;


### PR DESCRIPTION
Fixes https://github.com/dotnet/dotnet/issues/705

Removes the minimal console log switch.
Use the `StandardOutputImportance` parameter to only log warnings and errors (with context).