### PR TITLE
Ensure VerticalManifest.xml exists before creating artifacts tarball

### DIFF
--- a/eng/PublishSourceBuild.props
+++ b/eng/PublishSourceBuild.props
@@ -4,7 +4,7 @@
   <!-- Add targets here that run logic that depends on the merged asset manifest and published packages. -->
   <UsingTask TaskName="Microsoft.DotNet.SourceBuild.Tasks.LeakDetection.CheckForPoison" AssemblyFile="$(MicrosoftDotNetSourceBuildTasksLeakDetectionAssembly)" TaskFactory="TaskHostFactory" Condition="'$(EnablePoison)' == 'true'" />
   <Target Name="ReportPoisonUsage"
-          AfterTargets="DiscoverArtifacts"
+          AfterTargets="Publish"
           DependsOnTargets="CreatePrivateSourceBuiltArtifactsArchive"
           Condition="'$(EnablePoison)' == 'true'"
           Inputs="$(MSBuildProjectFullPath)"


### PR DESCRIPTION
## Problem

The `VerticalManifest.xml` file was not being included in the `Private.SourceBuilt.Artifacts` tarball for RIDs where `EnablePoison=true` (e.g. centos.10-x64). This prevents any previously source-built artifacts from being used by builds that consume such a tarball. Other RIDs (e.g. ubuntu.24.04-x64) were unaffected.

## Root Cause

A target ordering issue in `eng/PublishSourceBuild.props` caused `CreatePrivateSourceBuiltArtifactsArchive` to execute **before** the `VerticalManifest.xml` file was written to disk.

The `VerticalManifest.xml` file is written by the `PublishToAzureDevOpsArtifacts` target, which runs as part of the Publish pipeline. `CreatePrivateSourceBuiltArtifactsArchive` is designed to run `AfterTargets="Publish"`, so normally the manifest exists by the time the tarball is assembled.

However, when `EnablePoison=true`, the `ReportPoisonUsage` target disrupted this ordering:

1. `ReportPoisonUsage` had `AfterTargets="DiscoverArtifacts"`, causing it to be scheduled very early in the build.
2. Its `DependsOnTargets="CreatePrivateSourceBuiltArtifactsArchive"` forced the tarball creation target to execute immediately — well before `PublishToAzureDevOpsArtifacts` had run.
3. The `Copy` task that copies `$(AssetManifestFilePath)` (VerticalManifest.xml) into the tarball layout directory silently did nothing because the source file didn't exist yet.
4. The tarball was created without the manifest.
5. Later, `PublishToAzureDevOpsArtifacts` wrote `VerticalManifest.xml` — but the tarball had already been packaged.

### Target execution order comparison

**centos.10-x64 (broken, `EnablePoison=true`):**

```
DiscoverArtifacts
  └─ ReportPoisonUsage (AfterTargets="DiscoverArtifacts")
       └─ CreatePrivateSourceBuiltArtifactsArchive (DependsOn, runs NOW)
            └─ Copy VerticalManifest.xml → file doesn't exist yet! ❌
... (later) ...
PublishToAzureDevOpsArtifacts → writes VerticalManifest.xml (too late)
Publish
```

**ubuntu.24.04-x64 (working, `EnablePoison` not set):**

```
DiscoverArtifacts
... (ReportPoisonUsage skipped due to Condition) ...
PublishToAzureDevOpsArtifacts → writes VerticalManifest.xml ✅
Publish
  └─ CreatePrivateSourceBuiltArtifactsArchive (AfterTargets="Publish")
       └─ Copy VerticalManifest.xml → file exists ✅
```

## Fix

Changed `ReportPoisonUsage` from `AfterTargets="DiscoverArtifacts"` to `AfterTargets="Publish"`. This ensures the full publish pipeline — including `PublishToAzureDevOpsArtifacts` writing the manifest — completes before `ReportPoisonUsage` triggers and pulls in `CreatePrivateSourceBuiltArtifactsArchive`. The poison check doesn't need anything from `DiscoverArtifacts` specifically; it only needs the SDK archive and packages which are all available after `Publish`.
