### PR TITLE
[release/10.0.1xx] Rebrand to patch 5

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,10 +4,10 @@
     <VersionMajor>10</VersionMajor>
     <VersionMinor>0</VersionMinor>
     <VersionSDKMinor>1</VersionSDKMinor>
-    <VersionSDKMinorPatch>4</VersionSDKMinorPatch>
+    <VersionSDKMinorPatch>5</VersionSDKMinorPatch>
     <VersionFeature>$([System.String]::Copy('$(VersionSDKMinorPatch)').PadLeft(2, '0'))</VersionFeature>
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionSDKMinor)$(VersionFeature)</VersionPrefix>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <!-- 
       Allowed values: 'repodefault', 'unstable', 'preview', 'release'


### PR DESCRIPTION
Increment patch version 4 -> 5 on release/10.0.1xx

Sets prerelease label to 'servicing' and iteration to empty string.