### PR TITLE
[release/11.0.1xx-preview1] Fix aspnetcore BuildPass2 build

### DIFF
--- a/src/aspnetcore/eng/Build.props
+++ b/src/aspnetcore/eng/Build.props
@@ -72,7 +72,9 @@
 
   <!-- Build the RepoTasks before anything else -->
   <ItemGroup>
-    <ProjectToBuild Include="$(RepoRoot)eng\tools\RepoTasks\RepoTasks.csproj" BuildStep="repotasks" SkipProjectList="true" DotNetBuildPass="$(DotNetBuildPass)" />
+    <ProjectToBuild Include="$(RepoRoot)eng\tools\RepoTasks\RepoTasks.csproj" BuildStep="repotasks" SkipProjectList="true">
+      <DotNetBuildPass Condition="'$(DotNetBuildPass)' != ''">$(DotNetBuildPass)</DotNetBuildPass>
+    </ProjectToBuild>
   </ItemGroup>
 
   <Choose>


### PR DESCRIPTION
RepoTasks.csproj needs to be in the DotNetBuildPass=2 group as well so that it doesn't get filtered out.

Fixes failure in https://dev.azure.com/dnceng/internal/_build/results?buildId=2889543&view=results

... and minor syntax clean-up