### PR TITLE
[main] Align branding across VMR and SDK branches

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -66,8 +66,4 @@
     <!-- external dependencies -->
     <NewtonsoftJsonVersion>13.0.4</NewtonsoftJsonVersion>
   </PropertyGroup>
-<<<<<<< HEAD
-
-=======
->>>>>>> ae7c9f193e2 (Align branding across VMR and SDK branches)
 </Project>


### PR DESCRIPTION
The VMR uses SDK branding, and this allows the branding tooling to easily update the repo