### PR TITLE
[release/10.0.3xx] Remove internal darc-int feeds from NuGet.config files

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -8,7 +8,6 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-dotnet -->
-    <add key="darc-int-dotnet-dotnet-b16286c" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-dotnet-b16286c2/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-dotnet -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
@@ -21,7 +20,6 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-dotnet -->
-    <add key="darc-int-dotnet-dotnet-b16286c" value="true" />
     <!--  End: Package sources from dotnet-dotnet -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
   </disabledPackageSources>

--- a/src/scenario-tests/NuGet.config
+++ b/src/scenario-tests/NuGet.config
@@ -4,7 +4,6 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-dotnet -->
-    <add key="darc-int-dotnet-dotnet-b16286c" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-dotnet-b16286c2/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-dotnet -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
@@ -16,7 +15,6 @@
   <disabledPackageSources>
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-dotnet -->
-    <add key="darc-int-dotnet-dotnet-b16286c" value="true" />
     <!--  End: Package sources from dotnet-dotnet -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
   </disabledPackageSources>

--- a/src/sdk/NuGet.config
+++ b/src/sdk/NuGet.config
@@ -4,7 +4,6 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-dotnet -->
-    <add key="darc-int-dotnet-dotnet-b16286c" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-dotnet-b16286c2/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-dotnet -->
     <!--  Begin: Package sources from microsoft-testfx -->
     <!--  End: Package sources from microsoft-testfx -->
@@ -40,7 +39,6 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-dotnet -->
-    <add key="darc-int-dotnet-dotnet-b16286c" value="true" />
     <!--  End: Package sources from dotnet-dotnet -->
     <!--  Begin: Package sources from dotnet-runtime -->
     <!--  End: Package sources from dotnet-runtime -->

--- a/src/sourcelink/NuGet.config
+++ b/src/sourcelink/NuGet.config
@@ -4,7 +4,6 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-dotnet -->
-    <add key="darc-int-dotnet-dotnet-b16286c" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-dotnet-b16286c2/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-dotnet -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
@@ -16,7 +15,6 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-dotnet -->
-    <add key="darc-int-dotnet-dotnet-b16286c" value="true" />
     <!--  End: Package sources from dotnet-dotnet -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
   </disabledPackageSources>

--- a/src/templating/NuGet.config
+++ b/src/templating/NuGet.config
@@ -4,7 +4,6 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-dotnet -->
-    <add key="darc-int-dotnet-dotnet-b16286c" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-dotnet-b16286c2/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-dotnet -->
     <!--  Begin: Package sources from dotnet-runtime -->
     <!--  End: Package sources from dotnet-runtime -->
@@ -24,7 +23,6 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-dotnet -->
-    <add key="darc-int-dotnet-dotnet-b16286c" value="true" />
     <!--  End: Package sources from dotnet-dotnet -->
     <!--  Begin: Package sources from dotnet-runtime -->
     <!--  End: Package sources from dotnet-runtime -->


### PR DESCRIPTION
## Summary

Removes `darc-int-dotnet-dotnet-b16286c2` internal feed references from 5 NuGet.config files. These were added by PR #6224 (Change RepoDotNetFinalVersionKind to 'release') and cause **401 Unauthorized** errors on public CI builds, since the `dnceng/internal` feeds require authentication that public pipelines don't have.

## Problem

Public CI builds of forward flow PRs (e.g., [#6206](https://github.com/dotnet/dotnet/pull/6206)) fail in the scenario tests stage with:

```
error NU1301: Unable to load the service index for source
https://pkgs.dev.azure.com/dnceng/internal/_packaging/darc-int-dotnet-dotnet-b16286c2/nuget/v3/index.json.
Response status code does not indicate success: 401 (Unauthorized).
```

The `scenario-tests.proj` has `<KeepFeedPrefixes Include="darc-int" />` which preserves these feeds in the generated NuGet.config, causing the auth failure.

## Changes

Removed the `darc-int-dotnet-dotnet-b16286c` entries from both `<packageSources>` and `<disabledPackageSources>` sections in:
- `NuGet.config`
- `src/scenario-tests/NuGet.config`
- `src/sdk/NuGet.config`
- `src/sourcelink/NuGet.config`
- `src/templating/NuGet.config`