### PR TITLE
Skip prebuilt error when SkipErrorOnPrebuilts is set

### DIFF
--- a/eng/finish-source-only.proj
+++ b/eng/finish-source-only.proj
@@ -138,7 +138,7 @@
       <PrebuiltErrorMessage>$(PrebuiltErrorMessage)See https://aka.ms/dotnet/prebuilts for guidance on what prebuilts are and how to eliminate them.</PrebuiltErrorMessage>
     </PropertyGroup>
 
-    <Error Condition="'@(DetectedPrebuiltPackage)' != ''" Text="$(PrebuiltErrorMessage)" />
+    <Error Condition="'@(DetectedPrebuiltPackage)' != '' and '$(SkipErrorOnPrebuilts)' != 'true'" Text="$(PrebuiltErrorMessage)" />
 
     <MakeDir Directories="$(BaseIntermediateOutputPath)" />
     <Touch Files="$(BaseIntermediateOutputPath)ReportPrebuiltUsage.complete" AlwaysCreate="true">


### PR DESCRIPTION
5661a2c0a8 introduced a new form of error when prebuilt packages are used, but it didn't check SkipErrorOnPrebuilts.

Fixes https://github.com/dotnet/source-build/issues/5489