### PR TITLE
[release/10.0.1xx] Add task to remove blocked audit sources from NuGet.config

### DIFF
--- a/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/RemoveBlockedAuditSourcesFromNuGetConfig.cs
+++ b/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/RemoveBlockedAuditSourcesFromNuGetConfig.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using System.Xml.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.UnifiedBuild.Tasks
+{
+    /// <summary>
+    /// Removes blocked entries from the auditSources section of a NuGet.config file.
+    /// Audit sources can reach out to the internet at restore time which may not be available in CI builds.
+    /// </summary>
+    public class RemoveBlockedAuditSourcesFromNuGetConfig : Task
+    {
+        private static readonly string[] BlockedAuditSources = [ "nuget.org" ];
+
+        [Required]
+        public required string NuGetConfigFile { get; set; }
+
+        public override bool Execute()
+        {
+            string xml = File.ReadAllText(NuGetConfigFile);
+            string newLineChars = FileUtilities.DetectNewLineChars(xml);
+            XDocument d = XDocument.Parse(xml);
+
+            XElement? auditSourcesElement = d.Root?.Descendants().FirstOrDefault(e => e.Name == "auditSources");
+            if (auditSourcesElement == null)
+            {
+                return true;
+            }
+
+            foreach (string url in BlockedAuditSources)
+            {
+                auditSourcesElement.Descendants("add")
+                    .FirstOrDefault(e => e.Attribute("value")?.Value?.Contains(url, StringComparison.OrdinalIgnoreCase) == true)
+                    ?.Remove();
+            }
+
+            using (var w = XmlWriter.Create(NuGetConfigFile, new XmlWriterSettings { NewLineChars = newLineChars, Indent = true }))
+            {
+                d.Save(w);
+            }
+
+            return true;
+        }
+    }
+}

--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -109,10 +109,6 @@
     <CommonArgs>$(CommonArgs) $(FlagParameterPrefix)verbosity $(LogVerbosity)</CommonArgs>
     <CommonArgs>$(CommonArgs) /p:TargetRid=$(TargetRid)</CommonArgs>
 
-    <!-- Disable NuGet audit. Most repositories do NOT have nuget audit sources because nuget.org is typically a blocked
-         endpoint. However, NuGet itself keeps it for dogfooding in their own build. -->
-    <CommonArgs>$(CommonArgs) /p:NuGetAudit=false</CommonArgs>
-
     <!-- Pass through DotNetBuildPass for join point vertical support. -->
     <CommonArgs Condition="'$(DotNetBuildPass)' != '' and '$(DotNetBuildPass)' != '1'">$(CommonArgs) /p:DotNetBuildPass=$(DotNetBuildPass)</CommonArgs>
 

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -163,6 +163,7 @@
 
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.AddSourceToNuGetConfig" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.RemoveInternetSourcesFromNuGetConfig" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
+  <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.RemoveBlockedAuditSourcesFromNuGetConfig" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.UpdateNuGetConfigPackageSourcesMappings" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
   <Target Name="UpdateNuGetConfig"
           DependsOnTargets="ResolveProjectReferences;CopyNuGetConfig;GetRepositoryReferenceInfo"
@@ -212,6 +213,10 @@
       BuildWithOnlineFeeds="$(DotNetBuildWithOnlineFeeds)"
       KeepFeedPrefixes="@(KeepFeedPrefixes)"
       Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
+
+    <RemoveBlockedAuditSourcesFromNuGetConfig
+      NuGetConfigFile="$(NuGetConfigFile)"
+      Condition="'$(RemoveBlockedAuditSources)' == 'true'" />
 
     <AddSourceToNuGetConfig NuGetConfigFile="$(NuGetConfigFile)"
                             SourceName="$(PrebuiltNuGetSourceName)"

--- a/repo-projects/nuget-client.proj
+++ b/repo-projects/nuget-client.proj
@@ -7,6 +7,9 @@
     <BuildScript>$([MSBuild]::NormalizePath('$(ProjectDirectory)', 'eng', 'dotnet-build', 'build$(ShellExtension)'))</BuildScript>
     <!-- Passed for compatibility with new P4 SDK. -->
     <BuildArgs>$(BuildArgs) /p:GenerateResourceUsePreserializedResources=true</BuildArgs>
+
+    <!-- Remove nuget.org from auditSources to avoid reaching the internet during CI builds. -->
+    <RemoveBlockedAuditSources>true</RemoveBlockedAuditSources>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Port of https://github.com/dotnet/dotnet/pull/5607 to release/10.0.1xx.

Remove nuget.org from auditSources during nuget-client VMR builds to prevent internet access at restore time instead of turning off NuGetAudit completely.