### PR TITLE
Remove hotreload exclusion from SDK Diff

### DIFF
--- a/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/MsftToSbSdkFiles.diff
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/MsftToSbSdkFiles.diff
@@ -44,15 +44,3 @@ index ------------
  ./packs/Microsoft.NETCore.App.Ref/
  ./packs/Microsoft.NETCore.App.Ref/x.y.z/
  ./packs/Microsoft.NETCore.App.Ref/x.y.z/analyzers/
-@@ ------------ @@
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Web/tools/netx.y/
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.Web/tools/netx.y/Microsoft.NET.Sdk.Web.Tasks.dll
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/hotreload/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/hotreload/netx.y/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/hotreload/netx.y/Microsoft.DotNet.HotReload.WebAssembly.Browser.dll
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/hotreload/netx.y/wwwroot/
--./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/hotreload/netx.y/wwwroot/Microsoft.DotNet.HotReload.WebAssembly.Browser.lib.module.js
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/Sdk/
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/Sdk/Sdk.props
- ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/Sdk/Sdk.targets

--- a/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/SdkFileDiffExclusions.txt
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/SdkFileDiffExclusions.txt
@@ -21,9 +21,6 @@
 # Intentional - netfx excluded from source-build
 ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WindowsDesktop/tools/net472/|msft
 
-# https://github.com/dotnet/source-build/issues/5488
-./sdk/x.y.z/Sdks/Microsoft.NET.Sdk.WebAssembly/hotreload/|sb
-
 # netfx tooling and tasks, not building in source-build - https://github.com/dotnet/source-build/issues/3514
 ./sdk/x.y.z/Sdks/Microsoft.Build.Tasks.Git/tools/netframework/|msft
 ./sdk/x.y.z/Sdks/Microsoft.NET.Sdk/tools/net472/|msft


### PR DESCRIPTION
My changes in https://github.com/dotnet/dotnet/pull/4962 were overridden by the SDK Diff pipeline re-runs. This PR reapplies by changes and fixes the diff.