### PR TITLE
Avoid warning when copying test results

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -882,15 +882,17 @@ jobs:
     continueOnError: true
     condition: succeededOrFailed()
 
-  - task: CopyFiles@2
-    displayName: Copy TestResults to BuildLogs staging
-    inputs:
-      SourceFolder: '$(sourcesPath)/artifacts/TestResults'
-      Contents: '**'
-      TargetFolder: '$(Build.ArtifactStagingDirectory)/BuildLogs/artifacts/TestResults'
-      CleanTargetFolder: true
-    continueOnError: true
-    condition: succeededOrFailed()
+  # Only copy test results when tests ran
+  - ${{ if eq(parameters.runTests, 'True') }}:
+    - task: CopyFiles@2
+      displayName: Copy TestResults to BuildLogs staging
+      inputs:
+        SourceFolder: '$(sourcesPath)/artifacts/TestResults'
+        Contents: '**'
+        TargetFolder: '$(Build.ArtifactStagingDirectory)/BuildLogs/artifacts/TestResults'
+        CleanTargetFolder: true
+      continueOnError: true
+      condition: succeededOrFailed()
 
   - task: CopyFiles@2
     displayName: Copy unmerged artifacts to staging directory
@@ -912,7 +914,7 @@ jobs:
       continueOnError: true
       condition: always()
 
-  # Only upload test results if enabled
+  # Only upload test results when tests ran
   - ${{ if eq(parameters.runTests, 'True') }}:
     - task: PublishTestResults@2
       displayName: Publish Test Results


### PR DESCRIPTION
Modify conditions to copy and publish test results only when tests are run.

Noticed in https://dev.azure.com/dnceng/internal/_build/results?buildId=2904838&view=logs&j=ea8dc809-3d82-5dfe-4786-8045f0c9aa5d&s=30a1f0ac-cd7d-589b-9ce4-4355372c171e