### PR TITLE
[release/10.0.1xx] Add version-specific release branch triggers to SDK diff and license scan pipelines

### DIFF
--- a/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -23,6 +23,7 @@ resources:
         include:
         - refs/heads/release/*.0.1xx-preview*
         - refs/heads/internal/release/*.0.?xx*
+        - refs/heads/internal/release/*.0.???
       # Trigger on build stages vs successful pipeline completion for a higher run frequency when there are
       # publish/validation failures.
       stages:

--- a/eng/pipelines/vmr-license-scan.yml
+++ b/eng/pipelines/vmr-license-scan.yml
@@ -15,6 +15,7 @@ schedules:
     - release/*.0.3xx*
     - release/*.0.4xx*
     - internal/release/*.0.1xx*
+    - internal/release/*.0.???
 
 pr: none
 
@@ -30,6 +31,7 @@ trigger:
     - release/*.0.3xx*
     - release/*.0.4xx*
     - internal/release/*.0.?xx*
+    - internal/release/*.0.???
   paths:
     include:
     - test/Microsoft.DotNet.SourceBuild.Tests/LicenseScanTests.cs


### PR DESCRIPTION
Backport of #5703 to release/10.0.1xx

Add `internal/release/*.0.???` branch patterns to trigger these pipelines on version-specific release branches (e.g. `internal/release/10.0.106`, `internal/release/10.0.202`).

- **SDK diff**: added to `dotnet-unified-build` pipeline resource trigger
- **License scan**: added to both push trigger and schedule branches