### PR TITLE
Limit Parallel.ForEach concurrency in SourcelinkTests

### DIFF
--- a/test/Microsoft.DotNet.SourceBuild.Tests/SourcelinkTests.cs
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/SourcelinkTests.cs
@@ -111,7 +111,7 @@ public class SourcelinkTests : SdkTests
         var failedFiles = new ConcurrentBag<(string File, string StdOut, string StdErr)>();
 
         IEnumerable<string> allFiles = Directory.GetFiles(path, "*.pdb", SearchOption.AllDirectories);
-        Parallel.ForEach(allFiles, file =>
+        Parallel.ForEach(allFiles, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }, file =>
         {
             (Process Process, string StdOut, string StdErr) executeResult = ExecuteHelper.ExecuteProcess(
                 DotNetHelper.DotNetPath,


### PR DESCRIPTION
## Fix

The `VerifySourcelinks` test launches hundreds of `dotnet-sourcelink` processes simultaneously via `Parallel.ForEach` with no concurrency limit. Under resource contention, some processes exceed the 60-second timeout in `ExecuteHelper.ExecuteProcess`, get killed, and report false failures — the tool writes "validated" to stdout but gets killed before it can exit cleanly with code 0.

### Root Cause Analysis (from https://github.com/dotnet/dotnet/issues/5259#issuecomment-4031408856)

1. `Parallel.ForEach` launches `dotnet-sourcelink test --offline` for every PDB — potentially hundreds simultaneously
2. Each process has a 60-second timeout (`millisecondTimeout: 60000`)
3. Under contention, some take >60s to fully exit
4. The tool validates the file and writes "validated" to stdout, but gets killed during shutdown/cleanup
5. The killed process has a non-zero exit code → added to `failedFiles`
6. Different PDBs fail each time because it depends on which processes run during peak contention

### Change

Add `new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }` to bound concurrent process launches to the number of CPU cores.

Fixes #5259