### PR TITLE
Fix noisy warnings about node20 in Azure Pipelines agent

### DIFF
--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -143,6 +143,11 @@ variables:
   - name: signDacEnabled
     value: false
 
+# opt in to node24 in pipelines agent to fix noisy warnings: https://github.com/microsoft/azure-pipelines-agent/issues/5464
+# can be removed once it is the default
+- name: AZP_AGENT_USE_NODE24_TO_START_CONTAINER
+  value: true
+
 - name: almaLinuxContainerName
   value: almaLinuxContainer
 - name: almaLinuxContainerImage


### PR DESCRIPTION
This fixes the annoying `Using Node 20 for container startup` warnings that show up during the build.
I confirmed with the AZP team that this will be the default sometime in the future.