### PR TITLE
Pipeline fixes for internal package feeds

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -503,20 +503,23 @@ jobs:
       inputs:
         targetType: 'inline'
         script: |
-          $sourcesPath = "$(sourcesPath)"
-          $token = $env:Token
-          
-          Get-ChildItem -Path "$sourcesPath/src" -Directory | ForEach-Object {
-            $repoDir = $_.FullName
+          function Setup-NuGetFeeds($repoDir, $description) {
             $setupScript = Join-Path $repoDir "eng/common/SetupNugetSources.ps1"
-            
             # Search for nuget.config using "Filter" to allow for case-insensitive matching.
             $nugetConfigFile = Get-ChildItem -Path $repoDir -Filter "nuget.config" -File | Select-Object -First 1
             $nugetConfig = if ($nugetConfigFile) { $nugetConfigFile.FullName } else { Join-Path $repoDir "NuGet.config" }
             
-            Write-Host "Setting up internal NuGet feeds for $($_.Name)"
-            & $setupScript $nugetConfig $token
+            Write-Host "Setting up internal NuGet feeds for $description"
+            & $setupScript $nugetConfig $env:Token
             Write-Host ""
+          }
+          
+          # Setup internal feeds for root NuGet.config
+          Setup-NuGetFeeds "$(sourcesPath)" "root NuGet.config"
+          
+          # Setup internal feeds for each global tool project that has a NuGet.config in the repo.
+          Get-ChildItem -Path "$(sourcesPath)/src" -Directory | ForEach-Object {
+            Setup-NuGetFeeds $_.FullName $_.Name
           }
       env:
         Token: $(dn-bot-dnceng-artifact-feeds-rw)


### PR DESCRIPTION
This fixes a couple issues in the VMR build template that popped up when consuming internal feeds from the 10.0.2xx branch (see [dependency flow PR](https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet/pullrequest/57801), internal link).

## WASM issue in source-only tests

### Problem

The stage 2 source-build job (`SB_CentOSStream10_Offline_CurrentSourceBuiltSdk_x64`) fails with:

`error NU1102: Unable to find package Microsoft.NET.Runtime.WebAssembly.Sdk with version (= 10.0.4)`

The `wasm-dependencies.proj` restore is supposed to use `online.NuGet.Config` (which contains internal feed credentials), but the `--configfile` argument is never passed because the `SYSTEM_TEAMPROJECT` environment variable is missing.

### Root Cause

When `runOnline` is `False`, the test step runs under sudo without the `-E` flag, which strips environment variables including `SYSTEM_TEAMPROJECT`. This causes the MSBuild condition `'$(SYSTEM_TEAMPROJECT)' == 'internal'` in `tests.proj` to evaluate to false, so `_WasmRestoreConfigFileArg` is empty and the restore falls back to a default `NuGet.config` that lacks the internal feeds.

The build step already uses `sudo -E` (preserving the environment), but the test step did not.

### Fix

Add `-E` to the `sudo` call in the test run step, consistent with the build step.

## Missing internal feeds in root NuGet.config

### Problem

The `Ubuntu2404_Ubuntu_BuildTests_x64` job fails with:

`BuildComparer depends on Microsoft.DotNet.Build.Manifest (>= 10.0.0-beta.26110.123) but Microsoft.DotNet.Build.Manifest 10.0.0-beta.26110.123 was not found. Microsoft.DotNet.Build.Manifest 10.0.0-beta.26110.124 was resolved instead.`

### Root Cause

The `Microsoft.DotNet.Build.Manifest 10.0.0-beta.26110.123` package only exists in the `eng-internal` feed. The `BuildComparer` tool is a project in the VMR infrastructure which uses the NuGet.config at the VMR root for restoring packages. This package is unmodified by the `Setup Internal Feeds` step since that step only processes the product sub-repos.

### Fix

Include the root NuGet.config in the `Setup Internal Feeds` step so that it gets modified to include internal feeds.