### PR TITLE
Remove AzureLinux reference from vmr-validate-signing.yml

### DIFF
--- a/eng/pipelines/templates/steps/vmr-validate-signing.yml
+++ b/eng/pipelines/templates/steps/vmr-validate-signing.yml
@@ -98,4 +98,3 @@ steps:
     artifactName: SignCheck_${{ parameters.OS }}
     artifactType: Container
     parallel: true
-


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/dotnet/pull/4773

Also fix incorrect casing of Shortstack artifact name that caused it to not be downloaded.