### PR TITLE
Update VMR servicing workflows with validation steps

### DIFF
--- a/docs/VMR-Servicing-Workflows.md
+++ b/docs/VMR-Servicing-Workflows.md
@@ -124,9 +124,10 @@ gantt
     - If the approved milestone corresponds to the **Release Specific** branch, then the PR is targeted to the internal VMR **Release Specific** branch and merged.
     - If the approved milestone corresponds to the current state of the **General Servicing** branch (the branch is branded for that milestone), then the PR is targeted to the internal VMR **General Servicing** branch and merged.
     - If the approved milestone does not correspond to any currently open branch, the fix is parked until a **General Servicing** internal VMR branch matches the milestone, and then the fix is merged.
-5. Confirm that the fix made it into the VMR servicing branch matching the approved milestone.
-6. Wait for a validation build.
-7. Validate the fix in the shipping product.
+5. If a staging pull request was created against the component repository for repo-specific validation, be sure to Abandon the PR with a comment that the PR was used for validation, linking to the internal VMR pull request that was used to merge the fix.
+6. Confirm that the fix made it into the VMR servicing branch matching the approved milestone.
+7. Wait for a validation build.
+8. Validate the fix in the shipping product.
 
 #### Repository Owner - Preparing for Upcoming Release
 

--- a/docs/VMR-Servicing-Workflows.md
+++ b/docs/VMR-Servicing-Workflows.md
@@ -116,7 +116,7 @@ gantt
 #### Developer – Internal Fix
 
 1. Developer prepares source for their fix. This can be done in two ways:
-  - In the internal validation branch of their component repository (to enable repo-specific PR validation), followed by cherry-picking to the internal VMR servicing branch.
+  - In the internal validation branch of their component repository (to enable repo-specific PR validation), followed by cherry-picking to the internal VMR servicing branch. If a repo-specific PR is opened for validation, crosslink them for traceability.
   - Directly in the internal VMR servicing branch.
 2. Developer prepares an approval template and brings the fix to .NET Tactics.
 3. Tactics approves the bug for a specific release (e.g. 10.0.3 or 10.0.4)


### PR DESCRIPTION
Added a step to abandon staging PRs used for validation and link to the internal VMR PR.