### PR TITLE
Use branch name instead of author for validation script

### DIFF
--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -71,13 +71,13 @@ stages:
               eq(variables['isPRTrigger'], 'true'),
               and(
                   not(startsWith(variables['System.PullRequest.SourceBranch'], 'refs/heads/darc-')),
-                  not(startsWith(variables['System.PullRequest.SourceBranch'], 'darc-'))
+                  not(startsWith(variables['System.PullRequest.SourceBranch'], 'darc-')),
+                  not(startsWith(variables['System.PullRequest.SourceBranch'], 'release-pr-'))
               )
           )
   jobs:
     - job: Validate
       displayName: Run Validation Script
-      condition: not(eq(variables['Build.SourceVersionAuthor'], 'dotnet-bot'))
       pool:
         name: $(shortStackPoolName)
         demands: ImageOverride -equals $(poolImage_Linux)


### PR DESCRIPTION
Using the author doesn't seem to work for some reason: https://github.com/dotnet/dotnet/pull/5437