### PR TITLE
Add retryCountOnTaskFailure to checkout steps to mitigate transient git fetch failures

### DIFF
--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -91,6 +91,7 @@ stages:
         - checkout: self
           fetchDepth: 0
           persistCredentials: ${{ ne(variables['System.TeamProject'], 'public') }}
+          retryCountOnTaskFailure: 5
 
         - script: |
             set -ex

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -407,6 +407,7 @@ jobs:
   steps:
   - checkout: self
     fetchDepth: 1
+    retryCountOnTaskFailure: 5
 
 
   # Create artifact staging directories upfront to satisfy 1ES templateContext.outputs validation

--- a/eng/pipelines/templates/stages/vmr-scan.yml
+++ b/eng/pipelines/templates/stages/vmr-scan.yml
@@ -10,6 +10,7 @@ stages:
 
     steps:
     - checkout: self
+      retryCountOnTaskFailure: 5
 
     - script: |
         source ./eng/common/tools.sh


### PR DESCRIPTION
## Summary

Add `retryCountOnTaskFailure: 5` to all checkout steps in the unified-build pipeline to mitigate transient git fetch failures.

## Motivation

Over the last 14 days, **6 out of 461 public pipeline builds** (~1.3%) failed due to transient `git fetch exit code 128` errors. The AzDO checkout task has built-in git client retry (3 attempts with 2-10s backoff), but no task-level retry was configured — so when all 3 internal retries fail, the build fails immediately.

### Evidence (14-day analysis)

| Metric | Value |
|--------|-------|
| Git fetch 128 failures | 6 |
| Total builds | 461 |
| Failure rate | 1.3% |
| Daily rate | ~0.4/day |
| Pattern | Steady trickle, no burst |
| Internal pipeline | 0 occurrences |

All 6 failures show the same pattern: 2 internal retries with short backoff, then hard failure:
```
Git fetch failed with exit code 128, back off 3.994 seconds before retry.
Git fetch failed with exit code 128, back off 2.553 seconds before retry.
Git fetch failed with exit code: 128
```

## Changes

Added `retryCountOnTaskFailure: 5` to 3 checkout steps:
- `eng/pipelines/pr.yml` — PR validation
- `eng/pipelines/templates/jobs/vmr-build.yml` — main build job (used by both public and internal)
- `eng/pipelines/templates/stages/vmr-scan.yml` — license scan

This gives each failed checkout up to 5 additional full task-level attempts, each of which gets its own 3 internal git retries — effectively going from 3 fetch attempts to up to 18.

## Risk

Minimal. On success (99% of builds), there is zero overhead. On transient failure, builds retry instead of failing. The worst case is a slightly longer build on persistent network outages before ultimately still failing.
