### PR TITLE
Use sdk-task from VMR's eng/common instead of arcade

### DIFF
--- a/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/SigningValidation.cs
+++ b/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/SigningValidation.cs
@@ -291,9 +291,7 @@ public class SigningValidation : BuildTask
     /// </summary>
     private (string command, string arguments) GetSignCheckCommandAndArguments()
     {
-        // Target sdk-task scripts from Arcade to catch and fix issues with the scripts between releases
-        // This reduces our exposure to known issues in the local VMR copy and improves build reliability during the VMR bootstrap window.
-        string sdkTaskScript = Path.Combine(DotNetRootDirectory, "src", "arcade", "eng", "common", "sdk-task");
+        string sdkTaskScript = Path.Combine(DotNetRootDirectory, "eng", "common", "sdk-task");
 
         string argumentsTemplate =
             $"'{sdkTaskScript}.$scriptExtension$' " +


### PR DESCRIPTION
Reverts dotnet/dotnet#2447

The sdk-task script has been stable for some time, use the VMR copy instead. This ensures we're actually using the version of SignCheck defined in the VMR's nuget.config instead of the arcade one (which can be behind like we see right now due to https://github.com/dotnet/arcade/pull/16474 being blocked)