### PR TITLE
Remove auditSources from NuGet.Config

### DIFF
--- a/src/nuget-client/NuGet.Config
+++ b/src/nuget-client/NuGet.Config
@@ -9,10 +9,6 @@
     <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json" />
     <add key="vside" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption%40Local/nuget/v3/index.json" />
   </packageSources>
-  <auditSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </auditSources>
   <packageSourceMapping>
     <clear />
     <packageSource key="dotnet-public">


### PR DESCRIPTION
Removed auditSources section from Nuget.Client's NuGet.Config.