### PR TITLE
[release/10.0.3xx] Rebrand to patch 1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,10 +4,10 @@
     <VersionMajor>10</VersionMajor>
     <VersionMinor>0</VersionMinor>
     <VersionSDKMinor>3</VersionSDKMinor>
-    <VersionSDKMinorPatch>0</VersionSDKMinorPatch>
+    <VersionSDKMinorPatch>1</VersionSDKMinorPatch>
     <VersionFeature>$([System.String]::Copy('$(VersionSDKMinorPatch)').PadLeft(2, '0'))</VersionFeature>
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionSDKMinor)$(VersionFeature)</VersionPrefix>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <!-- 
       Allowed values: 'repodefault', 'unstable', 'preview', 'release'


### PR DESCRIPTION
Increment patch version 0 -> 1 on release/10.0.3xx

Sets prerelease label to 'servicing' and iteration to empty string.