### PR TITLE
Raise ulimit in cross-build containers to prevent NuGet restore failures

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -851,7 +851,11 @@ jobs:
 
           # Raise the open file descriptor limit to prevent NuGet restore failures
           # in cross-build containers with restrictive defaults (see dotnet/dotnet#5381)
-          ulimit -n 65536 2>/dev/null || true
+          if ! ulimit -n 65536 2>/dev/null; then
+            echo "Warning: failed to raise open file descriptor limit to 65536. Current limits:"
+            echo "  Soft nofile limit: $(ulimit -Sn 2>/dev/null || echo 'unknown')"
+            echo "  Hard nofile limit: $(ulimit -Hn 2>/dev/null || echo 'unknown')"
+          fi
 
           $customPreBuildArgs ./build.sh $buildArgs
 


### PR DESCRIPTION
## Summary

Raise the open file descriptor limit (`ulimit -n 65536`) before `./build.sh` in cross-build container legs to prevent NuGet restore from exhausting the default limit.

## Problem

Cross-build containers (e.g., `AzureLinux_x64_Cross_arm`, `AzureLinux_x64_Cross_Alpine_x64`) intermittently fail with:

```
Too many open files : '.local/share/NuGet/http-cache/...dat'
```

This was initially thought to be a one-off ([#5381](https://github.com/dotnet/dotnet/issues/5381)), but it's now hit on **two different branches** (`release/10.0.2xx` and `release/10.0.3xx`), confirming it's a chronic low-frequency issue. The Roslyn solution restore opens many concurrent NuGet HTTP connections that exceed the container's default `ulimit -n`.

## Fix

Add `ulimit -n 65536 2>/dev/null || true` before both `./build.sh` invocations in the Linux build path (`eng/pipelines/templates/jobs/vmr-build.yml`):

1. The main Build step (line ~794)
2. The Run Tests step (line ~850)

The `2>/dev/null || true` ensures the build doesn't fail if the limit can't be raised (e.g., if the container's hard limit is lower). Since containers already run with `--privileged`, this should always succeed.

## Why 65536?

- Default container limit is typically 1024
- Roslyn's NuGet restore can open 100+ concurrent connections × many packages
- 65536 is a standard elevated limit used across CI systems and matches typical Linux server defaults
- Well within the kernel maximum (`/proc/sys/fs/nr_open`, usually 1048576)

Fixes #5381