### PR TITLE
Run Validate Signing Linux job in a container

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -137,6 +137,9 @@ extends:
       ${{ variables.ubuntuArmContainerName }}:
         image: ${{ variables.ubuntuArmContainerImage }}
         options: ${{ variables.defaultContainerOptions }}
+      ${{ variables.azurelinuxBuildContainerName }}:
+        image: ${{ variables.azurelinuxBuildContainerImage }}
+        options: ${{ variables.defaultContainerOptions }}
       ${{ variables.azurelinuxX64CrossContainerName }}:
         image: ${{ variables.azurelinuxX64CrossContainerImage }}
         options: ${{ variables.defaultContainerOptions }}

--- a/eng/pipelines/templates/stages/vmr-validation.yml
+++ b/eng/pipelines/templates/stages/vmr-validation.yml
@@ -110,6 +110,7 @@ stages:
     - job: ValidateSigning_Linux
       displayName: Validate Signing - Linux
       pool: ${{ parameters.pool_Linux }}
+      container: ${{ variables.azurelinuxBuildContainerName }}
       timeoutInMinutes: 240
       steps:
       - template: ../steps/vmr-validate-signing.yml

--- a/eng/pipelines/templates/steps/vmr-validate-signing.yml
+++ b/eng/pipelines/templates/steps/vmr-validate-signing.yml
@@ -33,6 +33,10 @@ steps:
       xcrun simctl runtime delete all
     displayName: Reclaim disk space from unused simulator runtimes
 
+- ${{ if eq(parameters.OS, 'Linux') }}:
+  - script: df -h
+    displayName: Print free disk space
+
 - task: DownloadPipelineArtifact@2
   displayName: Download Shortstack Vertical Build Artifacts
   continueOnError: ${{ parameters.continueOnError }}

--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -178,6 +178,11 @@ variables:
 - name: ubuntuArmContainerImage
   value: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-24.04-arm64
 
+- name: azurelinuxBuildContainerName
+  value: azurelinuxBuildContainer
+- name: azurelinuxBuildContainerImage
+  value: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-build-amd64
+
 - name: azurelinuxX64CrossContainerName
   value: azurelinuxX64CrossContainer
 - name: azurelinuxX64CrossContainerImage

--- a/eng/pipelines/unofficial.yml
+++ b/eng/pipelines/unofficial.yml
@@ -92,6 +92,9 @@ extends:
       ${{ variables.ubuntuArmContainerName }}:
         image: ${{ variables.ubuntuArmContainerImage }}
         options: ${{ variables.defaultContainerOptions }}
+      ${{ variables.azurelinuxBuildContainerName }}:
+        image: ${{ variables.azurelinuxBuildContainerImage }}
+        options: ${{ variables.defaultContainerOptions }}
       ${{ variables.azurelinuxX64CrossContainerName }}:
         image: ${{ variables.azurelinuxX64CrossContainerImage }}
         options: ${{ variables.defaultContainerOptions }}


### PR DESCRIPTION
Run the ValidateSigning_Linux job inside the AzureLinux container instead of directly on the host agent. Add a disk space check step before artifact downloads on Linux.

There were a couple reports on FR recently about disk space issues when running directly on the build host, running inside a container works around this.

Fixes https://github.com/dotnet/dotnet/issues/5480