### PR TITLE
Fix dnx which is broken in 2xx because of a baseclass cast

### DIFF
--- a/src/sdk/src/Cli/dotnet/Commands/Tool/Execute/ToolExecuteCommand.cs
+++ b/src/sdk/src/Cli/dotnet/Commands/Tool/Execute/ToolExecuteCommand.cs
@@ -19,7 +19,7 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.Cli.Commands.Tool.Execute;
 
-internal sealed class ToolExecuteCommand : CommandBase<ToolExecuteCommandDefinition>
+internal sealed class ToolExecuteCommand : CommandBase<ToolExecuteCommandDefinitionBase>
 {
     const int ERROR_CANCELLED = 1223; //  Windows error code for "Operation canceled by user"
 


### PR DESCRIPTION
Change base class of ToolExecuteCommand to ToolExecuteCommandDefinitionBase

Fixes https://github.com/dotnet/sdk/issues/52819

We'll add a test in the PR to the SDK repo but this is to speed up flow.