### PR TITLE
Revert "[release/10.0.3xx] Sign Source Asset for Source-Build Release"

### DIFF
--- a/eng/PublishSourceBuild.props
+++ b/eng/PublishSourceBuild.props
@@ -214,8 +214,8 @@
         <Kind>Blob</Kind>
         <IsShipping>true</IsShipping>
       </SourceBuildArtifact>
-      <!-- Add the source artifact and signature to the publishing output. -->
-      <SourceBuildArtifact Include="$(ArtifactsAssetsDir)$(SourceBuiltSourceArtifactName)-*$(ArchiveExtension)*">
+      <!-- Add the source artifacts to the publishing output. -->
+      <SourceBuildArtifact Include="$(ArtifactsAssetsDir)$(SourceBuiltSourceArtifactName)-*">
         <Kind>Blob</Kind>
         <IsShipping>true</IsShipping>
       </SourceBuildArtifact>
@@ -248,7 +248,7 @@
     <ItemGroup Condition="'$(IsPublishPass2)' == 'true'">
       <SourceBuildArtifact Include="$(ArtifactsAssetsDir)/$(SourceBuiltArtifactsTarballName).*$(ArchiveExtension)" />
       <SourceBuildArtifact Include="$(SdkNonStableVersionedTarballPath)" />
-      <SourceBuildArtifact Include="$(ArtifactsAssetsDir)/$(SourceBuiltSourceArtifactName)-*$(ArchiveExtension)*" />
+      <SourceBuildArtifact Include="$(ArtifactsAssetsDir)/$(SourceBuiltSourceArtifactName)-*" />
       <Artifact Include="@(SourceBuildArtifact)">
         <IsShipping>true</IsShipping>
         <DotNetReleaseShipping Condition="'$(DotNetSourceOnlyPostBuildSign)' == 'true'">true</DotNetReleaseShipping>

--- a/eng/finish-source-only.proj
+++ b/eng/finish-source-only.proj
@@ -251,8 +251,7 @@
         SdkStableVersion="$(SourceBuiltSdkVersion)"
         SdkNonStableVersion="$(SourceBuiltSdkNonStableVersion)"
         RepoRoot="$(RepoRoot)"
-        OutputDirectory="$(ArtifactsAssetsDir)"
-        CreateEmptyDetachedSignature="$(DotNetSourceOnlyPostBuildSign)" />
+        OutputDirectory="$(ArtifactsAssetsDir)" />
   </Target>
 
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.UsageReport.WriteUsageBurndownData" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />

--- a/eng/sign-source-built-artifacts.proj
+++ b/eng/sign-source-built-artifacts.proj
@@ -49,13 +49,15 @@
       <SignableSourceBuiltAsset Include="@(SignableSourceBuiltArtifactsTarball)" />
 
       <!-- Source tarball -->
-      <SignableSourceBuiltSourceArtifact Include="$(SourceBuiltPublishAssetsDir)/$(SourceBuiltSourceArtifactName)-*$(ArchiveExtension)" />
-      <SignableSourceBuiltAsset Include="@(SignableSourceBuiltSourceArtifact)" />
+      <!-- Uncomment once https://github.com/dotnet/arcade/issues/16370 has been resolved. -->
+      <!-- <SignableSourceBuiltSourceArtifact Include="$(SourceBuiltPublishAssetsDir)/$(SourceBuiltSourceArtifactName)-*$(ArchiveExtension)" /> -->
+      <!-- <SignableSourceBuiltAsset Include="@(SignableSourceBuiltSourceArtifact)" /> -->
     </ItemGroup>
 
     <Error Text="$(SourceBuiltSdkTarballName) artifact count is @(SignableSourceBuiltSdkTarball->Count()) and should be 1" Condition="@(SignableSourceBuiltSdkTarball->Count()) != 1"/>
     <Error Text="$(SourceBuiltArtifactsTarballName) artifact count is @(SignableSourceBuiltArtifactsTarball->Count()) and should be 1" Condition="@(SignableSourceBuiltArtifactsTarball->Count()) != 1"/>
-    <Error Text="$(SourceBuiltSourceArtifactName) artifact count is @(SignableSourceBuiltSourceArtifact->Count()) and should be 1" Condition="@(SignableSourceBuiltSourceArtifact->Count()) != 1"/>
+    <!-- Enable once https://github.com/dotnet/arcade/issues/16370 has been resolved. -->
+    <!-- <Error Text="$(SourceBuiltSourceArtifactName) artifact count is @(SignableSourceBuiltSourceArtifact->Count()) and should be 1" Condition="@(SignableSourceBuiltSourceArtifact->Count()) != 1"/> -->
   </Target>
 
 </Project>

--- a/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/CreateSourceArtifact.cs
+++ b/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/CreateSourceArtifact.cs
@@ -52,17 +52,10 @@ public class CreateSourceArtifact : BuildTask
     [Required]
     public required string OutputDirectory { get; init; }
 
-    /// <summary>
-    /// Create an empty detached signature file alongside the source artifact
-    /// Ensures the signature is published via darc when signing occurs post-build
-    /// </summary>
-    public bool CreateEmptyDetachedSignature { get; init; } = false;
-
     private const string GitHubRepoName = "dotnet";
     private const string GitHubTimezone = "America/Los_Angeles"; // GitHub uses this timezone for commit timestamps in zip metadata
     private const int GitArchiveTimeout = 5 * 60 * 1000; // 5 minutes
     private const string TarExtension = "tar.gz";
-    private const string SignatureExtension = "sig";
 
     public override bool Execute() => ExecuteAsync().GetAwaiter().GetResult();
 
@@ -94,26 +87,6 @@ public class CreateSourceArtifact : BuildTask
             Log.LogError($"[{TarExtension}] Exception during artifact creation: {ex.Message}");
             return false;
         }
-
-        if (CreateEmptyDetachedSignature)
-        {
-            string signatureFilePath = $"{artifactFilePath}.{SignatureExtension}";
-            Log.LogMessage(MessageImportance.High, $"Creating empty detached signature at: {signatureFilePath}");
-
-            try
-            {
-                using (FileStream fs = File.Create(signatureFilePath))
-                {
-                    // Create an empty file
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.LogError($"[{SignatureExtension}] Exception during signature file creation: {ex.Message}");
-                return false;
-            }
-        }
-
         return true;
     }
 }

--- a/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/static/Signing.props
+++ b/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/static/Signing.props
@@ -1,9 +1,6 @@
 <Project>
 
-  <Import Project="$(RepositoryEngineeringDir)VmrLayout.props" />
-
   <PropertyGroup>
-    <SourceAssetCertificateId>LinuxSign500180PGP</SourceAssetCertificateId>
     <ExternalCertificateId>3PartySHA2</ExternalCertificateId>
     <UseDotNetCertificate>true</UseDotNetCertificate>
   </PropertyGroup>
@@ -13,31 +10,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Materialize an item list from the property so transforms work -->
-    <SignableSourceBuiltAsset Include="$(SignableSourceBuiltAssets)" />
+    <ItemsToSign Include="$(SignableSourceBuiltAssets)" />
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Sign all of the source built assets -->
-    <ItemsToSign Include="@(SignableSourceBuiltAsset)" />
-  </ItemGroup>
+    <!-- Some of the artifacts need to be strong-named with the AspNetCore snk -->
+    <!-- Remove once https://github.com/dotnet/arcade/issues/16105 has been addressed -->
+    <StrongNameSignInfo
+      Include="$(NuGetPackageRoot)microsoft.dotnet.arcade.sdk/$(MicrosoftDotNetArcadeSdkPackageVersion)/tools/snk/AspNetCore.snk"
+      PublicKeyToken="adb9793829ddae60"
+      CertificateName="MicrosoftDotNet500" />
 
-  <Target Name="SetFileSignInfoForSourceAsset" BeforeTargets="Sign">
-    <ItemGroup>
-      <SourceBuiltSourceAsset Include="@(SignableSourceBuiltAsset)" Condition="$([System.String]::new('%(Filename)').StartsWith('$(SourceBuiltSourceArtifactName)'))"/>
-    </ItemGroup>
-
-    <!-- Do not unpack the source asset -->
-    <!-- Sign the source asset using a detached signature. -->
-    <ItemGroup>
-      <FileSignInfo Include="@(SourceBuiltSourceAsset->'%(Filename)%(Extension)')">
-        <CertificateName>$(SourceAssetCertificateId)</CertificateName>
-        <DoNotUnpack>true</DoNotUnpack>
-      </FileSignInfo>
-    </ItemGroup>
-  </Target>
-
-  <ItemGroup>
     <!-- We don't need to code sign .js files because they are not used in Windows Script Host -->
     <FileExtensionSignInfo Update=".js" CertificateName="None" />
 


### PR DESCRIPTION
Reverts dotnet/dotnet#5533

release/10.0.3xx needs to be rebootstrapped with the latest 10.0.1xx release before these changes can be merged.