### PR TITLE
Handle internal package URLs for installer tests

### DIFF
--- a/eng/pipelines/templates/steps/vmr-validate-installers.yml
+++ b/eng/pipelines/templates/steps/vmr-validate-installers.yml
@@ -54,7 +54,7 @@ steps:
   - script: |
       runtimeSourceFeedKeyArgs=""
       if [[ "$(System.TeamProject)" == "internal" ]]; then
-        runtimeSourceFeedKeyArgs="/p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)"
+        runtimeSourceFeedKeyArgs="/p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)"
       fi
       ./build.sh --ci -t --projects $(Build.SourcesDirectory)/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj /p:TestRpmPackages=true /p:TestDebPackages=true $runtimeSourceFeedKeyArgs
     displayName: Validate installer packages

--- a/test/Microsoft.DotNet.Installer.Tests/Config.cs
+++ b/test/Microsoft.DotNet.Installer.Tests/Config.cs
@@ -52,6 +52,9 @@ public static class Config
     public static string TargetFrameworkVersion { get; } = TryGetRuntimeConfig(TargetFrameworkVersionSwitch, out string? value) ? value : string.Empty;
     const string TargetFrameworkVersionSwitch = RuntimeConfigSwitchPrefix + nameof(TargetFrameworkVersion);
 
+    public static string DotNetRuntimeSourceFeed { get; } = TryGetRuntimeConfig(DotNetRuntimeSourceFeedSwitch, out string? value) ? value : string.Empty;
+    const string DotNetRuntimeSourceFeedSwitch = RuntimeConfigSwitchPrefix + nameof(DotNetRuntimeSourceFeed);
+
     public static string DotNetRuntimeSourceFeedKey { get; } = TryGetRuntimeConfig(DotNetRuntimeSourceFeedKeySwitch, out string? value) ? value : string.Empty;
     const string DotNetRuntimeSourceFeedKeySwitch = RuntimeConfigSwitchPrefix + nameof(DotNetRuntimeSourceFeedKey);
 

--- a/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
+++ b/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
@@ -568,10 +568,10 @@ public partial class LinuxInstallerTests : IDisposable
         HttpResponseMessage response = await client.GetAsync(url);
         if (!response.IsSuccessStatusCode && !string.IsNullOrEmpty(Config.DotNetRuntimeSourceFeedKey))
         {
-            string internalUrlStr = url.ToString().Replace("https://ci.dot.net/public/", "https://ci.dot.net/internal/");
+            string internalUrlStr = url.ToString().Replace("https://ci.dot.net/public", Config.DotNetRuntimeSourceFeed);
             _outputHelper.WriteLine($"Public URL failed ({(int)response.StatusCode}), falling back to internal URL: {internalUrlStr}");
             // The feed key is a base64-encoded SAS token that must be decoded and appended to the URL as a query string
-            string decodedSasToken = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(Config.DotNetRuntimeSourceFeedKey));
+            string decodedSasToken = Encoding.UTF8.GetString(Convert.FromBase64String(Config.DotNetRuntimeSourceFeedKey));
             Uri internalUrl = new Uri($"{internalUrlStr}?{decodedSasToken}");
             response = await client.GetAsync(internalUrl);
         }

--- a/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
+++ b/test/Microsoft.DotNet.Installer.Tests/Microsoft.DotNet.Installer.Tests.csproj
@@ -71,6 +71,9 @@
       <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).TargetFrameworkVersion">
         <Value>$(_TargetFrameworkVersionWithoutV)</Value>
       </RuntimeHostConfigurationOption>
+      <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).DotNetRuntimeSourceFeed">
+        <Value>$(DotNetRuntimeSourceFeed)</Value>
+      </RuntimeHostConfigurationOption>
       <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).DotNetRuntimeSourceFeedKey">
         <Value>$(DotNetRuntimeSourceFeedKey)</Value>
       </RuntimeHostConfigurationOption>


### PR DESCRIPTION
Package installer tests fail in non-1xx internal release branches with this error:

```
[xUnit.net 00:00:00.76]     Microsoft.DotNet.Installer.Tests.LinuxInstallerTests.RpmScenarioTest(repo: "mcr.microsoft.com/dotnet/runtime-deps", tag: "10.0-azurelinux3.0") [FAIL]
[xUnit.net 00:00:00.76]       System.Net.Http.HttpRequestException : Response status code does not indicate success: 404 (The specified blob does not exist.).
[xUnit.net 00:00:00.76]       Stack Trace:
[xUnit.net 00:00:00.76]            at System.Net.Http.HttpResponseMessage.EnsureSuccessStatusCode()
[xUnit.net 00:00:00.76]         /_/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs(569,0): at Microsoft.DotNet.Installer.Tests.LinuxInstallerTests.DownloadFileAsync(Uri url, String filePath)
[xUnit.net 00:00:00.76]         /_/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs(303,0): at Microsoft.DotNet.Installer.Tests.LinuxInstallerTests.DownloadPackagesAsync(String packageArchitecture, PackageType packageType)
[xUnit.net 00:00:00.76]         /_/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs(206,0): at Microsoft.DotNet.Installer.Tests.LinuxInstallerTests.InitializeContextAsync(PackageType packageType, Boolean initializeSharedContext)
[xUnit.net 00:00:00.76]         /_/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs(138,0): at Microsoft.DotNet.Installer.Tests.LinuxInstallerTests.RpmScenarioTest(String repo, String tag)
[xUnit.net 00:00:00.76]         --- End of stack trace from previous location ---
[xUnit.net 00:00:00.76]       Output:
[xUnit.net 00:00:00.76]         Downloading https://ci.dot.net/public/Runtime/10.0.4-servicing.26119.110/dotnet-runtime-deps-10.0.4-azl.3-x64.rpm to /tmp/lc4pwxs0.rue/y55vf0ax.upn/dotnet-runtime-deps-10.0.4-azl.3-x64.rpm
```

The test is only configured to target https://ci.dot.net/public when downloading package files. But the package files it needs are internally published and so are only available from https://ci.dot.net/internal.

The test needs to be updated to fallback to the internal location and use the SAS token when the package isn't available at the public location.