### PR TITLE
[release/10.0.2xx] Cloak and condition the obfuscated test binaries (…

### DIFF
--- a/src/source-mappings.json
+++ b/src/source-mappings.json
@@ -47,7 +47,11 @@
         },
         {
             "name": "roslyn",
-            "defaultRemote": "https://github.com/dotnet/roslyn"
+            "defaultRemote": "https://github.com/dotnet/roslyn",
+            "exclude": [
+                // Obfuscated files are blocking the source tarball signing
+                "src/Compilers/Test/Resources/Core/MetadataTests/Invalid/Obfuscated*.dll"
+            ]
         },
         {
             "name": "scenario-tests",


### PR DESCRIPTION
…#4631)

Backport of https://github.com/dotnet/dotnet/pull/4631

Roslyn has already removed these binaries, but it may be wise to add them to the source-mappings just in case.