### PR TITLE
Disable Component Governance on Alpine source-build jobs

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -158,6 +158,11 @@ parameters:
   type: boolean
   default: false
 
+# Disable Component Governance detection (e.g. on unsupported platforms)
+- name: disableComponentGovernance
+  type: boolean
+  default: false
+
 jobs:
 - job: ${{ parameters.buildName }}_${{ parameters.targetArchitecture }}${{ replace(format('_BuildPass{0}', coalesce(parameters.buildPass, '1')), '_BuildPass1', '') }}
   pool: ${{ parameters.pool }}
@@ -238,6 +243,10 @@ jobs:
   - ${{ if eq(parameters.pool.os, 'macOS') }}:
     - name: ONEES_ENFORCED_CODEQL_ENABLED
       value: false
+
+  - ${{ if eq(parameters.disableComponentGovernance, true) }}:
+    - name: skipComponentGovernanceDetection
+      value: true
 
   # Build up the command line variables. We avoid doing this in the script sections below
   # because AzDO will not echo command lines if they are more than a single line.

--- a/eng/pipelines/templates/stages/source-build-and-validate.yml
+++ b/eng/pipelines/templates/stages/source-build-and-validate.yml
@@ -115,6 +115,8 @@ stages:
             image: ${{ variables.alpineContainerImage }}
           artifactsRid: ${{ variables.alpineX64Rid }}
           targetRid: ${{ variables.alpineX64Rid }}
+          # CG downloads linux-x64 binaries which won't work on musl-based distros like Alpine
+          disableComponentGovernance: true
           ${{ if ne(leg.reuseBuildArtifactsFrom, '') }}:
             reuseBuildArtifactsFrom:
             - ${{ format(leg.reuseBuildArtifactsFrom, variables.centOSStreamName) }}
@@ -214,6 +216,8 @@ stages:
               image: ${{ variables.alpineContainerImage }}
             artifactsRid: ${{ variables.alpineX64Rid }}
             targetRid: ${{ variables.alpineX64Rid }}
+            # CG downloads linux-x64 binaries which won't work on musl-based distros like Alpine
+            disableComponentGovernance: true
 
           targetArchitecture: ${{ leg.targetArchitecture }}
           isBuiltFromVmr: ${{ parameters.isBuiltFromVmr }}


### PR DESCRIPTION
The CG task injects a linux-x64 (glibc) binary that cannot run in Alpine (musl) containers, causing the job to fail.

Add a disableComponentGovernance parameter to the vmr-build job template and set it for both Alpine source-build and validation legs.

Fix https://github.com/dotnet/dotnet/issues/5481