### PR TITLE
Add OpenTelemetry DLLs to signing configuration

### DIFF
--- a/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/static/Signing.props
+++ b/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/static/Signing.props
@@ -51,6 +51,16 @@
     <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="$(ExternalCertificateId)" />
     <FileSignInfo Include="Spectre.Console.dll" CertificateName="$(ExternalCertificateId)" />
     <FileSignInfo Include="Valleysoft.DockerCredsProvider.dll" CertificateName="$(ExternalCertificateId)" />
+    <FileSignInfo Include="OpenTelemetry.dll" CertificateName="$(ExternalCertificateId)" />
+    <FileSignInfo Include="OpenTelemetry.Api.dll" CertificateName="$(ExternalCertificateId)" />
+    <FileSignInfo Include="OpenTelemetry.Api.ProviderBuilderExtensions.dll" CertificateName="$(ExternalCertificateId)" />
+    <FileSignInfo Include="OpenTelemetry.Exporter.InMemory.dll" CertificateName="$(ExternalCertificateId)" />
+    <FileSignInfo Include="OpenTelemetry.Exporter.OpenTelemetryProtocol.dll" CertificateName="$(ExternalCertificateId)" />
+    <FileSignInfo Include="OpenTelemetry.Extensions.Hosting.dll" CertificateName="$(ExternalCertificateId)" />
+    <FileSignInfo Include="OpenTelemetry.Instrumentation.Http.dll" CertificateName="$(ExternalCertificateId)" />
+    <FileSignInfo Include="OpenTelemetry.Instrumentation.Runtime.dll" CertificateName="$(ExternalCertificateId)" />
+    <FileSignInfo Include="OpenTelemetry.PersistentStorage.Abstractions.dll" CertificateName="$(ExternalCertificateId)" />
+    <FileSignInfo Include="OpenTelemetry.PersistentStorage.FileSystem.dll" CertificateName="$(ExternalCertificateId)" />
 
     <!--
         Skip warning on files that are marked as 3rd party but have .NET copyright:


### PR DESCRIPTION
Fixes official build signing error:

```
  /__w/1/s/artifacts/toolset/11.0.0-beta.26170.106/Sign.proj(77,5): error SIGN004: Signing 3rd party library '/__w/1/s/artifacts/tmp/Release/ContainerSigning/9342/lib/net11.0/OpenTelemetry.dll' with Microsoft certificate 'MicrosoftDotNet500'. The library is considered 3rd party library due to its copyright: 'Copyright The OpenTelemetry Authors'.
  /__w/1/s/artifacts/toolset/11.0.0-beta.26170.106/Sign.proj(77,5): error SIGN004: Signing 3rd party library '/__w/1/s/artifacts/tmp/Release/ContainerSigning/9344/lib/netstandard2.0/OpenTelemetry.dll' with Microsoft certificate 'MicrosoftDotNet500'. The library is considered 3rd party library due to its copyright: 'Copyright The OpenTelemetry Authors'.
  /__w/1/s/artifacts/toolset/11.0.0-beta.26170.106/Sign.proj(77,5): error SIGN004: Signing 3rd party library '/__w/1/s/artifacts/tmp/Release/ContainerSigning/9346/lib/netstandard2.1/OpenTelemetry.dll' with Microsoft certificate 'MicrosoftDotNet500'. The library is considered 3rd party library due to its copyright: 'Copyright The OpenTelemetry Authors'.
  /__w/1/s/artifacts/toolset/11.0.0-beta.26170.106/Sign.proj(77,5): error SIGN004: Signing 3rd party library '/__w/1/s/artifacts/tmp/Release/ContainerSigning/9353/lib/net11.0/OpenTelemetry.Api.dll' with Microsoft certificate 'MicrosoftDotNet500'. The library is considered 3rd party library due to its copyright: 'Copyright The OpenTelemetry Authors'.
  /__w/1/s/artifacts/toolset/11.0.0-beta.26170.106/Sign.proj(77,5): error SIGN004: Signing 3rd party library '/__w/1/s/artifacts/tmp/Release/ContainerSigning/9355/lib/netstandard2.0/OpenTelemetry.Api.dll' with Microsoft certificate 'MicrosoftDotNet500'. The library is considered 3rd party library due to its copyright: 'Copyright The OpenTelemetry Authors'.
  /__w/1/s/artifacts/toolset/11.0.0-beta.26170.106/Sign.proj(77,5): error SIGN004: Signing 3rd party library '/__w/1/s/artifacts/tmp/Release/ContainerSigning/9362/lib/net11.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll' with Microsoft certificate 'MicrosoftDotNet500'. The library is considered 3rd party library due to its copyright: 'Copyright The OpenTelemetry Authors'.
  /__w/1/s/artifacts/toolset/11.0.0-beta.26170.106/Sign.proj(77,5): error SIGN004: Signing 3rd party library '/__w/1/s/artifacts/tmp/Release/ContainerSigning/9364/lib/netstandard2.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll' with Microsoft certificate 'MicrosoftDotNet500'. The library is considered 3rd party library due to its copyright: 'Copyright The OpenTelemetry Authors'.
  /__w/1/s/artifacts/toolset/11.0.0-beta.26170.106/Sign.proj(77,5): error SIGN004: Signing 3rd party library '/__w/1/s/artifacts/tmp/Release/ContainerSigning/9370/lib/net11.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll' with Microsoft certificate 'MicrosoftDotNet500'. The library is considered 3rd party library due to its copyright: 'Copyright The OpenTelemetry Authors'.
  /__w/1/s/artifacts/toolset/11.0.0-beta.26170.106/Sign.proj(77,5): error SIGN004: Signing 3rd party library '/__w/1/s/artifacts/tmp/Release/ContainerSigning/9372/lib/netstandard2.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll' with Microsoft certificate 'MicrosoftDotNet500'. The library is considered 3rd party library due to its copyright: 'Copyright The OpenTelemetry Authors'.
  /__w/1/s/artifacts/toolset/11.0.0-beta.26170.106/Sign.proj(77,5): error SIGN004: Signing 3rd party library '/__w/1/s/artifacts/tmp/Release/ContainerSigning/9374/lib/netstandard2.1/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll' with Microsoft certificate 'MicrosoftDotNet500'. The library is considered 3rd party library due to its copyright: 'Copyright The OpenTelemetry Authors'.
  /__w/1/s/artifacts/toolset/11.0.0-beta.26170.106/Sign.proj(77,5): error SIGN004: Signing 3rd party library '/__w/1/s/artifacts/tmp/Release/ContainerSigning/9380/lib/net11.0/OpenTelemetry.Instrumentation.Http.dll' with Microsoft certificate 'MicrosoftDotNet500'. The library is considered 3rd party library due to its copyright: 'Copyright The OpenTelemetry Authors'.
  /__w/1/s/artifacts/toolset/11.0.0-beta.26170.106/Sign.proj(77,5): error SIGN004: Signing 3rd party library '/__w/1/s/artifacts/tmp/Release/ContainerSigning/9382/lib/netstandard2.0/OpenTelemetry.Instrumentation.Http.dll' with Microsoft certificate 'MicrosoftDotNet500'. The library is considered 3rd party library due to its copyright: 'Copyright The OpenTelemetry Authors'.
  /__w/1/s/artifacts/toolset/11.0.0-beta.26170.106/Sign.proj(77,5): error SIGN004: Signing 3rd party library '/__w/1/s/artifacts/tmp/Release/ContainerSigning/9389/lib/net11.0/OpenTelemetry.Instrumentation.Runtime.dll' with Microsoft certificate 'MicrosoftDotNet500'. The library is considered 3rd party library due to its copyright: 'Copyright The OpenTelemetry Authors'.
  /__w/1/s/artifacts/toolset/11.0.0-beta.26170.106/Sign.proj(77,5): error SIGN004: Signing 3rd party library '/__w/1/s/artifacts/tmp/Release/ContainerSigning/9391/lib/netstandard2.0/OpenTelemetry.Instrumentation.Runtime.dll' with Microsoft certificate 'MicrosoftDotNet500'. The library is considered 3rd party library due to its copyright: 'Copyright The OpenTelemetry Authors'.
```