### PR TITLE
Fix workload build break

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.Build.Tasks.Workloads/src/WorkloadPackageBase.cs
+++ b/src/arcade/src/Microsoft.DotNet.Build.Tasks.Workloads/src/WorkloadPackageBase.cs
@@ -200,7 +200,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads
             Title = nuspec.GetTitle();
 
             PackagePath = packagePath;
-            DestinationDirectory = Path.Combine(destinationBaseDirectory, $"{Identity}");
+            DestinationDirectory = Path.Combine(destinationBaseDirectory, Path.GetRandomFileName());
             ShortNames = shortNames;
 
             PackageFileName = Path.GetFileNameWithoutExtension(packagePath);


### PR DESCRIPTION
Workload packages currently extract into a path that contains the full identity, e.g. `D:\a\_work\1\s\src\sdk\artifacts\obj\workloads/pkg\Microsoft.NET.Runtime.Emscripten.3.1.56.Sdk.win-x64.11.0.0-preview.4.26213.117`. When the content is extracted, the paths are too deep for HEAT to harvest.