### PR TITLE
Avoid scanning inner-repos in "Prepare BuildLogs staging directory" step

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -875,7 +875,7 @@ jobs:
       Contents: |
         log/**
         TestResults/**
-      TargetFolder: '$(Build.ArtifactStagingDirectory)/BuildLogs'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)/BuildLogs/artifacts'
       CleanTargetFolder: true
     continueOnError: true
     condition: succeededOrFailed()


### PR DESCRIPTION
The CopyFiles AzDO task scans the entire SourceFolder even when passing Contents filter in. Set the SourceFolder to vmr/artifacts to only scan the artifacts folder to avoid issues like the following:

> ##[error]Error: Failed find: ENOENT: no such file or directory, lstat '/Users/runner/work/1/s/src/arcade/artifacts/.packages/microsoft.dotnet.build.tasks.feed/11.0.0-beta.26078.121/tools/net/runtimes'