### PR TITLE
Fix vmr-compare pipeline

### DIFF
--- a/eng/GatherDrops.ps1
+++ b/eng/GatherDrops.ps1
@@ -16,11 +16,11 @@ param(
 )
 $jsonContent = Get-Content -Path $filePath -Raw | ConvertFrom-Json
 foreach ($repo in $jsonContent.repositories) {
-    $remoteUri = $repo.remoteUri
-    $commitSha = $repo.commitSha
-    $path = "$outputPath$($repo.path)"
-    $darcCommand = "$darcPath gather-drop -c $commitSha -r $remoteUri --skip-existing --continue-on-error --use-azure-credential-for-blobs -o $path --github-pat $githubPat --azdev-pat $azdevPat --asset-filter $assetFilter --verbose --ci --include-released $(if ($nonShipping) { '--non-shipping' })"
-    Write-Output "Gathering drop for $remoteUri"
+    $barId = $repo.barId
+    $repoName = $repo.path
+    $path = "$outputPath$($repoName)"
+    $darcCommand = "$darcPath gather-drop --id $barId --skip-existing --continue-on-error --use-azure-credential-for-blobs --output-dir $path --github-pat $githubPat --azdev-pat $azdevPat --asset-filter $assetFilter --verbose --ci --include-released $(if ($nonShipping) { '--non-shipping' })"
+    Write-Output "Gathering drop for $repoName"
     Invoke-Expression $darcCommand
 }
 exit 0

--- a/eng/pipelines/templates/steps/vmr-compare.yml
+++ b/eng/pipelines/templates/steps/vmr-compare.yml
@@ -228,14 +228,7 @@ steps:
   name: SetAdditionalArgs
   displayName: Set additional command arguments
 
-- task: PowerShell@2
-  inputs:
-    filePath: $(Build.SourcesDirectory)/eng/common/build.ps1
-    arguments: -ci -projects $(Build.SourcesDirectory)/eng/tools/BuildComparer/BuildComparer.csproj -restore -build
-  displayName: Build BuildComparer
-
-- script: $(InstallDarc.dotnetPath)
-    $(Build.SourcesDirectory)/artifacts/bin/BuildComparer/Debug/BuildComparer.dll
+- script: $(InstallDarc.dotnetPath) run $(Build.SourcesDirectory)/eng/tools/BuildComparer/BuildComparer.csproj
     ${{ parameters.command }}
     -vmrAssetBasePath "$(Build.ArtifactStagingDirectory)/vmr-assets"
     -msftAssetBasePath "$(Build.ArtifactStagingDirectory)/base-assets"


### PR DESCRIPTION
Fixes https://github.com/dotnet/dotnet/issues/3572

Directly pass in the bar id to darc gather-drop instead of a commit for which multiple builds could exist. This wasn't done previously as the barId metadata didn't exist back then in the source-manifest.json.

Also simplify the vmr-compare.yml by using dotnet run.