### PR TITLE
Fix GatherDrop.ps1 script

### DIFF
--- a/eng/GatherDrops.ps1
+++ b/eng/GatherDrops.ps1
@@ -11,14 +11,16 @@ param(
   [Parameter(Mandatory=$true)]
   [String]$azdevPat,
   [Parameter(Mandatory=$true)]
-  [String]$includedRepositories,
+  [String[]]$includedRepositories,
   [Parameter(Mandatory=$false)]
   [String]$assetFilter = ".*",
   [Switch]$nonShipping = $false
 )
 
+$ErrorActionPreference = 'Stop'
+
 $jsonContent = Get-Content -Path $filePath -Raw | ConvertFrom-Json
-$includedReposList = $includedRepositories -split ',' | ForEach-Object { $_.Trim() }
+$includedReposList = $includedRepositories | ForEach-Object { $_.Trim() }
 
 foreach ($includedRepo in $includedReposList) {
   $repo = $jsonContent.repositories | Where-Object { $_.path -eq $includedRepo } | Select-Object -First 1
@@ -34,4 +36,5 @@ foreach ($includedRepo in $includedReposList) {
   Write-Output "Gathering drop for $repoName"
   Invoke-Expression $darcCommand
 }
+
 exit 0


### PR DESCRIPTION
```
D:\a\_work\1\s\eng\GatherDrops.ps1 : Cannot process argument transformation on parameter 'includedRepositories'. Cannot convert value to type System.String.
At D:\a\_work\_temp\azureclitaskscript1771192298769_inlinescript.ps1:34 char:25
+ … epositories arcade,deployment-tools,diagnostics,fsharp,msbuild,nuget- …
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : InvalidData: (:) [GatherDrops.ps1], ParentContainsErrorRecordException
+ FullyQualifiedErrorId : ParameterArgumentTransformationError,GatherDrops.ps1

##[error]Script failed with exit code: 1
```

https://dev.azure.com/dnceng/internal/_build/results?buildId=2905036&view=logs&j=7fac106a-c8df-57f0-d6f6-40d5df145b04&t=6719afc3-f369-5c20-06d7-6c3ca9698001

---

This time I really tested the script and didn't solely rely on CCA.