### PR TITLE
Fix Debian md5sums file

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateMD5SumsFile.cs
+++ b/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateMD5SumsFile.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
 #if NET
                 writer.Write($"{Convert.ToHexStringLower(hash)}  {relativePath}\n");
 #else
-                writer.Write($"{BitConverter.ToString(hash).Replace("-", "")} {relativePath}\n");
+                writer.Write($"{BitConverter.ToString(hash).Replace("-", "").ToLower()}  {relativePath}\n");
 #endif
             }
 


### PR DESCRIPTION
They are supposed to have two (not one) spaces separating the md5 hash and the path as per https://manpages.debian.org/testing/dpkg-dev/deb-md5sums.5.en.html . It seems that upper case hashes are supposed to be allowed, but both `debsums` and `dpkg --verify` seem to complain in practice about the upper case hash so I have also changed it to be lower case.