### PR TITLE
Manual cherry-pick of roslyn commit to unblock publishing

### DIFF
--- a/src/roslyn/eng/Publishing.props
+++ b/src/roslyn/eng/Publishing.props
@@ -14,6 +14,12 @@
     <FilesToPublishToSymbolServer Include="$(ArtifactsBinDir)**/Microsoft.Build.Tasks.CodeAnalysis.Sdk.pdb" />
   </ItemGroup>
 
+  <!-- When EnableDefaultRidSpecificArtifacts is true (dotnet/dotnet build), set the language server package
+       visibility to vertical so that only one leg (win-x64) publishes all the RID-specific tool packages. -->
+  <ItemGroup Condition="'$(EnableDefaultRidSpecificArtifacts)' == 'true'">
+    <Artifact Update="$(ArtifactsPackagesDir)**\roslyn-language-server.*.nupkg" Visibility="Vertical" />
+  </ItemGroup>
+
   <!--
     During PR Validation we only need to publish symbols with Arcade,
     since our packages are published separately to the CoreXT feed.


### PR DESCRIPTION
Manual cherry-pick as roslyn's CI has been failing since Thursday.

https://github.com/dotnet/roslyn/commit/baf2ab01565cd485838a62fe7b106d785f45c621 Fix to unblock the VMR build. For context, see
https://github.com/dotnet/dotnet/issues/4694