### PR TITLE
[release/10.0.4xx] Initialize SDK band versions

### DIFF
--- a/src/sdk/eng/Versions.props
+++ b/src/sdk/eng/Versions.props
@@ -6,8 +6,8 @@
   <PropertyGroup Label="Repo version information">
     <VersionMajor>10</VersionMajor>
     <VersionMinor>0</VersionMinor>
-    <VersionSDKMinor>3</VersionSDKMinor>
-    <VersionSDKMinorPatch>0</VersionSDKMinorPatch>
+    <VersionSDKMinor>4</VersionSDKMinor>
+    <VersionSDKMinorPatch>00</VersionSDKMinorPatch>
     <VersionFeature>$([System.String]::Copy('$(VersionSDKMinorPatch)').PadLeft(2, '0'))</VersionFeature>
     <!-- This property powers the SdkAnalysisLevel property in end-user MSBuild code.
          It should always be the hundreds-value of the current SDK version, never any

--- a/src/sdk/eng/Versions.props
+++ b/src/sdk/eng/Versions.props
@@ -7,7 +7,7 @@
     <VersionMajor>10</VersionMajor>
     <VersionMinor>0</VersionMinor>
     <VersionSDKMinor>4</VersionSDKMinor>
-    <VersionSDKMinorPatch>00</VersionSDKMinorPatch>
+    <VersionSDKMinorPatch>0</VersionSDKMinorPatch>
     <VersionFeature>$([System.String]::Copy('$(VersionSDKMinorPatch)').PadLeft(2, '0'))</VersionFeature>
     <!-- This property powers the SdkAnalysisLevel property in end-user MSBuild code.
          It should always be the hundreds-value of the current SDK version, never any

--- a/src/sdk/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers.sarif
+++ b/src/sdk/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers.sarif
@@ -1,11 +1,11 @@
-﻿{
+{
   "$schema": "http://json.schemastore.org/sarif-1.0.0",
   "version": "1.0.0",
   "runs": [
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.CSharp.NetAnalyzers",
-        "version": "10.0.300",
+        "version": "10.0.400",
         "language": "en-US"
       },
       "rules": {
@@ -727,7 +727,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.NetAnalyzers",
-        "version": "10.0.300",
+        "version": "10.0.400",
         "language": "en-US"
       },
       "rules": {
@@ -6522,7 +6522,7 @@
     {
       "tool": {
         "name": "Microsoft.CodeAnalysis.VisualBasic.NetAnalyzers",
-        "version": "10.0.300",
+        "version": "10.0.400",
         "language": "en-US"
       },
       "rules": {

--- a/src/sourcelink/eng/Versions.props
+++ b/src/sourcelink/eng/Versions.props
@@ -3,7 +3,7 @@
   <Import Project="Version.Details.props" />
 
   <PropertyGroup>
-    <VersionPrefix>10.0.300</VersionPrefix>
+    <VersionPrefix>10.0.400</VersionPrefix>
     <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <!-- Allowed values: '', 'prerelease', 'release'. Set to 'release' when stabilizing. -->

--- a/src/templating/eng/Versions.props
+++ b/src/templating/eng/Versions.props
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="Version.Details.props" Condition="Exists('Version.Details.props')" />
   <PropertyGroup>
-    <VersionPrefix>10.0.300</VersionPrefix>
+    <VersionPrefix>10.0.400</VersionPrefix>
     <!-- When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages.
          NOTE: This repository stabilizes via VMR and this should not be set except in dev scenarios -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>


### PR DESCRIPTION
Initialize SDK band versions on release/10.0.4xx.

Updated repositories:
- sdk: sdkminor 3 → 4, patch 0 → 00
- templating: patch 300 → 400
- sourcelink: patch 300 → 400
