### PR TITLE
Fix source tarball signing errors in Signing.props

### DIFF
--- a/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/static/Signing.props
+++ b/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/static/Signing.props
@@ -22,7 +22,7 @@
     <ItemsToSign Include="@(SignableSourceBuiltAsset)" />
   </ItemGroup>
 
-  <Target Name="SetFileSignInfoForSourceAsset" BeforeTargets="Sign">
+  <Target Name="SetFileSignInfoForSourceAsset" BeforeTargets="Execute">
     <ItemGroup>
       <SourceBuiltSourceAsset Include="@(SignableSourceBuiltAsset)" Condition="$([System.String]::new('%(Filename)').StartsWith('$(SourceBuiltSourceArtifactName)'))"/>
     </ItemGroup>


### PR DESCRIPTION
## Summary

Fixes signing errors (SIGN004, SIGN002) encountered when signing source-built artifacts.

## Root Cause

#5909 renamed the default target in [Arcade's `Sign.proj` from `Sign` to `Execute`](https://github.com/dotnet/dotnet/pull/5909/changes#diff-719671ab79e50c35d84ecf1fba4ff769b3c4d9e931f2ce923752f03300686807). The `SetFileSignInfoForSourceAsset` target in `Signing.props` used `BeforeTargets="Sign"`, which no longer matches any target. As a result, `DoNotUnpack=true` was never applied to the source tarball, causing SignTool to unpack it and attempt to sign every file inside.

## Fix

Changed `BeforeTargets` from `Sign` to `Execute` so the target actually fires and applies `DoNotUnpack=true` to the source tarball.

Fixes https://github.com/dotnet/source-build/issues/5551