### PR TITLE
Disable binary analysis caching for Fedora43 Offline MsftSdk job

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -153,6 +153,11 @@ parameters:
   displayName: True when build is running from dotnet/dotnet directly
   type: boolean
 
+# Disable binary analysis caching by busting the cache key
+- name: disableBinaryAnalysisCaching
+  type: boolean
+  default: false
+
 jobs:
 - job: ${{ parameters.buildName }}_${{ parameters.targetArchitecture }}${{ replace(format('_BuildPass{0}', coalesce(parameters.buildPass, '1')), '_BuildPass1', '') }}
   pool: ${{ parameters.pool }}
@@ -358,6 +363,10 @@ jobs:
     timeoutInMinutes: 240
 
   templateContext:
+    ${{ if eq(parameters.disableBinaryAnalysisCaching, true) }}:
+      sdl:
+        binaryAnalysisCaching:
+          userState: 'no-cache-$(Build.BuildId)-$(System.JobAttempt)'
     outputParentDirectory: $(Build.ArtifactStagingDirectory)
     outputs:
     - output: pipelineArtifact

--- a/eng/pipelines/templates/stages/source-build-and-validate.yml
+++ b/eng/pipelines/templates/stages/source-build-and-validate.yml
@@ -140,6 +140,8 @@ stages:
           signType: ${{ variables.signType }}
         excludeRuntimeDependentJobs: ${{ parameters.excludeRuntimeDependentJobs }}
         brandingType: ${{ variables.brandingType }}
+        ${{ if leg.disableBinaryAnalysisCaching }}:
+          disableBinaryAnalysisCaching: true
         
         # We only want to publish SB artifacts for each distinct distro/version/arch combination.
         # Stage 2 legs (those with reuseBuildArtifactsFrom) also get extraPropertiesStage2.
@@ -232,6 +234,8 @@ stages:
             /p:RestoreAdditionalProjectSources=$(Pipeline.Workspace)/msft-pkgs
           excludeRuntimeDependentJobs: ${{ parameters.excludeRuntimeDependentJobs }}
           brandingType: ${{ variables.brandingType }}
+          ${{ if leg.disableBinaryAnalysisCaching }}:
+            disableBinaryAnalysisCaching: true
           
           testInitSteps:
           # Ensure the artifacts staging directory exists so that even if no files get placed there, it won't fail

--- a/eng/pipelines/templates/stages/source-build-stages.yml
+++ b/eng/pipelines/templates/stages/source-build-stages.yml
@@ -234,6 +234,7 @@ stages:
               withPreviousSDK: false             # 🚫
               disableSigning: true               # ✅
               createSourceArtifact: false        # 🚫
+              disableBinaryAnalysisCaching: true
 
             - buildNameFormat: 'SB_{0}Arm64_Offline_MsftSdk'
               distro: ubuntu


### PR DESCRIPTION
Add a disableBinaryAnalysisCaching parameter to vmr-build.yml that busts the 1ES binary analysis cache key by setting a unique userState per build attempt. Enable it for the SB_Fedora43_Offline_MsftSdk leg.

Relates to https://github.com/dotnet/dotnet/issues/5429