### PR TITLE
[release/10.0.2xx] Suppress NuGet audit CVEs in VMR tooling projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -69,7 +69,6 @@
     <NuGetAuditMode>all</NuGetAuditMode>
     <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
     <WarningsNotAsErrors Condition="'$(OfficialBuildId)' == ''">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-    <NuGetAudit>false</NuGetAudit>
     
     <!--
       Until 2xx and later branches start consuming a newer 1xx build with SBRP repo renamed to source-build-assets,

--- a/eng/tools/Directory.Build.props
+++ b/eng/tools/Directory.Build.props
@@ -9,4 +9,13 @@
     <RestoreSources Condition="Exists('$(SharedComponentsArtifactsPath)')">$(RestoreSources);$(SharedComponentsArtifactsPath)</RestoreSources>
   </PropertyGroup>
 
+  <!-- Suppress known NuGet audit vulnerabilities in VMR tooling projects.
+       These are compile-only references to Microsoft.Build packages whose transitive
+       dependency on System.Security.Cryptography.Xml has no patched upstream version yet. -->
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-37gx-xxp4-5rgx" />
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-w3x6-4m5h-cxqf" />
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-g4vj-cjjj-v7hg" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary

Fixes NU1903/NU1901 build failures on `release/10.0.2xx` internal builds that have been blocking all cross-compilation container legs since ~April 16.

## Changes

1. **Removes** the non-working unconditional `<NuGetAudit>false</NuGetAudit>` from `Directory.Build.props` (added in ea3d1d5af53 on April 17 as an unsuccessful fix attempt).

2. **Adds** `NuGetAuditSuppress` entries in `eng/tools/Directory.Build.props` for the three specific CVEs affecting VMR tooling projects:
   - [GHSA-37gx-xxp4-5rgx](https://github.com/advisories/GHSA-37gx-xxp4-5rgx) — `System.Security.Cryptography.Xml` DoS via EncryptedXml infinite loop
   - [GHSA-w3x6-4m5h-cxqf](https://github.com/advisories/GHSA-w3x6-4m5h-cxqf) — `System.Security.Cryptography.Xml` additional vulnerability
   - [GHSA-g4vj-cjjj-v7hg](https://github.com/advisories/GHSA-g4vj-cjjj-v7hg) — `NuGet.Packaging` low-severity vulnerability

## Why suppression instead of upgrading

All available versions of `Microsoft.Build.Tasks.Core` (including the latest 18.4.0) depend on vulnerable versions of `System.Security.Cryptography.Xml` — no upstream patched version exists yet. The affected projects are compile-only VMR build tooling (`IncludeAssets="compile"`) that does not ship to customers.

## Affected builds

Example failing build: [2956836](https://dev.azure.com/dnceng/internal/_build/results?buildId=2956836) (release/10.0.2xx, 117 NU1903 errors across container legs).