### PR TITLE
Force the use of dotnet msbuild for SigningValidation

### DIFF
--- a/src/arcade/eng/common/core-templates/post-build/post-build.yml
+++ b/src/arcade/eng/common/core-templates/post-build/post-build.yml
@@ -225,7 +225,7 @@ stages:
         displayName: Validate
         inputs:
           filePath: eng\common\sdk-task.ps1
-          arguments: -task SigningValidation -restore
+          arguments: -task SigningValidation -restore -msbuildEngine dotnet
             /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts'
             /p:SignCheckExclusionsFile='$(System.DefaultWorkingDirectory)/eng/SignCheckExclusionsFile.txt'
             ${{ parameters.signingValidationAdditionalParameters }}


### PR DESCRIPTION
Repositories that define `vs` in their global.json use desktop (vs) msbuild by default. SigningValidation doesn't have any dependencies on desktop msbuild anymore. Force it to run with dotnet msbuild at all times. This resolves errors when i.e. devdiv pipelines use older VS images.