### PR TITLE
[release/10.0.3xx] Conditonalize strong naming on full assembly support

### DIFF
--- a/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/static/Signing.props
+++ b/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/static/Signing.props
@@ -19,7 +19,7 @@
     <StrongNameSignInfo
       Include="$(NuGetPackageRoot)microsoft.dotnet.arcade.sdk/$(MicrosoftDotNetArcadeSdkPackageVersion)/tools/snk/AspNetCore.snk"
       PublicKeyToken="adb9793829ddae60"
-      CertificateName="MicrosoftDotNet500" />
+      CertificateName="MicrosoftDotNet500" Condition="'$(FullAssemblySigningSupported)' != 'false'"/>
 
     <!-- We don't need to code sign .js files because they are not used in Windows Script Host -->
     <FileExtensionSignInfo Update=".js" CertificateName="None" />


### PR DESCRIPTION
The aspnetcore.snk is a full key and can't be used in signing when full assembly signing is not supported.

This won't resolve https://github.com/dotnet/dotnet/issues/4501, but it makes the config correct in those cases at least.