### PR TITLE
Update source-mappings.json to exclude antlr4 non-C# code

### DIFF
--- a/src/source-mappings.json
+++ b/src/source-mappings.json
@@ -95,7 +95,7 @@
             "include": [
                 "**/*",
                 "src/externalPackages/src/antlr4/runtime/CSharp/**"
-            ]
+            ],
             "exclude": [
                 // Contains disallowed binaries
                 // 1ES Secret Scanning does not allow any PFX files


### PR DESCRIPTION
Added exclusions for various antlr4 runtime files to limit compliance work.

Opening before we merge in https://github.com/dotnet/source-build-reference-packages/pull/1585