### PR TITLE
Remove stale comment for dotnet/source-build#5510 in SdkAssemblyVersionDiffExclusions.txt

### DIFF
--- a/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/SdkAssemblyVersionDiffExclusions.txt
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/SdkAssemblyVersionDiffExclusions.txt
@@ -24,8 +24,6 @@
 ./sdk/x.y.z/DotnetTools/dotnet-user-jwts/x.y.z/tools/netx.y/any/Microsoft.IdentityModel.*
 ./sdk/x.y.z/DotnetTools/dotnet-user-jwts/x.y.z/tools/netx.y/any/System.IdentityModel.Tokens.Jwt.dll
 
-# File version diff: https://github.com/dotnet/source-build/issues/5510
-
 # File version missing revision: https://github.com/dotnet/source-build/issues/5511
 ./sdk/**/Newtonsoft.Json.dll
 


### PR DESCRIPTION
Removes the stale `# File version diff: https://github.com/dotnet/source-build/issues/5510` comment from `SdkAssemblyVersionDiffExclusions.txt`. The corresponding exclusion entry for `Microsoft.ApplicationInsights.dll` was removed in #6041, but the comment was left behind.