### PR TITLE
[SbrpUsageReport] Fix SBRP detection for packages with versions in their name

### DIFF
--- a/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/WriteSbrpUsageReport.cs
+++ b/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/WriteSbrpUsageReport.cs
@@ -130,7 +130,8 @@ public partial class WriteSbrpUsageReport : Task
     {
         try
         {
-            using var archive = new ZipArchive(File.OpenRead(nupkgFilePath), ZipArchiveMode.Read);
+            using var fileStream = File.OpenRead(nupkgFilePath);
+            using var archive = new ZipArchive(fileStream, ZipArchiveMode.Read);
             var nuspecEntry = archive.Entries.FirstOrDefault(e => e.Name.EndsWith(".nuspec"));
             
             if (nuspecEntry == null)


### PR DESCRIPTION
Read package name and version from nuspec metadata instead of parsing the nupkg filename. This fixes incorrect detection of manifest packages like microsoft.net.sdk.android.manifest-10.0.100 which have version-like strings in their package name.

Before this change, the SbrpUsageReport contained two entries for each of the text-only manifest packages w/the second one being incorrect.

```json
    {
      "Name": "Microsoft.NET.Sdk.Android.Manifest-10.0.100",
      "Version": "36.1.2",
      "Path": "/__w/1/s/src/source-build-reference-packages/src/textOnlyPackages/src/microsoft.net.sdk.android.manifest-10.0.100/36.1.2",
      "Tfms": null,
      "Id": "microsoft.net.sdk.android.manifest-10.0.100/36.1.2",
      "References": {
        "/__w/1/s/src/sdk/artifacts/obj/redist/project.assets.json": []
      }
    },
    {
      "Name": "Microsoft.NET.Sdk.Android.Manifest-10",
      "Version": "0.100.36.1.2",
      "Path": "/__w/1/s/src/source-build-reference-packages/src/externalPackages/src/**/Microsoft.NET.Sdk.Android.Manifest-10/0.100.36.1.2",
      "Tfms": null,
      "Id": "microsoft.net.sdk.android.manifest-10/0.100.36.1.2",
      "References": {}
    },
```