### PR TITLE
Revert "Use N-1 SB version for source generators only (#4657)"

### DIFF
--- a/repo-projects/aspnetcore.proj
+++ b/repo-projects/aspnetcore.proj
@@ -56,7 +56,10 @@
     <RepositoryReference Include="efcore" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+  <!-- Temporarily use N-1 version for Roslyn across both official and non-official builds.
+       See https://github.com/dotnet/source-build/issues/5355 -->
+
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(OfficialBuild)' == 'true'">
     <!--
       From aspnetcore Versions.props:
           Versions of Microsoft.CodeAnalysis packages referenced by analyzers shipped in the SDK.
@@ -64,25 +67,25 @@
       In source-build these don't need to be pinned and can use the source-built versions since it doesn't
       need to support VS 2019.
     -->
-    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftCodeAnalysisVersion_LatestVS" Version="%24(MicrosoftCodeAnalysisCommonVersion)" />
+    <!-- <ExtraPackageVersionPropsPackageInfo Include="Analyzer_MicrosoftCodeAnalysisCSharpVersion" Version="%24(MicrosoftCodeAnalysisCSharpVersion)" />
+    <ExtraPackageVersionPropsPackageInfo Include="Analyzer_MicrosoftCodeAnalysisCSharpWorkspacesVersion" Version="%24(MicrosoftCodeAnalysisCSharpWorkspacesVersion)" />
+    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftCodeAnalysisVersion_LatestVS" Version="%24(MicrosoftCodeAnalysisCommonVersion)" /> -->
+  </ItemGroup>
 
-    <!-- Use the Roslyn version contained in the N-1 build because ASP.NET Core needs to build and execute a source generator which
-      must be built targeting a version of Roslyn contained in the executing SDK.
-      
-      In the case of non-official builds, because of how Arcade works for non-official builds, M.CA will get an assembly version of
-      42.42.42.42 and the source generator would target that version leading to an error like the following: 
+  <!-- For non-official builds, use the Roslyn version contained in the N-1 build because ASP.NET Core needs to build and execute
+      a source generator which must be built targeting a version of Roslyn contained in the executing SDK. Otherwise, because of how
+      Arcade works for non-official builds, M.CA will get an assembly version of 42.42.42.42 and the source generator would target that
+      version leading to an error like the following: 
         CSC error CS9057: Analyzer assembly '/repos/dotnet/src/aspnetcore/artifacts/bin/Microsoft.AspNetCore.Http.RequestDelegateGenerator/Release/netstandard2.0/Microsoft.AspNetCore.Http.RequestDelegateGenerator.dll'
         cannot be used because it references version '42.42.42.42' of the compiler, which is newer than the currently running version '5.0.0.0'.
-      
-      In the case of official build, there can be the scenario where M.CA has been upgraded in the live version so that it is higher
-      than the version contained in the executed SDK. This would lead to a similar error as above but with real version numbers.
-
       By not lifting the M.CA version to the current version and instead using the N-1 version, we guarantee that it will match the version
       containing in the executed SDK and avoiding this error.
-    -->
-    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftCodeAnalysisSourceGeneratorVersion" Version="%24(MicrosoftCodeAnalysisCSharpPreviousVersion)" />
+  -->
+  <!-- <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(OfficialBuild)' != 'true'"> -->
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <ExtraPackageVersionPropsPackageInfo Include="Analyzer_MicrosoftCodeAnalysisCSharpVersion" Version="%24(MicrosoftCodeAnalysisCSharpPreviousVersion)" />
     <ExtraPackageVersionPropsPackageInfo Include="Analyzer_MicrosoftCodeAnalysisCSharpWorkspacesVersion" Version="%24(MicrosoftCodeAnalysisCSharpWorkspacesPreviousVersion)" />
+    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftCodeAnalysisVersion_LatestVS" Version="%24(MicrosoftCodeAnalysisCommonPreviousVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/aspnetcore/eng/Versions.props
+++ b/src/aspnetcore/eng/Versions.props
@@ -112,6 +112,7 @@
     <!--
       Versions of Microsoft.CodeAnalysis packages referenced by analyzers shipped in the SDK.
       This need to be pinned since they're used in 3.1 apps and need to be loadable in VS 2019.
+      If you update these versions, make sure to also update https://github.com/dotnet/aspnetcore/blob/main/eng/SourceBuildPrebuiltBaseline.xml
     -->
     <Analyzer_MicrosoftCodeAnalysisCSharpVersion>3.3.1</Analyzer_MicrosoftCodeAnalysisCSharpVersion>
     <Analyzer_MicrosoftCodeAnalysisCSharpWorkspacesVersion>3.3.1</Analyzer_MicrosoftCodeAnalysisCSharpWorkspacesVersion>
@@ -122,9 +123,6 @@
     <MicrosoftCodeAnalysisCSharpAnalyzerTestingVersion>1.1.2</MicrosoftCodeAnalysisCSharpAnalyzerTestingVersion>
     <MicrosoftCodeAnalysisCSharpCodeFixTestingVersion>1.1.2</MicrosoftCodeAnalysisCSharpCodeFixTestingVersion>
     <MicrosoftCodeAnalysisCSharpSourceGeneratorsTestingVersion>1.1.2</MicrosoftCodeAnalysisCSharpSourceGeneratorsTestingVersion>
-    <!-- Specifies the version of Roslyn that should be referenced by source generators.
-         This gets overriden by source-build, separately from MicrosoftCodeAnalysisVersion_LatestVS. -->
-    <MicrosoftCodeAnalysisSourceGeneratorVersion>$(MicrosoftCodeAnalysisVersion_LatestVS)</MicrosoftCodeAnalysisSourceGeneratorVersion>
     <MicrosoftCssParserVersion>1.0.0-20230414.1</MicrosoftCssParserVersion>
     <MicrosoftIdentityModelLoggingVersion>$(IdentityModelVersion)</MicrosoftIdentityModelLoggingVersion>
     <MicrosoftIdentityModelProtocolsOpenIdConnectVersion>$(IdentityModelVersion)</MicrosoftIdentityModelProtocolsOpenIdConnectVersion>

--- a/src/aspnetcore/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/Microsoft.AspNetCore.Http.RequestDelegateGenerator.csproj
+++ b/src/aspnetcore/src/Http/Http.Extensions/gen/Microsoft.AspNetCore.Http.RequestDelegateGenerator/Microsoft.AspNetCore.Http.RequestDelegateGenerator.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="All" IsImplicitlyDefined="true" Version="$(MicrosoftCodeAnalysisSourceGeneratorVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" PrivateAssets="All" IsImplicitlyDefined="true" Version="$(MicrosoftCodeAnalysisSourceGeneratorVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="All" IsImplicitlyDefined="true" Version="$(MicrosoftCodeAnalysisVersion_LatestVS)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" PrivateAssets="All" IsImplicitlyDefined="true" Version="$(MicrosoftCodeAnalysisVersion_LatestVS)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/sdk/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
+++ b/src/sdk/src/BuiltInTools/dotnet-watch/dotnet-watch.csproj
@@ -12,17 +12,14 @@
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
 
     <!--
-      Disable CS9057. This is necessary because dotnet-watch distributes some ASP.NET Core analyzers. These analyzers get built
-      with a dependency on the live version of Microsoft.CodeAnalysis. There can be cases where the live version of
-      Microsoft.CodeAnalysis differs from the version contained in the SDK being used to build:
-        * In a dev/ci build, the assembly version associated with Microsoft.CodeAnalysis in that case is 42.42.42.4242, set by
-          Arcade in dev/ci builds.
-        * The Microsoft.CodeAnalysis has been upgraded in the live version such that it is a higher version than what is in the SDK.
-      In both cases, when building dotnet-watch with its analyzer dependencies, it will cause CS9057 because the analyzer assembly
-      version is not the same as the compiler assembly version being used by the sdk that the project is being built with. But this
-      is fine because the analyzer is just being used here to distribute it with the tool.
+      Disable CS9057 in source-only dev/ci builds. This is necessary because dotnet-watch distributes some ASP.NET Core
+      analyzers. These analyzers get built with a dependency on the live version of Microsoft.CodeAnalysis. In a dev/ci
+      build, the assembly version associated with Microsoft.CodeAnalysis in that case is 42.42.42.4242, set by Arcade in
+      dev/ci builds. So when building dotnet-watch with its analyzer dependencies, it will cause CS9057 because the 
+      analyzer assembly version is not the same as the compiler assembly version being used by the sdk that the project
+      is being built with. But this is fine because the analyzer is just being used here to distribute it with the tool.
     -->
-    <NoWarn Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(NoWarn);CS9057</NoWarn>
+    <NoWarn Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(OfficialBuild)' != 'true'">$(NoWarn);CS9057</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/sdk/src/WebSdk/Web/Tasks/Microsoft.NET.Sdk.Web.Tasks.csproj
+++ b/src/sdk/src/WebSdk/Web/Tasks/Microsoft.NET.Sdk.Web.Tasks.csproj
@@ -13,17 +13,15 @@
     <TargetFrameworks>$(SdkTargetFramework);net472</TargetFrameworks>
 
     <!--
-      Disable CS9057. This is necessary because Microsoft.NET.Sdk.Web.Tasks distributes some ASP.NET Core analyzers. These
-      analyzers get built with a dependency on the live version of Microsoft.CodeAnalysis. There can be cases where the live
-      version of Microsoft.CodeAnalysis differs from the version contained in the SDK being used to build:
-        * In a dev/ci build, the assembly version associated with Microsoft.CodeAnalysis in that case is 42.42.42.4242, set by
-          Arcade in dev/ci builds.
-        * The Microsoft.CodeAnalysis has been upgraded in the live version such that it is a higher version than what is in the SDK.
-      In both cases, when building Microsoft.NET.Sdk.Web.Tasks with its analyzer dependencies, it will cause CS9057 because the
-      analyzer assembly version is not the same as the compiler assembly version being used by the sdk that the project is being
-      built with. But this is fine because the analyzer is just being used here to distribute it with the tool.
+      Disable CS9057 in source-only dev/ci builds. This is necessary because the SDK distributes Microsoft.AspNetCore.Analyzers
+      with its Microsoft.NET.Sdk.Web.Tasks package. Microsoft.AspNetCore.Analyzers gets built with a dependency on the live
+      version of Microsoft.CodeAnalysis. In a dev/ci build, the assembly version associated with Microsoft.CodeAnalysis in 
+      that case is 42.42.42.4242, set by Arcade in dev/ci builds. So when building Microsoft.NET.Sdk.Web.Tasks with its
+      analyzer dependencies, it will cause CS9057 because the analyzer assembly version is not the same as the compiler
+      assembly version being used by the sdk that the project is being built with. But this is fine because the analyzer
+      is just being used here to distribute it with the Microsoft.NET.Sdk.Web.Tasks package.
     -->
-    <NoWarn Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(NoWarn);CS9057</NoWarn>
+    <NoWarn Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(OfficialBuild)' != 'true'">$(NoWarn);CS9057</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This reverts commit c7b9b2ea2f6cec6af4521ab2ddc0456933955e50.

The changes in #4657 broke the build for source-only mode:

```
CSC : error CS9057: Analyzer assembly '/__w/1/s/src/sdk/artifacts/.packages/microsoft.aspnetcore.app.ref/11.0.0-preview.2.26111.119/analyzers/dotnet/cs/Microsoft.AspNetCore.App.Analyzers.dll' cannot be used because it references version '5.5.0.0' of the compiler, which is newer than the currently running version '5.4.0.0'. [/__w/1/s/src/sdk/src/BuiltInTools/Watch/Microsoft.DotNet.HotReload.Watch.csproj]
CSC : error CS9057: Analyzer assembly '/__w/1/s/src/sdk/artifacts/.packages/microsoft.aspnetcore.app.ref/11.0.0-preview.2.26111.119/analyzers/dotnet/cs/Microsoft.AspNetCore.App.SourceGenerators.dll' cannot be used because it references version '5.5.0.0' of the compiler, which is newer than the currently running version '5.4.0.0'. [/__w/1/s/src/sdk/src/BuiltInTools/Watch/Microsoft.DotNet.HotReload.Watch.csproj]
CSC : error CS9057: Analyzer assembly '/__w/1/s/src/sdk/artifacts/.packages/microsoft.aspnetcore.app.ref/11.0.0-preview.2.26111.119/analyzers/dotnet/cs/Microsoft.Extensions.Validation.ValidationsGenerator.dll' cannot be used because it references version '5.5.0.0' of the compiler, which is newer than the currently running version '5.4.0.0'. [/__w/1/s/src/sdk/src/BuiltInTools/Watch/Microsoft.DotNet.HotReload.Watch.csproj]
```

Fixes https://github.com/dotnet/source-build/issues/5482