### PR TITLE
Disable signing validation of source artifact

### DIFF
--- a/eng/pipelines/templates/steps/vmr-validate-signing.yml
+++ b/eng/pipelines/templates/steps/vmr-validate-signing.yml
@@ -33,6 +33,10 @@ steps:
       xcrun simctl runtime delete all
     displayName: Reclaim disk space from unused simulator runtimes
 
+# Enable validation of the source artifact after the following issues have been addressed:
+# 1. https://github.com/dotnet/release/issues/1416
+# 2. https://github.com/dotnet/arcade/issues/16249
+# **SB_CentOSStream*_Offline_MsftSdk_x64_Artifacts/**/Release/source-build/dotnet-source-*
 - task: DownloadPipelineArtifact@2
   displayName: Download Vertical Build Artifacts
   continueOnError: ${{ parameters.continueOnError }}
@@ -43,7 +47,6 @@ steps:
       **Linux_*_Artifacts/**
       **OSX_*_Artifacts/**
       **Windows_*_Artifacts/**
-      **SB_CentOSStream*_Offline_MsftSdk_x64_Artifacts/**/Release/source-build/dotnet-source-*
       **SB_CentOSStream*_Offline_MsftSdk_x64_Artifacts/**/Release/source-build/dotnet-sdk-*.tar.gz
       **SB_CentOSStream*_Offline_MsftSdk_x64_Artifacts/**/Release/source-build/Private.SourceBuilt.Artifacts.*.tar.gz
     downloadPath: '${{ parameters.signCheckFilesDirectory }}'


### PR DESCRIPTION
The signing validation of the source artifact was enabled in https://github.com/dotnet/dotnet/pull/4789, probably because previous comment on the exclusion was out of date. I've removed the reference to the source artifact and added an updated comment.