### PR TITLE
Assign main pipeline for SDL baselining

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -115,6 +115,8 @@ extends:
         suppressionsFile: $(Build.SourcesDirectory)/.config/CredScanSuppressions.json
       componentgovernance:
         useExecutionTargetAsUserSteps: true
+      autobaseline:
+        isMainPipeline: true
 
     containers:
       ${{ variables.almaLinuxContainerName }}:


### PR DESCRIPTION
Fixes: https://github.com/dotnet/source-build/issues/5390

By marking the `official` pipeline as main one for baselining we avoid baseline checks in other pipelines, i.e. `source-build-outer-loop`.

More info at [1ES baselining guidance](https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/autobaselining)