### PR TITLE
Modify SbrpUsageReport to warn instead of fail on errors

### DIFF
--- a/eng/finish-source-only.proj
+++ b/eng/finish-source-only.proj
@@ -11,6 +11,9 @@
     <ProjectAssetsJsonArchiveFile>$(ArtifactsLogDir)all-project-assets-json-files.zip</ProjectAssetsJsonArchiveFile>
 
     <ResultingPrebuiltPackagesDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsLogDir)', 'prebuilt-packages'))</ResultingPrebuiltPackagesDir>
+
+    <!-- SBRP usage report is diagnostic-only and should not fail the build -->
+    <MSBuildWarningsNotAsErrors>$(MSBuildWarningsNotAsErrors);SBRP001</MSBuildWarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -153,7 +156,8 @@
       <ProjectAssetsJsonFile Include="$(SrcDir)**/artifacts/**/project.assets.json" />
     </ItemGroup>
 
-    <WriteSbrpUsageReport SbrpRepoSrcPath="$(SbrpRepoSrcDir)"
+    <WriteSbrpUsageReport ContinueOnError="WarnAndContinue"
+                          SbrpRepoSrcPath="$(SbrpRepoSrcDir)"
                           SbrpPackagesPath="$(ArtifactsShippingPackagesDir)/source-build-reference-packages"
                           ProjectAssetsJsons="@(ProjectAssetsJsonFile)"
                           OutputPath="$(ArtifactsLogDir)" />


### PR DESCRIPTION
Some [recent nuget changes](https://github.com/dotnet/dotnet/pull/4768) caused the SBRP usage report logic to fail.  This PR does two things:

- Modified the SbrpUsageReport to warn instead of fail on errors
- Capture any project.assets.json paths that may fail to parse in the diagnostic output.

