### PR TITLE
Build Microsoft.DotNet.HotReload.WebAssembly.Browser.csproj in source…

### DIFF
--- a/src/sdk/source-build.slnf
+++ b/src/sdk/source-build.slnf
@@ -8,6 +8,7 @@
       "src\\BuiltInTools\\DotNetDeltaApplier\\Microsoft.Extensions.DotNetDeltaApplier.csproj",
       "src\\BuiltInTools\\DotNetWatchTasks\\DotNetWatchTasks.csproj",
       "src\\BuiltInTools\\dotnet-watch\\dotnet-watch.csproj",
+      "src\\BuiltInTools\\HotReloadAgent.WebAssembly.Browser\\Microsoft.DotNet.HotReload.WebAssembly.Browser.csproj",
       "src\\Cli\\Microsoft.DotNet.Cli.Utils\\Microsoft.DotNet.Cli.Utils.csproj",
       "src\\Cli\\Microsoft.DotNet.Configurer\\Microsoft.DotNet.Configurer.csproj",
       "src\\Cli\\Microsoft.DotNet.InternalAbstractions\\Microsoft.DotNet.InternalAbstractions.csproj",


### PR DESCRIPTION
…-build

Resolves https://github.com/dotnet/source-build/issues/5488

```
$ tar -xvf artifacts/assets/Release/dotnet-sdk-11.0.100-preview.2.26112.113-centos.10-x64.tar.gz -C temp/
$ tree temp/sdk/11.0.100-preview.2.26112.113/Sdks/Microsoft.NET.Sdk.WebAssembly/
temp/sdk/11.0.100-preview.2.26112.113/Sdks/Microsoft.NET.Sdk.WebAssembly/
├── Sdk
│   ├── Sdk.props
│   └── Sdk.targets
├── hotreload
│   └── net10.0
│       ├── Microsoft.DotNet.HotReload.WebAssembly.Browser.dll
│       └── wwwroot
│           └── Microsoft.DotNet.HotReload.WebAssembly.Browser.lib.module.js
└── tools
    └── net11.0
        ├── Microsoft.NET.Sdk.WebAssembly.Tasks.dll
        └── wwwroot
            └── Microsoft.DotNet.HotReload.WebAssembly.Browser.lib.module.js
```