### PR TITLE
Include stdout/stderr in SourcelinkTests failure output

### DIFF
--- a/test/Microsoft.DotNet.SourceBuild.Tests/SourcelinkTests.cs
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/SourcelinkTests.cs
@@ -54,14 +54,24 @@ public class SourcelinkTests : SdkTests
                 symbolsRoot,
                 OutputHelper);
 
-            IList<string> failedFiles = ValidateSymbols(symbolsRoot, InitializeSourcelinkTool());
+            IList<(string File, string StdOut, string StdErr)> failedFiles = ValidateSymbols(symbolsRoot, InitializeSourcelinkTool());
 
             if (failedFiles.Count > 0)
             {
                 OutputHelper.WriteLine($"Sourcelink verification failed for the following files:");
-                foreach (string file in failedFiles)
+                foreach ((string file, string stdOut, string stdErr) in failedFiles)
                 {
-                    OutputHelper.WriteLine(file);
+                    OutputHelper.WriteLine($"--- {file} ---");
+                    if (!string.IsNullOrWhiteSpace(stdOut))
+                    {
+                        OutputHelper.WriteLine("stdout:");
+                        OutputHelper.WriteLine(stdOut);
+                    }
+                    if (!string.IsNullOrWhiteSpace(stdErr))
+                    {
+                        OutputHelper.WriteLine("stderr:");
+                        OutputHelper.WriteLine(stdErr);
+                    }
                 }
             }
 
@@ -94,11 +104,11 @@ public class SourcelinkTests : SdkTests
         return Utilities.GetFile(extractedToolPath, SourcelinkToolBinaryFilename);
     }
 
-    private IList<string> ValidateSymbols(string path, string sourcelinkToolPath)
+    private IList<(string File, string StdOut, string StdErr)> ValidateSymbols(string path, string sourcelinkToolPath)
     {
         Assert.True(Directory.Exists(path), $"Path, with symbol files to validate, does not exist: {path}");
 
-        var failedFiles = new ConcurrentBag<string>();
+        var failedFiles = new ConcurrentBag<(string File, string StdOut, string StdErr)>();
 
         IEnumerable<string> allFiles = Directory.GetFiles(path, "*.pdb", SearchOption.AllDirectories);
         Parallel.ForEach(allFiles, file =>
@@ -114,7 +124,7 @@ public class SourcelinkTests : SdkTests
 
             if (executeResult.Process.ExitCode != 0)
             {
-                failedFiles.Add(file);
+                failedFiles.Add((file, executeResult.StdOut, executeResult.StdErr));
             }
         });
 


### PR DESCRIPTION
When VerifySourcelinks fails, the test now captures and displays the stdout and stderr from each failed dotnet-sourcelink invocation, making it easier to diagnose why specific PDBs failed verification.

Before we were just getting this which doesn't help:
```
Executing: tar xzf /__w/1/s/artifacts/assets/Release/dotnet-symbols-all-11.0.100-preview.3.26153.119-fedora.43-x64.tar.gz -C /__w/1/s/artifacts/bin/Microsoft.DotNet.SourceBuild.Tests/Release/SourcelinkTests/symbols
Sourcelink verification failed for the following files:
/__w/1/s/artifacts/bin/Microsoft.DotNet.SourceBuild.Tests/Release/SourcelinkTests/symbols/runtime/obj/System.Security.Principal.Windows/Release/net11.0-windows/PreTrim/System.Security.Principal.Windows.pdb
```