### PR TITLE
Replace workload manifest dependency with SDK version parsing

### DIFF
--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -12,7 +12,6 @@ This file should be imported by eng/Versions.props
     <MicrosoftNETSdkPackageVersion>10.0.102-servicing.25612.105</MicrosoftNETSdkPackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>10.0.2</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftNETCorePlatformsPackageVersion>10.0.2-servicing.25612.105</MicrosoftNETCorePlatformsPackageVersion>
-    <MicrosoftNETWorkloadEmscriptenCurrentManifest100100PackageVersion>10.0.100</MicrosoftNETWorkloadEmscriptenCurrentManifest100100PackageVersion>
   </PropertyGroup>
   <!--Property group for alternate package version names-->
   <PropertyGroup>
@@ -23,6 +22,5 @@ This file should be imported by eng/Versions.props
     <MicrosoftNETSdkVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETSdkVersion>
     <MicrosoftNETCoreAppRefVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftNETCoreAppRefVersion>
     <MicrosoftNETCorePlatformsVersion>$(MicrosoftNETCorePlatformsPackageVersion)</MicrosoftNETCorePlatformsVersion>
-    <MicrosoftNETWorkloadEmscriptenCurrentManifest100100Version>$(MicrosoftNETWorkloadEmscriptenCurrentManifest100100PackageVersion)</MicrosoftNETWorkloadEmscriptenCurrentManifest100100Version>
   </PropertyGroup>
 </Project>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -18,10 +18,6 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>44525024595742ebe09023abe709df51de65009b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-10.0.100" Version="10.0.100">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>b0f34d51fccc69fd334253924abd8d6853fad7aa</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.2">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>44525024595742ebe09023abe709df51de65009b</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -38,7 +38,7 @@
     <PrivateSourceBuiltSdkVersion>10.0.102-servicing.25612.105</PrivateSourceBuiltSdkVersion>
     <PrivateSourceBuiltArtifactsVersion>10.0.102-servicing.25612.105</PrivateSourceBuiltArtifactsVersion>
     <!-- workload manifest version for 1xx SDK feature band, used by 2xx+ branches to include 1xx workloads -->
-    <DotNet1xxWorkloadManifestVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest100100Version)</DotNet1xxWorkloadManifestVersion>
+    <DotNet1xxWorkloadManifestVersion>$([System.Text.RegularExpressions.Regex]::Match($(MicrosoftNETSdkVersion), '^(\d+\.\d+\.\d+)').Value)</DotNet1xxWorkloadManifestVersion>
     <!-- command-line-api dependencies -->
     <SystemCommandLineVersion>2.0.0-beta5.25208.1</SystemCommandLineVersion>
     <!-- msbuild dependencies -->


### PR DESCRIPTION
This removes the dependency on `Microsoft.NET.Workload.Emscripten.Current.Manifest-10.0.100` which would have required maintenance over time due to the version being embedded in the package name. Instead the workload manifest version is derived from the 1xx SDK version.