### PR TITLE
Set PreReleaseVersionIteration to 0 for 10.0.3xx previews

### DIFF
--- a/src/sdk/eng/Versions.props
+++ b/src/sdk/eng/Versions.props
@@ -21,7 +21,7 @@
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration></PreReleaseVersionIteration>
+    <PreReleaseVersionIteration>0</PreReleaseVersionIteration>
     <!-- In source-build the version of the compiler must be same or newer than the version of the
          compiler API targeted by analyzer assemblies. This is mostly an issue on source-build as
          in that build mode analyzer assemblies always target the live compiler API. -->


### PR DESCRIPTION
The workload resolver uses the first digits after preview as part of the version. We settled on using preview.0 for sdk feature band previews to ensure we could produce workload sets and fallback could work correctly. We think this is affecting maui templates in VS main.