### PR TITLE
Fix Build.SourceVersionAuthor check for validation script

### DIFF
--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -93,6 +93,7 @@ stages:
 
         - script: |
             set -ex
+            echo "Validating changes made by $(Build.SourceVersionAuthor)"
             eng/common/dotnet.sh run --project eng/tools/ChangeValidation/ChangeValidation.csproj
           displayName: Run ChangeValidation tool
           env:


### PR DESCRIPTION
I noticed the check still failed in https://github.com/dotnet/dotnet/pull/5417, so the change in https://github.com/dotnet/dotnet/pull/4770#issuecomment-3887656953 didn't work.

This is because `Build.SourceVersionAuthor` looks at the git commit and that one uses `dotnet-maestro[bot]` as the author instead of `dotnet-bot`