### PR TITLE
Bump public macos AzDO image to macos-15

### DIFF
--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -269,7 +269,7 @@ variables:
   - name: poolName_LinuxArm64
     value: Docker-Linux-Arm-Public
   - name: poolImage_Mac
-    value: macos-14
+    value: macos-15
   - ${{ if eq(parameters.isScoutingJob, true) }}:
     - name: poolImage_Windows
       value: windows.vs2026preview.scout.amd64.open


### PR DESCRIPTION
This matches what the internal build uses and the macos-14 image will be discontinued later this year.