### PR TITLE
Remove duplicate bitbucket version

### DIFF
--- a/src/sdk/eng/Version.Details.xml
+++ b/src/sdk/eng/Version.Details.xml
@@ -429,10 +429,6 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>d346a57fc93fb42eb26f9da2aa66bfdeaa3372a5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceLink.Bitbucket.Git" Version="10.0.300-alpha.26118.105">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>d346a57fc93fb42eb26f9da2aa66bfdeaa3372a5</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.SourceLink.Bitbucket.Git" Version="10.0.105">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet</Uri>
       <Sha>a612c2a1056fe3265387ae3ff7c94eba1505caf9</Sha>


### PR DESCRIPTION
Remove extra dependency on bitbucket as a result of updating to 10.0.5 release (https://github.com/dotnet/dotnet/pull/5420/), as it is blocking sdk forward flows