### PR TITLE
Skip building winforms ScratchProject.csproj test project as self-contained in the VMR

### DIFF
--- a/src/winforms/src/test/integration/ScratchProject/ScratchProject.csproj
+++ b/src/winforms/src/test/integration/ScratchProject/ScratchProject.csproj
@@ -17,7 +17,8 @@
   <PropertyGroup>
     <PublishSingleFile>false</PublishSingleFile>
     <SelfContained>false</SelfContained>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <!-- don't set RID when building from the VMR to avoid circular runtime pack dependencies -->
+    <RuntimeIdentifier Condition="'$(DotNetBuild)' != 'true'">win-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <!-- These normally come from $(UseWindowsForms) when $(ImplicitUsings) is enabled -->


### PR DESCRIPTION
Fixes errors during restore when building the test project:
```
  D:\a\_work\1\s\src\winforms\src\test\integration\ScratchProject\ScratchProject.csproj : error NU1102: Unable to find package Microsoft.WindowsDesktop.App.Runtime.win-x64 with version (= 11.0.0-ci) [D:\a\_work\1\s\src\winforms\Winforms.sln]
  D:\a\_work\1\s\src\winforms\src\test\integration\ScratchProject\ScratchProject.csproj : error NU1102: Unable to find package Microsoft.AspNetCore.App.Runtime.win-x64 with version (= 11.0.0-ci) [D:\a\_work\1\s\src\winforms\Winforms.sln]
```

Test build: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1302765&view=results