### PR TITLE
[Validation] Disable full signing by default on non-Windows platforms

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/StrongName.props
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/StrongName.props
@@ -21,6 +21,6 @@
   -->
   
   <PropertyGroup>
-    <FullAssemblySigningSupported Condition="'$(FullAssemblySigningSupported)' == '' and ('$(OS)' != 'Windows_NT' and '$(OfficialBuilder)' != 'Microsoft'))">false</FullAssemblySigningSupported>
+    <FullAssemblySigningSupported Condition="'$(FullAssemblySigningSupported)' == '' and '$(OS)' != 'Windows_NT' and '$(OfficialBuilder)' != 'Microsoft'">false</FullAssemblySigningSupported>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This change moves the global default for FullAssemblySigningSupported to false on non-Windows platforms within the Arcade SDK tools.

this is a validation PR in the VMR to ensure that disabling full signing (to avoid RSA+SHA-1 issues on modern Linux) does not impact official builds or other repository workflows.

Ref: dotnet/runtime#123010
Ref: dotnet/arcade#16566