### PR TITLE
Reapply "Deduplicate files using links in mac and linux installers" (#4800)

### DIFF
--- a/src/sdk/src/Layout/pkg/dotnet-sdk.proj
+++ b/src/sdk/src/Layout/pkg/dotnet-sdk.proj
@@ -69,12 +69,9 @@
 
     <!-- Create layout: Binaries -->
     <Error Condition="'@(CLISdkFiles)' == ''" Text="The 'CLISdkFiles' items are empty. This shouldn't happen!" />
-    <Copy
-      DestinationFiles="@(CLISdkFiles->'$(OutputPath)/sdk/%(RecursiveDir)%(Filename)%(Extension)')"
+    <CopyPreservingRelativeSymlinks
       SourceFiles="@(CLISdkFiles)"
-      OverwriteReadOnlyFiles="True"
-      SkipUnchangedFiles="False"
-      UseHardlinksIfPossible="False" />
+      DestinationFiles="@(CLISdkFiles->'$(OutputPath)/sdk/%(RecursiveDir)%(Filename)%(Extension)')" />
 
     <!-- Create layout: Templates -->
     <Error Condition="'@(TemplatesFiles)' == ''" Text="The 'TemplatesFiles' items are empty. This shouldn't happen!" />

--- a/src/sdk/src/Layout/redist/targets/GenerateInstallerLayout.targets
+++ b/src/sdk/src/Layout/redist/targets/GenerateInstallerLayout.targets
@@ -112,14 +112,12 @@
       <SdkOutputFile Include="$(InstallerOutputDirectory)**\*" />
     </ItemGroup>
 
-    <Copy SourceFiles="@(SdkOutputFile)"
-          DestinationFiles="@(SdkOutputFile -> '$(IntermediateSdkInstallerOutputPath)sdk\$(Version)\%(RecursiveDir)%(Filename)%(Extension)')"
-          UseHardLinksIfPossible="true"
-          SkipUnchangedFiles="true" />
+    <CopyPreservingRelativeSymlinks
+          SourceFiles="@(SdkOutputFile)"
+          DestinationFiles="@(SdkOutputFile -> '$(IntermediateSdkInstallerOutputPath)sdk\$(Version)\%(RecursiveDir)%(Filename)%(Extension)')" />
 
     <!-- Copy dnx script to root dotnet folder (which will map to DOTNETHOME) -->
     <Copy SourceFiles="@(DnxShimSource)" DestinationFolder="$(IntermediateSdkInstallerOutputPath)" />
-
   </Target>
 
 </Project>

--- a/src/sdk/src/Tasks/sdk-tasks/CopyPreservingRelativeSymlinks.cs
+++ b/src/sdk/src/Tasks/sdk-tasks/CopyPreservingRelativeSymlinks.cs
@@ -1,0 +1,129 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if !NETFRAMEWORK
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.DotNet.Build.Tasks;
+
+/// <summary>
+/// Copies files while preserving relative symbolic links. Unlike the standard MSBuild Copy task,
+/// this task recreates symbolic links at the destination with their original relative targets
+/// instead of resolving and copying the target file contents.
+/// </summary>
+public sealed class CopyPreservingRelativeSymlinks : Task
+{
+    /// <summary>
+    /// The source files to copy.
+    /// </summary>
+    [Required]
+    public ITaskItem[] SourceFiles { get; set; } = [];
+
+    /// <summary>
+    /// The destination files (must match SourceFiles count).
+    /// </summary>
+    [Required]
+    public ITaskItem[] DestinationFiles { get; set; } = [];
+
+    /// <summary>
+    /// The files that were successfully copied.
+    /// </summary>
+    [Output]
+    public ITaskItem[] CopiedFiles { get; private set; } = [];
+
+    public override bool Execute()
+    {
+        if (SourceFiles.Length == 0)
+        {
+            return true;
+        }
+
+        if (SourceFiles.Length != DestinationFiles.Length)
+        {
+            Log.LogError($"SourceFiles count ({SourceFiles.Length}) must match DestinationFiles count ({DestinationFiles.Length}).");
+            return false;
+        }
+
+        // Build a set of normalized source paths for symlink target validation
+        var sourcePathSet = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var item in SourceFiles)
+        {
+            sourcePathSet.Add(Path.GetFullPath(item.ItemSpec));
+        }
+
+        var copiedFiles = new List<ITaskItem>();
+        bool hasErrors = false;
+
+        for (int i = 0; i < SourceFiles.Length; i++)
+        {
+            var sourcePath = SourceFiles[i].ItemSpec;
+            var destPath = DestinationFiles[i].ItemSpec;
+
+            try
+            {
+                CopyFile(sourcePath, destPath, sourcePathSet);
+                copiedFiles.Add(new TaskItem(destPath));
+            }
+            catch (Exception ex)
+            {
+                Log.LogError($"Failed to copy '{sourcePath}' to '{destPath}': {ex.Message}");
+                hasErrors = true;
+            }
+        }
+
+        CopiedFiles = copiedFiles.ToArray();
+        Log.LogMessage(MessageImportance.Normal, $"Copied {copiedFiles.Count} files.");
+
+        return !hasErrors;
+    }
+
+    private void CopyFile(string sourcePath, string destPath, HashSet<string> sourcePathSet)
+    {
+        var sourceInfo = new FileInfo(sourcePath);
+
+        if (!sourceInfo.Exists)
+        {
+            throw new FileNotFoundException($"Source file does not exist: '{sourcePath}'");
+        }
+
+        // Create destination directory if needed
+        var destDir = Path.GetDirectoryName(destPath);
+        if (!string.IsNullOrEmpty(destDir) && !Directory.Exists(destDir))
+        {
+            Directory.CreateDirectory(destDir);
+        }
+
+        // Remove existing file/link at destination
+        if (File.Exists(destPath))
+        {
+            File.Delete(destPath);
+        }
+
+        // Check if source is a symbolic link
+        if (sourceInfo.LinkTarget != null)
+        {
+            // Validate that the symlink target resolves to a file within the copy scope
+            var sourceDir = Path.GetDirectoryName(Path.GetFullPath(sourcePath))!;
+            var resolvedTarget = Path.GetFullPath(Path.Combine(sourceDir, sourceInfo.LinkTarget));
+
+            if (!sourcePathSet.Contains(resolvedTarget))
+            {
+                throw new InvalidOperationException(
+                    $"Symbolic link target '{sourceInfo.LinkTarget}' resolves to '{resolvedTarget}' which is outside the copy scope.");
+            }
+
+            // Recreate the symbolic link with the same relative target
+            File.CreateSymbolicLink(destPath, sourceInfo.LinkTarget);
+            Log.LogMessage(MessageImportance.Low, $"Created symlink: '{destPath}' -> '{sourceInfo.LinkTarget}'");
+        }
+        else
+        {
+            File.Copy(sourcePath, destPath);
+            Log.LogMessage(MessageImportance.Low, $"Copied: '{sourcePath}' -> '{destPath}'");
+        }
+    }
+}
+#endif

--- a/src/sdk/src/Tasks/sdk-tasks/sdk-tasks.InTree.targets
+++ b/src/sdk/src/Tasks/sdk-tasks/sdk-tasks.InTree.targets
@@ -33,6 +33,11 @@
   <UsingTask TaskName="UpdateRuntimeConfig" AssemblyFile="$(SdkTasksAssembly)" TaskFactory="TaskHostFactory" Runtime="NET" />
   <UsingTask TaskName="ZipFileCreateFromDirectory" AssemblyFile="$(SdkTasksAssembly)" TaskFactory="TaskHostFactory" Runtime="NET" />
 
+  <UsingTask TaskName="CopyPreservingRelativeSymlinks"
+             Condition="'$(MSBuildRuntimeType)' == 'Core'"
+             AssemblyFile="$(SdkTasksAssembly)"
+             TaskFactory="TaskHostFactory" />
+
   <UsingTask TaskName="DeduplicateAssembliesWithLinks"
              Condition="'$(MSBuildRuntimeType)' == 'Core'"
              AssemblyFile="$(SdkTasksAssembly)"

--- a/src/sdk/test/EndToEnd.Tests/GivenDotNetLinuxInstallers.cs
+++ b/src/sdk/test/EndToEnd.Tests/GivenDotNetLinuxInstallers.cs
@@ -1,74 +1,125 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace EndToEnd.Tests
-{
-    public class GivenDotNetLinuxInstallers(ITestOutputHelper log) : SdkTest(log)
-    {
-        [Fact]
-        public void ItHasExpectedDependencies()
-        {
-            var installerFile = Environment.GetEnvironmentVariable("SDK_INSTALLER_FILE");
-            if (string.IsNullOrEmpty(installerFile))
-            {
-                return;
-            }
+using System.Runtime.InteropServices;
+using EndToEnd.Tests.Utilities;
 
-            var ext = Path.GetExtension(installerFile);
-            switch (ext)
-            {
-                case ".deb":
-                    DebianPackageHasDependencyOnAspNetCoreStoreAndDotnetRuntime(installerFile);
-                    return;
-                case ".rpm":
-                    RpmPackageHasDependencyOnAspNetCoreStoreAndDotnetRuntime(installerFile);
-                    return;
-            }
+namespace EndToEnd.Tests;
+
+public class GivenDotNetLinuxInstallers(ITestOutputHelper log) : SdkTest(log)
+{
+    private static readonly string[] ExcludedDebSuffixes = ["-newkey"];
+    private static readonly string[] ExcludedRpmSuffixes = ["-newkey", "-azl"];
+
+    [Fact]
+    public void ItHasExpectedDependencies()
+    {
+        var installerFile = Environment.GetEnvironmentVariable("SDK_INSTALLER_FILE");
+        if (string.IsNullOrEmpty(installerFile))
+        {
+            return;
         }
 
-        private void DebianPackageHasDependencyOnAspNetCoreStoreAndDotnetRuntime(string installerFile) =>
-            // Example output:
-
-            // $ dpkg --info dotnet-sdk-2.1.105-ubuntu-x64.deb
-
-            // new debian package, version 2.0.
-            // size 75660448 bytes: control archive=29107 bytes.
-            //     717 bytes,    11 lines      control
-            // 123707 bytes,  1004 lines      md5sums
-            //     1710 bytes,    28 lines   *  postinst             #!/usr/bin/env
-            // Package: dotnet-sdk-2.1.104
-            // Version: 2.1.104-1
-            // Architecture: amd64
-            // Maintainer: Microsoft <dotnetcore@microsoft.com>
-            // Installed-Size: 201119
-            // Depends: dotnet-runtime-2.0.6, aspnetcore-store-2.0.6
-            // Section: devel
-            // Priority: standard
-            // Homepage: https://dotnet.github.io/core
-            // Description: Microsoft .NET Core SDK - 2.1.104
-
-            new RunExeCommand(Log, "dpkg")
-                .Execute("--info", installerFile)
-                .Should().Pass()
-                    .And.HaveStdOutMatching(@"Depends:.*\s?dotnet-runtime-\d+(\.\d+){2}")
-                    .And.HaveStdOutMatching(@"Depends:.*\s?aspnetcore-store-\d+(\.\d+){2}");
-
-        private void RpmPackageHasDependencyOnAspNetCoreStoreAndDotnetRuntime(string installerFile) =>
-            // Example output:
-
-            // $ rpm -qpR dotnet-sdk-2.1.105-rhel-x64.rpm
-
-            // dotnet-runtime-2.0.7 >= 2.0.7
-            // aspnetcore-store-2.0.7 >= 2.0.7
-            // /bin/sh
-            // /bin/sh
-            // rpmlib(PayloadFilesHavePrefix) <= 4.0-1
-            // rpmlib(CompressedFileNames) <= 3.0.4-1
-
-            new RunExeCommand(Log, "rpm")
-                .Execute("-qpR", installerFile)
-                .Should().Pass()
-                    .And.HaveStdOutMatching(@"dotnet-runtime-\d+(\.\d+){2} >= \d+(\.\d+){2}")
-                    .And.HaveStdOutMatching(@"aspnetcore-store-\d+(\.\d+){2} >= \d+(\.\d+){2}");
+        var ext = Path.GetExtension(installerFile);
+        switch (ext)
+        {
+            case ".deb":
+                DebianPackageHasDependencyOnAspNetCoreStoreAndDotnetRuntime(installerFile);
+                return;
+            case ".rpm":
+                RpmPackageHasDependencyOnAspNetCoreStoreAndDotnetRuntime(installerFile);
+                return;
+        }
     }
+
+    private void DebianPackageHasDependencyOnAspNetCoreStoreAndDotnetRuntime(string installerFile) =>
+        // Example output:
+
+        // $ dpkg --info dotnet-sdk-2.1.105-ubuntu-x64.deb
+
+        // new debian package, version 2.0.
+        // size 75660448 bytes: control archive=29107 bytes.
+        //     717 bytes,    11 lines      control
+        // 123707 bytes,  1004 lines      md5sums
+        //     1710 bytes,    28 lines   *  postinst             #!/usr/bin/env
+        // Package: dotnet-sdk-2.1.104
+        // Version: 2.1.104-1
+        // Architecture: amd64
+        // Maintainer: Microsoft <dotnetcore@microsoft.com>
+        // Installed-Size: 201119
+        // Depends: dotnet-runtime-2.0.6, aspnetcore-store-2.0.6
+        // Section: devel
+        // Priority: standard
+        // Homepage: https://dotnet.github.io/core
+        // Description: Microsoft .NET Core SDK - 2.1.104
+
+        new RunExeCommand(Log, "dpkg")
+            .Execute("--info", installerFile)
+            .Should().Pass()
+                .And.HaveStdOutMatching(@"Depends:.*\s?dotnet-runtime-\d+(\.\d+){2}")
+                .And.HaveStdOutMatching(@"Depends:.*\s?aspnetcore-store-\d+(\.\d+){2}");
+
+    private void RpmPackageHasDependencyOnAspNetCoreStoreAndDotnetRuntime(string installerFile) =>
+        // Example output:
+
+        // $ rpm -qpR dotnet-sdk-2.1.105-rhel-x64.rpm
+
+        // dotnet-runtime-2.0.7 >= 2.0.7
+        // aspnetcore-store-2.0.7 >= 2.0.7
+        // /bin/sh
+        // /bin/sh
+        // rpmlib(PayloadFilesHavePrefix) <= 4.0-1
+        // rpmlib(CompressedFileNames) <= 3.0.4-1
+
+        new RunExeCommand(Log, "rpm")
+            .Execute("-qpR", installerFile)
+            .Should().Pass()
+                .And.HaveStdOutMatching(@"dotnet-runtime-\d+(\.\d+){2} >= \d+(\.\d+){2}")
+                .And.HaveStdOutMatching(@"aspnetcore-store-\d+(\.\d+){2} >= \d+(\.\d+){2}");
+
+    [Fact]
+    public void DebPackagePreservesSymbolicLinks() =>
+        SymbolicLinkHelpers.VerifyInstallerSymlinks(
+            OSPlatform.Linux,
+            "dotnet-sdk-*.deb",
+            ExcludedDebSuffixes,
+            ExtractDebPackage,
+            TestAssetsManager,
+            Log);
+
+    private void ExtractDebPackage(string installerPath, string tempDir)
+    {
+        // Extract the deb package (ar archive containing data.tar.gz)
+        var dataDir = Path.Combine(tempDir, "data");
+        Directory.CreateDirectory(dataDir);
+
+        new RunExeCommand(Log, "ar")
+            .WithWorkingDirectory(tempDir)
+            .Execute("x", installerPath)
+            .Should().Pass();
+
+        // Find and extract data.tar (could be .gz, .xz, or .zst)
+        var dataTar = Directory.GetFiles(tempDir, "data.tar*").FirstOrDefault();
+        if (dataTar != null)
+        {
+            SymbolicLinkHelpers.ExtractTar(dataTar, dataDir, Log);
+        }
+    }
+
+    [Fact]
+    public void RpmPackagePreservesSymbolicLinks() =>
+        SymbolicLinkHelpers.VerifyInstallerSymlinks(
+            OSPlatform.Linux,
+            "dotnet-sdk-*.rpm",
+            ExcludedRpmSuffixes,
+            ExtractRpmPackage,
+            TestAssetsManager,
+            Log);
+
+    private void ExtractRpmPackage(string installerPath, string tempDir) =>
+        // Extract rpm using rpm2cpio and cpio
+        new RunExeCommand(Log, "sh")
+            .WithWorkingDirectory(tempDir)
+            .Execute("-c", $"rpm2cpio '{installerPath}' | cpio -idmv")
+            .Should().Pass();
 }

--- a/src/sdk/test/EndToEnd.Tests/GivenDotNetMacInstallers.cs
+++ b/src/sdk/test/EndToEnd.Tests/GivenDotNetMacInstallers.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using EndToEnd.Tests.Utilities;
+
+namespace EndToEnd.Tests;
+
+public class GivenDotNetMacInstallers(ITestOutputHelper log) : SdkTest(log)
+{
+    [Fact]
+    public void PkgPackagePreservesSymbolicLinks() =>
+        SymbolicLinkHelpers.VerifyInstallerSymlinks(
+            OSPlatform.OSX,
+            "dotnet-sdk-*.pkg",
+            excludeSubstrings: ["-internal"],
+            ExtractPkgPackage,
+            TestAssetsManager,
+            Log);
+
+    private void ExtractPkgPackage(string installerPath, string tempDir)
+    {
+        // Expand the pkg using pkgutil
+        var expandedDir = Path.Combine(tempDir, "expanded");
+        new RunExeCommand(Log, "pkgutil")
+            .Execute("--expand", installerPath, expandedDir)
+            .Should().Pass();
+
+        // Find and extract the Payload from each component
+        // pkg files contain one or more component directories, each with a Payload file
+        var payloadFiles = Directory.GetFiles(expandedDir, "Payload", SearchOption.AllDirectories);
+
+        foreach (var payloadFile in payloadFiles)
+        {
+            var componentDir = Path.GetDirectoryName(payloadFile)!;
+            var componentName = Path.GetFileName(componentDir);
+            var extractDir = Path.Combine(tempDir, "data", componentName);
+            Directory.CreateDirectory(extractDir);
+
+            // Payload is a cpio archive (possibly compressed)
+            // Use ditto which handles Apple's archive formats well
+            new RunExeCommand(Log, "ditto")
+                .Execute("-x", payloadFile, extractDir)
+                .Should().Pass();
+        }
+    }
+}

--- a/src/sdk/test/EndToEnd.Tests/GivenSdkArchives.cs
+++ b/src/sdk/test/EndToEnd.Tests/GivenSdkArchives.cs
@@ -11,9 +11,9 @@ public class GivenSdkArchives(ITestOutputHelper log) : SdkTest(log)
     [Fact]
     public void ItHasDeduplicatedAssemblies()
     {
-        // TODO: Windows is not supported yet - blocked on signing support (https://github.com/dotnet/sdk/issues/52182).
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
+            Log.WriteLine("SKIPPED: Windows deduplication not yet supported (https://github.com/dotnet/sdk/issues/52182)");
             return;
         }
 
@@ -34,7 +34,7 @@ public class GivenSdkArchives(ITestOutputHelper log) : SdkTest(log)
 
         Log.WriteLine($"Extracting archive to: {extractPath}");
 
-        SymbolicLinkHelpers.ExtractTarGz(archivePath, extractPath, Log);
+        SymbolicLinkHelpers.ExtractTar(archivePath, extractPath, Log);
 
         return extractPath;
     }

--- a/src/sdk/test/EndToEnd.Tests/Utilities/SymbolicLinkHelpers.cs
+++ b/src/sdk/test/EndToEnd.Tests/Utilities/SymbolicLinkHelpers.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.InteropServices;
+
 namespace EndToEnd.Tests.Utilities;
 
 /// <summary>
@@ -15,43 +17,53 @@ internal static class SymbolicLinkHelpers
     public const int MinExpectedDeduplicatedLinks = 100;
 
     /// <summary>
-    /// Extracts a tar.gz archive to a directory using system tar command.
-    /// Uses system tar for simplicity.
+    /// Extracts a tar archive to a directory using system tar command.
+    /// Auto-detects compression format (.gz, .xz, .zst, etc.).
     /// </summary>
-    /// <param name="tarGzPath">Path to the .tar.gz file to extract.</param>
+    /// <param name="tarPath">Path to the tar archive to extract.</param>
     /// <param name="destinationDirectory">Directory to extract files into.</param>
     /// <param name="log">Test output logger.</param>
-    public static void ExtractTarGz(string tarGzPath, string destinationDirectory, ITestOutputHelper log)
-    {
+    public static void ExtractTar(string tarPath, string destinationDirectory, ITestOutputHelper log) =>
         new RunExeCommand(log, "tar")
-            .Execute("-xzf", tarGzPath, "-C", destinationDirectory)
+            .Execute("-xf", tarPath, "-C", destinationDirectory)
             .Should().Pass();
-    }
 
     /// <summary>
-    /// Extracts an installer package to a temporary directory, verifies symbolic links, and cleans up.
+    /// Verifies that an installer package preserves symbolic links. Handles platform checking,
+    /// artifact discovery, extraction, and symlink validation.
     /// </summary>
-    /// <param name="installerFile">Path to the installer file.</param>
-    /// <param name="packageType">Type of package (e.g., "deb", "rpm", "pkg") for logging.</param>
-    /// <param name="extractPackage">Action that extracts the package contents to the provided temp directory.</param>
+    /// <param name="requiredPlatform">The platform this test should run on (e.g., OSPlatform.Linux).</param>
+    /// <param name="filePattern">The file pattern to search for (e.g., "dotnet-sdk-*.deb").</param>
+    /// <param name="excludeSubstrings">Substrings to exclude from filenames when finding artifacts.</param>
+    /// <param name="extractPackage">Action that extracts the package. Receives (installerPath, tempDir).</param>
+    /// <param name="testAssetsManager">Test assets manager for creating temp directories.</param>
     /// <param name="log">Test output logger.</param>
-    public static void VerifyPackageSymlinks(string installerFile, string packageType, Action<string> extractPackage, ITestOutputHelper log)
+    public static void VerifyInstallerSymlinks(
+        OSPlatform requiredPlatform,
+        string filePattern,
+        string[] excludeSubstrings,
+        Action<string, string> extractPackage,
+        TestAssetsManager testAssetsManager,
+        ITestOutputHelper log)
     {
-        var tempDir = Path.Combine(Path.GetTempPath(), $"{packageType}-test-{Guid.NewGuid()}");
-        Directory.CreateDirectory(tempDir);
+        if (!RuntimeInformation.IsOSPlatform(requiredPlatform))
+        {
+            log.WriteLine($"SKIPPED: Test requires {requiredPlatform} but running on {RuntimeInformation.OSDescription}");
+            return;
+        }
 
-        try
+        if (!SdkTestContext.FindOptionalSdkAcquisitionArtifact(filePattern, excludeSubstrings, out string? installerPath))
         {
-            extractPackage(tempDir);
-            VerifyDirectoryHasRelativeSymlinks(tempDir, log, $"{packageType} package");
+            log.WriteLine($"SKIPPED: No artifact matching '{filePattern}' found in shipping packages directory");
+            return;
         }
-        finally
-        {
-            if (Directory.Exists(tempDir))
-            {
-                Directory.Delete(tempDir, recursive: true);
-            }
-        }
+
+        log.WriteLine($"Validating: {Path.GetFileName(installerPath)}");
+        var packageType = Path.GetExtension(installerPath!).TrimStart('.');
+        var tempDir = testAssetsManager.CreateTestDirectory(packageType).Path;
+
+        extractPackage(installerPath!, tempDir);
+        VerifyDirectoryHasRelativeSymlinks(tempDir, log, packageType);
     }
 
     /// <summary>
@@ -59,7 +71,7 @@ internal static class SymbolicLinkHelpers
     /// </summary>
     /// <param name="directory">The directory to check for symbolic links.</param>
     /// <param name="log">Test output logger.</param>
-    /// <param name="contextName">Name of the context being tested (for error messages, e.g., "deb package", "archive").</param>
+    /// <param name="contextName">Name of the context being tested (for error messages, e.g., "deb", "archive").</param>
     public static void VerifyDirectoryHasRelativeSymlinks(string directory, ITestOutputHelper log, string contextName)
     {
         // Find all symbolic links in the directory

--- a/src/sdk/test/sdk-tasks.Tests/CopyPreservingRelativeSymlinksTests.cs
+++ b/src/sdk/test/sdk-tasks.Tests/CopyPreservingRelativeSymlinksTests.cs
@@ -1,0 +1,322 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.DotNet.Build.Tasks;
+
+namespace Microsoft.CoreSdkTasks.Tests;
+
+public class CopyPreservingRelativeSymlinksTests(ITestOutputHelper log) : SdkTest(log)
+{
+#if !NETFRAMEWORK
+    [Fact]
+    public void ItCopiesRegularFiles()
+    {
+        var (sourceDir, destDir) = CreateSourceAndDestDirs();
+
+        var sourceFile = Path.Combine(sourceDir, "file.txt");
+        var destFile = Path.Combine(destDir, "file.txt");
+
+        File.WriteAllText(sourceFile, "test content");
+
+        var task = CreateTask([sourceFile], [destFile]);
+
+        task.Execute().Should().BeTrue();
+
+        File.Exists(destFile).Should().BeTrue();
+        File.ReadAllText(destFile).Should().Be("test content");
+        task.CopiedFiles.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void ItPreservesRelativeSymbolicLinks()
+    {
+        var (sourceDir, destDir) = CreateSourceAndDestDirs();
+
+        // Create a target file and a symlink to it
+        var targetFile = Path.Combine(sourceDir, "target.dll");
+        var symlinkFile = Path.Combine(sourceDir, "link.dll");
+
+        File.WriteAllText(targetFile, "target content");
+        File.CreateSymbolicLink(symlinkFile, "target.dll");
+
+        // Verify the symlink was created correctly
+        new FileInfo(symlinkFile).LinkTarget.Should().Be("target.dll");
+
+        // Copy both the target and the symlink (symlink target must be in copy scope)
+        var destTarget = Path.Combine(destDir, "target.dll");
+        var destSymlink = Path.Combine(destDir, "link.dll");
+        var task = CreateTask([targetFile, symlinkFile], [destTarget, destSymlink]);
+
+        task.Execute().Should().BeTrue();
+
+        // Verify the destination is a symlink with the same relative target
+        File.Exists(destSymlink).Should().BeTrue();
+        var destInfo = new FileInfo(destSymlink);
+        destInfo.LinkTarget.Should().Be("target.dll");
+    }
+
+    [Fact]
+    public void ItPreservesRelativeSymbolicLinksWithPathTraversal()
+    {
+        var (sourceDir, destDir) = CreateSourceAndDestDirs();
+
+        // Create nested structure: sourceDir/sub/link.dll -> ../target.dll
+        var subDir = Path.Combine(sourceDir, "sub");
+        Directory.CreateDirectory(subDir);
+
+        var targetFile = Path.Combine(sourceDir, "target.dll");
+        var symlinkFile = Path.Combine(subDir, "link.dll");
+
+        File.WriteAllText(targetFile, "target content");
+        File.CreateSymbolicLink(symlinkFile, "../target.dll");
+
+        // Verify source symlink
+        new FileInfo(symlinkFile).LinkTarget.Should().Be("../target.dll");
+
+        // Copy to destination with same structure (both target and symlink)
+        var destSubDir = Path.Combine(destDir, "sub");
+        Directory.CreateDirectory(destSubDir);
+        var destTarget = Path.Combine(destDir, "target.dll");
+        var destSymlink = Path.Combine(destSubDir, "link.dll");
+
+        var task = CreateTask([targetFile, symlinkFile], [destTarget, destSymlink]);
+
+        task.Execute().Should().BeTrue();
+
+        // Verify the relative path is preserved
+        var destInfo = new FileInfo(destSymlink);
+        destInfo.LinkTarget.Should().Be("../target.dll");
+    }
+
+    [Fact]
+    public void ItCopiesMixedFilesAndSymlinks()
+    {
+        var (sourceDir, destDir) = CreateSourceAndDestDirs();
+
+        // Create regular file
+        var regularFile = Path.Combine(sourceDir, "regular.dll");
+        File.WriteAllText(regularFile, "regular content");
+
+        // Create target and symlink
+        var targetFile = Path.Combine(sourceDir, "target.dll");
+        var symlinkFile = Path.Combine(sourceDir, "symlink.dll");
+        File.WriteAllText(targetFile, "target content");
+        File.CreateSymbolicLink(symlinkFile, "target.dll");
+
+        var destRegular = Path.Combine(destDir, "regular.dll");
+        var destTarget = Path.Combine(destDir, "target.dll");
+        var destSymlink = Path.Combine(destDir, "symlink.dll");
+
+        // Copy all files including the target (symlink target must be in copy scope)
+        var task = CreateTask(
+            [regularFile, targetFile, symlinkFile],
+            [destRegular, destTarget, destSymlink]);
+
+        task.Execute().Should().BeTrue();
+
+        // Regular file should be copied as regular file
+        File.Exists(destRegular).Should().BeTrue();
+        new FileInfo(destRegular).LinkTarget.Should().BeNull();
+        File.ReadAllText(destRegular).Should().Be("regular content");
+
+        // Symlink should be preserved as symlink
+        File.Exists(destSymlink).Should().BeTrue();
+        new FileInfo(destSymlink).LinkTarget.Should().Be("target.dll");
+    }
+
+    [Fact]
+    public void ItCreatesDestinationDirectories()
+    {
+        var (sourceDir, destDir) = CreateSourceAndDestDirs();
+
+        var sourceFile = Path.Combine(sourceDir, "file.txt");
+        var destFile = Path.Combine(destDir, "nested", "deep", "file.txt");
+
+        File.WriteAllText(sourceFile, "test content");
+
+        var task = CreateTask([sourceFile], [destFile]);
+
+        task.Execute().Should().BeTrue();
+
+        File.Exists(destFile).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ItOverwritesExistingFiles()
+    {
+        var (sourceDir, destDir) = CreateSourceAndDestDirs();
+
+        var sourceFile = Path.Combine(sourceDir, "file.txt");
+        var destFile = Path.Combine(destDir, "file.txt");
+
+        File.WriteAllText(sourceFile, "new content");
+        File.WriteAllText(destFile, "old content");
+
+        var task = CreateTask([sourceFile], [destFile]);
+
+        task.Execute().Should().BeTrue();
+
+        File.ReadAllText(destFile).Should().Be("new content");
+    }
+
+    [Fact]
+    public void ItOverwritesExistingSymlinkWithRegularFile()
+    {
+        var (sourceDir, destDir) = CreateSourceAndDestDirs();
+
+        // Source is a regular file
+        var sourceFile = Path.Combine(sourceDir, "file.dll");
+        File.WriteAllText(sourceFile, "regular content");
+
+        // Destination is an existing symlink
+        var destFile = Path.Combine(destDir, "file.dll");
+        var dummyTarget = Path.Combine(destDir, "dummy.dll");
+        File.WriteAllText(dummyTarget, "dummy");
+        File.CreateSymbolicLink(destFile, "dummy.dll");
+
+        var task = CreateTask([sourceFile], [destFile]);
+
+        task.Execute().Should().BeTrue();
+
+        // Should now be a regular file, not a symlink
+        var destInfo = new FileInfo(destFile);
+        destInfo.LinkTarget.Should().BeNull();
+        File.ReadAllText(destFile).Should().Be("regular content");
+    }
+
+    [Fact]
+    public void ItOverwritesExistingRegularFileWithSymlink()
+    {
+        var (sourceDir, destDir) = CreateSourceAndDestDirs();
+
+        // Source is a symlink
+        var targetFile = Path.Combine(sourceDir, "target.dll");
+        var sourceFile = Path.Combine(sourceDir, "link.dll");
+        File.WriteAllText(targetFile, "target content");
+        File.CreateSymbolicLink(sourceFile, "target.dll");
+
+        // Destination is an existing regular file
+        var destTarget = Path.Combine(destDir, "target.dll");
+        var destFile = Path.Combine(destDir, "link.dll");
+        File.WriteAllText(destFile, "old content");
+
+        // Copy both the target and the symlink (symlink target must be in copy scope)
+        var task = CreateTask([targetFile, sourceFile], [destTarget, destFile]);
+
+        task.Execute().Should().BeTrue();
+
+        // Should now be a symlink
+        var destInfo = new FileInfo(destFile);
+        destInfo.LinkTarget.Should().Be("target.dll");
+    }
+
+    [Fact]
+    public void ItFailsWhenSymlinkTargetIsOutsideCopyScope()
+    {
+        var (sourceDir, destDir) = CreateSourceAndDestDirs();
+        var outsideDir = Path.Combine(Path.GetDirectoryName(sourceDir)!, "outside");
+        Directory.CreateDirectory(outsideDir);
+
+        // Create a target file outside the copy scope
+        var outsideTarget = Path.Combine(outsideDir, "outside.dll");
+        File.WriteAllText(outsideTarget, "outside content");
+
+        // Create a symlink that points outside the copy scope
+        var symlinkFile = Path.Combine(sourceDir, "link.dll");
+        var relativePath = Path.GetRelativePath(sourceDir, outsideTarget);
+        File.CreateSymbolicLink(symlinkFile, relativePath);
+
+        var destSymlink = Path.Combine(destDir, "link.dll");
+
+        // Only copying the symlink, not the target - should fail
+        var task = CreateTask([symlinkFile], [destSymlink]);
+
+        task.Execute().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ItSucceedsWhenSymlinkTargetIsWithinCopyScope()
+    {
+        var (sourceDir, destDir) = CreateSourceAndDestDirs();
+
+        // Create target and symlink in source
+        var targetFile = Path.Combine(sourceDir, "target.dll");
+        var symlinkFile = Path.Combine(sourceDir, "link.dll");
+        File.WriteAllText(targetFile, "target content");
+        File.CreateSymbolicLink(symlinkFile, "target.dll");
+
+        var destTarget = Path.Combine(destDir, "target.dll");
+        var destSymlink = Path.Combine(destDir, "link.dll");
+
+        // Copy both the symlink and its target - should succeed
+        var task = CreateTask(
+            [targetFile, symlinkFile],
+            [destTarget, destSymlink]);
+
+        task.Execute().Should().BeTrue();
+
+        // Verify symlink was preserved
+        new FileInfo(destSymlink).LinkTarget.Should().Be("target.dll");
+    }
+
+    [Fact]
+    public void ItFailsWhenSourceFileDoesNotExist()
+    {
+        var (_, destDir) = CreateSourceAndDestDirs();
+
+        var task = CreateTask(
+            ["/nonexistent/file.txt"],
+            [Path.Combine(destDir, "file.txt")]);
+
+        task.Execute().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ItFailsWhenSourceAndDestinationCountMismatch()
+    {
+        var (sourceDir, destDir) = CreateSourceAndDestDirs();
+
+        var file1 = Path.Combine(sourceDir, "file1.txt");
+        var file2 = Path.Combine(sourceDir, "file2.txt");
+        File.WriteAllText(file1, "content1");
+        File.WriteAllText(file2, "content2");
+
+        var task = CreateTask(
+            [file1, file2],
+            [Path.Combine(destDir, "file1.txt")]);
+
+        task.Execute().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ItSucceedsWithEmptySourceFiles()
+    {
+        var task = CreateTask([], []);
+
+        task.Execute().Should().BeTrue();
+        task.CopiedFiles.Should().BeEmpty();
+    }
+
+    private (string sourceDir, string destDir) CreateSourceAndDestDirs()
+    {
+        var testDir = TestAssetsManager.CreateTestDirectory().Path;
+        var sourceDir = Path.Combine(testDir, "source");
+        var destDir = Path.Combine(testDir, "dest");
+        Directory.CreateDirectory(sourceDir);
+        Directory.CreateDirectory(destDir);
+        return (sourceDir, destDir);
+    }
+
+    private static CopyPreservingRelativeSymlinks CreateTask(string[] sourceFiles, string[] destinationFiles)
+    {
+        return new CopyPreservingRelativeSymlinks
+        {
+            SourceFiles = sourceFiles.Select(f => new TaskItem(f)).ToArray(),
+            DestinationFiles = destinationFiles.Select(f => new TaskItem(f)).ToArray(),
+            BuildEngine = new MockBuildEngine()
+        };
+    }
+#endif
+}

--- a/src/sdk/test/sdk-tasks.Tests/DeduplicateAssembliesWithLinksTests.cs
+++ b/src/sdk/test/sdk-tasks.Tests/DeduplicateAssembliesWithLinksTests.cs
@@ -321,24 +321,5 @@ public class DeduplicateAssembliesWithLinksTests(ITestOutputHelper log) : SdkTes
         public uint nFileIndexHigh;
         public uint nFileIndexLow;
     }
-
-    private class MockBuildEngine : IBuildEngine
-    {
-        public bool ContinueOnError => false;
-        public int LineNumberOfTaskNode => 0;
-        public int ColumnNumberOfTaskNode => 0;
-        public string ProjectFileOfTaskNode => string.Empty;
-
-        public bool BuildProjectFile(string projectFileName, string[] targetNames,
-            System.Collections.IDictionary globalProperties, System.Collections.IDictionary targetOutputs)
-        {
-            return true;
-        }
-
-        public void LogCustomEvent(CustomBuildEventArgs e) { }
-        public void LogErrorEvent(BuildErrorEventArgs e) { }
-        public void LogMessageEvent(BuildMessageEventArgs e) { }
-        public void LogWarningEvent(BuildWarningEventArgs e) { }
-    }
 #endif
 }

--- a/src/sdk/test/sdk-tasks.Tests/MockBuildEngine.cs
+++ b/src/sdk/test/sdk-tasks.Tests/MockBuildEngine.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+
+namespace Microsoft.CoreSdkTasks.Tests;
+
+internal class MockBuildEngine : IBuildEngine
+{
+    public bool ContinueOnError => false;
+    public int LineNumberOfTaskNode => 0;
+    public int ColumnNumberOfTaskNode => 0;
+    public string ProjectFileOfTaskNode => string.Empty;
+
+    public bool BuildProjectFile(string projectFileName, string[] targetNames,
+        System.Collections.IDictionary globalProperties, System.Collections.IDictionary targetOutputs) => true;
+
+    public void LogCustomEvent(CustomBuildEventArgs e) { }
+    public void LogErrorEvent(BuildErrorEventArgs e) { }
+    public void LogMessageEvent(BuildMessageEventArgs e) { }
+    public void LogWarningEvent(BuildWarningEventArgs e) { }
+}


### PR DESCRIPTION
This reverts commit d5a0c5aaa52922ec2a82f8ceda9eb3533f253e57.

The arcade signing fixes flowed in with https://github.com/dotnet/dotnet/pull/4862

Validated with a [real sign build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2902616&view=results).