### PR TITLE
[release/10.0.1xx] Align branding across VMR and SDK branches

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,9 +1,13 @@
 ﻿<Project>
   <Import Project="Version.Details.props" />
   <PropertyGroup>
+    <VersionMajor>10</VersionMajor>
+    <VersionMinor>0</VersionMinor>
     <VersionSDKMinor>1</VersionSDKMinor>
-    <VersionPrefix>10.0.$(VersionSDKMinor)00</VersionPrefix>
-    <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
+    <VersionSDKMinorPatch>4</VersionSDKMinorPatch>
+    <VersionFeature>$([System.String]::Copy('$(VersionSDKMinorPatch)').PadLeft(2, '0'))</VersionFeature>
+    <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionSDKMinor)$(VersionFeature)</VersionPrefix>
+    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <!-- 
       Allowed values: 'repodefault', 'unstable', 'preview', 'release'


### PR DESCRIPTION
The VMR uses SDK branding, and this allows the branding tooling to easily update the repo