### PR TITLE
Remove feeds from test/Microsoft.DotNet.SourceBuild.Tests/assets/default.NuGet.Config

### DIFF
--- a/test/Microsoft.DotNet.SourceBuild.Tests/assets/default.NuGet.Config
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/assets/default.NuGet.Config
@@ -2,11 +2,5 @@
   <packageSources>
     <clear />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
-    <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
-    <add key="dotnet9-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9-transport/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-aspnetcore-3cc83de" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-3cc83de3/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-runtime-d398172" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-d3981726/nuget/v3/index.json" />
-    <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
-    <add key="dotnet10-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10-transport/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
They don't seem to be needed.