### PR TITLE
Fix source-build SourceBuildPackageIdCreator misattribution

### DIFF
--- a/eng/finish-source-only.proj
+++ b/eng/finish-source-only.proj
@@ -119,12 +119,11 @@
           DependsOnTargets="ResolveProjectReferences;WritePrebuiltUsageData"
           AfterTargets="Build">
     <ItemGroup>
-      <PackageVersionPropsSavedSnapshotFile Include="$(PackageVersionsDir)PackageVersions.*.Snapshot.props" />
+      <PackageVersionPropsProducedFile Include="$(PackageVersionsDir)PackageVersions.*.Produced.props" />
     </ItemGroup>
-    <Copy SourceFiles="@(PackageVersionPropsSnapshotFiles)" DestinationFolder="$(ArtifactsLogDir)snapshots/" />
 
     <WriteAnnotatedUsageReport DataFile="$(PrebuiltUsageReportFile)"
-                               PackageVersionPropsSnapshots="@(PackageVersionPropsSavedSnapshotFile)"
+                               PackageVersionPropsProducedFiles="@(PackageVersionPropsProducedFile)"
                                PoisonedReportFile="$(PoisonedReportFile)"
                                PrebuiltAnnotatedUsageReportFile="$(PrebuiltAnnotatedUsageReportFile)"
                                VersionPropertySuffix="$(PackageVersionPropertySuffix)" />

--- a/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/UsageReport/WriteAnnotatedUsageReport.cs
+++ b/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/UsageReport/WriteAnnotatedUsageReport.cs
@@ -16,8 +16,8 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks.UsageReport
 {
     public class WriteAnnotatedUsageReport : Task
     {
-        private const string SnapshotPrefix = "PackageVersions.";
-        private const string SnapshotSuffix = ".Snapshot.props";
+        private const string ProducedPrefix = "PackageVersions.";
+        private const string ProducedSuffix = ".Produced.props";
 
         /// <summary>
         /// Source usage data JSON file.
@@ -32,12 +32,13 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks.UsageReport
         public string VersionPropertySuffix { get; set; }
 
         /// <summary>
-        /// A set of "PackageVersions.{repo}.Snapshot.props" files. They are analyzed to find
-        /// packages built during source-build, and which repo built them. This info is added to the
-        /// report. New packages are associated to a repo by going through each PVP in ascending
-        /// file modification order.
+        /// A set of "PackageVersions.{repo}.Produced.props" files. Each file lists the packages
+        /// directly produced by a specific repo, providing accurate attribution without relying
+        /// on snapshot diffs (which can misattribute packages when repos have independent
+        /// dependency trees).
         /// </summary>
-        public ITaskItem[] PackageVersionPropsSnapshots { get; set; }
+        [Required]
+        public ITaskItem[] PackageVersionPropsProducedFiles { get; set; }
 
         /// <summary>
         /// File containing the results of poisoning the prebuilts. Example format:
@@ -142,57 +143,20 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks.UsageReport
 
         private RepoOutput[] GetSourceBuildRepoOutputs()
         {
-            var pvpSnapshotFiles = PackageVersionPropsSnapshots.NullAsEmpty()
+            return PackageVersionPropsProducedFiles.NullAsEmpty()
                 .Select(item =>
                 {
-                    var content = File.ReadAllText(item.ItemSpec);
-                    return new
+                    string filename = Path.GetFileName(item.ItemSpec);
+                    string repo = filename.Substring(
+                        ProducedPrefix.Length,
+                        filename.Length - ProducedPrefix.Length - ProducedSuffix.Length);
+
+                    var xml = XElement.Parse(File.ReadAllText(item.ItemSpec));
+                    return new RepoOutput
                     {
-                        Path = item.ItemSpec,
-                        Content = content,
-                        Xml = XElement.Parse(content)
+                        Repo = repo,
+                        Built = PackageVersionPropsElement.Parse(xml)
                     };
-                })
-                .OrderBy(snapshot =>
-                {
-                    // Get the embedded creation time if possible: the file's original metadata may
-                    // have been destroyed by copying, zipping, etc.
-                    string creationTime = snapshot.Xml
-                        // Get all elements
-                        .Elements()
-                        // Select all the subelements
-                        .SelectMany(e => e.Elements())
-                        // Find all that match the creation time property name
-                        .Where(e => e.Name == snapshot.Xml.GetDefaultNamespace().GetName(WritePackageVersionsProps.CreationTimePropertyName))
-                        // There should be only one or zero
-                        .SingleOrDefault()?.Value;
-
-                    if (string.IsNullOrEmpty(creationTime))
-                    {
-                        Log.LogError($"No creation time property found in snapshot {snapshot.Path}");
-                        return default(DateTime);
-                    }
-
-                    return new DateTime(long.Parse(creationTime));
-                })
-                .Select(snapshot =>
-                {
-                    string filename = Path.GetFileName(snapshot.Path);
-                    return new
-                    {
-                        Repo = filename.Substring(
-                            SnapshotPrefix.Length,
-                            filename.Length - SnapshotPrefix.Length - SnapshotSuffix.Length),
-                        PackageVersionProp = PackageVersionPropsElement.Parse(snapshot.Xml)
-                    };
-                })
-                .ToArray();
-
-            return pvpSnapshotFiles.Skip(1)
-                .Zip(pvpSnapshotFiles, (pvp, prev) => new RepoOutput
-                {
-                    Repo = prev.Repo,
-                    Built = pvp.PackageVersionProp.Except(prev.PackageVersionProp).ToArray()
                 })
                 .ToArray();
         }

--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -49,7 +49,7 @@
     <CurrentSourceBuiltPackageVersionPropsPath>$(PackageVersionsDir)PackageVersions.$(RepositoryName).Current.props</CurrentSourceBuiltPackageVersionPropsPath>
     <PreviouslySourceBuiltPackageVersionPropsPath>$(PackageVersionsDir)PackageVersions.$(RepositoryName).Previous.props</PreviouslySourceBuiltPackageVersionPropsPath>
     <PreviouslySourceBuiltSharedComponentsPackageVersionPropsPath>$(PackageVersionsDir)PackageVersions.$(RepositoryName).SharedComponents.props</PreviouslySourceBuiltSharedComponentsPackageVersionPropsPath>
-    <SnapshotPackageVersionPropsPath>$(PackageVersionsDir)PackageVersions.$(RepositoryName).Snapshot.props</SnapshotPackageVersionPropsPath>
+    <ProducedPackageVersionPropsPath>$(PackageVersionsDir)PackageVersions.$(RepositoryName).Produced.props</ProducedPackageVersionPropsPath>
     <PackageVersionPropsFlowType>DependenciesOnly</PackageVersionPropsFlowType>
 
     <GlobalJsonFile Condition="'$(GlobalJsonFile)' == '' and Exists('$(ProjectDirectory)global.json')">$(ProjectDirectory)global.json</GlobalJsonFile>

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -394,19 +394,6 @@
                                PropertySuffixes="@(PreviousPackageVersionPropertySuffixes)"
                                Condition="'$(_UsePackageVersionPropsAggregation)' == 'true'" />
 
-    <!-- Write a full package version props (unfiltered) that will be used to track which repo creates a package.
-         Because not all repos implement the repo API (e.g. some are external), it's difficult to consistently gather
-         a list of packages from the output of each repo. This may be an area for improvement later.
-
-         Instead, we rely on the package version props file that is built up
-         before each build. If the full list of packages grows by package A, B and C between repo Y and Z, then Y produced
-         A B and C.
-
-         A key element of this algorith is that we must write the full package version props and not the filtered version. -->
-    <WritePackageVersionsProps KnownPackages="@(_DependencyProducedPackage)"
-                               VersionPropsFlowType="AllPackages"
-                               PropertySuffixes="@(DefaultPackageVersionPropertySuffixes)"
-                               OutputPath="$(SnapshotPackageVersionPropsPath)" />
 
     <!-- Write a single file that contains imports for both the current and previously built packages -->
     <PropertyGroup>
@@ -620,6 +607,20 @@
     <Message Importance="High" Text="$([System.IO.File]::ReadAllText('$(RepoConsoleLogFile)'))" Condition="Exists('$(RepoConsoleLogFile)')" />
     <Message Importance="High" Text="'$(RepositoryName)' failed during build." />
     <Message Importance="High" Text="See '$(RepoConsoleLogFile)' for more information." Condition="Exists('$(RepoConsoleLogFile)')" />
+  </Target>
+
+  <!-- After a repository builds, write the list of packages it produced.
+       This is used by WriteAnnotatedUsageReport to directly attribute packages to the repo that
+       produced them, rather than inferring it from snapshot diffs (which is unreliable when repos
+       have independent dependency trees). -->
+  <Target Name="WriteProducedPackages"
+          AfterTargets="RepoBuild"
+          DependsOnTargets="GetProducedPackages"
+          Condition="'$(IsUtilityProject)' != 'true'">
+    <WritePackageVersionsProps KnownPackages="@(ProducedPackage);@(ProducedPackageFromDependentVertical)"
+                               VersionPropsFlowType="AllPackages"
+                               PropertySuffixes="@(DefaultPackageVersionPropertySuffixes)"
+                               OutputPath="$(ProducedPackageVersionPropsPath)" />
   </Target>
 
   <!-- Log the new repo artifacts -->


### PR DESCRIPTION
The prebuilt usage report attributed packages to the wrong repo because the old algorithm diffed consecutive PackageVersions.{repo}.Snapshot.props files to infer which repo produced which packages. Each snapshot only contained packages from the repo's transitive dependencies, so when repos had independent dependency trees (e.g. windowsdesktop doesn't depend on runtime on Linux), packages were misattributed.

Replace the snapshot-diff approach with direct per-repo output tracking: after each repo builds, write a PackageVersions.{repo}.Produced.props file listing exactly the packages that repo produced (from its asset manifests). The report task reads these files directly for attribution.