### PR TITLE
Fix Microsoft.DotNet.Installer.Tests due to property renaming

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -66,4 +66,5 @@
     <!-- external dependencies -->
     <NewtonsoftJsonVersion>13.0.4</NewtonsoftJsonVersion>
   </PropertyGroup>
+
 </Project>

--- a/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
+++ b/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
@@ -69,7 +69,7 @@
         <Value>$(MicrosoftNETCoreAppRefVersion)</Value>
       </RuntimeHostConfigurationOption>
       <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).TargetProductVersion">
-        <Value>$(MajorVersion).$(MinorVersion)</Value>
+        <Value>$(VersionMajor).$(VersionMinor)</Value>
       </RuntimeHostConfigurationOption>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
Regressed with https://github.com/dotnet/dotnet/pull/4567