### PR TITLE
nuget-client/eng/dotnet-build/build.sh: fix using bash 'local' for a global var.

### DIFF
--- a/src/nuget-client/eng/dotnet-build/build.sh
+++ b/src/nuget-client/eng/dotnet-build/build.sh
@@ -119,7 +119,7 @@ dotnetArguments+=("/p:DotNetBuild=$product_build")
 dotnetArguments+=("/p:DotNetBuildSourceOnly=$source_build")
 dotnetArguments+=("/p:DotNetBuildFromVMR=$from_vmr")
 
-local bl=""
+bl=""
 if [[ "$binary_log" == true ]]; then
   bl="/bl:\"${repo_root}artifacts/log/${configuration}/Build.binlog\""
 fi


### PR DESCRIPTION
I noticed bash printing a message for this. The accidental use of `local` here doesn't cause a functional issue.

@ViktorHofer ptal.