### PR TITLE
Only clear disabledPackageSources in internal builds

### DIFF
--- a/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/RemoveInternetSourcesFromNuGetConfig.cs
+++ b/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/RemoveInternetSourcesFromNuGetConfig.cs
@@ -34,6 +34,13 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
         /// </summary>
         public string[] KeepFeedPrefixes { get; set; } = [];
 
+        /// <summary>
+        /// Whether to clear the disabledPackageSources section. When true, all disabled entries are
+        /// removed so that internal feeds kept via KeepFeedPrefixes become active. Should only be set
+        /// to true for internal builds that have feed credentials (e.g., SYSTEM_TEAMPROJECT == 'internal').
+        /// </summary>
+        public bool ClearDisabledPackageSources { get; set; }
+
         private readonly string[] Sections = [ "packageSources" ];
 
         public override bool Execute()
@@ -48,8 +55,13 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks
                 ProcessSection(d, sectionName);
             }
 
-            // Remove disabledPackageSources element so if any internal packages remain, they are used in source-build
-            disabledPackageSourcesElement?.ReplaceNodes(new XElement("clear"));
+            // Clear disabledPackageSources only in internal builds where feed credentials are available.
+            // In public builds, disabled sources must remain so that internal feeds kept via
+            // KeepFeedPrefixes don't cause 401 Unauthorized errors.
+            if (ClearDisabledPackageSources)
+            {
+                disabledPackageSourcesElement?.ReplaceNodes(new XElement("clear"));
+            }
 
             using (var w = XmlWriter.Create(NuGetConfigFile, new XmlWriterSettings { NewLineChars = newLineChars, Indent = true }))
             {

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -183,6 +183,10 @@
       
       <AddPrebuiltFeeds>true</AddPrebuiltFeeds>
       <AddPrebuiltFeeds Condition="'$(DotNetSourceOnlyTestOnly)' == 'true' or '$(DotNetBuildSourceOnly)' != 'true'">false</AddPrebuiltFeeds>
+
+      <!-- Only clear disabledPackageSources in internal builds where feed credentials are available.
+           This prevents darc-int feeds (kept via KeepFeedPrefixes) from causing 401 errors in public CI. -->
+      <ClearDisabledPackageSources Condition="'$(SYSTEM_TEAMPROJECT)' == 'internal'">true</ClearDisabledPackageSources>
     </PropertyGroup>
 
     <ItemGroup>
@@ -195,6 +199,7 @@
       NuGetConfigFile="$(NuGetConfigFile)"
       BuildWithOnlineFeeds="$(DotNetBuildWithOnlineFeeds)"
       KeepFeedPrefixes="@(KeepFeedPrefixes)"
+      ClearDisabledPackageSources="$(ClearDisabledPackageSources)"
       Condition="'$(DotNetBuildSourceOnly)' == 'true'" />
 
     <RemoveBlockedAuditSourcesFromNuGetConfig

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -186,6 +186,7 @@
 
       <!-- Only clear disabledPackageSources in internal builds where feed credentials are available.
            This prevents darc-int feeds (kept via KeepFeedPrefixes) from causing 401 errors in public CI. -->
+      <ClearDisabledPackageSources>false</ClearDisabledPackageSources>
       <ClearDisabledPackageSources Condition="'$(SYSTEM_TEAMPROJECT)' == 'internal'">true</ClearDisabledPackageSources>
     </PropertyGroup>
 


### PR DESCRIPTION
## Summary

Fixes public CI builds failing with **401 Unauthorized** when restoring from `darc-int` internal NuGet feeds that were kept in `packageSources` but should have remained disabled.

## Root Cause

`RemoveInternetSourcesFromNuGetConfig` unconditionally cleared the `disabledPackageSources` section (line 52), enabling all package sources — including `darc-int` feeds that `scenario-tests.proj` preserves via `<KeepFeedPrefixes Include="darc-int" />`. Public CI doesn't have credentials for these internal feeds, causing NU1301 401 errors.

## Fix

Added a `ClearDisabledPackageSources` property to the task, gated on `$(SYSTEM_TEAMPROJECT) == 'internal'` — the same condition that controls `SetupNugetSources.ps1` in the pipeline YAML.

- **Public builds**: `disabledPackageSources` entries are preserved → `darc-int` feeds stay disabled → no 401 errors
- **Internal builds**: behavior unchanged — disabled sources are cleared so internal feeds with credentials work

## Changes

1. **`RemoveInternetSourcesFromNuGetConfig.cs`**: Added `bool ClearDisabledPackageSources` property; only clear the section when true
2. **`repo-projects/Directory.Build.targets`**: Set `ClearDisabledPackageSources=true` only when `SYSTEM_TEAMPROJECT=internal`; pass to task

## Example failures this fixes

- [PR #6206](https://github.com/dotnet/dotnet/pull/6206) (roslyn forward flow → 10.0.3xx)
- [PR #6224](https://github.com/dotnet/dotnet/pull/6224) (FinalVersionKind change)