### PR TITLE
Enable CFSClean* policies for dnceng/internal pipelines

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -74,6 +74,8 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive, CFSClean, CFSClean2
     featureFlags:
       incrementalSDLBinaryAnalysis: true
       autoEnablePREfastWithNewRuleset: false

--- a/eng/pipelines/source-build-outer-loop.yml
+++ b/eng/pipelines/source-build-outer-loop.yml
@@ -26,6 +26,8 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive, CFSClean, CFSClean2
     featureFlags:
       incrementalSDLBinaryAnalysis: true
     sdl:

--- a/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -54,6 +54,8 @@ parameters:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive, CFSClean, CFSClean2
     pool:
       name: NetCore1ESPool-Svc-Internal
       image: 1es-ubuntu-2204

--- a/eng/pipelines/unofficial.yml
+++ b/eng/pipelines/unofficial.yml
@@ -65,6 +65,8 @@ resources:
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive, CFSClean, CFSClean2
     featureFlags:
       incrementalSDLBinaryAnalysis: true
     sdl:

--- a/eng/pipelines/vmr-compare.yml
+++ b/eng/pipelines/vmr-compare.yml
@@ -53,6 +53,8 @@ variables:
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive, CFSClean, CFSClean2
     featureFlags:
       incrementalSDLBinaryAnalysis: true
     sdl:

--- a/eng/pipelines/vmr-license-scan.yml
+++ b/eng/pipelines/vmr-license-scan.yml
@@ -50,6 +50,8 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive, CFSClean, CFSClean2
     pool:
       name: NetCore1ESPool-Svc-Internal
       image: 1es-ubuntu-2204


### PR DESCRIPTION
Enable CFSClean network isolation policies for 1ES pipelines. Test builds have been validated.