### PR TITLE
Split SBRP license scanning into separate sub-scans

### DIFF
--- a/eng/pipelines/templates/stages/vmr-license-scan.yml
+++ b/eng/pipelines/templates/stages/vmr-license-scan.yml
@@ -45,7 +45,7 @@ stages:
               if [ -d "$subdir" ]; then
                 subdirName=$(basename "$subdir")
                 if [ ! -z "$ignorePatterns" ]; then
-                  ignorePatterns="$ignorePatterns;"
+                  ignorePatterns="$ignorePatterns,"
                 fi
                 ignorePatterns="$ignorePatterns$subdirName"
                 addMatrixEntry "${repoName}_${subdirName}" "$subdir"
@@ -70,7 +70,7 @@ stages:
                 if [ -d "$subdir" ]; then
                   subdirName=$(basename "$subdir")
                   if [ ! -z "$ignorePatterns" ]; then
-                    ignorePatterns="$ignorePatterns;"
+                    ignorePatterns="$ignorePatterns,"
                   fi
                   ignorePatterns="$ignorePatterns$subdirName"
                   addMatrixEntry "${repoName}_${subdirName}" "$subdir"

--- a/eng/pipelines/templates/stages/vmr-license-scan.yml
+++ b/eng/pipelines/templates/stages/vmr-license-scan.yml
@@ -19,17 +19,58 @@ stages:
         # Trim leading/trailing spaces from the repo name
         specificRepoName=$(echo "${{ parameters.specificRepoName }}" | awk '{$1=$1};1')
 
+        addMatrixEntry() {
+          local name="$1"
+          local repoPath="$2"
+          local scanIgnorePatterns="${3:-}"
+          if [ ! -z "$matrix" ]; then
+            matrix="$matrix,"
+          fi
+          matrix="$matrix \"$name\": { \"repoPath\": \"$repoPath\", \"scanIgnorePatterns\": \"$scanIgnorePatterns\" }"
+        }
+
+        # Repos whose src/ subdirectories should be scanned as separate jobs.
+        # The repo root is also scanned with --ignore to skip subdirectories covered by sub-scans.
+        splitRepos="source-build-reference-packages"
+
         # If the repo name is provided, only scan that repo.
         if [ ! -z "$specificRepoName" ]; then
-          matrix="\"$specificRepoName\": { \"repoPath\": \"$vmrSrcDir/$specificRepoName\" }"
+          repoName="$specificRepoName"
+          dir="$vmrSrcDir/$specificRepoName"
+
+          if echo "$splitRepos" | grep -qw "$repoName"; then
+            addMatrixEntry "$repoName" "$dir" "src"
+
+            for subdir in "$dir"/src/*/
+            do
+              if [ -d "$subdir" ]; then
+                subdirName=$(basename "$subdir")
+                addMatrixEntry "${repoName}_${subdirName}" "$subdir"
+              fi
+            done
+          else
+            addMatrixEntry "$repoName" "$dir"
+          fi
         else
-          for dir in $vmrSrcDir/*/
+          for dir in "$vmrSrcDir"/*/
           do
-            if [ ! -z "$matrix" ]; then
-              matrix="$matrix,"
+            repoName=$(basename "$dir")
+
+            if echo "$splitRepos" | grep -qw "$repoName"; then
+              # Root scan: skip subdirectories that are covered by sub-scans
+              addMatrixEntry "$repoName" "$dir" "src"
+
+              # Sub-scans: one job per subdirectory under src/
+              for subdir in "$dir"src/*/
+              do
+                if [ -d "$subdir" ]; then
+                  subdirName=$(basename "$subdir")
+                  addMatrixEntry "${repoName}_${subdirName}" "$subdir"
+                fi
+              done
+            else
+              addMatrixEntry "$repoName" "$dir"
             fi
-            repoName=$(basename $dir)
-            matrix="$matrix \"$repoName\": { \"repoPath\": \"$dir\" }"
           done
         fi
 
@@ -65,6 +106,7 @@ stages:
         -flp:LogFile=$(Build.SourcesDirectory)/artifacts/logs/BuildTests_$(date +"%m%d%H%M%S").log
         -clp:v=m
         /p:SourceBuildTestsLicenseScanPath=$(repoPath)
+        /p:SourceBuildTestsLicenseScanIgnorePatterns=$(scanIgnorePatterns)
         /p:TargetRid=linux-x64
         /p:PortableTargetRid=linux-x64
         /p:SkipPrepareSdkArchive=true

--- a/eng/pipelines/templates/stages/vmr-license-scan.yml
+++ b/eng/pipelines/templates/stages/vmr-license-scan.yml
@@ -45,7 +45,7 @@ stages:
               if [ -d "$subdir" ]; then
                 subdirName=$(basename "$subdir")
                 if [ ! -z "$ignorePatterns" ]; then
-                  ignorePatterns="$ignorePatterns,"
+                  ignorePatterns="$ignorePatterns "
                 fi
                 ignorePatterns="$ignorePatterns$subdirName"
                 addMatrixEntry "${repoName}_${subdirName}" "$subdir"
@@ -70,7 +70,7 @@ stages:
                 if [ -d "$subdir" ]; then
                   subdirName=$(basename "$subdir")
                   if [ ! -z "$ignorePatterns" ]; then
-                    ignorePatterns="$ignorePatterns,"
+                    ignorePatterns="$ignorePatterns "
                   fi
                   ignorePatterns="$ignorePatterns$subdirName"
                   addMatrixEntry "${repoName}_${subdirName}" "$subdir"

--- a/eng/pipelines/templates/stages/vmr-license-scan.yml
+++ b/eng/pipelines/templates/stages/vmr-license-scan.yml
@@ -39,15 +39,19 @@ stages:
           dir="$vmrSrcDir/$specificRepoName"
 
           if echo "$splitRepos" | grep -qw "$repoName"; then
-            addMatrixEntry "$repoName" "$dir" "src"
-
+            ignorePatterns=""
             for subdir in "$dir"/src/*/
             do
               if [ -d "$subdir" ]; then
                 subdirName=$(basename "$subdir")
+                if [ ! -z "$ignorePatterns" ]; then
+                  ignorePatterns="$ignorePatterns;"
+                fi
+                ignorePatterns="$ignorePatterns$subdirName"
                 addMatrixEntry "${repoName}_${subdirName}" "$subdir"
               fi
             done
+            addMatrixEntry "$repoName" "$dir" "$ignorePatterns"
           else
             addMatrixEntry "$repoName" "$dir"
           fi
@@ -58,16 +62,21 @@ stages:
 
             if echo "$splitRepos" | grep -qw "$repoName"; then
               # Root scan: skip subdirectories that are covered by sub-scans
-              addMatrixEntry "$repoName" "$dir" "src"
-
-              # Sub-scans: one job per subdirectory under src/
+              # Build ignore patterns from subdirectory names so that files
+              # directly under src/ are still scanned by the root job.
+              ignorePatterns=""
               for subdir in "$dir"src/*/
               do
                 if [ -d "$subdir" ]; then
                   subdirName=$(basename "$subdir")
+                  if [ ! -z "$ignorePatterns" ]; then
+                    ignorePatterns="$ignorePatterns;"
+                  fi
+                  ignorePatterns="$ignorePatterns$subdirName"
                   addMatrixEntry "${repoName}_${subdirName}" "$subdir"
                 fi
               done
+              addMatrixEntry "$repoName" "$dir" "$ignorePatterns"
             else
               addMatrixEntry "$repoName" "$dir"
             fi

--- a/eng/pipelines/templates/stages/vmr-license-scan.yml
+++ b/eng/pipelines/templates/stages/vmr-license-scan.yml
@@ -115,7 +115,7 @@ stages:
         -flp:LogFile=$(Build.SourcesDirectory)/artifacts/logs/BuildTests_$(date +"%m%d%H%M%S").log
         -clp:v=m
         /p:SourceBuildTestsLicenseScanPath=$(repoPath)
-        /p:SourceBuildTestsLicenseScanIgnorePatterns=$(scanIgnorePatterns)
+        "/p:SourceBuildTestsLicenseScanIgnorePatterns=$(scanIgnorePatterns)"
         /p:TargetRid=linux-x64
         /p:PortableTargetRid=linux-x64
         /p:SkipPrepareSdkArchive=true

--- a/test/Microsoft.DotNet.SourceBuild.Tests/Config.cs
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/Config.cs
@@ -20,6 +20,7 @@ internal static class Config
 
     public static string? CustomPackagesPath => (string)AppContext.GetData(ConfigSwitchPrefix + nameof(CustomPackagesPath))!;
     public static string? LicenseScanPath => (string)AppContext.GetData(ConfigSwitchPrefix + nameof(LicenseScanPath))!;
+    public static string? LicenseScanIgnorePatterns => (string)AppContext.GetData(ConfigSwitchPrefix + nameof(LicenseScanIgnorePatterns))!;
     public static string? MsftSdkTarballPath => (string)AppContext.GetData(ConfigSwitchPrefix + nameof(MsftSdkTarballPath))!;
     public static string? PoisonReportPath => (string)AppContext.GetData(ConfigSwitchPrefix + nameof(PoisonReportPath))!;
     public static string? SdkTarballPath => (string)AppContext.GetData(ConfigSwitchPrefix + nameof(SdkTarballPath))!;

--- a/test/Microsoft.DotNet.SourceBuild.Tests/LicenseScanTests.cs
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/LicenseScanTests.cs
@@ -160,7 +160,7 @@ public class LicenseScanTests : TestBase
         // Combine default and additional ignore patterns
         IEnumerable<string> allIgnorePatterns = s_ignoredFilePatterns;
         string[]? additionalIgnorePatterns = Config.LicenseScanIgnorePatterns?
-            .Split(';', StringSplitOptions.RemoveEmptyEntries);
+            .Split(',', StringSplitOptions.RemoveEmptyEntries);
         if (additionalIgnorePatterns?.Length > 0)
         {
             allIgnorePatterns = allIgnorePatterns.Concat(additionalIgnorePatterns);

--- a/test/Microsoft.DotNet.SourceBuild.Tests/LicenseScanTests.cs
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/LicenseScanTests.cs
@@ -139,12 +139,10 @@ public class LicenseScanTests : TestBase
         Assert.True(relativePathMatch.Success);
         _relativeScanPath = relativePathMatch.Value;
 
-        // Derive target name for baseline file naming.
+        // Derive target name for baseline file naming from the relative scan path.
         // For "src/runtime" -> "runtime"
         // For "src/source-build-reference-packages/src/externalPackages" -> "source-build-reference-packages.externalPackages"
-        Match repoMatch = Regex.Match(normalizedPath, @"src/([^/]+)");
-        Assert.True(repoMatch.Success);
-        string repoName = repoMatch.Groups[1].Value;
+        string repoName = _relativeScanPath.Split('/')[1];
         string dirName = new DirectoryInfo(normalizedPath).Name;
         _targetName = dirName == repoName ? repoName : $"{repoName}.{dirName}";
     }

--- a/test/Microsoft.DotNet.SourceBuild.Tests/LicenseScanTests.cs
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/LicenseScanTests.cs
@@ -160,7 +160,7 @@ public class LicenseScanTests : TestBase
         // Combine default and additional ignore patterns
         IEnumerable<string> allIgnorePatterns = s_ignoredFilePatterns;
         string[]? additionalIgnorePatterns = Config.LicenseScanIgnorePatterns?
-            .Split(',', StringSplitOptions.RemoveEmptyEntries);
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries);
         if (additionalIgnorePatterns?.Length > 0)
         {
             allIgnorePatterns = allIgnorePatterns.Concat(additionalIgnorePatterns);

--- a/test/Microsoft.DotNet.SourceBuild.Tests/LicenseScanTests.cs
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/LicenseScanTests.cs
@@ -19,6 +19,9 @@ namespace Microsoft.DotNet.SourceBuild.Tests;
 /// </summary>
 /// <remarks>
 /// Each sub-repo of the VMR is scanned separately because of the amount of time it takes.
+/// Large repos may be further split into sub-scans of their subdirectories; each sub-scan is an independent matrix job
+/// in the pipeline. When a repo is split, the root directory is also scanned with --ignore patterns to skip subdirectories
+/// covered by sub-scans.
 /// When scanning is run, the test provides a list of files for the scanner to ignore. These include binary file types. It also includes
 /// .il/.ildump file types which are massive, causing the scanner to choke and don't include license references anyway.
 /// Once the scanner returns the results, a filtering process occurs. First, any detected license that is in the allowed list of licenses
@@ -28,7 +31,7 @@ namespace Microsoft.DotNet.SourceBuild.Tests;
 /// tool has detected something in the file that makes it think it's a license reference when that's not actually the intent. Other cases
 /// that are excluded are when the license is meant as configuration or test data and not actually applying to the code. These exclusions
 /// further filter down the set of the detected licenses for each file. Everything that's left at this point is reported. It gets compared
-/// to a baseline file (which is defined for each sub-repo). If the filtered results differ from what's defined in the baseline, the test fails.
+/// to a baseline file (which is defined for each scan target). If the filtered results differ from what's defined in the baseline, the test fails.
 /// 
 /// Rules for determining how to resolve a detected license:
 ///   1. If it's an allowed open-source license, add it to the list of allowed licenses in LicenseScanTests.cs.
@@ -119,18 +122,31 @@ public class LicenseScanTests : TestBase
         "*.ildump",
     };
 
-    private readonly string _targetRepo;
-    private readonly string _relativeRepoPath;
+    private readonly string _targetName;
+    private readonly string _relativeScanPath;
     public static bool IncludeLicenseScanTests => !string.IsNullOrWhiteSpace(Config.LicenseScanPath);
 
     public LicenseScanTests(ITestOutputHelper outputHelper) : base(outputHelper)
     {
         Assert.NotNull(Config.LicenseScanPath);
-        _targetRepo = new DirectoryInfo(Config.LicenseScanPath).Name;
-        
-        Match relativeRepoPathMatch = Regex.Match(Config.LicenseScanPath, @"(src/)[^/]+");
-        Assert.True(relativeRepoPathMatch.Success);
-        _relativeRepoPath = relativeRepoPathMatch.Value;
+
+        // Normalize the path to remove any double slashes that may result from path concatenation in the pipeline.
+        string normalizedPath = Regex.Replace(Config.LicenseScanPath, @"//+", "/").TrimEnd('/');
+
+        // Extract the full relative path from VMR src/ to the scan target.
+        // LicenseScanPath is an absolute path like: /path/to/vmr/src/<repo>[/<subpath>]
+        Match relativePathMatch = Regex.Match(normalizedPath, @"src/[^/]+(/.*)?$");
+        Assert.True(relativePathMatch.Success);
+        _relativeScanPath = relativePathMatch.Value;
+
+        // Derive target name for baseline file naming.
+        // For "src/runtime" -> "runtime"
+        // For "src/source-build-reference-packages/src/externalPackages" -> "source-build-reference-packages.externalPackages"
+        Match repoMatch = Regex.Match(normalizedPath, @"src/([^/]+)");
+        Assert.True(repoMatch.Success);
+        string repoName = repoMatch.Groups[1].Value;
+        string dirName = new DirectoryInfo(normalizedPath).Name;
+        _targetName = dirName == repoName ? repoName : $"{repoName}.{dirName}";
     }
 
     [ConditionalFact(typeof(LicenseScanTests), nameof(IncludeLicenseScanTests))]
@@ -143,8 +159,17 @@ public class LicenseScanTests : TestBase
 
         string scancodeResultsPath = Path.Combine(Config.LogsDirectory, "scancode-results.json");
 
+        // Combine default and additional ignore patterns
+        IEnumerable<string> allIgnorePatterns = s_ignoredFilePatterns;
+        string[]? additionalIgnorePatterns = Config.LicenseScanIgnorePatterns?
+            .Split(';', StringSplitOptions.RemoveEmptyEntries);
+        if (additionalIgnorePatterns?.Length > 0)
+        {
+            allIgnorePatterns = allIgnorePatterns.Concat(additionalIgnorePatterns);
+        }
+
         // Scancode Doc: https://scancode-toolkit.readthedocs.io/en/latest/index.html
-        string ignoreOptions = string.Join(" ", s_ignoredFilePatterns.Select(pattern => $"--ignore {pattern}"));
+        string ignoreOptions = string.Join(" ", allIgnorePatterns.Select(pattern => $"--ignore {pattern}"));
         ExecuteHelper.ExecuteProcessValidateExitCode(
             "scancode",
             $"--license --processes 4 --timeout {FileScanTimeoutSeconds} --strip-root --only-findings {ignoreOptions} --json-pp {scancodeResultsPath} {Config.LicenseScanPath}",
@@ -154,7 +179,7 @@ public class LicenseScanTests : TestBase
         ScancodeResults? scancodeResults = doc.Deserialize<ScancodeResults>();
         Assert.NotNull(scancodeResults);
 
-        FilterFiles(scancodeResults);
+        FilterFiles(scancodeResults, additionalIgnorePatterns);
 
         JsonSerializerOptions options = new()
         {
@@ -162,7 +187,7 @@ public class LicenseScanTests : TestBase
         };
         string json = JsonSerializer.Serialize(scancodeResults, options);
 
-        string baselineName = $"Licenses.{_targetRepo}.json";
+        string baselineName = $"Licenses.{_targetName}.json";
 
         string baselinePath = BaselineHelper.GetBaselineFilePath(baselineName, BaselineSubDir);
         string expectedFilePath = Path.Combine(Config.LogsDirectory, baselineName);
@@ -184,7 +209,7 @@ public class LicenseScanTests : TestBase
         BaselineHelper.CompareFiles(expectedFilePath, actualFilePath, OutputHelper);
     }
 
-    private void FilterFiles(ScancodeResults scancodeResults)
+    private void FilterFiles(ScancodeResults scancodeResults, string[]? additionalIgnorePatterns)
     {
         // This will filter out files that we don't want to include in the baseline.
         // Filtering can happen in two ways:
@@ -195,8 +220,23 @@ public class LicenseScanTests : TestBase
         // In that case, the baseline will list all of the licenses for that file, even if some were originally excluded during this processing.
         // In other words, the baseline will be fully representative of the licenses that apply to the files that are listed there.
 
-        // We only care about the license expressions that are in the target repo.
-        ExclusionsHelper exclusionsHelper = new("LicenseExclusions.txt", Config.LogsDirectory, BaselineSubDir, "^" + Regex.Escape(_relativeRepoPath) + "/");
+        // Build the exclusion regex to scope which exclusions from LicenseExclusions.txt are loaded.
+        // We use the relative scan path so that sub-scans of a repo only load exclusions for their specific subdirectory.
+        // When ignore patterns are specified (e.g., for root scans that skip subdirectories handled by sub-scans),
+        // add negative lookaheads to avoid loading exclusions for the ignored paths. This prevents the updated
+        // exclusion file from incorrectly marking those exclusions as unused.
+        string exclusionRegex = "^" + Regex.Escape(_relativeScanPath) + "/";
+        if (additionalIgnorePatterns?.Length > 0)
+        {
+            string lookaheads = string.Join("", additionalIgnorePatterns.Select(p =>
+            {
+                string prefix = p.TrimEnd('*').TrimEnd('/');
+                return $"(?!{Regex.Escape(prefix)}/)";
+            }));
+            exclusionRegex += lookaheads;
+        }
+
+        ExclusionsHelper exclusionsHelper = new("LicenseExclusions.txt", Config.LogsDirectory, BaselineSubDir, exclusionRegex);
 
         for (int i = scancodeResults.Files.Count - 1; i >= 0; i--)
         {
@@ -228,8 +268,8 @@ public class LicenseScanTests : TestBase
                 // There are some licenses that are not allowed. Now check whether the file is excluded.
 
                 // The path in the exclusion file is rooted from the VMR. But the path in the scancode results is rooted from the
-                // target repo within the VMR. So we need to add back the beginning part of the path.
-                string fullRelativePath = Path.Combine(_relativeRepoPath, file.Path);
+                // scan target directory. So we need to add back the beginning part of the path.
+                string fullRelativePath = Path.Combine(_relativeScanPath, file.Path);
 
                 var remainingLicenses = disallowedLicenses.Where(license => !exclusionsHelper.IsFileExcluded(fullRelativePath, license));
 
@@ -239,7 +279,7 @@ public class LicenseScanTests : TestBase
                 }
             }
         }
-        exclusionsHelper.GenerateNewBaselineFile(_targetRepo);
+        exclusionsHelper.GenerateNewBaselineFile(_targetName);
     }
 
     private class ScancodeResults

--- a/test/Microsoft.DotNet.SourceBuild.Tests/Microsoft.DotNet.SourceBuild.Tests.csproj
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/Microsoft.DotNet.SourceBuild.Tests.csproj
@@ -72,6 +72,10 @@
       <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).LicenseScanPath">
         <Value>$(SourceBuildTestsLicenseScanPath)</Value>
       </RuntimeHostConfigurationOption>
+      <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).LicenseScanIgnorePatterns"
+                                      Condition="'$(SourceBuildTestsLicenseScanIgnorePatterns)' != ''">
+        <Value>$(SourceBuildTestsLicenseScanIgnorePatterns)</Value>
+      </RuntimeHostConfigurationOption>
       <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).MsftSdkTarballPath">
         <Value>$(MsftSdkTarballPath)</Value>
       </RuntimeHostConfigurationOption>

--- a/test/Microsoft.DotNet.SourceBuild.Tests/assets/LicenseScanTests/Licenses.source-build-reference-packages.externalPackages.json
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/assets/LicenseScanTests/Licenses.source-build-reference-packages.externalPackages.json
@@ -1,7 +1,7 @@
 {
   "files": [
     {
-      "path": "src/externalPackages/src/application-insights/LOGGING/ThirdPartyNotices.txt",
+      "path": "src/application-insights/LOGGING/ThirdPartyNotices.txt",
       "detected_license_expression": "(unknown-license-reference AND apache-2.0) AND mit AND bsd-new"
     }
   ]


### PR DESCRIPTION
Split the source-build-reference-packages license scan into separate pipeline jobs - one per subdirectory under src/source-build-reference-packages/src/ plus a root scan with --ignore src for non-src content. This avoids the scancode timeout caused by processing too many files in a single run (dotnet/source-build#5470).

Fixes dotnet/source-build#5470