### PR TITLE
Prefer dotnet MSBuild.dll for worker nodes when hosted by dotnet.exe

### DIFF
--- a/src/msbuild/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
+++ b/src/msbuild/src/Build/BackEnd/Components/Communications/NodeProviderOutOfProcBase.cs
@@ -228,6 +228,33 @@ namespace Microsoft.Build.BackEnd
                 msbuildLocation = _componentHost.BuildParameters.NodeExeLocation;
             }
 
+            // Extract the expected NodeMode from the command line arguments
+            NodeMode? expectedNodeMode = NodeModeHelper.ExtractFromCommandLine(commandLineArgs);
+
+#if RUNTIME_TYPE_NETCORE
+            // When MSBuild is hosted by dotnet.exe (e.g. `dotnet build`), NodeExeLocation may resolve
+            // to the AppHost (MSBuild.exe on Windows, MSBuild on Unix) because BuildEnvironmentHelper
+            // prefers the AppHost over MSBuild.dll. Launching worker nodes as AppHost processes incurs
+            // significant native bootstrap overhead. Prefer MSBuild.dll so worker nodes are launched
+            // via dotnet.exe, matching the parent process.
+            // This only applies to regular out-of-proc worker nodes (nodemode:1), not task host nodes
+            // (nodemode:2) which may need the AppHost for COM host object support.
+            if (expectedNodeMode == NodeMode.OutOfProcNode
+                && !String.IsNullOrEmpty(msbuildLocation)
+                && Path.GetFileName(msbuildLocation).Equals(Constants.MSBuildExecutableName, StringComparison.OrdinalIgnoreCase))
+            {
+                string currentProcessName = Path.GetFileName(EnvironmentUtilities.ProcessPath);
+                if (currentProcessName?.Equals(Constants.DotnetProcessName, StringComparison.OrdinalIgnoreCase) == true)
+                {
+                    string dllPath = Path.Combine(Path.GetDirectoryName(msbuildLocation), Constants.MSBuildAssemblyName);
+                    if (File.Exists(dllPath))
+                    {
+                        msbuildLocation = dllPath;
+                    }
+                }
+            }
+#endif
+
             if (String.IsNullOrEmpty(msbuildLocation))
             {
                 string msbuildExeName = Environment.GetEnvironmentVariable("MSBUILD_EXE_NAME");
@@ -240,9 +267,6 @@ namespace Microsoft.Build.BackEnd
             }
 
             bool nodeReuseRequested = Handshake.IsHandshakeOptionEnabled(nodeLaunchData.Handshake.HandshakeOptions, HandshakeOptions.NodeReuse);
-
-            // Extract the expected NodeMode from the command line arguments
-            NodeMode? expectedNodeMode = NodeModeHelper.ExtractFromCommandLine(commandLineArgs);
       
             // Get all process of possible running node processes for reuse and put them into ConcurrentQueue.
             // Processes from this queue will be concurrently consumed by TryReusePossibleRunningNodes while


### PR DESCRIPTION
When MSBuild is launched via dotnet.exe (e.g. dotnet build, dotnet msbuild), BuildEnvironmentHelper resolves CurrentMSBuildExePath to MSBuild.exe (the AppHost) because it prefers .exe over .dll. This causes all out-of-proc worker nodes to launch as MSBuild.exe AppHost processes, which seems to have regressed NuGet perf tests.

This change detects when the current process is dotnet.exe and the resolved MSBuild location is the AppHost, then substitutes MSBuild.dll so worker nodes are launched via dotnet.exe instead. This only applies to regular worker nodes (nodemode:1), not task host nodes (nodemode:2) which may need the AppHost for COM host object support.