### PR TITLE
Sign additional Mono binaries

### DIFF
--- a/src/runtime/eng/Signing.props
+++ b/src/runtime/eng/Signing.props
@@ -44,7 +44,7 @@
     <FileSignInfo Condition="'$(TargetsOSX)' == 'true'" Include="dotnet;apphost;createdump;singlefilehost;crossgen2" CertificateName="MacDeveloperHarden" />
     <!-- Sign these Mac binaries without hardening enabled, making them compatible with hardening needs more work -->
     <FileSignInfo Condition="'$(TargetsOSX)' == 'true'" Include="corerun;ilc;ilasm;ildasm;mono-aot-cross;Mono;llc;opt" CertificateName="MacDeveloper" />
-    <FileSignInfo Condition="'$(TargetsMacCatalyst)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'" Include="Mono" CertificateName="MacDeveloper" />
+    <FileSignInfo Condition="'$(TargetsAppleMobile)' == 'true'" Include="Mono" CertificateName="MacDeveloper" />
     <!-- Additionally, we need to notarize any .pkg files -->
     <MacOSPkg Include="$(ArtifactsPackagesDir)**/dotnet-runtime*.pkg" Exclude="$(ArtifactsPackagesDir)**/dotnet-runtime-internal*.pkg" />
     <FileSignInfo Include="@(MacOSPkg->'%(Filename)%(Extension)')" CertificateName="MacDeveloperWithNotarization" />


### PR DESCRIPTION
These are in packages like `Microsoft.NETCore.App.Runtime.Mono.maccatalyst-arm64.11.0.0-preview.3.26158.101.nupkg/runtimes/maccatalyst-arm64/native/Mono.debug.framework/Mono`