### PR TITLE
Simplify reuseBuildArtifactsFrom dependsOn build conditions in vmr-build.yml

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -174,19 +174,8 @@ jobs:
         options: $(defaultContainerOptions)
 
   ${{ if gt(length(parameters.reuseBuildArtifactsFrom), 0) }}:
-    ${{ if eq(parameters.buildPass, '') }}:
-      # For PR builds, skip the stage 2 build if the stage 1 build fails.
-      # Otherwise, run the stage 2 build even if the stage 1 build fails so that we can get a complete assessment of the build status.
-      # The build shortcuts when stage 1 build fails and doesn't produce the SDK.
-      ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-        condition: succeeded()
-      ${{ else }}:
-        condition: succeededOrFailed()
-    ${{ else }}:
-      condition: succeeded()
     dependsOn:
-    - ${{ if gt(length(parameters.reuseBuildArtifactsFrom), 0) }}:
-      - ${{ parameters.reuseBuildArtifactsFrom }}
+    - ${{ parameters.reuseBuildArtifactsFrom }}
   variables:
   - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
     - group: AzureDevOps-Artifact-Feeds-Pats


### PR DESCRIPTION
This didn't work as expected since when we upload the "failed" artifacts we append the System.JobAttempt to the artifact name: 

https://github.com/dotnet/dotnet/blob/f12904215d9817e5614391f7d2f8c9a6d198f5c7/eng/pipelines/templates/jobs/vmr-build.yml#L239-L240

https://github.com/dotnet/dotnet/blob/f12904215d9817e5614391f7d2f8c9a6d198f5c7/eng/pipelines/templates/jobs/vmr-build.yml#L381-L397

But this means that when a later job runs after a failed job and uses `reuseBuildArtifactsFrom` it tries to download from the "success" artifact name which doesn't exist.

Example of where this happened is https://dev.azure.com/dnceng/internal/_build/results?buildId=2928711&view=logs&j=2e6065a6-204b-52a8-7ec8-d3ca39c48aae&t=588d6c87-657f-5e0b-4514-931edd65a77d