### PR TITLE
Revert "Disable sdk file deduplication for osx because of a runtime issue which breaks signing (#5323)

### DIFF
--- a/src/sdk/src/Layout/redist/targets/GenerateInstallerLayout.targets
+++ b/src/sdk/src/Layout/redist/targets/GenerateInstallerLayout.targets
@@ -102,8 +102,7 @@
       <_UseHardLinks Condition="!$([MSBuild]::IsOSPlatform('Windows'))">false</_UseHardLinks>
     </PropertyGroup>
 
-    <!-- OSX is disabled until https://github.com/dotnet/runtime/issues/125332 is fixed. -->
-    <DeduplicateAssembliesWithLinks Condition="!$([MSBuild]::IsOSPlatform('OSX'))" LayoutDirectory="$(RedistInstallerLayoutPath)sdk\" UseHardLinks="$(_UseHardLinks)" />
+    <DeduplicateAssembliesWithLinks LayoutDirectory="$(RedistInstallerLayoutPath)sdk\" UseHardLinks="$(_UseHardLinks)" />
   </Target>
 
   <!-- Copy the sdk layout into a temporary folder so that it's nested under "sdk\$(Version)\" which is

--- a/src/sdk/test/EndToEnd.Tests/GivenDotNetMacInstallers.cs
+++ b/src/sdk/test/EndToEnd.Tests/GivenDotNetMacInstallers.cs
@@ -6,43 +6,42 @@ using EndToEnd.Tests.Utilities;
 
 namespace EndToEnd.Tests;
 
-// Disabled until https://github.com/dotnet/runtime/issues/125332 is fixed.
-// public class GivenDotNetMacInstallers(ITestOutputHelper log) : SdkTest(log)
-// {
-//     [Fact]
-//     public void PkgPackagePreservesSymbolicLinks() =>
-//         FileLinkHelpers.VerifyInstallerSymlinks(
-//             OSPlatform.OSX,
-//             "dotnet-sdk-*.pkg",
-//             excludeSubstrings: ["-internal"],
-//             ExtractPkgPackage,
-//             TestAssetsManager,
-//             Log);
+public class GivenDotNetMacInstallers(ITestOutputHelper log) : SdkTest(log)
+{
+    [Fact]
+    public void PkgPackagePreservesSymbolicLinks() =>
+        FileLinkHelpers.VerifyInstallerSymlinks(
+            OSPlatform.OSX,
+            "dotnet-sdk-*.pkg",
+            excludeSubstrings: ["-internal"],
+            ExtractPkgPackage,
+            TestAssetsManager,
+            Log);
 
-//     private void ExtractPkgPackage(string installerPath, string tempDir)
-//     {
-//         // Expand the pkg using pkgutil
-//         var expandedDir = Path.Combine(tempDir, "expanded");
-//         new RunExeCommand(Log, "pkgutil")
-//             .Execute("--expand", installerPath, expandedDir)
-//             .Should().Pass();
+    private void ExtractPkgPackage(string installerPath, string tempDir)
+    {
+        // Expand the pkg using pkgutil
+        var expandedDir = Path.Combine(tempDir, "expanded");
+        new RunExeCommand(Log, "pkgutil")
+            .Execute("--expand", installerPath, expandedDir)
+            .Should().Pass();
 
-//         // Find and extract the Payload from each component
-//         // pkg files contain one or more component directories, each with a Payload file
-//         var payloadFiles = Directory.GetFiles(expandedDir, "Payload", SearchOption.AllDirectories);
+        // Find and extract the Payload from each component
+        // pkg files contain one or more component directories, each with a Payload file
+        var payloadFiles = Directory.GetFiles(expandedDir, "Payload", SearchOption.AllDirectories);
 
-//         foreach (var payloadFile in payloadFiles)
-//         {
-//             var componentDir = Path.GetDirectoryName(payloadFile)!;
-//             var componentName = Path.GetFileName(componentDir);
-//             var extractDir = Path.Combine(tempDir, "data", componentName);
-//             Directory.CreateDirectory(extractDir);
+        foreach (var payloadFile in payloadFiles)
+        {
+            var componentDir = Path.GetDirectoryName(payloadFile)!;
+            var componentName = Path.GetFileName(componentDir);
+            var extractDir = Path.Combine(tempDir, "data", componentName);
+            Directory.CreateDirectory(extractDir);
 
-//             // Payload is a cpio archive (possibly compressed)
-//             // Use ditto which handles Apple's archive formats well
-//             new RunExeCommand(Log, "ditto")
-//                 .Execute("-x", payloadFile, extractDir)
-//                 .Should().Pass();
-//         }
-//     }
-// }
+            // Payload is a cpio archive (possibly compressed)
+            // Use ditto which handles Apple's archive formats well
+            new RunExeCommand(Log, "ditto")
+                .Execute("-x", payloadFile, extractDir)
+                .Should().Pass();
+        }
+    }
+}

--- a/src/sdk/test/EndToEnd.Tests/GivenSdkArchives.cs
+++ b/src/sdk/test/EndToEnd.Tests/GivenSdkArchives.cs
@@ -11,13 +11,6 @@ public class GivenSdkArchives(ITestOutputHelper log) : SdkTest(log)
     [Fact]
     public void ItHasDeduplicatedAssemblies()
     {
-        // OSX is disabled until https://github.com/dotnet/runtime/issues/125332 is fixed.
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-        {
-            Log.WriteLine("SKIPPED: OSX deduplication not yet supported (https://github.com/dotnet/runtime/issues/125332)");
-            return;
-        }
-
         // Find and extract archive
         string archivePath = SdkTestContext.FindSdkAcquisitionArtifact("dotnet-sdk-*.tar.gz");
         Log.WriteLine($"Found SDK archive: {Path.GetFileName(archivePath)}");


### PR DESCRIPTION
This reverts commit f78fb5c718604451fc452ad925861f6ebc45c7e3.

Validated with signed build - https://dev.azure.com/dnceng/internal/_build/results?buildId=2928681&view=results