### PR TITLE
Disable sdk file deduplication for osx because of a runtime issue which breaks signing

### DIFF
--- a/src/sdk/src/Layout/redist/targets/GenerateInstallerLayout.targets
+++ b/src/sdk/src/Layout/redist/targets/GenerateInstallerLayout.targets
@@ -97,7 +97,7 @@
                             ReplaceBundledRuntimePackFilesWithSymbolicLinks"
           AfterTargets="AfterBuild">
     <!-- TODO: This will eventually be done for all platforms as part of the deduplication work (https://github.com/dotnet/sdk/issues/52183). -->
-    <DeduplicateAssembliesWithLinks Condition="!$([MSBuild]::IsOSPlatform('Windows'))" LayoutDirectory="$(RedistInstallerLayoutPath)sdk\" UseHardLinks="false" />
+    <DeduplicateAssembliesWithLinks Condition="!$([MSBuild]::IsOSPlatform('Windows')) and !$([MSBuild]::IsOSPlatform('OSX'))" LayoutDirectory="$(RedistInstallerLayoutPath)sdk\" UseHardLinks="false" />
   </Target>
 
   <!-- Copy the sdk layout into a temporary folder so that it's nested under "sdk\$(Version)\" which is

--- a/src/sdk/test/EndToEnd.Tests/GivenDotNetMacInstallers.cs
+++ b/src/sdk/test/EndToEnd.Tests/GivenDotNetMacInstallers.cs
@@ -6,42 +6,43 @@ using EndToEnd.Tests.Utilities;
 
 namespace EndToEnd.Tests;
 
-public class GivenDotNetMacInstallers(ITestOutputHelper log) : SdkTest(log)
-{
-    [Fact]
-    public void PkgPackagePreservesSymbolicLinks() =>
-        SymbolicLinkHelpers.VerifyInstallerSymlinks(
-            OSPlatform.OSX,
-            "dotnet-sdk-*.pkg",
-            excludeSubstrings: ["-internal"],
-            ExtractPkgPackage,
-            TestAssetsManager,
-            Log);
+// TODO: Disabled for 11.0.100-preview.2 - https://github.com/dotnet/dotnet/issues/5281
+// public class GivenDotNetMacInstallers(ITestOutputHelper log) : SdkTest(log)
+// {
+//     [Fact]
+//     public void PkgPackagePreservesSymbolicLinks() =>
+//         SymbolicLinkHelpers.VerifyInstallerSymlinks(
+//             OSPlatform.OSX,
+//             "dotnet-sdk-*.pkg",
+//             excludeSubstrings: ["-internal"],
+//             ExtractPkgPackage,
+//             TestAssetsManager,
+//             Log);
 
-    private void ExtractPkgPackage(string installerPath, string tempDir)
-    {
-        // Expand the pkg using pkgutil
-        var expandedDir = Path.Combine(tempDir, "expanded");
-        new RunExeCommand(Log, "pkgutil")
-            .Execute("--expand", installerPath, expandedDir)
-            .Should().Pass();
+//     private void ExtractPkgPackage(string installerPath, string tempDir)
+//     {
+//         // Expand the pkg using pkgutil
+//         var expandedDir = Path.Combine(tempDir, "expanded");
+//         new RunExeCommand(Log, "pkgutil")
+//             .Execute("--expand", installerPath, expandedDir)
+//             .Should().Pass();
 
-        // Find and extract the Payload from each component
-        // pkg files contain one or more component directories, each with a Payload file
-        var payloadFiles = Directory.GetFiles(expandedDir, "Payload", SearchOption.AllDirectories);
+//         // Find and extract the Payload from each component
+//         // pkg files contain one or more component directories, each with a Payload file
+//         var payloadFiles = Directory.GetFiles(expandedDir, "Payload", SearchOption.AllDirectories);
 
-        foreach (var payloadFile in payloadFiles)
-        {
-            var componentDir = Path.GetDirectoryName(payloadFile)!;
-            var componentName = Path.GetFileName(componentDir);
-            var extractDir = Path.Combine(tempDir, "data", componentName);
-            Directory.CreateDirectory(extractDir);
+//         foreach (var payloadFile in payloadFiles)
+//         {
+//             var componentDir = Path.GetDirectoryName(payloadFile)!;
+//             var componentName = Path.GetFileName(componentDir);
+//             var extractDir = Path.Combine(tempDir, "data", componentName);
+//             Directory.CreateDirectory(extractDir);
 
-            // Payload is a cpio archive (possibly compressed)
-            // Use ditto which handles Apple's archive formats well
-            new RunExeCommand(Log, "ditto")
-                .Execute("-x", payloadFile, extractDir)
-                .Should().Pass();
-        }
-    }
-}
+//             // Payload is a cpio archive (possibly compressed)
+//             // Use ditto which handles Apple's archive formats well
+//             new RunExeCommand(Log, "ditto")
+//                 .Execute("-x", payloadFile, extractDir)
+//                 .Should().Pass();
+//         }
+//     }
+// }

--- a/src/sdk/test/EndToEnd.Tests/GivenSdkArchives.cs
+++ b/src/sdk/test/EndToEnd.Tests/GivenSdkArchives.cs
@@ -11,7 +11,7 @@ public class GivenSdkArchives(ITestOutputHelper log) : SdkTest(log)
     [Fact]
     public void ItHasDeduplicatedAssemblies()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
             Log.WriteLine("SKIPPED: Windows deduplication not yet supported (https://github.com/dotnet/sdk/issues/52182)");
             return;


### PR DESCRIPTION
11.0 Preview 2 workaround for https://github.com/dotnet/dotnet/issues/5281