### PR TITLE
Remove PublishingVersion from Publishing.props

### DIFF
--- a/src/winforms/eng/Publishing.props
+++ b/src/winforms/eng/Publishing.props
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
    <PropertyGroup>
-      <PublishingVersion>3</PublishingVersion>
       <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
    </PropertyGroup>
 </Project>


### PR DESCRIPTION
Need to default to v4 for stable publishing.