### PR TITLE
Fix license scan exclusion regex to match ignore patterns at any depth

### DIFF
--- a/test/Microsoft.DotNet.SourceBuild.Tests/LicenseScanTests.cs
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/LicenseScanTests.cs
@@ -229,7 +229,7 @@ public class LicenseScanTests : TestBase
             string lookaheads = string.Join("", additionalIgnorePatterns.Select(p =>
             {
                 string prefix = p.TrimEnd('*').TrimEnd('/');
-                return $"(?!{Regex.Escape(prefix)}/)";
+                return $"(?!(?:.*/)?{Regex.Escape(prefix)}/)";
             }));
             exclusionRegex += lookaheads;
         }


### PR DESCRIPTION
The negative lookaheads for ignore patterns only checked the first path component after the repo root, but scancode `--ignore` matches directory names at any depth. For source-build-assets, exclusion paths like `src/source-build-assets/src/externalPackages/...` have an intermediate `src/` directory, so the lookahead `(?!externalPackages/)` didn't filter them. Changed to `(?!(?:.*/)?externalPackages/)` to match at any depth.

This fixes the issue with `source-build-assets` paths being [removed from the exclusions file](https://github.com/dotnet/dotnet/pull/6056).

Regression from https://github.com/dotnet/dotnet/pull/6009