### PR TITLE
Increase mem alloc for license scanning container

### DIFF
--- a/eng/pipelines/vmr-license-scan-unofficial.yml
+++ b/eng/pipelines/vmr-license-scan-unofficial.yml
@@ -27,7 +27,7 @@ extends:
     containers:
       azurelinuxSourceBuildTestContainer:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-source-build-test-amd64
-        options: '--memory=6g'
+        options: '--memory=12g'
     sdl:
       sourceAnalysisPool:
           name: NetCore1ESPool-Svc-Internal

--- a/eng/pipelines/vmr-license-scan.yml
+++ b/eng/pipelines/vmr-license-scan.yml
@@ -59,7 +59,7 @@ extends:
     containers:
       azurelinuxSourceBuildTestContainer:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-source-build-test-amd64
-        options: '--memory=6g'
+        options: '--memory=12g'
     sdl:
       sourceAnalysisPool:
           name: NetCore1ESPool-Svc-Internal


### PR DESCRIPTION
Fixes dotnet/source-build#5470

The root cause is likely https://github.com/aboutcode-org/scancode-toolkit/issues/4709. Increasing the memory allocation in the container fixes the issue.