### PR TITLE
[release/10.0.1xx] Run Validate Signing Linux job in a container

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -130,6 +130,9 @@ extends:
       ${{ variables.ubuntuArmContainerName }}:
         image: ${{ variables.ubuntuArmContainerImage }}
         options: ${{ variables.defaultContainerOptions }}
+      ${{ variables.azurelinuxBuildContainerName }}:
+        image: ${{ variables.azurelinuxBuildContainerImage }}
+        options: ${{ variables.defaultContainerOptions }}
       ${{ variables.azurelinuxX64CrossContainerName }}:
         image: ${{ variables.azurelinuxX64CrossContainerImage }}
         options: ${{ variables.defaultContainerOptions }}

--- a/eng/pipelines/templates/stages/vmr-validation.yml
+++ b/eng/pipelines/templates/stages/vmr-validation.yml
@@ -110,6 +110,7 @@ stages:
     - job: ValidateSigning_Linux
       displayName: Validate Signing - Linux
       pool: ${{ parameters.pool_Linux }}
+      container: ${{ variables.azurelinuxBuildContainerName }}
       timeoutInMinutes: 240
       steps:
       - template: ../steps/vmr-validate-signing.yml

--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -173,6 +173,11 @@ variables:
 - name: ubuntuArmContainerImage
   value: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-24.04-arm64
 
+- name: azurelinuxBuildContainerName
+  value: azurelinuxBuildContainer
+- name: azurelinuxBuildContainerImage
+  value: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-build-amd64
+
 - name: azurelinuxX64CrossContainerName
   value: azurelinuxX64CrossContainer
 - name: azurelinuxX64CrossContainerImage

--- a/eng/pipelines/unofficial.yml
+++ b/eng/pipelines/unofficial.yml
@@ -92,6 +92,9 @@ extends:
       ${{ variables.ubuntuArmContainerName }}:
         image: ${{ variables.ubuntuArmContainerImage }}
         options: ${{ variables.defaultContainerOptions }}
+      ${{ variables.azurelinuxBuildContainerName }}:
+        image: ${{ variables.azurelinuxBuildContainerImage }}
+        options: ${{ variables.defaultContainerOptions }}
       ${{ variables.azurelinuxX64CrossContainerName }}:
         image: ${{ variables.azurelinuxX64CrossContainerImage }}
         options: ${{ variables.defaultContainerOptions }}


### PR DESCRIPTION
Run the ValidateSigning_Linux job inside the Ubuntu container instead of directly on the host agent.

Backport of #5525 