### PR TITLE
Replace ubuntu22 VM images with Azure Linux 3 in sdk-diff and license…

### DIFF
--- a/eng/pipelines/source-build-sdk-diff-tests-unofficial.yml
+++ b/eng/pipelines/source-build-sdk-diff-tests-unofficial.yml
@@ -28,7 +28,7 @@ extends:
   parameters:
     pool:
       name: NetCore1ESPool-Svc-Internal
-      image: 1es-ubuntu-2204
+      image: build.azurelinux.3.amd64
       os: linux
     sdl:
       sourceAnalysisPool:

--- a/eng/pipelines/source-build-sdk-diff-tests.yml
+++ b/eng/pipelines/source-build-sdk-diff-tests.yml
@@ -59,7 +59,7 @@ extends:
       networkIsolationPolicy: Permissive, CFSClean, CFSClean2
     pool:
       name: NetCore1ESPool-Svc-Internal
-      image: 1es-ubuntu-2204
+      image: build.azurelinux.3.amd64
       os: linux
     sdl:
       sourceAnalysisPool:

--- a/eng/pipelines/templates/stages/vmr-scan.yml
+++ b/eng/pipelines/templates/stages/vmr-scan.yml
@@ -7,7 +7,7 @@ stages:
     displayName: Tag & Scan
     pool:
       name: $(DncEngInternalBuildPool)
-      image: 1es-ubuntu-2204
+      image: build.azurelinux.3.amd64
       os: linux
 
     steps:

--- a/eng/pipelines/vmr-license-scan-unofficial.yml
+++ b/eng/pipelines/vmr-license-scan-unofficial.yml
@@ -22,7 +22,7 @@ extends:
   parameters:
     pool:
       name: NetCore1ESPool-Svc-Internal
-      image: 1es-ubuntu-2204
+      image: build.azurelinux.3.amd64
       os: linux
     containers:
       azurelinuxSourceBuildTestContainer:

--- a/eng/pipelines/vmr-license-scan.yml
+++ b/eng/pipelines/vmr-license-scan.yml
@@ -56,7 +56,7 @@ extends:
       networkIsolationPolicy: Permissive, CFSClean, CFSClean2
     pool:
       name: NetCore1ESPool-Svc-Internal
-      image: 1es-ubuntu-2204
+      image: build.azurelinux.3.amd64
       os: linux
     containers:
       azurelinuxSourceBuildTestContainer:


### PR DESCRIPTION
…-scan pipelines

Replace Ubuntu 22.04 VM pool images with Azure Linux 3 equivalents in source-build SDK diff tests, VMR license scan, and VMR tag/scan pipelines.

- [License scan test](https://dev.azure.com/dnceng/internal/_build/results?buildId=2953272&view=results)
- [SDK diff test](https://dev.azure.com/dnceng/internal/_build/results?buildId=2953273&view=results)

Related to https://github.com/dotnet/source-build/issues/5542