### PR TITLE
Clean-up tests.proj and improve test times

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,8 +3,6 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" Condition="'$(SkipArcadeSdkImport)' != 'true'" />
   <Import Project="$(RepositoryEngineeringDir)shared-source-only.targets" Condition="'$(SkipSharedSourceOnlyImport)' != 'true'" />
 
-  <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.GetKnownArtifactsFromAssetManifests" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
-
   <!-- The SkipPrepareSdkArchive switch exists so that outside components like the license scan test pipeline
        can run a subset of tests that don't need the SDK archive without building the VMR.
        The switch is also useful for the local dev innerloop to build the test projects without needing to run them. -->

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -898,7 +898,8 @@
     CleanupRepo" />
 
   <Target Name="RepoTest"
-          DependsOnTargets="DiscoverBuiltSdkOverrides;
+          DependsOnTargets="ResolveProjectReferences;
+                            DiscoverBuiltSdkOverrides;
                             SetSourceBuiltSdkOverrides">
     <PropertyGroup>
       <TestCommand>$(BuildScript) $(TestActions) $(CommonArgs) $(TestArgs)</TestCommand>

--- a/repo-projects/scenario-tests.proj
+++ b/repo-projects/scenario-tests.proj
@@ -23,7 +23,7 @@
   <PropertyGroup Condition="'$(SkipScenarioTestsDependencies)' == 'true'">
     <UseBootstrapArcade>true</UseBootstrapArcade>
     <DisableTransitiveProjectReferences>true</DisableTransitiveProjectReferences>
-    <_GlobalPropertiesToRemoveFromProjectReferences>$(_GlobalPropertiesToRemoveFromProjectReferences);SkipScenarioTestsDependencies</_GlobalPropertiesToRemoveFromProjectReferences>
+    <_GlobalPropertiesToRemoveFromProjectReferences>$(_GlobalPropertiesToRemoveFromProjectReferences);SkipScenarioTestsDependencies;SkipExtractSdkArchive</_GlobalPropertiesToRemoveFromProjectReferences>
   </PropertyGroup>
 
   <!-- Use PrivateAssets="all" to not flow repo dependencies to consuming projects (for installer tests). -->
@@ -34,8 +34,16 @@
     <RepositoryReference Include="sdk" PrivateAssets="all" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference
+      Include="$(RepositoryEngineeringDir)extract-sdk-archive.proj"
+      ReferenceOutputAssembly="false"
+      SkipGetTargetFrameworkProperties="true"
+      Condition="'$(SkipExtractSdkArchive)' != 'true'" />
+  </ItemGroup>
+
   <Target Name="PrepareScenarioTestsInputs"
-          DependsOnTargets="DetermineSourceBuiltSdkVersion;DetermineSourceBuiltRuntimeVersion"
+          DependsOnTargets="ResolveProjectReferences;DetermineSourceBuiltSdkVersion;DetermineSourceBuiltRuntimeVersion"
           BeforeTargets="RepoTest">
     <PropertyGroup>
       <TestArgs>$(TestArgs) /p:TestSdkVersion=$(SourceBuiltSdkVersion)</TestArgs>

--- a/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
+++ b/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
-    <ProjectReference Include="$(RepoProjectsDir)scenario-tests.proj" AdditionalProperties="SkipScenarioTestsDependencies=true" />
+    <ProjectReference Include="$(RepoProjectsDir)scenario-tests.proj" AdditionalProperties="SkipScenarioTestsDependencies=true;SkipExtractSdkArchive=true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/tests.proj
+++ b/test/tests.proj
@@ -1,65 +1,52 @@
 <Project Sdk="Microsoft.Build.Traversal">
 
   <PropertyGroup>
-    <_RunScenarioTests>true</_RunScenarioTests>
+    <RunScenarioTests>true</RunScenarioTests>
 
     <!-- Skip scenario tests if the host architecture is different from the target architecture since the tests
         require the ability to execute the built SDK. But the CLI is not capable of running on a host with a
         different architecture (i.e. "cannot execute binary file: Exec format error"). -->
-    <_RunScenarioTests Condition="'$(BuildArchitecture.ToLowerInvariant())' != '$(TargetArchitecture.ToLowerInvariant())'">false</_RunScenarioTests>
+    <RunScenarioTests Condition="'$(BuildArchitecture.ToLowerInvariant())' != '$(TargetArchitecture.ToLowerInvariant())'">false</RunScenarioTests>
 
     <!-- Skip scenario tests if the build OS (determined from the host machine) is different from the target OS
         since the tests require the ability to execute the built SDK. An example of where this would be disabled is
         cross-build of using Azure Linux to build for Alpine (linux vs linux-musl). -->
-    <_RunScenarioTests Condition="'$(BuildOS)' != 'windows' and '$(DotNetBuildSourceOnly)' != 'true' and '$(BuildOS.ToLowerInvariant())' != '$(TargetOS.ToLowerInvariant())'">false</_RunScenarioTests>
+    <RunScenarioTests Condition="'$(BuildOS)' != 'windows' and '$(DotNetBuildSourceOnly)' != 'true' and '$(BuildOS.ToLowerInvariant())' != '$(TargetOS.ToLowerInvariant())'">false</RunScenarioTests>
 
     <!-- Short stack builds can't run scenario-tests as no SDK gets produced. -->
-    <_RunScenarioTests Condition="'$(ShortStack)' == 'true' or '$(PgoInstrument)' == 'true'">false</_RunScenarioTests>
+    <RunScenarioTests Condition="'$(ShortStack)' == 'true' or '$(PgoInstrument)' == 'true'">false</RunScenarioTests>
 
     <!-- Skip BuildPass>1 verticals as the live built SDK already got validated in the BuildPass=1 vertical. -->
-    <_RunScenarioTests Condition="'$(DotNetBuildPass)' != '' and '$(DotNetBuildPass)' != '1'">false</_RunScenarioTests>
+    <RunScenarioTests Condition="'$(DotNetBuildPass)' != '' and '$(DotNetBuildPass)' != '1'">false</RunScenarioTests>
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Shared tests - applicable to unified-build and source-build. -->
+    <ProjectReference Include="$(RepoProjectsDir)scenario-tests.proj" Condition="'$(RunScenarioTests)' == 'true'" />
     <ProjectReference Include="Microsoft.DotNet.Tests\Microsoft.DotNet.Tests.csproj" />
+
     <!-- Source-build specific tests. -->
     <ProjectReference Include="Microsoft.DotNet.SourceBuild.Tests\Microsoft.DotNet.SourceBuild.Tests.csproj"
                       Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
   </ItemGroup>
 
-  <!-- Make sure that the sdk archive is extracted before running the scenario-tests. Need to do this here as it's hard
-       to define the dependency directly in scenario-tests.proj. -->
-  <ItemGroup>
-    <ProjectReference Include="$(RepositoryEngineeringDir)extract-sdk-archive.proj" BuildInParallel="false" Condition="'$(_RunScenarioTests)' == 'true' and '$(SkipPrepareSdkArchive)' != 'true'" />
-    <ProjectReference Include="$(RepoProjectsDir)scenario-tests.proj" Condition="'$(_RunScenarioTests)' == 'true'" BuildInParallel="false" />
-  </ItemGroup>
-
-  <PropertyGroup>
-    <_DownloadWasmPackages Condition="'$(DotNetBuildSharedComponents)' != 'true' and '$(DotNetBuildSourceOnly)' == 'true'">true</_DownloadWasmPackages>
-  </PropertyGroup>
-
   <!-- Download WASM packages for non-1xx source-only builds -->
-  <Target Name="DownloadWasmPackages" BeforeTargets="Test" Condition="'$(_DownloadWasmPackages)' == 'true'">
-
+  <Target Name="DownloadWasmPackages" BeforeTargets="Test" Condition="'$(DotNetBuildSharedComponents)' != 'true' and '$(DotNetBuildSourceOnly)' == 'true'">
     <PropertyGroup>
-      <_TmpPackagesRoot>$(ArtifactsTmpDir)wasm-dependencies/</_TmpPackagesRoot>
-      <_WasmRestoreConfigFileArg Condition="'$(SYSTEM_TEAMPROJECT)' == 'internal'">--configfile &quot;$(MSBuildThisFileDirectory)Microsoft.DotNet.SourceBuild.Tests/assets/online.NuGet.Config&quot;</_WasmRestoreConfigFileArg>
+      <TmpPackagesRoot>$(ArtifactsTmpDir)wasm-dependencies/</TmpPackagesRoot>
+      <WasmRestoreConfigFileArg Condition="'$(SYSTEM_TEAMPROJECT)' == 'internal'">--configfile &quot;$(MSBuildThisFileDirectory)Microsoft.DotNet.SourceBuild.Tests/assets/online.NuGet.Config&quot;</WasmRestoreConfigFileArg>
     </PropertyGroup>
     
-    <Exec
-        Command="&quot;$(DOTNET_HOST_PATH)&quot; restore &quot;$(MSBuildThisFileDirectory)wasm-dependencies.proj&quot; $(_WasmRestoreConfigFileArg) -bl:$(ArtifactsLogDir)/wasm-test-dependencies.binlog"
-        EnvironmentVariables="NUGET_PACKAGES=$(_TmpPackagesRoot)"
-    />
+    <Exec Command="&quot;$(DOTNET_HOST_PATH)&quot; restore &quot;$(MSBuildThisFileDirectory)wasm-dependencies.proj&quot; $(WasmRestoreConfigFileArg) -bl:$(ArtifactsLogDir)/wasm-test-dependencies.binlog"
+          EnvironmentVariables="NUGET_PACKAGES=$(TmpPackagesRoot)" />
     
     <!-- Copy the nupkg files to the extra custom restore path for the tests -->
     <ItemGroup>
-      <_DownloadedNupkgs Include="$(_TmpPackagesRoot)**/*.nupkg" />
+      <DownloadedNupkg Include="$(TmpPackagesRoot)**/*.nupkg" />
     </ItemGroup>
     
-    <Copy SourceFiles="@(_DownloadedNupkgs)"
+    <Copy SourceFiles="@(DownloadedNupkg)"
           DestinationFolder="$(ExtraTestDependenciesRestoreSourcePath)" 
-          Condition="@(_DownloadedNupkgs->Count()) > 0" />
+          Condition="@(DownloadedNupkg->Count()) > 0" />
   </Target>
 
 </Project>


### PR DESCRIPTION
- Now that repo-projects use the P2P protocol, define a P2P from scenario-tests.proj to extract-sdk-archive.proj. Add a condition as installer.tests.csproj is special and doesn't want that.
- Remove the serial step in tests.proj which results in all test projects building and testing truely in parallel now.
- Remove one unnecessary UsingTask in D.B.targets.