### PR TITLE
Add dnceng skills and agents from dotnet/arcade-skills

### DIFF
--- a/.github/agents/CiInvestigator.agent.md
+++ b/.github/agents/CiInvestigator.agent.md
@@ -1,0 +1,87 @@
+---
+name: CiInvestigator
+description: >
+  Orchestrate CI failure investigations for dotnet repositories. Routes to
+  specialized skills based on failure type: ci-analysis for triage, helix-investigation
+  for deep Helix log analysis, pipeline-investigation for build/infra failures,
+  ci-crash-dump for crash dumps, known-issue-history for failure trends.
+  USE FOR: "investigate CI failures", "debug this build", "why is CI red and what
+  should I do", multi-skill CI investigations, complex failure triage.
+  DO NOT USE FOR: codeflow PRs (use flow-analysis), dependency tracing (use flow-tracing).
+---
+
+# CI Investigator
+
+Orchestrate CI failure investigations across dotnet repositories. You are the router — assess the situation, delegate to specialized skills, chain when needed, and synthesize a combined report.
+
+**Your job is routing and synthesis, not failure classification.** The skills own domain expertise. You decide which skills to invoke, in what order, and how to combine their results.
+
+## Entry Point Routing
+
+Assess what the user has and route to the first skill:
+
+| User provides | First skill | Why |
+|---|---|---|
+| PR URL/number, "why is CI red?" | **ci-analysis** | Needs triage: build status, failure counts, known issues |
+| AzDO build URL with test failures | **ci-analysis** | Classify failures first, then decide on deep-dive |
+| Helix job/work item URL directly | **helix-investigation** | User already knows the Helix layer — skip triage |
+| "Test crashed" or crash dump request | **ci-crash-dump** | Direct to crash analysis |
+| "Is this known issue still active?" | **known-issue-history** | Historical failure data |
+| "Pipeline health" or build frequency | **pipeline-investigation** | Pipeline-level health assessment |
+| AzDO build URL with build errors (not test failures) | **pipeline-investigation** | Build/infra failure, not Helix |
+
+## Chaining Rules
+
+After the first skill completes, check if escalation is needed:
+
+### ci-analysis → specialist
+
+When ci-analysis identifies failures, route based on what it found:
+
+- **Helix test failures needing deeper analysis** (intermittent, machine-specific, platform-specific patterns) → invoke **helix-investigation** with the build ID and failing job names
+- **Non-Helix pipeline failures** (build errors, scan failures, infra crashes) → invoke **pipeline-investigation** with the build URL
+- **Test crashes** (exit codes -4, 139, 134, 0xC0000005) → invoke **ci-crash-dump** with the Helix job ID, work item name, and exit code
+- **Known issue matches needing trend data** → invoke **known-issue-history** with the issue number
+
+### helix-investigation → ci-crash-dump
+
+If helix-investigation discovers a crashed work item (negative exit code, dump files in artifacts):
+- Invoke **ci-crash-dump** — pass the Helix job ID, work item name, and exit code
+- Tell the model: "The crashed work item has already been identified. Skip ci-crash-dump Step 1 (triage) and begin at Step 2 (console log inspection)."
+
+### pipeline-investigation → helix-investigation
+
+If pipeline-investigation encounters a Helix test leg among pipeline failures:
+- Invoke **helix-investigation** with the Helix job ID from the timeline
+
+## Handoff Context
+
+When routing between skills, carry forward what's already been discovered. Pass these fields when available so the next skill doesn't re-fetch:
+
+- **Repository**: `dotnet/{repo}`
+- **PR number** and build URL
+- **Build ID** and failing job/leg names
+- **Helix job ID** and work item name
+- **Exit code** and crash evidence
+- **Known issue matches** from Build Analysis
+
+> ❌ **Don't let skills re-discover what you already know.** If ci-analysis already identified the Helix job ID, pass it to helix-investigation — don't let it re-query the build timeline.
+
+## Synthesis
+
+After all skills complete, combine findings into one report:
+
+1. **Verdict** — 1-2 sentence summary ("3 failures: 2 matched known issues, 1 crash needs investigation")
+2. **Failure table** — one row per failure, with verdict and evidence source
+3. **Recommended actions** — retry, file issue, needs fix, escalate
+4. **Trend context** — if known-issue-history was invoked, include whether failures are increasing/decreasing
+
+## Anti-Patterns
+
+> ❌ **Don't classify failures yourself.** That's ci-analysis's job. Your triage is: "what does the user have?" → pick a skill.
+
+> ❌ **Don't invoke all skills.** Route to the minimum set. Most investigations need ci-analysis + one specialist.
+
+> ❌ **Don't re-fetch data.** If a skill already retrieved build status or Helix job details, pass that context forward.
+
+> ❌ **Don't skip ci-analysis for PR URLs.** Even if the user points at a specific failure, ci-analysis catches context you'd miss — known issue matches, other failing legs, build progression.

--- a/.github/skills/ci-analysis/SKILL.md
+++ b/.github/skills/ci-analysis/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: ci-analysis
+description: >
+  Analyze CI build and test status from Azure DevOps and Helix for dotnet repository PRs.
+  Use when checking CI status, investigating failures, determining if a PR is ready to merge,
+  or given URLs containing dev.azure.com or helix.dot.net. Also use when asked "why is CI red",
+  "test failures", "retry CI", "rerun tests", "is CI green", "build failed", "checks failing",
+  or "flaky tests". DO NOT USE FOR: investigating stale codeflow PRs or dependency update health,
+  tracing whether a commit has flowed from one repo to another, reviewing code changes for
+  correctness or style.
+---
+
+# Azure DevOps and Helix CI Analysis
+
+Analyze CI build status and test failures in Azure DevOps and Helix for dotnet repositories (runtime, sdk, aspnetcore, roslyn, and more).
+
+> 🚨 **NEVER** use `gh pr review --approve` or `--request-changes`. Only `--comment` is allowed. Approval and blocking are human-only actions.
+
+**Workflow**: Gather PR context (Step 0) → collect failure data → synthesize recommendations. The agent drives the investigation; tools provide the data.
+
+**Accessing services**: Start with MCP tools if available. Get repo-specific CI guidance early — it provides the investigation workflow, tool selection, failure patterns, and classification algorithm for that repo. The guidance evolves with the toolset, so it always reflects current capabilities.
+
+If MCP tools aren't loaded, the Helix CLI tool provides the same capabilities via bash with progressive discovery.
+
+For AzDO, multiple tool sets may exist for different organizations — match the org in the build URL to the correct tools (see [references/azdo-helix-reference.md](references/azdo-helix-reference.md#azure-devops-organizations)). If queries return null, check the org before trying other approaches. For complex investigations, track what you've tried in SQL to avoid repeating failed approaches.
+
+## When to Use This Skill
+
+- Checking CI status ("is CI passing?", "why is CI red?")
+- Investigating CI failures or determining merge readiness
+- Debugging Helix test issues or build errors
+- URLs containing `dev.azure.com`, `helix.dot.net`, or GitHub PR links with failing checks
+- Questions like "retry CI", "rerun tests", "test failures", "checks failing"
+- Investigating canceled or timed-out jobs for recoverable results
+
+**Not for**: GitHub Actions workflows, non-Helix repos, or build performance (use binlog analysis).
+
+> 💡 **Per-repo CI patterns differ significantly.** Get repo-specific guidance early — it tells you which tools to use, what log patterns to search for, and what gotchas to expect. This is the fastest path and prevents wasted calls.
+
+## Quick Start
+
+1. **Get repo-specific CI guidance** — investigation workflow, tool selection, search patterns, and failure classification for that repo
+2. **Find builds** for the PR or use a build ID directly
+3. **Follow the investigation order** from the guidance — it tells you what to check and in what sequence
+
+If MCP tools aren't available, the Helix CLI tool provides the same capabilities via bash. A legacy PowerShell script is also available for environments that support it.
+
+For full parameter reference and mode details, see [references/script-modes.md](references/script-modes.md).
+
+## Step 0: Gather Context (before running anything)
+
+1. **Read PR metadata** — title, description, author, labels, linked issues
+2. **Classify the PR type**:
+
+| PR Type | How to detect | Interpretation shift |
+|---------|--------------|---------------------|
+| **Code PR** | Human author, code changes | Failures likely relate to the changes |
+| **Flow/Codeflow PR** | Author is `dotnet-maestro[bot]`, "Update dependencies" | Missing packages may be behavioral, not infrastructure |
+| **Backport** | Title mentions "backport", targets release branch | Check if test exists on target branch |
+| **Merge PR** | Merging between branches | Conflicts cause failures, not individual changes |
+| **Dependency update** | Bumps package versions, global.json | Build failures often trace to the dependency |
+
+3. **Check existing comments** — has someone already diagnosed failures or is a retry pending?
+4. **Note the changed files** — you'll use these for failure correlation
+
+## After Data Collection: Synthesize
+
+> 🚨 **Don't re-fetch data you already have.** Only make additional calls for deeper investigation (Helix log searches, binlog analysis, build progression).
+
+**Classify each failure.** Determine whether it's a build error, test failure, crash, timeout, or infrastructure issue. Exit codes, log patterns, and Helix work item state all contribute — the repo-specific CI guidance includes a classification algorithm with the patterns and recommended next steps for each category. Crashes (exit code -4, 139, 134) don't always mean tests failed — check for recoverable test results before concluding.
+
+**Cross-reference with known issues.** Check which failures are already matched by Build Analysis — green means all failures are accounted for, red means some are unmatched. For each unmatched failure, search for related known issues by error message, test name, or job type. The user needs a per-failure verdict, not two separate lists.
+
+**Correlate with PR changes.** If the same files appear in both the PR diff and the failure messages, the failure is likely PR-related. If not, check whether the same test fails on the target branch — that distinguishes pre-existing flakes from regressions.
+
+**Verify before claiming.** Don't call it "infrastructure" without a Build Analysis match or target-branch verification. Don't call it "safe to retry" unless ALL failures are accounted for.
+
+> 🚨 **Check build progression on multi-commit PRs.** If the PR has multiple commits, query AzDO for builds on `refs/pull/{PR}/merge` (sorted by queue time, top 10-20). Present a progression table showing which builds passed/failed at which SHAs — this narrows failures to the commit that introduced them. See [references/build-progression-analysis.md](references/build-progression-analysis.md).
+
+For interpreting error categories, crash recovery, and canceled jobs: [references/failure-interpretation.md](references/failure-interpretation.md)
+
+For generating recommendations from `[CI_ANALYSIS_SUMMARY]` JSON: [references/recommendation-generation.md](references/recommendation-generation.md)
+
+## Presenting Results
+
+> 🚨 **Keep tables narrow — 4 short columns max (# | Job | Verdict | Issue).** Put error descriptions, work item lists, and evidence in **detail bullets below the table**, not in cells. Wide tables wrap and become unreadable in terminals.
+
+> 🚨 **Use markdown links** for PRs (`[#121195](url)`), builds (`[Build 1305302](url)`), and jobs (`[job name](azdo-job-url)`). The script output and MCP tools provide URLs — thread them through.
+
+Lead with a 1-2 sentence verdict, then the summary table, then detail bullets (one per failure), then recommended actions. For the full format example: [references/recommendation-generation.md](references/recommendation-generation.md).
+
+## Anti-Patterns
+
+> 🚨 **Every failure verdict needs evidence — no "Likely flaky" without proof.** Each row in your summary table must cite a specific source: known issue number, Build Analysis match, or target-branch verification. If Build Analysis didn't match it and you haven't verified the target branch, the verdict is **"Unmatched — needs investigation"**, not "Likely flaky." A test that *looks* like it could be flaky is not the same as one you've *verified* is flaky.
+
+> ❌ **Don't label failures "infrastructure" without evidence.** Requires: Build Analysis match, identical failure on target branch, or confirmed outage. Exception: `tests-passed-reporter-failed` is genuinely infrastructure.
+
+> ❌ **Don't dismiss timed-out builds.** A build "failed" due to AzDO timeout can have 100% passing Helix work items. Check Helix job status before concluding failure.
+
+> ❌ **Missing packages on flow PRs ≠ infrastructure.** Flow PRs request *different* packages. Check *which* package and *why* before assuming feed delay.
+
+> ❌ **Don't present failures and known issues as separate lists.** Cross-reference them: for each `failedJobDetails` entry, state whether it matches a `knownIssues` entry or is unmatched. An `unclassified` failure can still match a known issue by error pattern.
+
+> ❌ **Don't say "safe to retry" with Build Analysis red.** Map each failing job to a specific known issue first.
+
+> ❌ **Don't execute `gh issue create` without explicit user approval.** Always present the draft command as text and ask the user to confirm before running it. This applies to KBE issues and any other GitHub issue creation.
+
+> ❌ **Don't use raw REST APIs when higher-level tools are available.** Check your available tools for Azure DevOps and Helix operations first. REST API fallback is for when those tools are genuinely unavailable, not a first resort.
+
+## References
+
+- **Script modes & parameters**: [references/script-modes.md](references/script-modes.md)
+- **Failure interpretation**: [references/failure-interpretation.md](references/failure-interpretation.md)
+- **Recommendation generation**: [references/recommendation-generation.md](references/recommendation-generation.md)
+- **Analysis workflow (Steps 1–3)**: [references/analysis-workflow.md](references/analysis-workflow.md)
+- **Helix artifacts & binlogs**: [references/helix-artifacts.md](references/helix-artifacts.md)
+- **Binlog comparison**: For cross-build binlog diffs, use deep investigation techniques from [references/delegation-patterns.md](references/delegation-patterns.md)
+- **Build progression analysis**: [references/build-progression-analysis.md](references/build-progression-analysis.md)
+- **Subagent delegation**: [references/delegation-patterns.md](references/delegation-patterns.md)
+- **Azure CLI investigation**: [references/azure-cli.md](references/azure-cli.md)
+- **Manual investigation**: [references/manual-investigation.md](references/manual-investigation.md)
+- **SQL tracking**: [references/sql-tracking.md](references/sql-tracking.md)
+- **Known Build Error issue creation**: [references/kbe-issue-creation.md](references/kbe-issue-creation.md)
+- **AzDO/Helix details**: [references/azdo-helix-reference.md](references/azdo-helix-reference.md)
+
+## Tips
+
+1. Get repo-specific CI guidance first — it gives you the investigation order, search patterns, and gotchas
+2. Check if same test fails on target branch before assuming transient
+3. Look for `[ActiveIssue]` attributes for known skipped tests
+4. Search for related issues across dotnet repos when failures don't match known patterns
+5. "Canceled" ≠ "Failed" — canceled jobs may have recoverable Helix results. Helix data may persist even when AzDO builds have expired.

--- a/.github/skills/ci-analysis/references/analysis-workflow.md
+++ b/.github/skills/ci-analysis/references/analysis-workflow.md
@@ -1,0 +1,39 @@
+# Analysis Workflow (Steps 1–3)
+
+After completing Step 0 (Gather Context — see SKILL.md), follow these steps.
+
+## Step 1: Run the Script
+
+Run with `-ShowLogs` for detailed failure info. See [script-modes.md](script-modes.md) for parameter details.
+
+## Step 1b: Investigate with AzDO Tools
+
+When the script output is insufficient (e.g., build timeline fetch fails), use AzDO MCP tools to query builds directly. **Match the org from the build URL to the correct AzDO tools** — see [azdo-helix-reference.md](azdo-helix-reference.md#azure-devops-organizations). PR builds are in `dnceng-public`; internal builds are in `dnceng`.
+
+## Step 2: Analyze Results
+
+1. **Check Build Analysis** — If the Build Analysis GitHub check is **green**, all failures matched known issues and it's safe to retry. If it's **red**, some failures are unaccounted for — you must identify which failing jobs are covered by known issues and which are not. For 3+ failures, use SQL tracking to avoid missed matches (see [sql-tracking.md](sql-tracking.md)).
+2. **Correlate with PR changes** — Same files failing = likely PR-related
+3. **Compare with baseline** — If a test passes on the target branch but fails on the PR, compare Helix binlogs. See [binlog-comparison.md](binlog-comparison.md) — **delegate binlog download/extraction to subagents** to avoid burning context on mechanical work.
+4. **Check build progression** — If the PR has multiple builds (multiple pushes), check whether earlier builds passed. A failure that appeared after a specific push narrows the investigation to those commits. See [build-progression-analysis.md](build-progression-analysis.md). Present findings as facts, not fix recommendations.
+5. **Interpret patterns** (but don't jump to conclusions):
+   - Same error across many jobs → Real code issue
+   - Build Analysis flags a known issue → That *specific failure* is safe to retry (but others may not be)
+   - Failure is **not** in Build Analysis → Investigate further before assuming transient
+   - Device failures, Docker pulls, network timeouts → *Could* be infrastructure, but verify against the target branch first
+   - Test timeout but tests passed → Executor issue, not test failure
+6. **Check for mismatch with user's question** — The script only reports builds for the current head SHA. If the user asks about a job, error, or cancellation that doesn't appear in the results, **ask** if they're referring to a prior build. Common triggers:
+   - User mentions a canceled job but `canceledJobNames` is empty
+   - User says "CI is failing" but the latest build is green
+   - User references a specific job name not in the current results
+   Offer to re-run with `-BuildId` if the user can provide the earlier build ID from AzDO.
+
+## Step 3: Verify Before Claiming
+
+Before stating a failure's cause, verify your claim:
+
+- **"Infrastructure failure"** → Did Build Analysis flag it? Does the same test pass on the target branch? If neither, don't call it infrastructure.
+- **"Transient/flaky"** → Has it failed before? Is there a known issue? A single non-reproducing failure isn't enough to call it flaky.
+- **"PR-related"** → Do the changed files actually relate to the failing test? Correlation in the script output is heuristic, not proof.
+- **"Safe to retry"** → Are ALL failures accounted for (known issues or infrastructure), or are you ignoring some? Check the Build Analysis check status — if it's red, not all failures are matched. Map each failing job to a specific known issue before concluding "safe to retry."
+- **"Not related to this PR"** → Have you checked if the test passes on the target branch? Don't assume — verify.

--- a/.github/skills/ci-analysis/references/azdo-helix-reference.md
+++ b/.github/skills/ci-analysis/references/azdo-helix-reference.md
@@ -1,0 +1,96 @@
+# Azure DevOps and Helix Reference
+
+## Supported Repositories
+
+The script works with any dotnet repository that uses Azure DevOps and Helix:
+
+| Repository | Common Pipelines |
+|------------|-----------------|
+| `dotnet/runtime` | runtime, runtime-dev-innerloop, dotnet-linker-tests |
+| `dotnet/sdk` | dotnet-sdk (mix of local and Helix tests) |
+| `dotnet/aspnetcore` | aspnetcore-ci |
+| `dotnet/roslyn` | roslyn-CI |
+| `dotnet/maui` | maui-public |
+
+Use `-Repository` to specify the target:
+```powershell
+./scripts/Get-CIStatus.ps1 -PRNumber 12345 -Repository "dotnet/aspnetcore"
+```
+
+## Build Definition IDs (Example: dotnet/runtime)
+
+Each repository has its own build definition IDs. Here are common ones for dotnet/runtime:
+
+| Definition ID | Name | Description |
+|---------------|------|-------------|
+| `129` | runtime | Main PR validation build |
+| `133` | runtime-dev-innerloop | Fast innerloop validation |
+| `139` | dotnet-linker-tests | ILLinker/trimming tests |
+
+**Note:** The script auto-discovers builds for a PR, so you rarely need to know definition IDs.
+
+## Azure DevOps Organizations
+
+Builds live in two Azure DevOps organizations. **Determine the org from the build URL**, then use AzDO tools for that org:
+
+| Organization | URL pattern | Project | When used |
+|---|---|---|---|
+| `dnceng-public` | `dev.azure.com/dnceng-public/...` | `public` (GUID: `cbb18261-c48f-4abb-8651-8cdcb5474649`) | PR validation builds (most common) |
+| `dnceng` | `dev.azure.com/dnceng/...` | `internal` or varies | Official/internal builds, signed builds |
+
+**How to pick the right tools:** Look at the build URL from `gh pr checks` output or the script's `[CI_ANALYSIS_SUMMARY]`. The URL contains the org name (e.g., `dev.azure.com/dnceng-public/...`). Search your available AzDO tools for ones matching that org name — there may be multiple sets of AzDO tools for different organizations. If a query returns null, you're likely using tools for the wrong org.
+
+> ⚠️ **Common mistake:** Wrong org = null results. PR validation builds are almost always in `dnceng-public`. If you get null, check the org before trying other approaches.
+
+Override with:
+```powershell
+./scripts/Get-CIStatus.ps1 -BuildId 1276327 -Organization "dnceng" -Project "internal-project-guid"
+```
+
+## Common Pipeline Names (Example: dotnet/runtime)
+
+| Pipeline | Description |
+|----------|-------------|
+| `runtime` | Main PR validation build |
+| `runtime-dev-innerloop` | Fast innerloop validation |
+| `dotnet-linker-tests` | ILLinker/trimming tests |
+| `runtime-wasm-perf` | WASM performance tests |
+| `runtime-libraries enterprise-linux` | Enterprise Linux compatibility |
+
+Other repos have different pipelines - the script discovers them automatically from the PR.
+
+## Useful Links
+
+- [Helix Portal](https://helix.dot.net/): View Helix jobs and work items (all repos)
+- [Helix API Documentation](https://helix.dot.net/swagger/): Swagger docs for Helix REST API
+- [Build Analysis](https://github.com/dotnet/arcade/blob/main/Documentation/Projects/Build%20Analysis/LandingPage.md): Known issues tracking (arcade infrastructure)
+- [dnceng-public AzDO](https://dev.azure.com/dnceng-public/public/_build): Public builds for all dotnet repos
+
+### Repository-specific docs:
+- [runtime: Triaging Failures](https://github.com/dotnet/runtime/blob/main/docs/workflow/ci/triaging-failures.md)
+- [runtime: Area Owners](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md)
+
+## Test Execution Types
+
+### Helix Tests
+Tests run on Helix distributed test infrastructure. The script extracts console log URLs and can fetch detailed failure info with `-ShowLogs`.
+
+### Local Tests (Non-Helix)
+Some repositories (e.g., dotnet/sdk) run tests directly on the build agent. The script detects these and extracts Azure DevOps Test Run URLs.
+
+## Known Issue Labels
+
+- `Known Build Error` - Used by Build Analysis across all dotnet repositories
+- Search syntax: `repo:<owner>/<repo> is:issue is:open label:"Known Build Error" <test-name>`
+
+Example searches (use `search_issues` when GitHub MCP is available, `gh` CLI otherwise):
+```bash
+# Search in runtime
+gh issue list --repo dotnet/runtime --label "Known Build Error" --search "FileSystemWatcher"
+
+# Search in aspnetcore
+gh issue list --repo dotnet/aspnetcore --label "Known Build Error" --search "Blazor"
+
+# Search in sdk
+gh issue list --repo dotnet/sdk --label "Known Build Error" --search "template"
+```

--- a/.github/skills/ci-analysis/references/azure-cli.md
+++ b/.github/skills/ci-analysis/references/azure-cli.md
@@ -1,0 +1,96 @@
+# Deep Investigation with Azure CLI
+
+The AzDO MCP tools handle most pipeline queries directly. This reference covers the Azure CLI fallback for cases where MCP tools are unavailable or the endpoint isn't exposed (e.g., downloading artifacts, inspecting pipeline definitions).
+
+When the CI script and GitHub APIs aren't enough (e.g., investigating internal pipeline definitions or downloading build artifacts), use the Azure CLI with the `azure-devops` extension.
+
+> 💡 Use `az pipelines` before raw REST. `--query` (JMESPath) and `-o table` are useful for filtering.
+
+## Checking Authentication
+
+Before making AzDO API calls, verify the CLI is installed and authenticated:
+
+```powershell
+# Ensure az is on PATH (Windows may need a refresh after install)
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+
+# Check if az CLI is available
+az --version 2>$null | Select-Object -First 1
+
+# Check if logged in and get current account
+az account show --query "{name:name, user:user.name}" -o table 2>$null
+
+# If not logged in, prompt the user to authenticate:
+#   az login                              # Interactive browser login
+#   az login --use-device-code            # Device code flow (for remote/headless)
+
+# Get an AAD access token for AzDO REST API calls (only needed for raw REST)
+$accessToken = (az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
+$headers = @{ "Authorization" = "Bearer $accessToken" }
+```
+
+> ⚠️ If `az` is not installed, use `winget install -e --id Microsoft.AzureCLI` (Windows). The `azure-devops` extension is also required — install or verify it with `az extension add --name azure-devops` (safe to run if already installed). Ask the user to authenticate if needed.
+
+> ⚠️ **Do NOT use `az devops configure --defaults`** — it sets user-wide defaults that may not match the organization/project needed for dotnet repositories. Always pass `--org` and `--project` (or `-p`) explicitly on each command.
+
+## Querying Pipeline Definitions and Builds
+
+```powershell
+$org = "https://dev.azure.com/dnceng"
+$project = "internal"
+
+# Find a pipeline definition by name
+az pipelines list --name "dotnet-unified-build" --org $org -p $project --query "[].{id:id, name:name, path:path}" -o table
+
+# Get pipeline definition details (shows YAML path, triggers, etc.)
+az pipelines show --id 1330 --org $org -p $project --query "{id:id, name:name, yamlPath:process.yamlFilename, repo:repository.name}" -o table
+
+# List recent builds for a pipeline (replace {TARGET_BRANCH} with the PR's base branch, e.g., main or release/9.0)
+az pipelines runs list --pipeline-ids 1330 --branch "refs/heads/{TARGET_BRANCH}" --top 5 --org $org -p $project --query "[].{id:id, result:result, finish:finishTime}" -o table
+
+# Get a specific build's details
+az pipelines runs show --id $buildId --org $org -p $project --query "{id:id, result:result, sourceBranch:sourceBranch}" -o table
+
+# List build artifacts
+az pipelines runs artifact list --run-id $buildId --org $org -p $project --query "[].{name:name, type:resource.type}" -o table
+
+# Download a build artifact
+az pipelines runs artifact download --run-id $buildId --artifact-name "TestBuild_linux_x64" --path "$env:TEMP\artifact" --org $org -p $project
+```
+
+## REST API Fallback
+
+Fall back to REST API only when the CLI doesn't expose what you need:
+
+```powershell
+# Get build timeline (stages, jobs, tasks with results and durations) — no CLI equivalent
+$accessToken = (az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
+$headers = @{ "Authorization" = "Bearer $accessToken" }
+$timelineUrl = "https://dev.azure.com/dnceng/internal/_apis/build/builds/$buildId/timeline?api-version=7.1"
+$timeline = (Invoke-RestMethod -Uri $timelineUrl -Headers $headers)
+$timeline.records | Where-Object { $_.result -eq "failed" -and $_.type -eq "Job" }
+```
+
+## Examining Pipeline YAML
+
+All dotnet repos that use arcade put their pipeline definitions under `eng/pipelines/`. Use `az pipelines show` to find the YAML file path, then fetch it:
+
+```powershell
+# Find the YAML path for a pipeline
+az pipelines show --id 1330 --org $org -p $project --query "{yamlPath:process.yamlFilename, repo:repository.name}" -o table
+
+# Fetch the YAML from the repo (example: dotnet/runtime's runtime-official pipeline)
+#   Read the pipeline YAML from the repo to understand build stages and conditions
+#   e.g., eng/pipelines/runtime-official.yml in dotnet/runtime
+
+# For VMR unified builds, the YAML is in dotnet/dotnet:
+#   eng/pipelines/unified-build.yml
+
+# Templates are usually in eng/pipelines/common/ or eng/pipelines/templates/
+```
+
+This is especially useful when:
+- A job name doesn't clearly indicate what it builds
+- You need to understand stage dependencies (why a job was canceled)
+- You want to find which template defines a specific step
+- Investigating whether a pipeline change caused new failures

--- a/.github/skills/ci-analysis/references/build-progression-analysis.md
+++ b/.github/skills/ci-analysis/references/build-progression-analysis.md
@@ -1,0 +1,217 @@
+# Deep Investigation: Build Progression Analysis
+
+When the current build is failing, the PR's build history can reveal whether the failure existed from the start or appeared after specific changes. This is a fact-gathering technique — like target-branch comparison — that provides context for understanding the current failure.
+
+## When to Use This Pattern
+
+- Standard analysis (script + logs) hasn't identified the root cause of the current failure
+- The PR has multiple pushes and you want to know whether earlier builds passed or failed
+- You need to understand whether a failure is inherent to the PR's approach or was introduced by a later change
+
+## The Pattern
+
+### Step 0: Start with the recent builds
+
+Start with the 5-8 most recent builds. Present the progression table and offer to look at earlier builds if needed.
+
+### Step 1: List builds for the PR
+
+`gh pr checks` only shows checks for the current HEAD SHA. To see the full build history, use AzDO or CLI:
+
+**With AzDO (preferred):**
+
+Query AzDO for builds on `refs/pull/{PR}/merge` branch, sorted by queue time descending, top 20, in the `public` project. The response includes `triggerInfo` with `pr.sourceSha` — the PR's HEAD commit for each build.
+
+> Key parameters: `branchName: "refs/pull/{PR}/merge"`, `queryOrder: "QueueTimeDescending"`, `top: 20`, project `public` (for dnceng-public org).
+
+**Without MCP (fallback):**
+```powershell
+$org = "https://dev.azure.com/dnceng-public"
+$project = "public"
+az pipelines runs list --branch "refs/pull/{PR}/merge" --top 20 --org $org -p $project -o json
+```
+
+### Step 2: Map builds to the PR's head commit
+
+Each build's `triggerInfo` contains `pr.sourceSha` — the PR's HEAD commit when the build was triggered. Extract it from the build response or CLI output.
+
+> ⚠️ **`sourceVersion` is the merge commit**, not the PR's head commit. Use `triggerInfo.'pr.sourceSha'` instead.
+
+> ⚠️ **Target branch moves between builds.** Each build merges `pr.sourceSha` into the target branch HEAD *at the time the build starts*. If `main` received new commits between build N and N+1, the two builds merged against different baselines — even if `pr.sourceSha` is the same. Always extract the target branch HEAD to detect baseline shifts.
+
+### Step 2b: Extract the target branch HEAD
+
+**Shortcut for the latest build — use the GitHub merge commit:**
+
+For the current/latest build, the merge ref (`refs/pull/{PR}/merge`) is available via the GitHub API. The merge commit's first parent is the target branch HEAD at the time GitHub computed the merge:
+
+Look up the merge commit's parents — the first parent is the target branch HEAD. Use the GitHub API or MCP (`get_commit` with the `sourceVersion` SHA) to get the commit details. The `sourceVersion` from the AzDO build is the merge commit SHA (not `pr.sourceSha`). Example:
+
+```
+gh api repos/{owner}/{repo}/git/commits/{sourceVersion} --jq '.parents[0].sha'
+```
+
+This is simpler than parsing checkout logs.
+
+> ⚠️ **This only works for the latest build.** GitHub recomputes `refs/pull/{PR}/merge` on each push, so the merge commit changes. For historical builds in a progression analysis, the merge ref no longer reflects what was built — use the checkout log method below.
+
+**For historical builds — extract from checkout logs:**
+
+The AzDO build API doesn't expose the target branch SHA. Extract it from the checkout task log.
+
+**With AzDO (preferred):**
+
+Fetch the checkout task log for the build — typically **log ID 5**, starting around **line 500+** (skip the early git-fetch output). Search the output for the merge line:
+```
+HEAD is now at {mergeCommit} Merge {prSourceSha} into {targetBranchHead}
+```
+
+> 💡 `logId: 5` is the first checkout task in most dotnet pipelines. If it doesn't contain the merge line, check the build timeline for "Checkout" tasks to find the correct log ID.
+
+**Without MCP (fallback):**
+```powershell
+$token = az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query accessToken -o tsv
+$headers = @{ Authorization = "Bearer $token" }
+$logUrl = "https://dev.azure.com/{org}/{project}/_apis/build/builds/{BUILD_ID}/logs/5"
+$log = Invoke-RestMethod -Uri $logUrl -Headers $headers
+```
+
+> Note: log ID 5 is the first checkout task in most pipelines. The merge line is typically around line 500-650. If log 5 doesn't contain it, check the build timeline for "Checkout" tasks.
+
+Note: a PR may have more unique `pr.sourceSha` values than commits visible on GitHub, because force-pushes replace the commit history. Each force-push triggers a new build with a new merge commit and a new `pr.sourceSha`.
+
+### Step 3: Store progression in SQL
+
+Use the SQL tool to track builds as you discover them. This avoids losing context and enables queries across the full history:
+
+```sql
+CREATE TABLE IF NOT EXISTS build_progression (
+  build_id INT PRIMARY KEY,
+  pr_sha TEXT,
+  target_sha TEXT,
+  result TEXT,       -- passed, failed, canceled
+  queued_at TEXT,
+  failed_jobs TEXT,  -- comma-separated job names
+  notes TEXT
+);
+```
+
+Insert rows as you extract data from each build:
+
+```sql
+INSERT INTO build_progression VALUES
+  (1283986, '7af79ad', '2d638dc', 'failed', '2026-02-08T10:00:00Z', 'WasmBuildTests', 'Initial commits'),
+  (1284169, '28ec8a0', '0b691ba', 'failed', '2026-02-08T14:00:00Z', 'WasmBuildTests', 'Iteration 2'),
+  (1284433, '39dc0a6', '18a3069', 'passed', '2026-02-09T09:00:00Z', NULL, 'Iteration 3');
+```
+
+Then query to find the pass→fail transition:
+
+```sql
+-- Find where it went from passing to failing
+SELECT * FROM build_progression ORDER BY queued_at;
+
+-- Did the target branch move between pass and fail?
+SELECT pr_sha, target_sha, result FROM build_progression
+WHERE result IN ('passed', 'failed') ORDER BY queued_at;
+
+-- Which builds share the same PR SHA? (force-push detection)
+SELECT pr_sha, COUNT(*) as builds, GROUP_CONCAT(result) as results
+FROM build_progression GROUP BY pr_sha HAVING builds > 1;
+```
+
+Present the table to the user:
+
+| PR HEAD | Target HEAD | Builds | Result | Notes |
+|---------|-------------|--------|--------|-------|
+| 7af79ad | 2d638dc | 1283986 | ❌ | Initial commits |
+| 28ec8a0 | 0b691ba | 1284169 | ❌ | Iteration 2 |
+| 39dc0a6 | 18a3069 | 1284433 | ✅ | Iteration 3 |
+| f186b93 | 5709f35 | 1286087 | ❌ | Added commit C; target moved ~35 commits |
+| 2e74845 | 482d8f9 | 1286967 | ❌ | Modified commit C |
+
+When both `pr.sourceSha` AND `Target HEAD` change between a pass→fail transition, either could be the cause. Analyze the failure content to determine which. If only the target moved (same `pr.sourceSha`), the failure came from the new baseline.
+
+#### Tracking individual test failures across builds
+
+For deeper analysis, track which tests failed in each build:
+
+```sql
+CREATE TABLE IF NOT EXISTS build_failures (
+  build_id INT,
+  job_name TEXT,
+  test_name TEXT,
+  error_snippet TEXT,
+  helix_job TEXT,
+  work_item TEXT,
+  PRIMARY KEY (build_id, job_name, test_name)
+);
+```
+
+Insert failures as you investigate each build, then query for patterns:
+
+```sql
+-- Tests that fail in every build (persistent, not flaky)
+SELECT test_name, COUNT(DISTINCT build_id) as fail_count, GROUP_CONCAT(build_id) as builds
+FROM build_failures GROUP BY test_name HAVING fail_count > 1;
+
+-- New failures in the latest build (what changed?)
+SELECT f.* FROM build_failures f
+LEFT JOIN build_failures prev ON f.test_name = prev.test_name AND prev.build_id = {PREV_BUILD_ID}
+WHERE f.build_id = {LATEST_BUILD_ID} AND prev.test_name IS NULL;
+
+-- Flaky tests: fail in some builds, pass in others
+SELECT test_name FROM build_failures GROUP BY test_name
+HAVING COUNT(DISTINCT build_id) < (SELECT COUNT(*) FROM build_progression WHERE result = 'failed');
+```
+
+### Step 4: Present findings, not conclusions
+
+Report what the progression shows:
+- Which builds passed and which failed
+- What commits were added between the last passing and first failing build
+- Whether the failing commits were added in response to review feedback (check review threads)
+
+> 💡 **Stop when you have the progression table and the pass→fail transition identified.** The table + transition commits + error category is enough for the user to act. Don't investigate further (e.g., comparing individual commits, checking passing builds, exploring main branch history) unless the user asks.
+
+**Do not** make fix recommendations based solely on build progression. The progression narrows the investigation — it doesn't determine the right fix. The human may have context about why changes were made, what constraints exist, or what the reviewer intended.
+
+## Checking review context
+
+When the progression shows that a failure appeared after new commits, check whether those commits were review-requested:
+
+```powershell
+# Get review comments with timestamps
+gh api "repos/{OWNER}/{REPO}/pulls/{PR}/comments" `
+    --jq '.[] | {author: .user.login, body: .body, created: .created_at}'
+```
+
+Present this as additional context: "Commit C was pushed after reviewer X commented requesting Y." Let the author decide how to proceed.
+
+## Combining with Binlog Comparison
+
+Build progression identifies **which change** correlates with the current failure. Binlog comparison (see [binlog-comparison.md](binlog-comparison.md)) shows **what's different** in the build between a passing and failing state. Together they provide a complete picture:
+
+1. Progression → "The current failure first appeared in build N+1, which added commit C"
+2. Binlog comparison → "In the current (failing) build, task X receives parameter Y=Z, whereas in the passing build it received Y=W"
+
+## Relationship to Target-Branch Comparison
+
+Both techniques compare a failing build against a passing one:
+
+| Technique | Passing build from | Answers |
+|-----------|-------------------|---------|
+| **Target-branch comparison** | Recent build on the base branch (e.g., main) | "Does this test pass without the PR's changes at all?" |
+| **Build progression** | Earlier build on the same PR | "Did this test pass with the PR's *earlier* changes?" |
+
+Use target-branch comparison first to confirm the failure is PR-related. Use build progression to narrow down *which part* of the PR introduced it. If build progression shows a pass→fail transition with the same `pr.sourceSha`, the target branch is the more likely culprit — use target-branch comparison to confirm.
+
+## Anti-Patterns
+
+> ❌ **Don't treat build history as a substitute for analyzing the current build.** The current build determines CI status. Build history is context for understanding and investigating the current failure.
+
+> ❌ **Don't make fix recommendations from progression alone.** "Build N passed and build N+1 failed after adding commit C" is a fact worth reporting. "Therefore revert commit C" is a judgment that requires more context than the agent has — the commit may be addressing a critical review concern, fixing a different bug, or partially correct.
+
+> ❌ **Don't assume earlier passing builds prove the original approach was complete.** A build may pass because it didn't change enough to trigger the failing test scenario. The reviewer who requested additional changes may have identified a real gap.
+
+> ❌ **Don't assume MSBuild changes only affect the platform you're looking at.** MSBuild properties, conditions, and targets are shared infrastructure. A commit that changes a condition, moves a property, or modifies a restore flag can impact any platform that evaluates the same code path. When a commit touches MSBuild files, verify its impact across all platforms — don't assume it's scoped to the one you're investigating.

--- a/.github/skills/ci-analysis/references/delegation-patterns.md
+++ b/.github/skills/ci-analysis/references/delegation-patterns.md
@@ -1,0 +1,126 @@
+# Subagent Delegation Patterns
+
+Delegate data gathering to subagents; keep interpretation in main.
+
+## Pattern 1: Scanning Multiple Console Logs
+
+**When:** Multiple failing work items across several jobs.
+
+**Delegate:**
+```
+Extract all unique test failures from these Helix work items:
+
+Job: {JOB_ID_1}, Work items: {ITEM_1}, {ITEM_2}
+Job: {JOB_ID_2}, Work items: {ITEM_3}
+
+For each, search console logs for lines ending with [FAIL] (xUnit format).
+If hlx MCP is not available, fall back to:
+  ./scripts/Get-CIStatus.ps1 -HelixJob "{JOB}" -WorkItem "{ITEM}"
+
+Extract lines ending with [FAIL] (xUnit format). Ignore [OUTPUT] and [PASS] lines.
+
+Return JSON: { "failures": [{ "test": "Namespace.Class.Method", "workItems": ["item1", "item2"] }] }
+```
+
+## Pattern 2: Finding a Baseline Build
+
+**When:** A test fails on a PR — need to confirm it passes on the target branch.
+
+**Delegate:**
+```
+Find a recent passing build on {TARGET_BRANCH} of dotnet/{REPO} that ran the same test leg.
+
+Failing build: {BUILD_ID}, job: {JOB_NAME}, work item: {WORK_ITEM}
+
+Steps:
+1. Search for recently merged PRs:
+   Search for recently merged PRs on {TARGET_BRANCH}
+2. Run: ./scripts/Get-CIStatus.ps1 -PRNumber {MERGED_PR} -Repository "dotnet/{REPO}"
+3. Find the build with same job name that passed
+4. Locate the Helix job ID (may need artifact download — see [azure-cli.md](azure-cli.md))
+
+Return JSON: { "found": true, "buildId": N, "helixJob": "...", "workItem": "...", "result": "Pass" }
+Or: { "found": false, "reason": "no passing build in last 5 merged PRs" }
+
+If authentication fails or API returns errors, STOP and return the error — don't troubleshoot.
+```
+
+## Pattern 3: Extracting Merge PR Changed Files
+
+**When:** A large merge PR (hundreds of files) has test failures — need the file list for the main agent to analyze.
+
+**Delegate:**
+```
+List all changed files on merge PR #{PR_NUMBER} in dotnet/{REPO}.
+
+Get the list of changed files for PR #{PR_NUMBER} in dotnet/{REPO}
+
+For each file, note: path, change type (added/modified/deleted), lines changed.
+
+Return JSON: { "totalFiles": N, "files": [{ "path": "...", "changeType": "modified", "linesChanged": N }] }
+```
+
+> The main agent decides which files are relevant to the specific failures — don't filter in the subagent.
+
+## Pattern 4: Parallel Artifact Extraction
+
+**When:** Multiple builds or artifacts need independent analysis — binlog comparison, canceled job recovery, multi-build progression.
+
+**Key insight:** Launch one subagent per build/artifact in parallel. Each does its mechanical extraction independently. The main agent synthesizes results across all of them.
+
+**Delegate (per build, for binlog analysis):**
+```
+Download and analyze binlog from AzDO build {BUILD_ID}, artifact {ARTIFACT_NAME}.
+
+Steps:
+1. Download the artifact (see [azure-cli.md](azure-cli.md))
+2. Load the binlog, find the {TASK_NAME} task invocations, get full task details including CommandLineArguments.
+
+Return JSON: { "buildId": N, "project": "...", "args": ["..."] }
+```
+
+**Delegate (per build, for canceled job recovery):**
+```
+Check if canceled job "{JOB_NAME}" from build {BUILD_ID} has recoverable Helix results.
+
+Steps:
+1. Parse TRX test results from the work item for pass/fail counts.
+   NOTE: TRX parsing may error if no TRX files were uploaded (common for non-.NET-test work items like mobile device tests). If it errors, proceed to step 2.
+2. If no structured results, search the work item's uploaded testResults.xml file for "total" to get pass/fail counts
+3. If found, parse the XML for pass/fail counts on the <assembly> element
+4. If neither is available, search the console log for test summary lines containing "passed"
+
+Return JSON: { "jobName": "...", "hasResults": true, "passed": N, "failed": N }
+Or: { "jobName": "...", "hasResults": false, "reason": "no testResults.xml uploaded" }
+```
+
+This pattern scales to any number of builds — launch N subagents for N builds, collect results, compare.
+
+## Pattern 5: Build Progression with Target HEAD Extraction
+
+**When:** PR has multiple builds and you need the full progression table with target branch HEADs.
+
+**Delegate (one subagent per build):**
+```
+Extract the target branch HEAD from AzDO build {BUILD_ID}.
+
+Fetch the checkout task log (typically LOG ID 5, starting around LINE 500+ to skip git-fetch output)
+
+Search for: "HEAD is now at {mergeCommit} Merge {prSourceSha} into {targetBranchHead}"
+
+Return JSON: { "buildId": N, "targetHead": "abc1234", "mergeCommit": "def5678" }
+Or: { "buildId": N, "targetHead": null, "error": "merge line not found in log 5" }
+```
+
+Launch one per build in parallel. The main agent combines with the build list to build the full progression table.
+
+## General Guidelines
+
+- **Use `general-purpose` agent type** — it has shell + MCP access for Helix, AzDO, binlog, and GitHub queries
+- **Run independent tasks in parallel** — the whole point of delegation
+- **Include script paths** — subagents don't inherit skill context
+- **Require structured JSON output** — enables comparison across subagents
+- **Don't delegate interpretation** — subagents return facts, main agent reasons
+- **STOP on errors** — subagents should return error details immediately, not troubleshoot auth/environment issues
+- **Use SQL for many results** — when launching 5+ subagents or doing multi-phase delegation, store results in a SQL table (`CREATE TABLE results (agent_id TEXT, build_id INT, data TEXT, status TEXT)`) so you can query across all results instead of holding them in context
+- **Specify `model: "claude-sonnet-4"` for MCP-heavy tasks** — default model may time out on multi-step MCP tool chains

--- a/.github/skills/ci-analysis/references/failure-interpretation.md
+++ b/.github/skills/ci-analysis/references/failure-interpretation.md
@@ -1,0 +1,50 @@
+# Interpreting CI Results
+
+## Result Categories
+
+**Known Issues section**: Failures matching existing GitHub issues.
+
+**Build Analysis check status**: Green = *every* failure matched a known issue. Red = at least one unmatched. Verify each failing job is covered before calling it safe to retry.
+
+**Canceled/timed-out jobs**: Jobs canceled due to earlier stage failures or AzDO timeouts. Dependency-canceled jobs don't need investigation. **Timeout-canceled jobs may have all-passing Helix results** — the "failure" is just the AzDO job wrapper timing out, not actual test failures. To verify: get the Helix job pass/fail summary for each job in the timed-out build (include passed work items). If all work items passed, the build effectively passed.
+
+**PR Change Correlation**: Files changed by PR appearing in failures — likely PR-related.
+
+**Build errors**: Compilation failures need code fixes.
+
+**Helix failures**: Test failures on distributed infrastructure.
+
+**Local test failures**: Some repos (e.g., dotnet/sdk) run tests directly on build agents. These can also match known issues — search for the test name with the "Known Build Error" label.
+
+**Unmatched failures**: If a failure has no known issue match and is not PR-related, it may be a candidate for a new Known Build Error issue. See [kbe-issue-creation.md](kbe-issue-creation.md) for when and how to file one.
+
+## Per-Failure Details
+
+`failedJobDetails` in JSON: Each failed job includes `errorCategory`, `errorSnippet`, and `helixWorkItems`. Use these for per-job classification instead of applying a single `recommendationHint` to all failures.
+
+Error categories: `test-failure`, `build-error`, `test-timeout`, `crash` (exit codes 139/134/-4), `tests-passed-reporter-failed` (all tests passed but reporter crashed — genuinely infrastructure), `unclassified` (investigate manually).
+
+> ⚠️ **`crash` does NOT always mean tests failed.** Exit code -4 often means the Helix work item wrapper timed out *after* tests completed. Always check `testResults.xml` before concluding a crash is a real failure. See [Recovering Results](#recovering-results-from-crashedcanceled-jobs) below.
+
+> ⚠️ **Be cautious labeling failures as "infrastructure."** Only conclude infrastructure with strong evidence: Build Analysis match, identical failure on target branch, or confirmed outage. Exception: `tests-passed-reporter-failed` is genuinely infrastructure.
+
+> ❌ **Missing packages on flow PRs ≠ infrastructure.** Flow PRs can cause builds to request *different* packages. Check *which* package and *why* before assuming feed delay.
+
+## Recovering Results from Crashed/Canceled Jobs
+
+When an AzDO job is canceled (timeout) or Helix work items show `Crash` (exit code -4), the tests may have actually passed. Follow this procedure:
+
+1. **Find the Helix job IDs** — Read the AzDO "Send to Helix" step log and search for lines containing `Sent Helix Job`. Extract the job GUIDs.
+
+2. **Check Helix job status** — Get pass/fail summary for each job. Look at `failedCount` vs `passedCount`.
+
+3. **For work items marked Crash/Failed** — Check if tests actually passed despite the crash. Try structured test results first (TRX parsing), then search for pass/fail counts in result files without downloading, then download as last resort:
+   - Parse the XML: `total`, `passed`, `failed` attributes on the `<assembly>` element
+   - If `failed=0` and `passed > 0`, the tests passed — the "crash" is the wrapper timing out after test completion
+
+4. **Verdict**:
+   - All work items passed or crash-with-passing-results → **Tests effectively passed.** The failure is infrastructure (wrapper timeout).
+   - Some work items have `failed > 0` in testResults.xml → **Real test failures.** Investigate those specific tests.
+   - No testResults.xml uploaded → Tests may not have run at all. Check console logs for errors.
+
+> This pattern is common with long-running test suites (e.g., WasmBuildTests) where tests complete but the Helix work item wrapper exceeds its timeout during result upload or cleanup.

--- a/.github/skills/ci-analysis/references/helix-artifacts.md
+++ b/.github/skills/ci-analysis/references/helix-artifacts.md
@@ -1,0 +1,283 @@
+# Helix Work Item Artifacts
+
+Guide to finding and analyzing artifacts from Helix test runs.
+
+## Accessing Artifacts
+
+### Via the Script
+
+Query a specific work item to see its artifacts:
+
+```powershell
+./scripts/Get-CIStatus.ps1 -HelixJob "4b24b2c2-..." -WorkItem "Microsoft.NET.Sdk.Tests.dll.1" -ShowLogs
+```
+
+### Via API
+
+```bash
+# Get work item details including Files array
+curl -s "https://helix.dot.net/api/2019-06-17/jobs/{jobId}/workitems/{workItemName}"
+```
+
+The `Files` array contains artifacts with `FileName` and `Uri` properties.
+
+## Artifact Availability Varies
+
+**Not all test types produce the same artifacts.** What you see depends on the repo, test type, and configuration:
+
+- **Build/publish tests** (SDK, WASM) → Multiple binlogs
+- **AOT compilation tests** (iOS/Android) → `AOTBuild.binlog` plus device logs
+- **Standard unit tests** → Console logs only, no binlogs
+- **Crash failures** (exit code 134) → Core dumps may be present
+
+## Common Artifact Patterns
+
+| File Pattern | Purpose | When Useful |
+|--------------|---------|-------------|
+| `*.binlog` | MSBuild binary logs | AOT/build failures, MSB4018 errors |
+| `console.*.log` | Console output | Always available, general output |
+| `run-*.log` | XHarness execution logs | Mobile test failures |
+| `device-*.log` | Device-specific logs | iOS/Android device issues |
+| `dotnetTestLog.*.log` | dotnet test output | Test framework issues |
+| `vstest.*.log` | VSTest output | aspnetcore/SDK test issues |
+| `core.*`, `*.dmp` | Core dumps | Crashes, hangs |
+| `testResults.xml` | Test results | Detailed pass/fail info |
+
+Artifacts may be at the root level or nested in subdirectories like `xharness-output/logs/`.
+
+> **Note:** The Helix work item Details API has a known bug ([dotnet/dnceng#6072](https://github.com/dotnet/dnceng/issues/6072)) where
+> file URIs for subdirectory files are incorrect, and unicode characters in filenames are rejected.
+> The script works around this by using the separate `ListFiles` endpoint (`GET .../workitems/{workItemName}/files`)
+> which returns direct blob storage URIs that work for all filenames regardless of subdirectories or unicode.
+
+## Binlog Files
+
+Binlogs are **only present for tests that invoke MSBuild** (build/publish tests, AOT compilation). Standard unit tests don't produce binlogs.
+
+### Common Names
+
+| File | Description |
+|------|-------------|
+| `build.msbuild.binlog` | Build phase |
+| `publish.msbuild.binlog` | Publish phase |
+| `AOTBuild.binlog` | AOT compilation |
+| `msbuild.binlog` | General MSBuild operations |
+| `msbuild0.binlog`, `msbuild1.binlog` | Per-test-run logs (numbered) |
+
+### Analyzing Binlogs
+
+**Online viewer (no download):**
+1. Copy the binlog URI from the script output
+2. Go to https://live.msbuildlog.com/
+3. Paste the URL to load and analyze
+
+**Download and view locally:**
+```bash
+curl -o build.binlog "https://helix.dot.net/api/jobs/{jobId}/workitems/{workItem}/files/build.msbuild.binlog?api-version=2019-06-17"
+# Open with MSBuild Structured Log Viewer
+```
+
+**AI-assisted analysis:**
+Use the MSBuild MCP server to analyze binlogs for errors and warnings.
+
+## Core Dumps
+
+Core dumps appear when tests crash (typically exit code 134 on Linux/macOS):
+
+```
+core.1000.34   # Format: core.{uid}.{pid}
+```
+
+## Mobile Test Artifacts (iOS/Android)
+
+Mobile device tests typically include XHarness orchestration logs:
+
+- `run-ios-device.log` / `run-android.log` - Execution log
+- `device-{machine}-*.log` - Device output
+- `list-ios-device-*.log` - Device discovery
+- `AOTBuild.binlog` - AOT compilation (when applicable)
+- `*.crash` - iOS crash reports
+
+## Finding the Right Work Item
+
+1. Run the script with `-ShowLogs` to see Helix job/work item info
+2. Look for lines like:
+   ```
+   Helix Job: 4b24b2c2-ad5a-4c46-8a84-844be03b1d51
+   Work Item: Microsoft.NET.Sdk.Tests.dll.1
+   ```
+3. Query that specific work item for full artifact list
+
+## AzDO Build Artifacts (Pre-Helix)
+
+Helix work items contain artifacts from **test execution**. But there's another source of binlogs: **AzDO build artifacts** from the build phase before tests are sent to Helix.
+
+### When to Use Build Artifacts
+
+- Failed work item has no binlogs (unit tests don't produce them)
+- You need to see how tests were **built**, not how they **executed**
+- Investigating build/restore issues that happen before Helix
+
+### Listing Build Artifacts
+
+```powershell
+# List all artifacts for a build
+$org = "dnceng-public"
+$project = "public"
+$buildId = 1280125
+
+$url = "https://dev.azure.com/$org/$project/_apis/build/builds/$buildId/artifacts?api-version=5.0"
+$artifacts = (Invoke-RestMethod -Uri $url).value
+
+# Show artifacts with sizes
+$artifacts | ForEach-Object {
+    $sizeMB = [math]::Round($_.resource.properties.artifactsize / 1MB, 2)
+    Write-Host "$($_.name) - $sizeMB MB"
+}
+```
+
+### Common Build Artifacts
+
+| Artifact Pattern | Contents | Size |
+|------------------|----------|------|
+| `TestBuild_*` | Test build outputs + binlogs | 30-100 MB |
+| `BuildConfiguration` | Build config metadata | <1 MB |
+| `TemplateEngine_*` | Template engine outputs | ~40 MB |
+| `AoT_*` | AOT compilation outputs | ~3 MB |
+| `FullFramework_*` | .NET Framework test outputs | ~40 MB |
+
+### Downloading and Finding Binlogs
+
+```powershell
+# Download a specific artifact
+$artifactName = "TestBuild_linux_x64"
+$downloadUrl = "https://dev.azure.com/$org/$project/_apis/build/builds/$buildId/artifacts?artifactName=$artifactName&api-version=5.0&`$format=zip"
+$zipPath = "$env:TEMP\$artifactName.zip"
+$extractPath = "$env:TEMP\$artifactName"
+
+Invoke-WebRequest -Uri $downloadUrl -OutFile $zipPath
+Expand-Archive -Path $zipPath -DestinationPath $extractPath -Force
+
+# Find binlogs
+Get-ChildItem -Path $extractPath -Filter "*.binlog" -Recurse | ForEach-Object {
+    $sizeMB = [math]::Round($_.Length / 1MB, 2)
+    Write-Host "$($_.Name) ($sizeMB MB) - $($_.FullName)"
+}
+```
+
+### Typical Binlogs in Build Artifacts
+
+| File | Description |
+|------|-------------|
+| `log/Release/Build.binlog` | Main build log |
+| `log/Release/TestBuildTests.binlog` | Test build verification |
+| `log/Release/ToolsetRestore.binlog` | Toolset restore |
+
+### Build vs Helix Binlogs
+
+| Source | When Generated | What It Shows |
+|--------|----------------|---------------|
+| AzDO build artifacts | During CI build phase | How tests were compiled/packaged |
+| Helix work item artifacts | During test execution | What happened when tests ran `dotnet build` etc. |
+
+If a test runs `dotnet build` internally (like SDK end-to-end tests), both sources may have relevant binlogs.
+
+## Downloaded Artifact Layout
+
+When you download artifacts via MCP tools or manually, the directory structure can be confusing. Here's what to expect.
+
+### Helix Work Item Downloads
+
+Use your Helix MCP tools to download artifacts:
+- **Download from a work item** — downloads multiple files (supports glob patterns like `*.binlog`). Returns local file paths.
+- **Download by direct URL** — downloads a single file by blob storage URI (from the file listing output). Use when you know exactly which file you need.
+
+> 💡 **Prefer remote investigation first**: search file contents, parse test results, and search logs remotely before downloading. Only download when you need to load binlogs or do offline analysis.
+
+Downloading from a work item saves files to a temp directory. The structure is **flat** — all files land in one directory:
+
+```
+C:\...\Temp\helix-{hash}\
+├── console.d991a56d.log          # Console output
+├── testResults.xml               # Test pass/fail details
+├── msbuild.binlog                # Only if test invoked MSBuild
+├── publish.msbuild.binlog        # Only if test did a publish
+├── msbuild0.binlog               # Numbered: first test's build
+├── msbuild1.binlog               # Numbered: second test's build
+└── core.1000.34                  # Only on crash
+```
+
+**Key confusion point:** Numbered binlogs (`msbuild0.binlog`, `msbuild1.binlog`) correspond to individual test cases within the work item, not to build phases. A work item like `Microsoft.NET.Build.Tests.dll.18` runs dozens of tests, each invoking MSBuild separately. To map a binlog to a specific test:
+1. Load it with the binlog analysis tools
+2. Check the project paths inside — they usually contain the test name
+3. Or check `testResults.xml` to correlate test execution order with binlog numbering
+
+### AzDO Build Artifact Downloads
+
+AzDO artifacts download as **ZIP files** with nested directory structures:
+
+```
+$env:TEMP\TestBuild_linux_x64\
+└── TestBuild_linux_x64\          # Artifact name repeated as subfolder
+    └── log\Release\
+        ├── Build.binlog           # Main build
+        ├── TestBuildTests.binlog   # Test build verification
+        ├── ToolsetRestore.binlog   # Toolset restore
+        └── SendToHelix.binlog     # Contains Helix job GUIDs
+```
+
+**Key confusion point:** The artifact name appears twice in the path (extract folder + subfolder inside the ZIP). Use the full nested path when loading binlogs.
+
+### Mapping Binlogs to Failures
+
+This table shows the **typical** source for each binlog type. The boundaries aren't absolute — some repos run tests on the build agent (producing test binlogs in AzDO artifacts), and Helix work items for SDK/Blazor tests invoke `dotnet build` internally (producing build binlogs as Helix artifacts).
+
+| You want to investigate... | Look here first | But also check... |
+|---------------------------|-----------------|-------------------|
+| Why a test's internal `dotnet build` failed | Helix work item (`msbuild{N}.binlog`) | AzDO artifact if tests ran on agent |
+| Why the CI build itself failed to compile | AzDO build artifact (`Build.binlog`) | — |
+| Which Helix jobs were dispatched | AzDO build artifact (`SendToHelix.binlog`) | — |
+| AOT compilation failure | Helix work item (`AOTBuild.binlog`) | — |
+| Test build/publish behavior | Helix work item (`publish.msbuild.binlog`) | AzDO artifact (`TestBuildTests.binlog`) |
+
+> **Rule of thumb:** If the failing job name contains "Helix" or "Send to Helix", the test binlogs are in Helix. If the job runs tests directly (common in dotnet/sdk), check AzDO artifacts.
+
+### Tracking Downloaded Artifacts with SQL
+
+When downloading from multiple work items (e.g., binlog comparison between passing and failing builds), use SQL to avoid losing track of what's where:
+
+```sql
+CREATE TABLE IF NOT EXISTS downloaded_artifacts (
+  local_path TEXT PRIMARY KEY,
+  helix_job TEXT,
+  work_item TEXT,
+  build_id INT,
+  artifact_source TEXT,  -- 'helix' or 'azdo'
+  file_type TEXT,        -- 'binlog', 'testResults', 'console', 'crash'
+  notes TEXT             -- e.g., 'passing baseline', 'failing PR build'
+);
+```
+
+Key queries:
+```sql
+-- Find the pair of binlogs for comparison
+SELECT local_path, notes FROM downloaded_artifacts
+WHERE file_type = 'binlog' ORDER BY notes;
+
+-- What have I downloaded from a specific work item?
+SELECT local_path, file_type FROM downloaded_artifacts
+WHERE work_item = 'Microsoft.NET.Build.Tests.dll.18';
+```
+
+Use this whenever you're juggling artifacts from 2+ Helix jobs (especially during the binlog comparison pattern in [binlog-comparison.md](binlog-comparison.md)).
+
+### Tips
+
+- **Multiple binlogs ≠ multiple builds.** A single work item can produce several binlogs if the test suite runs multiple `dotnet build`/`dotnet publish` commands.
+- **Helix and AzDO binlogs can overlap.** Helix binlogs are *usually* from test execution and AzDO binlogs from the build phase, but SDK/Blazor tests invoke MSBuild inside Helix (producing build-like binlogs), and some repos run tests directly on the build agent (producing test binlogs in AzDO). Check both sources if you can't find what you need.
+- **Not all work items have binlogs.** Standard unit tests only produce `testResults.xml` and console logs.
+- **Filter downloads with `*.binlog` pattern** to avoid pulling large console logs.
+
+## Artifact Retention
+
+Helix artifacts are retained for a limited time (typically 30 days). Download important artifacts promptly if needed for long-term analysis.

--- a/.github/skills/ci-analysis/references/kbe-issue-creation.md
+++ b/.github/skills/ci-analysis/references/kbe-issue-creation.md
@@ -1,0 +1,248 @@
+# Creating Known Build Error Issues
+
+When Build Analysis shows **unmatched failures** (check is red) and investigation confirms the failure is not PR-specific, file a Known Build Error (KBE) issue so Build Analysis can track it across all affected builds.
+
+## When to File
+
+File a KBE issue when **all** of these are true:
+
+1. The failure is **not caused by the PR's changes** (verified via target-branch comparison or PR correlation)
+2. The failure is **not already tracked** — search first (see [Duplicate Check](#duplicate-check))
+3. The failure **affects or could affect multiple builds** (not a one-off environment glitch)
+4. Build Analysis check is **red** (at least one failure is unmatched)
+
+Do **not** file a KBE issue when:
+- The failure is clearly caused by the PR's code changes (`LIKELY_PR_RELATED`)
+- An existing KBE issue already covers the error pattern
+- The failure occurred once and is not reproducible
+
+## Infrastructure vs Repository Issue
+
+| Type | When | Where to file | Who investigates |
+|------|------|---------------|------------------|
+| **Infrastructure** | Not repo-specific; affects multiple repos; needs engineering services | [dotnet/dnceng](https://github.com/dotnet/dnceng) | @dotnet/dnceng |
+| **Repository** | Repo-specific; should be investigated by repo owners | The affected repo (e.g., `dotnet/runtime`) | Repo owners |
+
+**Examples:**
+- Agent connection timeout, Helix machine pool issues, NuGet feed outage → **Infrastructure**
+- Test `FileSystemWatcher.Tests` crashes on linux-x64 in dotnet/runtime → **Repository**
+
+## Duplicate Check
+
+Before filing, search for existing KBE issues:
+
+```bash
+# Search in the affected repo
+gh issue list --repo dotnet/<REPO> --label "Known Build Error" --state open --search "<error-text>"
+
+# Search infrastructure issues
+gh issue list --repo dotnet/dnceng --label "Known Build Error" --state open --search "<error-text>"
+
+# Browse all active KBE issues
+# https://github.com/orgs/dotnet/projects/111
+```
+
+Also check the `knownIssues` array from the `[CI_ANALYSIS_SUMMARY]` JSON — Build Analysis may have already matched the failure to an existing issue.
+
+## Issue Template
+
+The issue body must contain a `## Build Information` section, a `## Error Details` section with the full exception/stack trace, and a `## Error Message` section with a JSON blob that Build Analysis parses for matching.
+
+````markdown
+## Build Information
+Build: <!-- Link to the AzDO build with the error -->
+Leg Name: <!-- Name of the failing job/leg -->
+
+## Error Details
+<!-- Paste the full stack trace or exception output below so readers can understand the failure at a glance.
+     This section is for humans — Build Analysis only parses the ## Error Message section. -->
+```
+<full exception / stack trace here>
+```
+
+## Error Message
+<!-- The JSON blob below is parsed by Build Analysis for automatic matching -->
+```json
+{
+    "ErrorMessage": "",
+    "BuildRetry": false,
+    "ErrorPattern": "",
+    "ExcludeConsoleLog": false
+}
+```
+````
+
+**Required label:** `Known Build Error`
+
+> If the label doesn't exist in the target repo, the repo needs to be onboarded to Build Analysis. See [How to get onboard](https://github.com/dotnet/arcade/blob/main/Documentation/Projects/Build%20Analysis/KnownIssues.md#how-to-get-onboard).
+
+## Filling Out the JSON Blob
+
+Use **either** `ErrorMessage` (string matching) **or** `ErrorPattern` (regex matching) — not both. Remove the unused field or leave it empty.
+
+### String Matching (`ErrorMessage`)
+
+Build Analysis uses `String.Contains` (case-sensitive, ordinal) to match each log line against the value.
+
+**Rules for choosing the error string:**
+1. Must match at least one line in the build/test error output
+2. Strip unique identifiers: machine names, paths, timestamps, GUIDs, port numbers
+3. **Be as specific as possible** — the pattern must match every occurrence of *this particular failure* but **never** match unrelated failures. Don't worry about pattern length; specificity matters more than brevity
+4. **Prefer multi-line patterns** (array syntax) when a single line could plausibly match unrelated errors. Include the test name, exception type, and key assertion details as separate lines
+5. Only use a short single-line pattern when it is genuinely unique to this failure (e.g., a specific telemetry tag + unique error text)
+
+**Example — single-line is sufficient** (the telemetry tag + specific package name makes it unique):
+```
+##[error].dotnet/sdk/6.0.100-rc.1.21411.28/NuGet.RestoreEx.targets(19,5): error : (NETCORE_ENGINEERING_TELEMETRY=Restore) Failed to retrieve information about 'Microsoft.Extensions.Hosting.WindowsServices'
+```
+
+```json
+{
+    "ErrorMessage": "(NETCORE_ENGINEERING_TELEMETRY=Restore) Failed to retrieve information about 'Microsoft.Extensions.Hosting.WindowsServices'"
+}
+```
+
+**Example — multi-line needed** (a generic assertion like `Assert.True() Failure` alone would match many unrelated tests):
+```
+Failed test: System.Net.Http.Tests.HttpClientHandlerTest.GetAsync_UnknownHost_Throws
+   System.Net.Http.HttpRequestException : Name or service not known (nonexistent.example.com:443)
+   Assert.True() Failure
+   Expected: True
+   Actual:   False
+```
+
+Use multi-line to pin down the specific test and exception:
+```json
+{
+    "ErrorMessage": [
+        "System.Net.Http.Tests.HttpClientHandlerTest.GetAsync_UnknownHost_Throws",
+        "System.Net.Http.HttpRequestException : Name or service not known"
+    ]
+}
+```
+
+> ⚠️ **Each array element must match a different log line.** If two substrings appear on the same line, combine them into one element.
+
+### Regex Matching (`ErrorPattern`)
+
+Build Analysis uses `Regex` with options: **Singleline**, **IgnoreCase**, **NonBacktracking**, and a 50ms timeout per line.
+
+The same specificity rules apply: **be as specific as possible**. Use multi-line array syntax if needed to avoid matching unrelated failures.
+
+```json
+{
+    "ErrorPattern": "The command .+ failed"
+}
+```
+
+Test your regex at a site like regex101.com with **.NET (C#)** flavor, options: single line, insensitive, no backtracking.
+
+### Multi-Line Matching (Array Syntax)
+
+Both `ErrorMessage` and `ErrorPattern` accept an **array of strings** for matching multiple lines in order (AND condition, positional):
+
+```json
+{
+    "ErrorMessage": ["Assert.True() Failure", "Actual:   False"]
+}
+```
+
+**How it works:**
+- Each string matches against a single line (not multi-line)
+- The first string is searched first; if it matches, the second is searched in subsequent lines
+- **All** strings must match, in order, for the issue to match
+- Lines between matches are allowed (they don't need to be consecutive)
+
+Do **not** mix `ErrorMessage` and `ErrorPattern` in the same array.
+
+### `BuildRetry`
+
+Set to `true` when the failure is transient and a retry is likely to succeed (e.g., agent connection timeouts, intermittent network failures). Build Analysis will automatically retry the build on first occurrence.
+
+Limitations: only retries on the **first** attempt. If the failure recurs on retry, no further retries are attempted.
+
+### `ExcludeConsoleLog`
+
+Set to `true` to exclude Helix console logs from the matching scope. Use when the error pattern could falsely match console log output that isn't the actual error.
+
+## JSON Escaping
+
+Special characters in `ErrorMessage`/`ErrorPattern` values must be JSON-escaped:
+- `"` → `\"`
+- `\` → `\\`
+- Newlines → `\n`
+
+Use GitHub's issue preview tab to validate — invalid JSON is highlighted.
+
+For regex patterns, remember **double escaping**: a literal dot needs `\\.` in the JSON value (the JSON parser consumes one backslash, leaving `\.` for the regex engine).
+
+## Validating Patterns Before Filing (MANDATORY)
+
+> 🚨 **This step is NOT optional.** You MUST validate every pattern against the actual failure log before drafting a KBE issue. Patterns that appear correct frequently fail due to invisible characters, inconsistent whitespace, log line prefixes, or timestamp formatting. Never draft a `gh issue create` command without a `RESULT: PASS` from this script.
+
+**Steps:**
+1. Download or extract the failure log (from Helix console log, AzDO build log, or script output saved to a file)
+2. Run the validation script with the candidate pattern and log file
+3. If `RESULT: FAIL` — refine the pattern and re-test (the script shows what didn't match)
+4. If `RESULT: PASS` — use the script's "Validated JSON blob" and "Issue body template" output directly
+
+```powershell
+# Test string matching against a log file
+./scripts/Test-KnownIssuePattern.ps1 -ErrorMessage "Failed to retrieve information" -LogFile ./failure.log
+
+# Test regex matching
+./scripts/Test-KnownIssuePattern.ps1 -ErrorPattern "The command .+ failed" -LogContent "The command 'dotnet build' failed with exit code 1"
+
+# Test multi-line matching
+./scripts/Test-KnownIssuePattern.ps1 -ErrorMessage "Assert.True() Failure","Actual:   False" -LogFile ./test-output.log
+
+# Outputs: PASS/FAIL, matched lines with line numbers, and validated JSON blob
+```
+
+The script uses the **same matching logic** as Build Analysis (case-sensitive `String.Contains` for `ErrorMessage`; `Regex` with `Singleline | IgnoreCase | NonBacktracking` for `ErrorPattern`).
+
+## Filing the Issue
+
+> 🚨 **NEVER run `gh issue create` directly.** Always present the full `gh issue create` command to the user as a draft and **wait for their explicit approval** before executing it. The user must review the title, labels, target repo, and JSON blob before any issue is created on GitHub.
+
+Once the pattern is validated, **present** the following command to the user for review (do NOT execute it):
+
+```bash
+# Repository issue
+gh issue create --repo dotnet/<REPO> \
+  --label "Known Build Error" \
+  --title "<Test or build step name>: <brief failure description>" \
+  --body "## Build Information
+Build: <AzDO build URL>
+Leg Name: <failing job name>
+
+## Error Details
+\`\`\`
+<full stack trace or exception output>
+\`\`\`
+
+## Error Message
+\`\`\`json
+{
+    \"ErrorMessage\": \"<validated pattern>\",
+    \"BuildRetry\": false
+}
+\`\`\`"
+
+# Infrastructure issue
+gh issue create --repo dotnet/dnceng \
+  --label "Known Build Error" \
+  --title "<brief infra failure description>" \
+  --body "..."
+```
+
+## What Happens After Filing
+
+- Build Analysis scans all builds from the **last 24 hours** and matches them against the new issue
+- All future failing builds are also matched automatically
+- Matches appear in the Build Analysis check on PRs
+- The issue is tracked on the [Known Build Errors project board](https://github.com/orgs/dotnet/projects/111)
+
+## Reference
+
+Full upstream documentation: [dotnet/arcade — Known Issues](https://github.com/dotnet/arcade/blob/main/Documentation/Projects/Build%20Analysis/KnownIssues.md)

--- a/.github/skills/ci-analysis/references/manual-investigation.md
+++ b/.github/skills/ci-analysis/references/manual-investigation.md
@@ -1,0 +1,109 @@
+# Manual Investigation Guide
+
+If the script doesn't provide enough information, use these manual investigation steps.
+
+## Table of Contents
+- [Get Build Timeline](#get-build-timeline)
+- [Find Helix Tasks](#find-helix-tasks)
+- [Get Build Logs](#get-build-logs)
+- [Query Helix APIs](#query-helix-apis)
+- [Download Artifacts](#download-artifacts)
+- [Analyze Binlogs](#analyze-binlogs)
+- [Extract Environment Variables](#extract-environment-variables)
+
+## Get Build Timeline
+
+```powershell
+$buildId = 1276327
+$response = Invoke-RestMethod -Uri "https://dev.azure.com/dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649/_apis/build/builds/$buildId/timeline?api-version=7.0"
+$failedJobs = $response.records | Where-Object { $_.type -eq "Job" -and $_.result -eq "failed" }
+$failedJobs | Select-Object id, name, result | Format-Table
+```
+
+## Find Helix Tasks
+
+```powershell
+$jobId = "90274d9a-fbd8-54f8-6a7d-8dfc4e2f6f3f"  # From timeline
+$helixTasks = $response.records | Where-Object { $_.parentId -eq $jobId -and $_.name -like "*Helix*" }
+$helixTasks | Select-Object id, name, result, log | Format-Table
+```
+
+## Get Build Logs
+
+```powershell
+$logId = 565  # From task.log.id
+$logContent = Invoke-RestMethod -Uri "https://dev.azure.com/dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649/_apis/build/builds/$buildId/logs/${logId}?api-version=7.0"
+$logContent | Select-String -Pattern "error|FAIL" -Context 2,5
+```
+
+## Search Helix Logs and Artifacts Remotely
+
+> 💡 Search logs remotely before downloading.
+
+Use your Helix MCP tools to:
+- **Search a work item's console log** for error patterns (with context lines)
+- **Search an uploaded file** (e.g., testResults.xml) for specific text like "Failed"
+- **Find which work items have specific file types** (e.g., `*.binlog`, `*.trx`, `*.dmp`)
+
+These return matching lines with context — much faster than downloading full logs and grepping locally.
+
+## Query Helix APIs
+
+> 💡 **Prefer MCP tools when available** — your Helix MCP tools handle job status, log search, file listing, and artifact download without manual curl commands. Use the APIs below only as fallback when MCP tools are unavailable.
+
+```bash
+# Get job details
+curl -s "https://helix.dot.net/api/2019-06-17/jobs/JOB_ID"
+
+# List work items
+curl -s "https://helix.dot.net/api/2019-06-17/jobs/JOB_ID/workitems"
+
+# Get work item details
+curl -s "https://helix.dot.net/api/2019-06-17/jobs/JOB_ID/workitems/WORK_ITEM_NAME"
+
+# Get console log
+curl -s "https://helix.dot.net/api/2019-06-17/jobs/JOB_ID/workitems/WORK_ITEM_NAME/console"
+```
+
+## Download Artifacts
+
+```powershell
+$workItem = Invoke-RestMethod -Uri "https://helix.dot.net/api/2019-06-17/jobs/$jobId/workitems/$workItemName"
+$workItem.Files | ForEach-Object { Write-Host "$($_.FileName): $($_.Uri)" }
+```
+
+Common artifacts:
+- `console.*.log` - Console output
+- `*.binlog` - MSBuild binary logs
+- `run-*.log` - XHarness/test runner logs
+- Core dumps and crash reports
+
+## Analyze Binlogs
+
+Binlogs contain detailed MSBuild execution traces for diagnosing:
+- AOT compilation failures
+- Static web asset issues
+- NuGet restore problems
+- Target execution order issues
+
+**Using MSBuild binlog MCP tools:**
+
+Load the binlog, then search for errors/diagnostics or specific queries. The binlog MCP tools handle loading, searching, and extracting task details.
+
+**Manual Analysis:**
+Use [MSBuild Structured Log Viewer](https://msbuildlog.com/) or https://live.msbuildlog.com/
+
+## Extract Environment Variables
+
+```bash
+curl -s "https://helix.dot.net/api/2019-06-17/jobs/JOB_ID/workitems/WORK_ITEM_NAME/console" | grep "DOTNET_"
+```
+
+Example output:
+```
+DOTNET_JitStress=1
+DOTNET_TieredCompilation=0
+DOTNET_GCStress=0xC
+```
+
+These are critical for reproducing failures locally.

--- a/.github/skills/ci-analysis/references/recommendation-generation.md
+++ b/.github/skills/ci-analysis/references/recommendation-generation.md
@@ -1,0 +1,61 @@
+# Generating Recommendations
+
+After the script outputs the `[CI_ANALYSIS_SUMMARY]` JSON block, **you** synthesize recommendations. Do not parrot the JSON — reason over it.
+
+## Decision Logic
+
+Read `recommendationHint` as a starting point, then layer in context:
+
+| Hint | Action |
+|------|--------|
+| `BUILD_SUCCESSFUL` | No failures. Confirm CI is green. |
+| `KNOWN_ISSUES_DETECTED` | Known tracked issues found — but this does NOT mean all failures are covered. Check the Build Analysis check status: if it's red, some failures are unmatched. Only recommend retry for failures that specifically match a known issue; investigate the rest. |
+| `LIKELY_PR_RELATED` | Failures correlate with PR changes. Lead with "fix these before retrying" and list `correlatedFiles`. |
+| `POSSIBLY_TRANSIENT` | Failures could not be automatically classified — does NOT mean they are transient. Use `failedJobDetails` to investigate each failure individually. |
+| `REVIEW_REQUIRED` | Could not auto-determine cause. Review failures manually. If Build Analysis is red and failures are not PR-related, suggest filing a Known Build Error issue — see [kbe-issue-creation.md](kbe-issue-creation.md). |
+| `MERGE_CONFLICTS` | PR has merge conflicts — CI won't run. Tell the user to resolve conflicts. Offer to analyze a previous build by ID. |
+| `NO_BUILDS` | No AzDO builds found (CI not triggered). Offer to check if CI needs to be triggered or analyze a previous build. |
+
+## Refining with Context
+
+Refine the recommendation with context the heuristic can't capture:
+
+- **Unmatched novel failures**: Build Analysis is red and some failures don't match any known issue or PR correlation → suggest the user consider filing a Known Build Error issue. **Before drafting any issue, you MUST first**: (1) download/extract the actual failure log, (2) run `scripts/Test-KnownIssuePattern.ps1 -ErrorMessage "<pattern>" -LogFile <log>` (or `-ErrorPattern` for regex), (3) confirm the script outputs `RESULT: PASS`. Only then draft a `gh issue create` command. Do NOT skip validation — patterns that look correct often don't match due to invisible characters, line breaks, or log formatting. See [kbe-issue-creation.md](kbe-issue-creation.md).
+- **Mixed signals**: Some failures match known issues AND some correlate with PR changes → separate them. Known issues = safe to retry; correlated = fix first.
+- **Canceled jobs with recoverable results**: If `canceledJobNames` is non-empty, mention that canceled jobs may have passing Helix results (see [failure-interpretation.md](failure-interpretation.md) — Recovering Results).
+- **Build still in progress**: If `lastBuildJobSummary.pending > 0`, note that more failures may appear.
+- **Multiple builds**: If `builds` has >1 entry, `lastBuildJobSummary` reflects only the last build — use `totalFailedJobs` for the aggregate count.
+- **BuildId mode**: `knownIssues` and `prCorrelation` won't be populated. Say "Build Analysis and PR correlation not available in BuildId mode."
+
+## How to Retry
+
+- **AzDO builds**: Comment `/azp run {pipeline-name}` on the PR (e.g., `/azp run dotnet-sdk-public`)
+- **All pipelines**: Comment `/azp run` to retry all failing pipelines
+- **Helix work items**: Cannot be individually retried — must re-run the entire AzDO build
+
+## Tone and Output Format
+
+Be direct. Lead with the most important finding. Structure your response as:
+1. **Summary verdict** (1-2 sentences) — Is CI green? Failures PR-related? Known issues?
+2. **Failure summary table** — narrow columns only (Job, Verdict, Issue). Keep job names short (drop redundant prefixes like `runtime-dev-innerloop`). Do NOT put error text or work item lists in the table — those go in the detail section below.
+3. **Failure details** — one bullet per failure with error description, affected work items, and evidence
+4. **Recommended actions** (numbered) — retry, fix, investigate. Include `/azp run` commands.
+
+**Use markdown links** for PRs, issues, builds, and jobs so they're clickable: `[#121195](url)`, `[Build 1305302](url)`, `[job name](azdo-job-url)`. The script output and MCP tools provide the URLs — thread them through to your response.
+
+Example layout for step 2+3:
+
+```
+| # | Job | Verdict | Issue |
+|---|-----|---------|-------|
+| 1 | [browser-wasm linux Release WasmBuildTests](https://dev.azure.com/…) | Known flaky ✅ | [#121195](https://github.com/dotnet/runtime/issues/121195) |
+| 2 | [linux-x64 Debug Mono Interpreter LibTests](https://dev.azure.com/…) | Known flaky ✅ | [#100800](https://github.com/dotnet/runtime/issues/100800) |
+| 3 | [coreclr Pri0 Runtime Tests linux x64](https://dev.azure.com/…) | Known flaky ✅ | [#110173](https://github.com/dotnet/runtime/issues/110173) |
+
+**Details:**
+- **#1**: Playwright.TargetClosedException + dbus socket missing in WBT-NoWorkload
+- **#2**: 8 work items (ComInterfaceGen, IntrinsicsInSPC, JSImportGen, …) — all exit code 139 (SIGSEGV), mono interpreter crashes
+- **#3**: stackoverflowtester timeout in baseservices-exceptions — ASSERT: "Target stack has been corrupted"
+```
+
+Synthesize from: JSON summary (structured facts) + human-readable output (details/logs) + Step 0 context (PR type, author intent).

--- a/.github/skills/ci-analysis/references/script-modes.md
+++ b/.github/skills/ci-analysis/references/script-modes.md
@@ -1,0 +1,46 @@
+# Script Modes and Parameters
+
+## Key Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `-PRNumber` | GitHub PR number to analyze |
+| `-BuildId` | Azure DevOps build ID |
+| `-ShowLogs` | Fetch and display Helix console logs |
+| `-Repository` | Target repo (default: dotnet/runtime) |
+| `-MaxJobs` | Max failed jobs to show (default: 5) |
+| `-SearchMihuBot` | Search MihuBot for related issues |
+
+## Three Modes
+
+The script operates in three distinct modes depending on what information you have:
+
+| You have... | Use | What you get |
+|-------------|-----|-------------|
+| A GitHub PR number | `-PRNumber 12345` | Full analysis: all builds, failures, known issues, structured JSON summary |
+| An AzDO build ID | `-BuildId 1276327` | Single build analysis: timeline, failures, Helix results |
+| A Helix job ID (optionally a specific work item) | `-HelixJob "..." [-WorkItem "..."]` | Deep dive: list work items for the job, or with `-WorkItem`, focus on a single work item's console logs, artifacts, and test results |
+
+## What the Script Does
+
+### PR Analysis Mode (`-PRNumber`)
+1. Discovers AzDO builds associated with the PR (from GitHub check status; for full build history, query AzDO builds on `refs/pull/{PR}/merge` branch)
+2. Fetches Build Analysis for known issues
+3. Gets failed jobs from Azure DevOps timeline
+4. **Separates canceled jobs from failed jobs** (canceled may be dependency-canceled or timeout-canceled)
+5. Extracts Helix work item failures from each failed job
+6. Fetches console logs (with `-ShowLogs`)
+7. Searches for known issues with "Known Build Error" label
+8. Correlates failures with PR file changes
+9. **Emits structured summary** — `[CI_ANALYSIS_SUMMARY]` JSON block with all key facts for the agent to reason over
+
+For recommendation generation, see [recommendation-generation.md](recommendation-generation.md).
+
+### Build ID Mode (`-BuildId`)
+1. Fetches the build timeline directly (skips PR discovery)
+2. Performs steps 3–7 from PR Analysis Mode, but does **not** fetch Build Analysis known issues or correlate failures with PR file changes (those require a PR number). Still emits `[CI_ANALYSIS_SUMMARY]` JSON.
+
+### Helix Job Mode (`-HelixJob` [and optional `-WorkItem`])
+1. With `-HelixJob` alone: enumerates work items for the job and summarizes their status
+2. With `-HelixJob` and `-WorkItem`: queries the specific work item for status and artifacts
+3. Fetches console logs and file listings, displays detailed failure information

--- a/.github/skills/ci-analysis/references/sql-tracking.md
+++ b/.github/skills/ci-analysis/references/sql-tracking.md
@@ -1,0 +1,107 @@
+# SQL Tracking for CI Investigations
+
+Use the SQL tool to track structured data during complex investigations. This avoids losing context across tool calls and enables queries that catch mistakes (like claiming "all failures known" when some are unmatched).
+
+## Failed Job Tracking
+
+Track each failure from the script output and map it to known issues as you verify them:
+
+```sql
+CREATE TABLE IF NOT EXISTS failed_jobs (
+  build_id INT,
+  job_name TEXT,
+  error_category TEXT,   -- from failedJobDetails: test-failure, build-error, crash, etc.
+  error_snippet TEXT,
+  known_issue_url TEXT,  -- NULL if unmatched
+  known_issue_title TEXT,
+  is_pr_correlated BOOLEAN DEFAULT FALSE,
+  recovery_status TEXT DEFAULT 'not-checked',  -- effectively-passed, real-failure, no-results
+  notes TEXT,
+  PRIMARY KEY (build_id, job_name)
+);
+```
+
+### Key queries
+
+```sql
+-- Unmatched failures (Build Analysis red = these exist)
+SELECT job_name, error_category, error_snippet FROM failed_jobs
+WHERE known_issue_url IS NULL;
+
+-- Are ALL failures accounted for?
+SELECT COUNT(*) as total,
+       SUM(CASE WHEN known_issue_url IS NOT NULL THEN 1 ELSE 0 END) as matched
+FROM failed_jobs;
+
+-- Which crash/canceled jobs need recovery verification?
+SELECT job_name, build_id FROM failed_jobs
+WHERE error_category IN ('crash', 'unclassified') AND recovery_status = 'not-checked';
+
+-- PR-correlated failures (fix before retrying)
+SELECT job_name, error_snippet FROM failed_jobs WHERE is_pr_correlated = TRUE;
+```
+
+### Workflow
+
+1. After the script runs, insert one row per failed job from `failedJobDetails` (each entry includes `buildId`)
+2. For each known issue from `knownIssues`, UPDATE matching rows with the issue URL
+3. Query for unmatched failures — these need investigation
+4. For crash/canceled jobs, update `recovery_status` after checking Helix results
+
+## Build Progression
+
+See [build-progression-analysis.md](build-progression-analysis.md) for the `build_progression` and `build_failures` tables that track pass/fail across multiple builds.
+
+> **`failed_jobs` vs `build_failures` — when to use each:**
+> - `failed_jobs` (above): **Job-level** — maps each failed AzDO job to a known issue. Use for single-build triage ("are all failures accounted for?").
+> - `build_failures` (build-progression-analysis.md): **Test-level** — tracks individual test names across builds. Use for progression analysis ("which tests started failing after commit X?").
+
+## PR Comment Tracking
+
+For deep-dive analysis — especially across a chain of related PRs (e.g., dependency flow failures, sequential merge PRs, or long-lived PRs with weeks of triage) — store PR comments so you can query them without re-fetching:
+
+```sql
+CREATE TABLE IF NOT EXISTS pr_comments (
+  pr_number INT,
+  repo TEXT DEFAULT 'dotnet/runtime',
+  comment_id INT PRIMARY KEY,
+  author TEXT,
+  created_at TEXT,
+  body TEXT,
+  is_triage BOOLEAN DEFAULT FALSE  -- set TRUE if comment diagnoses a failure
+);
+```
+
+### Key queries
+
+```sql
+-- What has already been diagnosed? (avoid re-investigating)
+SELECT author, created_at, substr(body, 1, 200) FROM pr_comments
+WHERE is_triage = TRUE ORDER BY created_at;
+
+-- Cross-PR: same failure discussed in multiple PRs?
+SELECT pr_number, author, substr(body, 1, 150) FROM pr_comments
+WHERE body LIKE '%BlazorWasm%' ORDER BY created_at;
+
+-- Who was asked to investigate what?
+SELECT author, substr(body, 1, 200) FROM pr_comments
+WHERE body LIKE '%PTAL%' OR body LIKE '%could you%look%';
+```
+
+### When to use
+
+- Long-lived PRs (>1 week) with 10+ comments containing triage context
+- Analyzing a chain of related PRs where earlier PRs have relevant diagnosis
+- When the same failure appears across multiple merge/flow PRs and you need to know what was already tried
+
+## When to Use SQL vs. Not
+
+| Situation | Use SQL? |
+|-----------|----------|
+| 1-2 failed jobs, all match known issues | No — straightforward, hold in context |
+| 3+ failed jobs across multiple builds | Yes — prevents missed matches |
+| Build progression with 5+ builds | Yes — see [build-progression-analysis.md](build-progression-analysis.md) |
+| Crash recovery across multiple work items | Yes — cache testResults.xml findings |
+| Single build, single failure | No — overkill |
+| PR chain or long-lived PR with extensive triage comments | Yes — preserves diagnosis context across tool calls |
+| Downloading artifacts from 2+ Helix jobs (e.g., binlog comparison) | Yes — see [helix-artifacts.md](helix-artifacts.md) |

--- a/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
+++ b/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
@@ -1,0 +1,2275 @@
+<#
+.SYNOPSIS
+    Retrieves test failures from Azure DevOps builds and Helix test runs.
+
+.DESCRIPTION
+    This script queries Azure DevOps for failed jobs in a build and retrieves
+    the corresponding Helix console logs to show detailed test failure information.
+    It can also directly query a specific Helix job and work item.
+
+.PARAMETER BuildId
+    The Azure DevOps build ID to query.
+
+.PARAMETER PRNumber
+    The GitHub PR number to find the associated build.
+
+.PARAMETER HelixJob
+    The Helix job ID (GUID) to query directly.
+
+.PARAMETER WorkItem
+    The Helix work item name to query (requires -HelixJob).
+
+.PARAMETER Repository
+    The GitHub repository (owner/repo format). Default: dotnet/runtime
+
+.PARAMETER Organization
+    The Azure DevOps organization. Default: dnceng-public
+
+.PARAMETER Project
+    The Azure DevOps project GUID. Default: cbb18261-c48f-4abb-8651-8cdcb5474649
+
+.PARAMETER ShowLogs
+    If specified, fetches and displays the Helix console logs for failed tests.
+
+.PARAMETER MaxJobs
+    Maximum number of failed jobs to process. Default: 5
+
+.PARAMETER MaxFailureLines
+    Maximum number of lines to capture per test failure. Default: 50
+
+.PARAMETER TimeoutSec
+    Timeout in seconds for API calls. Default: 30
+
+.PARAMETER ContextLines
+    Number of context lines to show before errors. Default: 0
+
+.PARAMETER NoCache
+    Bypass cache and fetch fresh data for all API calls.
+
+.PARAMETER CacheTTLSeconds
+    Cache lifetime in seconds. Default: 30
+
+.PARAMETER ClearCache
+    Clear all cached files and exit.
+
+.PARAMETER ContinueOnError
+    Continue processing remaining jobs if an API call fails, showing partial results.
+
+.PARAMETER SearchMihuBot
+    Search MihuBot's semantic database for related issues and discussions.
+    Uses https://mihubot.xyz/mcp to find conceptually related issues across dotnet repositories.
+
+.PARAMETER FindBinlogs
+    Scan work items in a Helix job to find which ones contain MSBuild binlog files.
+    Useful when the failed work item doesn't have binlogs (e.g., unit tests) but you need
+    to find related build tests that do have binlogs for deeper analysis.
+
+.EXAMPLE
+    .\Get-CIStatus.ps1 -BuildId 1276327
+
+.EXAMPLE
+    .\Get-CIStatus.ps1 -PRNumber 123445 -ShowLogs
+
+.EXAMPLE
+    .\Get-CIStatus.ps1 -PRNumber 123445 -Repository dotnet/aspnetcore
+
+.EXAMPLE
+    .\Get-CIStatus.ps1 -HelixJob "4b24b2c2-ad5a-4c46-8a84-844be03b1d51" -WorkItem "iOS.Device.Aot.Test"
+
+.EXAMPLE
+    .\Get-CIStatus.ps1 -BuildId 1276327 -SearchMihuBot
+
+.EXAMPLE
+    .\Get-CIStatus.ps1 -HelixJob "4b24b2c2-ad5a-4c46-8a84-844be03b1d51" -FindBinlogs
+    # Scans work items to find which ones contain MSBuild binlog files
+
+.EXAMPLE
+    .\Get-CIStatus.ps1 -ClearCache
+#>
+
+[CmdletBinding(DefaultParameterSetName = 'BuildId')]
+param(
+    [Parameter(ParameterSetName = 'BuildId', Mandatory = $true)]
+    [int]$BuildId,
+
+    [Parameter(ParameterSetName = 'PRNumber', Mandatory = $true)]
+    [int]$PRNumber,
+
+    [Parameter(ParameterSetName = 'HelixJob', Mandatory = $true)]
+    [string]$HelixJob,
+
+    [Parameter(ParameterSetName = 'HelixJob')]
+    [string]$WorkItem,
+
+    [Parameter(ParameterSetName = 'ClearCache', Mandatory = $true)]
+    [switch]$ClearCache,
+
+    [string]$Repository = "dotnet/runtime",
+    [string]$Organization = "dnceng-public",
+    [string]$Project = "cbb18261-c48f-4abb-8651-8cdcb5474649",
+    [switch]$ShowLogs,
+    [int]$MaxJobs = 5,
+    [int]$MaxFailureLines = 50,
+    [int]$TimeoutSec = 30,
+    [int]$ContextLines = 0,
+    [switch]$NoCache,
+    [int]$CacheTTLSeconds = 30,
+    [switch]$ContinueOnError,
+    [switch]$SearchMihuBot,
+    [switch]$FindBinlogs
+)
+
+$ErrorActionPreference = "Stop"
+
+#region Caching Functions
+
+# Cross-platform temp directory detection
+function Get-TempDirectory {
+    # Try common environment variables in order of preference
+    $tempPath = $env:TEMP
+    if (-not $tempPath) { $tempPath = $env:TMP }
+    if (-not $tempPath) { $tempPath = $env:TMPDIR }  # macOS
+    if (-not $tempPath -and $IsLinux) { $tempPath = "/tmp" }
+    if (-not $tempPath -and $IsMacOS) { $tempPath = "/tmp" }
+    if (-not $tempPath) {
+        # Fallback: use .cache in user's home directory
+        $home = $env:HOME
+        if (-not $home) { $home = $env:USERPROFILE }
+        if ($home) {
+            $tempPath = Join-Path $home ".cache"
+            if (-not (Test-Path $tempPath)) {
+                New-Item -ItemType Directory -Path $tempPath -Force | Out-Null
+            }
+        }
+    }
+    if (-not $tempPath) {
+        throw "Could not determine temp directory. Set TEMP, TMP, or TMPDIR environment variable."
+    }
+    return $tempPath
+}
+
+$script:TempDir = Get-TempDirectory
+
+# Handle -ClearCache parameter
+if ($ClearCache) {
+    $cacheDir = Join-Path $script:TempDir "ci-analysis-cache"
+    if (Test-Path $cacheDir) {
+        $files = Get-ChildItem -Path $cacheDir -File
+        $count = $files.Count
+        Remove-Item -Path $cacheDir -Recurse -Force
+        Write-Host "Cleared $count cached files from $cacheDir" -ForegroundColor Green
+    }
+    else {
+        Write-Host "Cache directory does not exist: $cacheDir" -ForegroundColor Yellow
+    }
+    exit 0
+}
+
+# Setup caching
+$script:CacheDir = Join-Path $script:TempDir "ci-analysis-cache"
+if (-not (Test-Path $script:CacheDir)) {
+    New-Item -ItemType Directory -Path $script:CacheDir -Force | Out-Null
+}
+
+# Clean up expired cache files on startup (files older than 2x TTL)
+function Clear-ExpiredCache {
+    param([int]$TTLSeconds = $CacheTTLSeconds)
+
+    $maxAge = $TTLSeconds * 2
+    $cutoff = (Get-Date).AddSeconds(-$maxAge)
+
+    Get-ChildItem -Path $script:CacheDir -File -ErrorAction SilentlyContinue | Where-Object {
+        $_.LastWriteTime -lt $cutoff
+    } | ForEach-Object {
+        Write-Verbose "Removing expired cache file: $($_.Name)"
+        try {
+            Remove-Item $_.FullName -Force -ErrorAction Stop
+        }
+        catch {
+            Write-Verbose "Failed to remove cache file '$($_.Name)': $($_.Exception.Message)"
+        }
+    }
+}
+
+# Run cache cleanup at startup (non-blocking)
+if (-not $NoCache) {
+    Clear-ExpiredCache -TTLSeconds $CacheTTLSeconds
+}
+
+function Get-UrlHash {
+    param([string]$Url)
+    
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        return [System.BitConverter]::ToString(
+            $sha256.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($Url))
+        ).Replace("-", "")
+    }
+    finally {
+        $sha256.Dispose()
+    }
+}
+
+function Get-CachedResponse {
+    param(
+        [string]$Url,
+        [int]$TTLSeconds = $CacheTTLSeconds
+    )
+
+    if ($NoCache) { return $null }
+
+    $hash = Get-UrlHash -Url $Url
+    $cacheFile = Join-Path $script:CacheDir "$hash.json"
+
+    if (Test-Path $cacheFile) {
+        $cacheInfo = Get-Item $cacheFile
+        $age = (Get-Date) - $cacheInfo.LastWriteTime
+
+        if ($age.TotalSeconds -lt $TTLSeconds) {
+            Write-Verbose "Cache hit for $Url (age: $([int]$age.TotalSeconds) sec)"
+            return Get-Content $cacheFile -Raw
+        }
+        else {
+            Write-Verbose "Cache expired for $Url"
+        }
+    }
+
+    return $null
+}
+
+function Set-CachedResponse {
+    param(
+        [string]$Url,
+        [string]$Content
+    )
+
+    if ($NoCache) { return }
+
+    $hash = Get-UrlHash -Url $Url
+    $cacheFile = Join-Path $script:CacheDir "$hash.json"
+    
+    # Use atomic write: write to temp file, then rename
+    $tempFile = Join-Path $script:CacheDir "$hash.tmp.$([System.Guid]::NewGuid().ToString('N'))"
+    try {
+        $Content | Set-Content -LiteralPath $tempFile -Force
+        Move-Item -LiteralPath $tempFile -Destination $cacheFile -Force
+        Write-Verbose "Cached response for $Url"
+    }
+    catch {
+        # Clean up temp file on failure
+        if (Test-Path $tempFile) {
+            Remove-Item -LiteralPath $tempFile -Force -ErrorAction SilentlyContinue
+        }
+        Write-Verbose "Failed to cache response: $_"
+    }
+}
+
+function Invoke-CachedRestMethod {
+    param(
+        [string]$Uri,
+        [int]$TimeoutSec = 30,
+        [switch]$AsJson,
+        [switch]$SkipCache,
+        [switch]$SkipCacheWrite
+    )
+
+    # Check cache first (unless skipping)
+    if (-not $SkipCache) {
+        $cached = Get-CachedResponse -Url $Uri
+        if ($cached) {
+            if ($AsJson) {
+                try {
+                    return $cached | ConvertFrom-Json -ErrorAction Stop
+                }
+                catch {
+                    Write-Verbose "Failed to parse cached response as JSON, treating as cache miss: $_"
+                }
+            }
+            else {
+                return $cached
+            }
+        }
+    }
+
+    # Make the actual request
+    Write-Verbose "GET $Uri"
+    $response = Invoke-RestMethod -Uri $Uri -Method Get -TimeoutSec $TimeoutSec
+
+    # Cache the response (unless skipping write)
+    if (-not $SkipCache -and -not $SkipCacheWrite) {
+        if ($AsJson -or $response -is [PSCustomObject]) {
+            $content = $response | ConvertTo-Json -Depth 100 -Compress
+            Set-CachedResponse -Url $Uri -Content $content
+        }
+        else {
+            Set-CachedResponse -Url $Uri -Content $response
+        }
+    }
+
+    return $response
+}
+
+#endregion Caching Functions
+
+#region Validation Functions
+
+function Test-RepositoryFormat {
+    param([string]$Repo)
+    
+    # Validate repository format to prevent command injection
+    $repoPattern = '^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$'
+    if ($Repo -notmatch $repoPattern) {
+        throw "Invalid repository format '$Repo'. Expected 'owner/repo' (e.g., 'dotnet/runtime')."
+    }
+    return $true
+}
+
+function Get-SafeSearchTerm {
+    param([string]$Term)
+    
+    # Sanitize search term to avoid passing unsafe characters to gh CLI
+    # Keep: alphanumeric, spaces, dots, hyphens, colons (for namespaces like System.Net),
+    # and slashes (for paths). These are safe for GitHub search and common in .NET names.
+    $safeTerm = $Term -replace '[^\w\s\-.:/]', ''
+    return $safeTerm.Trim()
+}
+
+#endregion Validation Functions
+
+#region Azure DevOps API Functions
+
+function Get-AzDOBuildIdFromPR {
+    param([int]$PR)
+
+    # Check for gh CLI dependency
+    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+        throw "GitHub CLI (gh) is required for PR lookup. Install from https://cli.github.com/ or use -BuildId instead."
+    }
+
+    # Validate repository format
+    Test-RepositoryFormat -Repo $Repository | Out-Null
+
+    Write-Host "Finding builds for PR #$PR in $Repository..." -ForegroundColor Cyan
+    Write-Verbose "Running: gh pr checks $PR --repo $Repository"
+
+    # Use gh cli to get the checks with splatted arguments
+    $checksOutput = & gh pr checks $PR --repo $Repository 2>&1
+    $ghExitCode = $LASTEXITCODE
+
+    if ($ghExitCode -ne 0 -and -not ($checksOutput | Select-String -Pattern "buildId=")) {
+        throw "Failed to fetch CI status for PR #$PR in $Repository - check PR number and permissions"
+    }
+
+    # Check if PR has merge conflicts (no CI runs when mergeable_state is dirty)
+    $prMergeState = $null
+    $prMergeStateOutput = & gh api "repos/$Repository/pulls/$PR" --jq '.mergeable_state' 2>$null
+    $ghMergeStateExitCode = $LASTEXITCODE
+    if ($ghMergeStateExitCode -eq 0 -and $prMergeStateOutput) {
+        $prMergeState = $prMergeStateOutput.Trim()
+    } else {
+        Write-Verbose "Could not determine PR merge state (gh exit code $ghMergeStateExitCode)."
+    }
+
+    # Find ALL failing Azure DevOps builds
+    $failingBuilds = @{}
+    foreach ($line in $checksOutput) {
+        if ($line -match 'fail.*buildId=(\d+)') {
+            $buildId = $Matches[1]
+            # Extract pipeline name (first column before 'fail')
+            $pipelineName = ($line -split '\s+fail')[0].Trim()
+            if (-not $failingBuilds.ContainsKey($buildId)) {
+                $failingBuilds[$buildId] = $pipelineName
+            }
+        }
+    }
+
+    if ($failingBuilds.Count -eq 0) {
+        # No failing builds - try to find any build
+        $anyBuild = $checksOutput | Select-String -Pattern "buildId=(\d+)" | Select-Object -First 1
+        if ($anyBuild) {
+            $anyBuildMatch = [regex]::Match($anyBuild.ToString(), "buildId=(\d+)")
+            if ($anyBuildMatch.Success) {
+                $buildIdStr = $anyBuildMatch.Groups[1].Value
+                $buildIdInt = 0
+                if ([int]::TryParse($buildIdStr, [ref]$buildIdInt)) {
+                    return @{ BuildIds = @($buildIdInt); Reason = $null; MergeState = $prMergeState }
+                }
+            }
+        }
+        if ($prMergeState -eq 'dirty') {
+            Write-Host "`nPR #$PR has merge conflicts (mergeable_state: dirty)" -ForegroundColor Red
+            Write-Host "CI will not run until conflicts are resolved." -ForegroundColor Yellow
+            Write-Host "Resolve conflicts and push to trigger CI, or use -BuildId to analyze a previous build." -ForegroundColor Gray
+            return @{ BuildIds = @(); Reason = "MERGE_CONFLICTS"; MergeState = $prMergeState }
+        }
+        Write-Host "`nNo CI build found for PR #$PR in $Repository" -ForegroundColor Red
+        Write-Host "The CI pipeline has not been triggered yet." -ForegroundColor Yellow
+        return @{ BuildIds = @(); Reason = "NO_BUILDS"; MergeState = $prMergeState }
+    }
+
+    # Return all unique failing build IDs
+    $buildIds = $failingBuilds.Keys | ForEach-Object { [int]$_ } | Sort-Object -Unique
+
+    if ($buildIds.Count -gt 1) {
+        Write-Host "Found $($buildIds.Count) failing builds:" -ForegroundColor Yellow
+        foreach ($id in $buildIds) {
+            Write-Host "  - Build $id ($($failingBuilds[$id.ToString()]))" -ForegroundColor Gray
+        }
+    }
+
+    return @{ BuildIds = $buildIds; Reason = $null; MergeState = $prMergeState }
+}
+
+function Get-BuildAnalysisKnownIssues {
+    param([int]$PR)
+
+    # Check for gh CLI dependency
+    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+        Write-Verbose "GitHub CLI (gh) not available for Build Analysis check"
+        return @()
+    }
+
+    Write-Verbose "Fetching Build Analysis check for PR #$PR..."
+
+    try {
+        # Get the head commit SHA for the PR
+        $headSha = gh pr view $PR --repo $Repository --json headRefOid --jq '.headRefOid' 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Verbose "Failed to get PR head SHA: $headSha"
+            return @()
+        }
+
+        # Validate headSha is a valid git SHA (40 hex characters)
+        if ($headSha -notmatch '^[a-fA-F0-9]{40}$') {
+            Write-Verbose "Invalid head SHA format: $headSha"
+            return @()
+        }
+
+        # Get the Build Analysis check run
+        $checkRuns = gh api "repos/$Repository/commits/$headSha/check-runs" --jq '.check_runs[] | select(.name == "Build Analysis") | .output' 2>&1
+        if ($LASTEXITCODE -ne 0 -or -not $checkRuns) {
+            Write-Verbose "No Build Analysis check found"
+            return @()
+        }
+
+        $output = $checkRuns | ConvertFrom-Json -ErrorAction SilentlyContinue
+        if (-not $output -or -not $output.text) {
+            Write-Verbose "Build Analysis check has no output text"
+            return @()
+        }
+
+        # Parse known issues from the output text
+        # Format: <a href="https://github.com/dotnet/runtime/issues/117164">Issue Title</a>
+        $knownIssues = @()
+        $issuePattern = '<a href="(https://github\.com/[^/]+/[^/]+/issues/(\d+))">([^<]+)</a>'
+        $matches = [regex]::Matches($output.text, $issuePattern)
+
+        foreach ($match in $matches) {
+            $issueUrl = $match.Groups[1].Value
+            $issueNumber = $match.Groups[2].Value
+            $issueTitle = $match.Groups[3].Value
+
+            # Avoid duplicates
+            if (-not ($knownIssues | Where-Object { $_.Number -eq $issueNumber })) {
+                $knownIssues += @{
+                    Number = $issueNumber
+                    Url = $issueUrl
+                    Title = $issueTitle
+                }
+            }
+        }
+
+        if ($knownIssues.Count -gt 0) {
+            Write-Host "`nBuild Analysis found $($knownIssues.Count) known issue(s):" -ForegroundColor Yellow
+            foreach ($issue in $knownIssues) {
+                Write-Host "  - #$($issue.Number): $($issue.Title)" -ForegroundColor Gray
+                Write-Host "    $($issue.Url)" -ForegroundColor DarkGray
+            }
+        }
+
+        return $knownIssues
+    }
+    catch {
+        Write-Verbose "Error fetching Build Analysis: $_"
+        return @()
+    }
+}
+
+function Get-PRChangedFiles {
+    param(
+        [int]$PR,
+        [int]$MaxFiles = 100
+    )
+
+    # Check for gh CLI dependency
+    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+        Write-Verbose "GitHub CLI (gh) not available for PR file lookup"
+        return @()
+    }
+
+    Write-Verbose "Fetching changed files for PR #$PR..."
+
+    try {
+        # Get the file count first to avoid fetching huge PRs
+        $fileCount = gh pr view $PR --repo $Repository --json files --jq '.files | length' 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Verbose "Failed to get PR file count: $fileCount"
+            return @()
+        }
+
+        $count = [int]$fileCount
+        if ($count -gt $MaxFiles) {
+            Write-Verbose "PR has $count files (exceeds limit of $MaxFiles) - skipping correlation"
+            Write-Host "PR has $count changed files - skipping detailed correlation (limit: $MaxFiles)" -ForegroundColor Gray
+            return @()
+        }
+
+        # Get the list of changed files
+        $filesJson = gh pr view $PR --repo $Repository --json files --jq '.files[].path' 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Verbose "Failed to get PR files: $filesJson"
+            return @()
+        }
+
+        $files = $filesJson -split "`n" | Where-Object { $_ }
+        return $files
+    }
+    catch {
+        Write-Verbose "Error fetching PR files: $_"
+        return @()
+    }
+}
+
+function Get-PRCorrelation {
+    param(
+        [array]$ChangedFiles,
+        [array]$AllFailures
+    )
+
+    $result = @{ CorrelatedFiles = @(); TestFiles = @() }
+    if ($ChangedFiles.Count -eq 0 -or $AllFailures.Count -eq 0) { return $result }
+
+    $failureText = ($AllFailures | ForEach-Object {
+        $_.TaskName
+        $_.JobName
+        $_.Errors -join "`n"
+        $_.HelixLogs -join "`n"
+        $_.FailedTests -join "`n"
+    }) -join "`n"
+
+    foreach ($file in $ChangedFiles) {
+        $fileName = [System.IO.Path]::GetFileNameWithoutExtension($file)
+        $fileNameWithExt = [System.IO.Path]::GetFileName($file)
+        $baseTestName = $fileName -replace '\.[^.]+$', ''
+
+        $isCorrelated = $false
+        if ($failureText -match [regex]::Escape($fileName) -or
+            $failureText -match [regex]::Escape($fileNameWithExt) -or
+            $failureText -match [regex]::Escape($file) -or
+            ($baseTestName -and $failureText -match [regex]::Escape($baseTestName))) {
+            $isCorrelated = $true
+        }
+
+        if ($isCorrelated) {
+            $isTestFile = $file -match '\.Tests?\.' -or $file -match '[/\\]tests?[/\\]' -or $file -match 'Test\.cs$' -or $file -match 'Tests\.cs$'
+            if ($isTestFile) { $result.TestFiles += $file } else { $result.CorrelatedFiles += $file }
+        }
+    }
+
+    $result.CorrelatedFiles = @($result.CorrelatedFiles | Select-Object -Unique)
+    $result.TestFiles = @($result.TestFiles | Select-Object -Unique)
+    return $result
+}
+
+function Show-PRCorrelationSummary {
+    param(
+        [array]$ChangedFiles,
+        [array]$AllFailures
+    )
+
+    if ($ChangedFiles.Count -eq 0) {
+        return
+    }
+
+    $correlation = Get-PRCorrelation -ChangedFiles $ChangedFiles -AllFailures $AllFailures
+    $correlatedFiles = $correlation.CorrelatedFiles
+    $testFiles = $correlation.TestFiles
+
+    # Show results
+    if ($correlatedFiles.Count -gt 0 -or $testFiles.Count -gt 0) {
+        Write-Host "`n=== PR Change Correlation ===" -ForegroundColor Magenta
+
+        if ($testFiles.Count -gt 0) {
+            Write-Host "⚠️  Test files changed by this PR are failing:" -ForegroundColor Yellow
+            $shown = 0
+            foreach ($file in $testFiles) {
+                if ($shown -ge 10) {
+                    Write-Host "    ... and $($testFiles.Count - 10) more test files" -ForegroundColor Gray
+                    break
+                }
+                Write-Host "    $file" -ForegroundColor Red
+                $shown++
+            }
+        }
+
+        if ($correlatedFiles.Count -gt 0) {
+            Write-Host "⚠️  Files changed by this PR appear in failures:" -ForegroundColor Yellow
+            $shown = 0
+            foreach ($file in $correlatedFiles) {
+                if ($shown -ge 10) {
+                    Write-Host "    ... and $($correlatedFiles.Count - 10) more files" -ForegroundColor Gray
+                    break
+                }
+                Write-Host "    $file" -ForegroundColor Red
+                $shown++
+            }
+        }
+
+        Write-Host "`nCorrelated files found — check JSON summary for details." -ForegroundColor Yellow
+    }
+}
+
+function Get-AzDOBuildStatus {
+    param([int]$Build)
+
+    $url = "https://dev.azure.com/$Organization/$Project/_apis/build/builds/${Build}?api-version=7.0"
+
+    try {
+        # First check cache to see if we have a completed status
+        $cached = Get-CachedResponse -Url $url
+        if ($cached) {
+            $cachedData = $cached | ConvertFrom-Json
+            # Only use cache if build was completed - in-progress status goes stale quickly
+            if ($cachedData.status -eq "completed") {
+                return @{
+                    Status = $cachedData.status
+                    Result = $cachedData.result
+                    StartTime = $cachedData.startTime
+                    FinishTime = $cachedData.finishTime
+                }
+            }
+            Write-Verbose "Skipping cached in-progress build status"
+        }
+
+        # Fetch fresh status
+        $response = Invoke-CachedRestMethod -Uri $url -TimeoutSec $TimeoutSec -AsJson -SkipCache
+
+        # Only cache if completed
+        if ($response.status -eq "completed") {
+            $content = $response | ConvertTo-Json -Depth 10 -Compress
+            Set-CachedResponse -Url $url -Content $content
+        }
+
+        return @{
+            Status = $response.status        # notStarted, inProgress, completed
+            Result = $response.result        # succeeded, failed, canceled (only set when completed)
+            StartTime = $response.startTime
+            FinishTime = $response.finishTime
+        }
+    }
+    catch {
+        Write-Verbose "Failed to fetch build status: $_"
+        return $null
+    }
+}
+
+function Get-AzDOTimeline {
+    param(
+        [int]$Build,
+        [switch]$BuildInProgress
+    )
+
+    $url = "https://dev.azure.com/$Organization/$Project/_apis/build/builds/$Build/timeline?api-version=7.0"
+    Write-Host "Fetching build timeline..." -ForegroundColor Cyan
+
+    try {
+        # Don't cache timeline for in-progress builds - it changes as jobs complete
+        $response = Invoke-CachedRestMethod -Uri $url -TimeoutSec $TimeoutSec -AsJson -SkipCacheWrite:$BuildInProgress
+        return $response
+    }
+    catch {
+        if ($ContinueOnError) {
+            Write-Warning "Failed to fetch build timeline: $_"
+            return $null
+        }
+        throw "Failed to fetch build timeline: $_"
+    }
+}
+
+function Get-FailedJobs {
+    param($Timeline)
+
+    if ($null -eq $Timeline -or $null -eq $Timeline.records) {
+        return @()
+    }
+
+    $failedJobs = $Timeline.records | Where-Object {
+        $_.type -eq "Job" -and $_.result -eq "failed"
+    }
+
+    return $failedJobs
+}
+
+function Get-CanceledJobs {
+    param($Timeline)
+
+    if ($null -eq $Timeline -or $null -eq $Timeline.records) {
+        return @()
+    }
+
+    $canceledJobs = $Timeline.records | Where-Object {
+        $_.type -eq "Job" -and $_.result -eq "canceled"
+    }
+
+    return $canceledJobs
+}
+
+function Get-HelixJobInfo {
+    param($Timeline, $JobId)
+
+    if ($null -eq $Timeline -or $null -eq $Timeline.records) {
+        return @()
+    }
+
+    # Find tasks in this job that mention Helix
+    $helixTasks = $Timeline.records | Where-Object {
+        $_.parentId -eq $JobId -and
+        $_.name -like "*Helix*" -and
+        $_.result -eq "failed"
+    }
+
+    return $helixTasks
+}
+
+function Get-BuildLog {
+    param([int]$Build, [int]$LogId)
+
+    $url = "https://dev.azure.com/$Organization/$Project/_apis/build/builds/$Build/logs/${LogId}?api-version=7.0"
+
+    try {
+        $response = Invoke-CachedRestMethod -Uri $url -TimeoutSec $TimeoutSec
+        return $response
+    }
+    catch {
+        Write-Warning "Failed to fetch log ${LogId}: $_"
+        return $null
+    }
+}
+
+#endregion Azure DevOps API Functions
+
+#region Log Parsing Functions
+
+function Extract-HelixUrls {
+    param([string]$LogContent)
+
+    $urls = @()
+
+    # First, normalize the content by removing line breaks that might split URLs
+    $normalizedContent = $LogContent -replace "`r`n", "" -replace "`n", ""
+
+    # Match Helix console log URLs - workitem names can contain dots, dashes, and other chars
+    $urlMatches = [regex]::Matches($normalizedContent, 'https://helix\.dot\.net/api/[^/]+/jobs/[a-f0-9-]+/workitems/[^/\s]+/console')
+    foreach ($match in $urlMatches) {
+        $urls += $match.Value
+    }
+
+    Write-Verbose "Found $($urls.Count) Helix URLs"
+    return $urls | Select-Object -Unique
+}
+
+function Extract-TestFailures {
+    param([string]$LogContent)
+
+    $failures = @()
+
+    # Match test failure patterns from MSBuild output
+    $pattern = 'error\s*:\s*.*Test\s+(\S+)\s+has failed'
+    $failureMatches = [regex]::Matches($LogContent, $pattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+
+    foreach ($match in $failureMatches) {
+        $failures += @{
+            TestName = $match.Groups[1].Value
+            FullMatch = $match.Value
+        }
+    }
+
+    Write-Verbose "Found $($failures.Count) test failures"
+    return $failures
+}
+
+function Extract-BuildErrors {
+    param(
+        [string]$LogContent,
+        [int]$Context = 5
+    )
+
+    $errors = @()
+    $lines = $LogContent -split "`n"
+
+    # Patterns for common build errors - ordered from most specific to least specific
+    $errorPatterns = @(
+        'error\s+CS\d+:.*',                        # C# compiler errors
+        'error\s+MSB\d+:.*',                       # MSBuild errors
+        'error\s+NU\d+:.*',                        # NuGet errors
+        '\.pcm: No such file or directory',        # Clang module cache
+        'EXEC\s*:\s*error\s*:.*',                  # Exec task errors
+        'fatal error:.*',                          # Fatal errors (clang, etc)
+        ':\s*error:',                              # Clang/GCC errors (file.cpp:123: error:)
+        'undefined reference to',                  # Linker errors
+        'cannot find -l',                          # Linker missing library
+        'collect2: error:',                        # GCC linker wrapper errors
+        '##\[error\].*'                            # AzDO error annotations (last - catch-all)
+    )
+
+    $combinedPattern = ($errorPatterns -join '|')
+
+    # Track if we only found MSBuild wrapper errors
+    $foundRealErrors = $false
+    $msbWrapperLines = @()
+
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        if ($lines[$i] -match $combinedPattern) {
+            # Skip MSBuild wrapper "exited with code" if we find real errors
+            if ($lines[$i] -match 'exited with code \d+') {
+                $msbWrapperLines += $i
+                continue
+            }
+
+            # Skip duplicate MSBuild errors (they often repeat)
+            if ($lines[$i] -match 'error MSB3073.*exited with code') {
+                continue
+            }
+
+            $foundRealErrors = $true
+
+            # Clean up the line (remove timestamps, etc)
+            $cleanLine = $lines[$i] -replace '^\d{4}-\d{2}-\d{2}T[\d:\.]+Z\s*', ''
+            $cleanLine = $cleanLine -replace '##\[error\]', 'ERROR: '
+
+            # Add context lines if requested
+            if ($Context -gt 0) {
+                $contextStart = [Math]::Max(0, $i - $Context)
+                $contextLines = @()
+                for ($j = $contextStart; $j -lt $i; $j++) {
+                    $contextLines += "  " + $lines[$j].Trim()
+                }
+                if ($contextLines.Count -gt 0) {
+                    $errors += ($contextLines -join "`n")
+                }
+            }
+
+            $errors += $cleanLine.Trim()
+        }
+    }
+
+    # If we only found MSBuild wrapper errors, show context around them
+    if (-not $foundRealErrors -and $msbWrapperLines.Count -gt 0) {
+        $wrapperLine = $msbWrapperLines[0]
+        # Look for real errors in the 50 lines before the wrapper error
+        $searchStart = [Math]::Max(0, $wrapperLine - 50)
+        for ($i = $searchStart; $i -lt $wrapperLine; $i++) {
+            $line = $lines[$i]
+            # Look for C++/clang/gcc style errors
+            if ($line -match ':\s*error:' -or $line -match 'fatal error:' -or $line -match 'undefined reference') {
+                $cleanLine = $line -replace '^\d{4}-\d{2}-\d{2}T[\d:\.]+Z\s*', ''
+                $errors += $cleanLine.Trim()
+            }
+        }
+    }
+
+    return $errors | Select-Object -First 20 | Select-Object -Unique
+}
+
+function Extract-HelixLogUrls {
+    param([string]$LogContent)
+
+    $urls = @()
+
+    # Match Helix console log URLs from log content
+    # Pattern: https://helix.dot.net/api/2019-06-17/jobs/{jobId}/workitems/{workItemName}/console
+    $pattern = 'https://helix\.dot\.net/api/[^/]+/jobs/([a-f0-9-]+)/workitems/([^/\s]+)/console'
+    $urlMatches = [regex]::Matches($LogContent, $pattern)
+
+    foreach ($match in $urlMatches) {
+        $urls += @{
+            Url = $match.Value
+            JobId = $match.Groups[1].Value
+            WorkItem = $match.Groups[2].Value
+        }
+    }
+
+    # Deduplicate by URL
+    $uniqueUrls = @{}
+    foreach ($url in $urls) {
+        if (-not $uniqueUrls.ContainsKey($url.Url)) {
+            $uniqueUrls[$url.Url] = $url
+        }
+    }
+
+    return $uniqueUrls.Values
+}
+
+#endregion Log Parsing Functions
+
+#region Known Issues Search
+
+function Search-MihuBotIssues {
+    param(
+        [string[]]$SearchTerms,
+        [string]$ExtraContext = "",
+        [string]$Repository = "dotnet/runtime",
+        [bool]$IncludeOpen = $true,
+        [bool]$IncludeClosed = $true,
+        [int]$TimeoutSec = 30
+    )
+
+    $results = @()
+
+    if (-not $SearchTerms -or $SearchTerms.Count -eq 0) {
+        return $results
+    }
+
+    try {
+        # MihuBot MCP endpoint - call as JSON-RPC style request
+        $mcpUrl = "https://mihubot.xyz/mcp"
+
+        # Build the request payload matching the MCP tool schema
+        $payload = @{
+            jsonrpc = "2.0"
+            method = "tools/call"
+            id = [guid]::NewGuid().ToString()
+            params = @{
+                name = "search_dotnet_repos"
+                arguments = @{
+                    repository = $Repository
+                    searchTerms = $SearchTerms
+                    extraSearchContext = $ExtraContext
+                    includeOpen = $IncludeOpen
+                    includeClosed = $IncludeClosed
+                    includeIssues = $true
+                    includePullRequests = $true
+                    includeComments = $false
+                }
+            }
+        } | ConvertTo-Json -Depth 10
+
+        Write-Verbose "Calling MihuBot MCP endpoint with terms: $($SearchTerms -join ', ')"
+
+        $response = Invoke-RestMethod -Uri $mcpUrl -Method Post -Body $payload -ContentType "application/json" -TimeoutSec $TimeoutSec
+
+        # Parse MCP response
+        if ($response.result -and $response.result.content) {
+            foreach ($content in $response.result.content) {
+                if ($content.type -eq "text" -and $content.text) {
+                    $issueData = $content.text | ConvertFrom-Json -ErrorAction SilentlyContinue
+                    if ($issueData) {
+                        foreach ($issue in $issueData) {
+                            $results += @{
+                                Number = $issue.Number
+                                Title = $issue.Title
+                                Url = $issue.Url
+                                Repository = $issue.Repository
+                                State = $issue.State
+                                Source = "MihuBot"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        # Deduplicate by issue number and repo
+        $unique = @{}
+        foreach ($issue in $results) {
+            $key = "$($issue.Repository)#$($issue.Number)"
+            if (-not $unique.ContainsKey($key)) {
+                $unique[$key] = $issue
+            }
+        }
+
+        return $unique.Values | Select-Object -First 5
+    }
+    catch {
+        Write-Verbose "MihuBot search failed: $_"
+        return @()
+    }
+}
+
+function Search-KnownIssues {
+    param(
+        [string]$TestName,
+        [string]$ErrorMessage,
+        [string]$Repository = "dotnet/runtime"
+    )
+
+    # Search for known issues using the "Known Build Error" label
+    # This label is used by Build Analysis across dotnet repositories
+
+    $knownIssues = @()
+
+    # Check if gh CLI is available
+    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+        Write-Verbose "GitHub CLI not available for searching known issues"
+        return $knownIssues
+    }
+
+    try {
+        # Extract search terms from test name and error message
+        $searchTerms = @()
+
+        # First priority: Look for [FAIL] test names in the error message
+        # Pattern: "TestName [FAIL]" - the test name comes BEFORE [FAIL]
+        if ($ErrorMessage -match '(\S+)\s+\[FAIL\]') {
+            $failedTest = $Matches[1]
+            # Extract just the method name (after last .)
+            if ($failedTest -match '\.([^.]+)$') {
+                $searchTerms += $Matches[1]
+            }
+            # Also add the full test name
+            $searchTerms += $failedTest
+        }
+
+        # Second priority: Extract test class/method from stack traces
+        if ($ErrorMessage -match 'at\s+(\w+\.\w+)\(' -and $searchTerms.Count -eq 0) {
+            $searchTerms += $Matches[1]
+        }
+
+        if ($TestName) {
+            # Try to get the test method name from the work item
+            if ($TestName -match '\.([^.]+)$') {
+                $methodName = $Matches[1]
+                # Only add if it looks like a test name (not just "Tests")
+                if ($methodName -ne "Tests" -and $methodName.Length -gt 5) {
+                    $searchTerms += $methodName
+                }
+            }
+            # Also try the full test name if it's not too long and looks specific
+            if ($TestName.Length -lt 100 -and $TestName -notmatch '^System\.\w+\.Tests$') {
+                $searchTerms += $TestName
+            }
+        }
+
+        # Third priority: Extract specific exception patterns (but not generic TimeoutException)
+        if ($ErrorMessage -and $searchTerms.Count -eq 0) {
+            # Look for specific exception types
+            if ($ErrorMessage -match '(System\.(?:InvalidOperation|ArgumentNull|Format)\w*Exception)') {
+                $searchTerms += $Matches[1]
+            }
+        }
+
+        # Deduplicate and limit search terms
+        $searchTerms = $searchTerms | Select-Object -Unique | Select-Object -First 3
+
+        foreach ($term in $searchTerms) {
+            if (-not $term) { continue }
+
+            # Sanitize the search term to avoid passing unsafe characters to gh CLI
+            $safeTerm = Get-SafeSearchTerm -Term $term
+            if (-not $safeTerm) { continue }
+
+            Write-Verbose "Searching for known issues with term: $safeTerm"
+
+            # Search for open issues with the "Known Build Error" label
+            $results = & gh issue list `
+                --repo $Repository `
+                --label "Known Build Error" `
+                --state open `
+                --search $safeTerm `
+                --limit 3 `
+                --json number,title,url 2>$null | ConvertFrom-Json
+
+            if ($results) {
+                foreach ($issue in $results) {
+                    # Check if the title actually contains our search term (avoid false positives)
+                    if ($issue.title -match [regex]::Escape($safeTerm)) {
+                        $knownIssues += @{
+                            Number = $issue.number
+                            Title = $issue.title
+                            Url = $issue.url
+                            SearchTerm = $safeTerm
+                        }
+                    }
+                }
+            }
+
+            # If we found issues, stop searching
+            if ($knownIssues.Count -gt 0) {
+                break
+            }
+        }
+
+        # Deduplicate by issue number
+        $unique = @{}
+        foreach ($issue in $knownIssues) {
+            if (-not $unique.ContainsKey($issue.Number)) {
+                $unique[$issue.Number] = $issue
+            }
+        }
+
+        return $unique.Values
+    }
+    catch {
+        Write-Verbose "Failed to search for known issues: $_"
+        return @()
+    }
+}
+
+function Show-KnownIssues {
+    param(
+        [string]$TestName = "",
+        [string]$ErrorMessage = "",
+        [string]$Repository = $script:Repository,
+        [switch]$IncludeMihuBot
+    )
+
+    # Search for known issues if we have a test name or error
+    if ($TestName -or $ErrorMessage) {
+        $knownIssues = Search-KnownIssues -TestName $TestName -ErrorMessage $ErrorMessage -Repository $Repository
+        if ($knownIssues -and $knownIssues.Count -gt 0) {
+            Write-Host "`n  Known Issues:" -ForegroundColor Magenta
+            foreach ($issue in $knownIssues) {
+                Write-Host "    #$($issue.Number): $($issue.Title)" -ForegroundColor Magenta
+                Write-Host "    $($issue.Url)" -ForegroundColor Gray
+            }
+        }
+
+        # Search MihuBot for related issues/discussions
+        if ($IncludeMihuBot) {
+            $searchTerms = @()
+
+            # Extract meaningful search terms
+            if ($ErrorMessage -match '(\S+)\s+\[FAIL\]') {
+                $failedTest = $Matches[1]
+                if ($failedTest -match '\.([^.]+)$') {
+                    $searchTerms += $Matches[1]
+                }
+            }
+
+            if ($TestName -and $TestName -match '\.([^.]+)$') {
+                $methodName = $Matches[1]
+                if ($methodName -ne "Tests" -and $methodName.Length -gt 5) {
+                    $searchTerms += $methodName
+                }
+            }
+
+            # Add test name as context
+            if ($TestName) {
+                $searchTerms += $TestName
+            }
+
+            $searchTerms = $searchTerms | Select-Object -Unique | Select-Object -First 3
+
+            if ($searchTerms.Count -gt 0) {
+                $mihuBotResults = Search-MihuBotIssues -SearchTerms $searchTerms -Repository $Repository -ExtraContext "test failure $TestName"
+                if ($mihuBotResults -and $mihuBotResults.Count -gt 0) {
+                    # Filter out issues already shown from Known Build Error search
+                    $knownNumbers = @()
+                    if ($knownIssues) {
+                        $knownNumbers = $knownIssues | ForEach-Object { $_.Number }
+                    }
+                    $newResults = $mihuBotResults | Where-Object { $_.Number -notin $knownNumbers }
+
+                    if ($newResults -and @($newResults).Count -gt 0) {
+                        Write-Host "`n  Related Issues (MihuBot):" -ForegroundColor Blue
+                        foreach ($issue in $newResults) {
+                            $stateIcon = if ($issue.State -eq "open") { "[open]" } else { "[closed]" }
+                            Write-Host "    #$($issue.Number): $($issue.Title) $stateIcon" -ForegroundColor Blue
+                            Write-Host "    $($issue.Url)" -ForegroundColor Gray
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#endregion Known Issues Search
+
+#region Test Results Functions
+
+function Get-AzDOTestResults {
+    param(
+        [string]$RunId,
+        [string]$Org = "https://dev.azure.com/$Organization"
+    )
+
+    # Check if az devops CLI is available
+    if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+        Write-Verbose "Azure CLI not available for fetching test results"
+        return $null
+    }
+
+    try {
+        Write-Verbose "Fetching test results for run $RunId via az devops CLI..."
+        $results = az devops invoke `
+            --org $Org `
+            --area test `
+            --resource Results `
+            --route-parameters project=$Project runId=$RunId `
+            --api-version 7.0 `
+            --query "value[?outcome=='Failed'].{name:testCaseTitle, outcome:outcome, error:errorMessage}" `
+            -o json 2>$null | ConvertFrom-Json
+
+        return $results
+    }
+    catch {
+        Write-Verbose "Failed to fetch test results via az devops: $_"
+        return $null
+    }
+}
+
+function Extract-TestRunUrls {
+    param([string]$LogContent)
+
+    $testRuns = @()
+
+    # Match Azure DevOps Test Run URLs
+    # Pattern: Published Test Run : https://dev.azure.com/dnceng-public/public/_TestManagement/Runs?runId=35626550&_a=runCharts
+    $pattern = 'Published Test Run\s*:\s*(https://dev\.azure\.com/[^/]+/[^/]+/_TestManagement/Runs\?runId=(\d+)[^\s]*)'
+    $matches = [regex]::Matches($LogContent, $pattern)
+
+    foreach ($match in $matches) {
+        $testRuns += @{
+            Url = $match.Groups[1].Value
+            RunId = $match.Groups[2].Value
+        }
+    }
+
+    Write-Verbose "Found $($testRuns.Count) test run URLs"
+    return $testRuns
+}
+
+function Get-LocalTestFailures {
+    param(
+        [object]$Timeline,
+        [int]$BuildId
+    )
+
+    $localFailures = @()
+
+    # Find failed test tasks (non-Helix)
+    # Look for tasks with "Test" in name that have issues but no Helix URLs
+    $testTasks = $Timeline.records | Where-Object {
+        ($_.name -match 'Test|xUnit' -or $_.type -eq 'Task') -and
+        $_.issues -and
+        $_.issues.Count -gt 0
+    }
+
+    foreach ($task in $testTasks) {
+        # Check if this task has test failures (XUnit errors)
+        $testErrors = $task.issues | Where-Object {
+            $_.message -match 'Tests failed:' -or
+            $_.message -match 'error\s*:.*Test.*failed'
+        }
+
+        if ($testErrors.Count -gt 0) {
+            # This is a local test failure - find the parent job for URL construction
+            $parentJob = $Timeline.records | Where-Object { $_.id -eq $task.parentId -and $_.type -eq "Job" } | Select-Object -First 1
+
+            $failure = @{
+                TaskName = $task.name
+                TaskId = $task.id
+                ParentJobId = if ($parentJob) { $parentJob.id } else { $task.parentId }
+                LogId = if ($task.log) { $task.log.id } else { $null }
+                Issues = $testErrors
+                TestRunUrls = @()
+            }
+
+            # Try to get test run URLs from the publish task
+            $publishTask = $Timeline.records | Where-Object {
+                $_.parentId -eq $task.parentId -and
+                $_.name -match 'Publish.*Test.*Results' -and
+                $_.log
+            } | Select-Object -First 1
+
+            if ($publishTask -and $publishTask.log) {
+                $logContent = Get-BuildLog -Build $BuildId -LogId $publishTask.log.id
+                if ($logContent) {
+                    $testRunUrls = Extract-TestRunUrls -LogContent $logContent
+                    $failure.TestRunUrls = $testRunUrls
+                }
+            }
+
+            $localFailures += $failure
+        }
+    }
+
+    return $localFailures
+}
+
+#endregion Test Results Functions
+
+#region Helix API Functions
+
+function Get-HelixJobDetails {
+    param([string]$JobId)
+
+    $url = "https://helix.dot.net/api/2019-06-17/jobs/$JobId"
+
+    try {
+        $response = Invoke-CachedRestMethod -Uri $url -TimeoutSec $TimeoutSec -AsJson
+        return $response
+    }
+    catch {
+        Write-Warning "Failed to fetch Helix job ${JobId}: $_"
+        return $null
+    }
+}
+
+function Get-HelixWorkItems {
+    param([string]$JobId)
+
+    $url = "https://helix.dot.net/api/2019-06-17/jobs/$JobId/workitems"
+
+    try {
+        $response = Invoke-CachedRestMethod -Uri $url -TimeoutSec $TimeoutSec -AsJson
+        return $response
+    }
+    catch {
+        Write-Warning "Failed to fetch work items for job ${JobId}: $_"
+        return $null
+    }
+}
+
+function Get-HelixWorkItemFiles {
+    <#
+    .SYNOPSIS
+        Fetches work item files via the ListFiles endpoint which returns direct blob storage URIs.
+    .DESCRIPTION
+        Workaround for https://github.com/dotnet/dnceng/issues/6072:
+        The Details endpoint returns incorrect permalink URIs for files in subdirectories
+        and rejects unicode characters in filenames. The ListFiles endpoint returns direct
+        blob storage URIs that always work, regardless of subdirectory depth or unicode.
+    #>
+    param([string]$JobId, [string]$WorkItemName)
+
+    $encodedWorkItem = [uri]::EscapeDataString($WorkItemName)
+    $url = "https://helix.dot.net/api/2019-06-17/jobs/$JobId/workitems/$encodedWorkItem/files"
+
+    try {
+        $files = Invoke-CachedRestMethod -Uri $url -TimeoutSec $TimeoutSec -AsJson
+        return $files
+    }
+    catch {
+        Write-Warning "Failed to fetch files for work item ${WorkItemName}: $_"
+        return $null
+    }
+}
+
+function Get-HelixWorkItemDetails {
+    param([string]$JobId, [string]$WorkItemName)
+
+    $encodedWorkItem = [uri]::EscapeDataString($WorkItemName)
+    $url = "https://helix.dot.net/api/2019-06-17/jobs/$JobId/workitems/$encodedWorkItem"
+
+    try {
+        $response = Invoke-CachedRestMethod -Uri $url -TimeoutSec $TimeoutSec -AsJson
+
+        # Replace Files from the Details endpoint with results from ListFiles.
+        # The Details endpoint has broken URIs for subdirectory and unicode filenames
+        # (https://github.com/dotnet/dnceng/issues/6072). ListFiles returns direct
+        # blob storage URIs that always work.
+        $listFiles = Get-HelixWorkItemFiles -JobId $JobId -WorkItemName $WorkItemName
+        if ($null -ne $listFiles) {
+            $response.Files = @($listFiles | ForEach-Object {
+                [PSCustomObject]@{
+                    FileName = $_.Name
+                    Uri = $_.Link
+                }
+            })
+        }
+
+        return $response
+    }
+    catch {
+        Write-Warning "Failed to fetch work item ${WorkItemName}: $_"
+        return $null
+    }
+}
+
+function Get-HelixConsoleLog {
+    param([string]$Url)
+
+    try {
+        $response = Invoke-CachedRestMethod -Uri $Url -TimeoutSec $TimeoutSec
+        return $response
+    }
+    catch {
+        Write-Warning "Failed to fetch Helix log from ${Url}: $_"
+        return $null
+    }
+}
+
+function Find-WorkItemsWithBinlogs {
+    <#
+    .SYNOPSIS
+        Scans work items in a Helix job to find which ones contain binlog files.
+    .DESCRIPTION
+        Not all work items produce binlogs - only build/publish tests do.
+        This function helps locate work items that have binlogs for deeper analysis.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$JobId,
+        [int]$MaxItems = 30,
+        [switch]$IncludeDetails
+    )
+
+    $workItems = Get-HelixWorkItems -JobId $JobId
+    if (-not $workItems) {
+        Write-Warning "No work items found for job $JobId"
+        return @()
+    }
+
+    Write-Host "Scanning up to $MaxItems work items for binlogs..." -ForegroundColor Gray
+
+    $results = @()
+    $scanned = 0
+
+    foreach ($wi in $workItems | Select-Object -First $MaxItems) {
+        $scanned++
+        $details = Get-HelixWorkItemDetails -JobId $JobId -WorkItemName $wi.Name
+        if ($details -and $details.Files) {
+            $binlogs = @($details.Files | Where-Object { $_.FileName -like "*.binlog" })
+            if ($binlogs.Count -gt 0) {
+                $result = @{
+                    Name = $wi.Name
+                    BinlogCount = $binlogs.Count
+                    Binlogs = $binlogs | ForEach-Object { $_.FileName }
+                    ExitCode = $details.ExitCode
+                    State = $details.State
+                }
+                if ($IncludeDetails) {
+                    $result.BinlogUris = $binlogs | ForEach-Object { $_.Uri }
+                }
+                $results += $result
+            }
+        }
+
+        # Progress indicator every 10 items
+        if ($scanned % 10 -eq 0) {
+            Write-Host "  Scanned $scanned/$MaxItems..." -ForegroundColor DarkGray
+        }
+    }
+
+    return $results
+}
+
+#endregion Helix API Functions
+
+#region Output Formatting
+
+function Format-TestFailure {
+    param(
+        [string]$LogContent,
+        [int]$MaxLines = $MaxFailureLines,
+        [int]$MaxFailures = 3
+    )
+
+    $lines = $LogContent -split "`n"
+    $allFailures = @()
+    $currentFailure = @()
+    $inFailure = $false
+    $emptyLineCount = 0
+    $failureCount = 0
+
+    # Expanded failure detection patterns
+    # CAUTION: These trigger "failure block" capture. Overly broad patterns (e.g. \w+Error:)
+    # will grab Python harness/reporter noise and swamp the real test failure.
+    $failureStartPatterns = @(
+        '\[FAIL\]',
+        'Assert\.\w+\(\)\s+Failure',
+        'Expected:.*but was:',
+        'BUG:',
+        'FAILED\s*$',
+        'END EXECUTION - FAILED',
+        'System\.\w+Exception:',
+        'Timed Out \(timeout'
+    )
+    $combinedPattern = ($failureStartPatterns -join '|')
+
+    foreach ($line in $lines) {
+        # Check for new failure start
+        if ($line -match $combinedPattern) {
+            # Save previous failure if exists
+            if ($currentFailure.Count -gt 0) {
+                $allFailures += ($currentFailure -join "`n")
+                $failureCount++
+                if ($failureCount -ge $MaxFailures) {
+                    break
+                }
+            }
+            # Start new failure
+            $currentFailure = @($line)
+            $inFailure = $true
+            $emptyLineCount = 0
+            continue
+        }
+
+        if ($inFailure) {
+            $currentFailure += $line
+
+            # Track consecutive empty lines to detect end of stack trace
+            if ($line -match '^\s*$') {
+                $emptyLineCount++
+            }
+            else {
+                $emptyLineCount = 0
+            }
+
+            # Stop this failure after stack trace ends (2+ consecutive empty lines) or max lines reached
+            if ($emptyLineCount -ge 2 -or $currentFailure.Count -ge $MaxLines) {
+                $allFailures += ($currentFailure -join "`n")
+                $currentFailure = @()
+                $inFailure = $false
+                $failureCount++
+                if ($failureCount -ge $MaxFailures) {
+                    break
+                }
+            }
+        }
+    }
+
+    # Don't forget last failure
+    if ($currentFailure.Count -gt 0 -and $failureCount -lt $MaxFailures) {
+        $allFailures += ($currentFailure -join "`n")
+    }
+
+    if ($allFailures.Count -eq 0) {
+        return $null
+    }
+
+    $result = $allFailures -join "`n`n--- Next Failure ---`n`n"
+
+    if ($failureCount -ge $MaxFailures) {
+        $result += "`n`n... (more failures exist, showing first $MaxFailures)"
+    }
+
+    return $result
+}
+
+# Helper to display test results from a test run
+function Show-TestRunResults {
+    param(
+        [object[]]$TestRunUrls,
+        [string]$Org = "https://dev.azure.com/$Organization"
+    )
+
+    if (-not $TestRunUrls -or $TestRunUrls.Count -eq 0) { return }
+
+    Write-Host "`n  Test Results:" -ForegroundColor Yellow
+    foreach ($testRun in $TestRunUrls) {
+        Write-Host "    Run $($testRun.RunId): $($testRun.Url)" -ForegroundColor Gray
+
+        $testResults = Get-AzDOTestResults -RunId $testRun.RunId -Org $Org
+        if ($testResults -and $testResults.Count -gt 0) {
+            Write-Host "`n    Failed tests ($($testResults.Count)):" -ForegroundColor Red
+            foreach ($result in $testResults | Select-Object -First 10) {
+                Write-Host "      - $($result.name)" -ForegroundColor White
+            }
+            if ($testResults.Count -gt 10) {
+                Write-Host "      ... and $($testResults.Count - 10) more" -ForegroundColor Gray
+            }
+        }
+    }
+}
+
+#endregion Output Formatting
+
+#region Main Execution
+
+# Main execution
+try {
+    # Handle direct Helix job query
+    if ($PSCmdlet.ParameterSetName -eq 'HelixJob') {
+        Write-Host "`n=== Helix Job $HelixJob ===" -ForegroundColor Yellow
+        Write-Host "URL: https://helix.dot.net/api/2019-06-17/jobs/$HelixJob" -ForegroundColor Gray
+
+        # Get job details
+        $jobDetails = Get-HelixJobDetails -JobId $HelixJob
+        if ($jobDetails) {
+            Write-Host "`nQueue: $($jobDetails.QueueId)" -ForegroundColor Cyan
+            Write-Host "Source: $($jobDetails.Source)" -ForegroundColor Cyan
+        }
+
+        if ($WorkItem) {
+            # Query specific work item
+            Write-Host "`n--- Work Item: $WorkItem ---" -ForegroundColor Cyan
+
+            $workItemDetails = Get-HelixWorkItemDetails -JobId $HelixJob -WorkItemName $WorkItem
+            if ($workItemDetails) {
+                Write-Host "  State: $($workItemDetails.State)" -ForegroundColor $(if ($workItemDetails.State -eq 'Passed') { 'Green' } else { 'Red' })
+                Write-Host "  Exit Code: $($workItemDetails.ExitCode)" -ForegroundColor White
+                Write-Host "  Machine: $($workItemDetails.MachineName)" -ForegroundColor Gray
+                Write-Host "  Duration: $($workItemDetails.Duration)" -ForegroundColor Gray
+
+                # Show artifacts with binlogs highlighted
+                if ($workItemDetails.Files -and $workItemDetails.Files.Count -gt 0) {
+                    Write-Host "`n  Artifacts:" -ForegroundColor Yellow
+                    $binlogs = $workItemDetails.Files | Where-Object { $_.FileName -like "*.binlog" }
+                    $otherFiles = $workItemDetails.Files | Where-Object { $_.FileName -notlike "*.binlog" }
+
+                    # Show binlogs first with special formatting
+                    foreach ($file in $binlogs | Select-Object -Unique FileName, Uri) {
+                        Write-Host "    📋 $($file.FileName): $($file.Uri)" -ForegroundColor Cyan
+                    }
+                    if ($binlogs.Count -gt 0) {
+                        Write-Host "    (Tip: Use MSBuild MCP server or https://live.msbuildlog.com/ to analyze binlogs)" -ForegroundColor DarkGray
+                    }
+
+                    # Show other files
+                    foreach ($file in $otherFiles | Select-Object -Unique FileName, Uri | Select-Object -First 10) {
+                        Write-Host "    $($file.FileName): $($file.Uri)" -ForegroundColor Gray
+                    }
+                }
+
+                # Fetch console log
+                $escapedWorkItem = [uri]::EscapeDataString($WorkItem)
+                $consoleUrl = "https://helix.dot.net/api/2019-06-17/jobs/$HelixJob/workitems/$escapedWorkItem/console"
+                Write-Host "`n  Console Log: $consoleUrl" -ForegroundColor Yellow
+
+                $consoleLog = Get-HelixConsoleLog -Url $consoleUrl
+                if ($consoleLog) {
+                    $failureInfo = Format-TestFailure -LogContent $consoleLog
+                    if ($failureInfo) {
+                        Write-Host $failureInfo -ForegroundColor White
+
+                        # Search for known issues
+                        Show-KnownIssues -TestName $WorkItem -ErrorMessage $failureInfo -IncludeMihuBot:$SearchMihuBot
+                    }
+                    else {
+                        # Show last 50 lines if no failure pattern detected
+                        $lines = $consoleLog -split "`n"
+                        $lastLines = $lines | Select-Object -Last 50
+                        Write-Host ($lastLines -join "`n") -ForegroundColor White
+                    }
+                }
+            }
+        }
+        else {
+            # List all work items in the job
+            Write-Host "`nWork Items:" -ForegroundColor Yellow
+            $workItems = Get-HelixWorkItems -JobId $HelixJob
+            if ($workItems) {
+                Write-Host "  Total: $($workItems.Count)" -ForegroundColor Cyan
+                Write-Host "  Checking for failures..." -ForegroundColor Gray
+
+                # Need to fetch details for each to find failures (list API only shows 'Finished')
+                $failedItems = @()
+                foreach ($wi in $workItems | Select-Object -First 20) {
+                    $details = Get-HelixWorkItemDetails -JobId $HelixJob -WorkItemName $wi.Name
+                    if ($details -and $null -ne $details.ExitCode -and $details.ExitCode -ne 0) {
+                        $failedItems += @{
+                            Name = $wi.Name
+                            ExitCode = $details.ExitCode
+                            State = $details.State
+                        }
+                    }
+                }
+
+                if ($failedItems.Count -gt 0) {
+                    Write-Host "`n  Failed Work Items:" -ForegroundColor Red
+                    foreach ($wi in $failedItems | Select-Object -First $MaxJobs) {
+                        Write-Host "    - $($wi.Name) (Exit: $($wi.ExitCode))" -ForegroundColor White
+                    }
+                    Write-Host "`n  Use -WorkItem '<name>' to see details" -ForegroundColor Gray
+                }
+                else {
+                    Write-Host "  No failures found in first 20 work items" -ForegroundColor Green
+                }
+
+                Write-Host "`n  All work items:" -ForegroundColor Yellow
+                foreach ($wi in $workItems | Select-Object -First 10) {
+                    Write-Host "    - $($wi.Name)" -ForegroundColor White
+                }
+                if ($workItems.Count -gt 10) {
+                    Write-Host "    ... and $($workItems.Count - 10) more" -ForegroundColor Gray
+                }
+
+                # Find work items with binlogs if requested
+                if ($FindBinlogs) {
+                    Write-Host "`n  === Binlog Search ===" -ForegroundColor Yellow
+                    $binlogResults = Find-WorkItemsWithBinlogs -JobId $HelixJob -MaxItems 30 -IncludeDetails
+
+                    if ($binlogResults.Count -gt 0) {
+                        Write-Host "`n  Work items with binlogs:" -ForegroundColor Cyan
+                        foreach ($result in $binlogResults) {
+                            $stateColor = if ($result.ExitCode -eq 0) { 'Green' } else { 'Red' }
+                            Write-Host "    $($result.Name)" -ForegroundColor $stateColor
+                            Write-Host "      Binlogs ($($result.BinlogCount)):" -ForegroundColor Gray
+                            foreach ($binlog in $result.Binlogs | Select-Object -First 5) {
+                                Write-Host "        - $binlog" -ForegroundColor White
+                            }
+                            if ($result.Binlogs.Count -gt 5) {
+                                Write-Host "        ... and $($result.Binlogs.Count - 5) more" -ForegroundColor DarkGray
+                            }
+                        }
+                        Write-Host "`n  Tip: Use -WorkItem '<name>' to get full binlog URIs" -ForegroundColor DarkGray
+                    }
+                    else {
+                        Write-Host "  No binlogs found in scanned work items." -ForegroundColor Yellow
+                        Write-Host "  This job may contain only unit tests (which don't produce binlogs)." -ForegroundColor Gray
+                    }
+                }
+            }
+        }
+
+        exit 0
+    }
+
+    # Get build ID(s) if using PR number
+    $buildIds = @()
+    $knownIssuesFromBuildAnalysis = @()
+    $prChangedFiles = @()
+    $noBuildReason = $null
+    if ($PSCmdlet.ParameterSetName -eq 'PRNumber') {
+        $buildResult = Get-AzDOBuildIdFromPR -PR $PRNumber
+        if ($buildResult.Reason) {
+            # No builds found — emit summary with reason and exit
+            $noBuildReason = $buildResult.Reason
+            $buildIds = @()
+            $summary = [ordered]@{
+                mode = "PRNumber"
+                repository = $Repository
+                prNumber = $PRNumber
+                builds = @()
+                totalFailedJobs = 0
+                totalLocalFailures = 0
+                lastBuildJobSummary = [ordered]@{
+                    total = 0; succeeded = 0; failed = 0; canceled = 0; pending = 0; warnings = 0; skipped = 0
+                }
+                failedJobNames = @()
+                failedJobDetails = @()
+                canceledJobNames = @()
+                knownIssues = @()
+                prCorrelation = [ordered]@{
+                    changedFileCount = 0
+                    hasCorrelation = $false
+                    correlatedFiles = @()
+                }
+                recommendationHint = if ($noBuildReason -eq "MERGE_CONFLICTS") { "MERGE_CONFLICTS" } else { "NO_BUILDS" }
+                noBuildReason = $noBuildReason
+                mergeState = $buildResult.MergeState
+            }
+            Write-Host ""
+            Write-Host "[CI_ANALYSIS_SUMMARY]"
+            Write-Host ($summary | ConvertTo-Json -Depth 5)
+            Write-Host "[/CI_ANALYSIS_SUMMARY]"
+            exit 0
+        }
+        $buildIds = @($buildResult.BuildIds)
+
+        # Check Build Analysis for known issues
+        $knownIssuesFromBuildAnalysis = @(Get-BuildAnalysisKnownIssues -PR $PRNumber)
+
+        # Get changed files for correlation
+        $prChangedFiles = @(Get-PRChangedFiles -PR $PRNumber)
+        if ($prChangedFiles.Count -gt 0) {
+            Write-Verbose "PR has $($prChangedFiles.Count) changed files"
+        }
+    }
+    else {
+        $buildIds = @($BuildId)
+    }
+
+    # Process each build
+    $totalFailedJobs = 0
+    $totalLocalFailures = 0
+    $allFailuresForCorrelation = @()
+    $allFailedJobNames = @()
+    $allCanceledJobNames = @()
+    $allFailedJobDetails = @()
+    $lastBuildJobSummary = $null
+
+    foreach ($currentBuildId in $buildIds) {
+        Write-Host "`n=== Azure DevOps Build $currentBuildId ===" -ForegroundColor Yellow
+        Write-Host "URL: https://dev.azure.com/$Organization/$Project/_build/results?buildId=$currentBuildId" -ForegroundColor Gray
+
+        # Get and display build status
+        $buildStatus = Get-AzDOBuildStatus -Build $currentBuildId
+        if ($buildStatus) {
+            $statusColor = switch ($buildStatus.Status) {
+                "inProgress" { "Cyan" }
+                "completed" { if ($buildStatus.Result -eq "succeeded") { "Green" } else { "Red" } }
+                default { "Gray" }
+            }
+            $statusText = $buildStatus.Status
+            if ($buildStatus.Status -eq "completed" -and $buildStatus.Result) {
+                $statusText = "$($buildStatus.Status) ($($buildStatus.Result))"
+            }
+            elseif ($buildStatus.Status -eq "inProgress") {
+                $statusText = "IN PROGRESS - showing failures so far"
+            }
+            Write-Host "Status: $statusText" -ForegroundColor $statusColor
+        }
+
+        # Get timeline
+        $isInProgress = $buildStatus -and $buildStatus.Status -eq "inProgress"
+        $timeline = Get-AzDOTimeline -Build $currentBuildId -BuildInProgress:$isInProgress
+
+        # Handle timeline fetch failure
+        if (-not $timeline) {
+            Write-Host "`nCould not fetch build timeline" -ForegroundColor Red
+            Write-Host "Build URL: https://dev.azure.com/$Organization/$Project/_build/results?buildId=$currentBuildId" -ForegroundColor Gray
+            continue
+        }
+
+        # Get failed jobs
+        $failedJobs = Get-FailedJobs -Timeline $timeline
+
+        # Get canceled jobs (different from failed - typically due to dependency failures)
+        $canceledJobs = Get-CanceledJobs -Timeline $timeline
+
+        # Also check for local test failures (non-Helix)
+        $localTestFailures = Get-LocalTestFailures -Timeline $timeline -BuildId $currentBuildId
+
+        # Accumulate totals and compute job summary BEFORE any continue branches
+        $totalFailedJobs += $failedJobs.Count
+        $totalLocalFailures += $localTestFailures.Count
+        $allFailedJobNames += @($failedJobs | ForEach-Object { $_.name })
+        $allCanceledJobNames += @($canceledJobs | ForEach-Object { $_.name })
+
+        $allJobs = @()
+        $succeededJobs = 0
+        $pendingJobs = 0
+        $canceledJobCount = 0
+        $skippedJobs = 0
+        $warningJobs = 0
+        if ($timeline -and $timeline.records) {
+            $allJobs = @($timeline.records | Where-Object { $_.type -eq "Job" })
+            $succeededJobs = @($allJobs | Where-Object { $_.result -eq "succeeded" }).Count
+            $warningJobs = @($allJobs | Where-Object { $_.result -eq "succeededWithIssues" }).Count
+            $pendingJobs = @($allJobs | Where-Object { -not $_.result -or $_.state -eq "pending" -or $_.state -eq "inProgress" }).Count
+            $canceledJobCount = @($allJobs | Where-Object { $_.result -eq "canceled" }).Count
+            $skippedJobs = @($allJobs | Where-Object { $_.result -eq "skipped" }).Count
+        }
+        $lastBuildJobSummary = [ordered]@{
+            total = $allJobs.Count
+            succeeded = $succeededJobs
+            failed = if ($failedJobs) { $failedJobs.Count } else { 0 }
+            canceled = $canceledJobCount
+            pending = $pendingJobs
+            warnings = $warningJobs
+            skipped = $skippedJobs
+        }
+
+        if ((-not $failedJobs -or $failedJobs.Count -eq 0) -and $localTestFailures.Count -eq 0) {
+            if ($buildStatus -and $buildStatus.Status -eq "inProgress") {
+                Write-Host "`nNo failures yet - build still in progress" -ForegroundColor Cyan
+                Write-Host "Run again later to check for failures, or use -NoCache to get fresh data" -ForegroundColor Gray
+            }
+            else {
+                Write-Host "`nNo failed jobs found in build $currentBuildId" -ForegroundColor Green
+            }
+            # Still show canceled jobs if any
+            if ($canceledJobs -and $canceledJobs.Count -gt 0) {
+                Write-Host "`nNote: $($canceledJobs.Count) job(s) were canceled (not failed):" -ForegroundColor DarkYellow
+                foreach ($job in $canceledJobs | Select-Object -First 5) {
+                    Write-Host "  - $($job.name)" -ForegroundColor DarkGray
+                }
+                if ($canceledJobs.Count -gt 5) {
+                    Write-Host "  ... and $($canceledJobs.Count - 5) more" -ForegroundColor DarkGray
+                }
+                Write-Host "  (Canceled jobs are typically due to earlier stage failures or timeouts)" -ForegroundColor DarkGray
+            }
+            continue
+        }
+
+        # Report local test failures first (these may exist even without failed jobs)
+        if ($localTestFailures.Count -gt 0) {
+            Write-Host "`n=== Local Test Failures (non-Helix) ===" -ForegroundColor Yellow
+            Write-Host "Build: https://dev.azure.com/$Organization/$Project/_build/results?buildId=$currentBuildId" -ForegroundColor Gray
+
+            foreach ($failure in $localTestFailures) {
+                Write-Host "`n--- $($failure.TaskName) ---" -ForegroundColor Cyan
+
+                # Collect issues for correlation
+                $issueMessages = $failure.Issues | ForEach-Object { $_.message }
+                $allFailuresForCorrelation += @{
+                    TaskName = $failure.TaskName
+                    JobName = "Local Test"
+                    Errors = $issueMessages
+                    HelixLogs = @()
+                    FailedTests = @()
+                }
+
+                # Show build and log links
+                $jobLogUrl = "https://dev.azure.com/$Organization/$Project/_build/results?buildId=$currentBuildId&view=logs&j=$($failure.ParentJobId)"
+                if ($failure.TaskId) {
+                    $jobLogUrl += "&t=$($failure.TaskId)"
+                }
+                Write-Host "  Log: $jobLogUrl" -ForegroundColor Gray
+
+                # Show issues
+                foreach ($issue in $failure.Issues) {
+                    Write-Host "  $($issue.message)" -ForegroundColor Red
+                }
+
+                # Show test run URLs if available
+                if ($failure.TestRunUrls.Count -gt 0) {
+                    Show-TestRunResults -TestRunUrls $failure.TestRunUrls -Org "https://dev.azure.com/$Organization"
+                }
+
+                # Try to get more details from the task log
+                if ($failure.LogId) {
+                    $logContent = Get-BuildLog -Build $currentBuildId -LogId $failure.LogId
+                    if ($logContent) {
+                        # Extract test run URLs from this log too
+                        $additionalRuns = Extract-TestRunUrls -LogContent $logContent
+                        if ($additionalRuns.Count -gt 0 -and $failure.TestRunUrls.Count -eq 0) {
+                            Show-TestRunResults -TestRunUrls $additionalRuns -Org "https://dev.azure.com/$Organization"
+                        }
+
+                        # Search for known issues based on build errors and task name
+                        $buildErrors = Extract-BuildErrors -LogContent $logContent
+                        if ($buildErrors.Count -gt 0) {
+                            Show-KnownIssues -ErrorMessage ($buildErrors -join "`n") -IncludeMihuBot:$SearchMihuBot
+                        }
+                        elseif ($failure.TaskName) {
+                            # If no specific errors, try searching by task name
+                            Show-KnownIssues -TestName $failure.TaskName -IncludeMihuBot:$SearchMihuBot
+                        }
+                    }
+                }
+            }
+        }
+
+        if (-not $failedJobs -or $failedJobs.Count -eq 0) {
+            Write-Host "`n=== Summary ===" -ForegroundColor Yellow
+            Write-Host "Local test failures: $($localTestFailures.Count)" -ForegroundColor Red
+            Write-Host "Build URL: https://dev.azure.com/$Organization/$Project/_build/results?buildId=$currentBuildId" -ForegroundColor Cyan
+            continue
+        }
+
+        Write-Host "`nFound $($failedJobs.Count) failed job(s):" -ForegroundColor Red
+
+        # Show canceled jobs if any (these are different from failed)
+        if ($canceledJobs -and $canceledJobs.Count -gt 0) {
+            Write-Host "Also $($canceledJobs.Count) job(s) were canceled (due to earlier failures/timeouts):" -ForegroundColor DarkYellow
+            foreach ($job in $canceledJobs | Select-Object -First 3) {
+                Write-Host "  - $($job.name)" -ForegroundColor DarkGray
+            }
+            if ($canceledJobs.Count -gt 3) {
+                Write-Host "  ... and $($canceledJobs.Count - 3) more" -ForegroundColor DarkGray
+            }
+        }
+
+        $processedJobs = 0
+        $errorCount = 0
+        foreach ($job in $failedJobs) {
+            if ($processedJobs -ge $MaxJobs) {
+                Write-Host "`n... and $($failedJobs.Count - $MaxJobs) more failed jobs (use -MaxJobs to see more)" -ForegroundColor Yellow
+                break
+            }
+
+            try {
+                Write-Host "`n--- $($job.name) ---" -ForegroundColor Cyan
+                Write-Host "  Build: https://dev.azure.com/$Organization/$Project/_build/results?buildId=$currentBuildId&view=logs&j=$($job.id)" -ForegroundColor Gray
+
+                # Track per-job failure details for JSON summary
+                $jobDetail = [ordered]@{
+                    jobName = $job.name
+                    buildId = $currentBuildId
+                    errorSnippet = ""
+                    helixWorkItems = @()
+                    errorCategory = "unclassified"
+                }
+
+                # Get Helix tasks for this job
+                $helixTasks = Get-HelixJobInfo -Timeline $timeline -JobId $job.id
+
+                if ($helixTasks) {
+                    foreach ($task in $helixTasks) {
+                        if ($task.log) {
+                            Write-Host "  Fetching Helix task log..." -ForegroundColor Gray
+                            $logContent = Get-BuildLog -Build $currentBuildId -LogId $task.log.id
+
+                            if ($logContent) {
+                                # Extract test failures
+                                $failures = Extract-TestFailures -LogContent $logContent
+
+                                if ($failures.Count -gt 0) {
+                                    Write-Host "  Failed tests:" -ForegroundColor Red
+                                    foreach ($failure in $failures) {
+                                        Write-Host "    - $($failure.TestName)" -ForegroundColor White
+                                    }
+
+                                    # Collect for PR correlation
+                                    $allFailuresForCorrelation += @{
+                                        TaskName = $task.name
+                                        JobName = $job.name
+                                        Errors = @()
+                                        HelixLogs = @()
+                                        FailedTests = $failures | ForEach-Object { $_.TestName }
+                                    }
+                                    $jobDetail.errorCategory = "test-failure"
+                                    $jobDetail.errorSnippet = ($failures | Select-Object -First 3 | ForEach-Object { $_.TestName }) -join "; "
+                                }
+
+                            # Extract and optionally fetch Helix URLs
+                            $helixUrls = Extract-HelixUrls -LogContent $logContent
+
+                            if ($helixUrls.Count -gt 0 -and $ShowLogs) {
+                                Write-Host "`n  Helix Console Logs:" -ForegroundColor Yellow
+
+                                foreach ($url in $helixUrls | Select-Object -First 3) {
+                                    Write-Host "`n  $url" -ForegroundColor Gray
+
+                                    # Extract work item name from URL for known issue search
+                                    $workItemName = ""
+                                    if ($url -match '/workitems/([^/]+)/console') {
+                                        $workItemName = $Matches[1]
+                                        $jobDetail.helixWorkItems += $workItemName
+                                    }
+
+                                    $helixLog = Get-HelixConsoleLog -Url $url
+                                    if ($helixLog) {
+                                        $failureInfo = Format-TestFailure -LogContent $helixLog
+                                        if ($failureInfo) {
+                                            Write-Host $failureInfo -ForegroundColor White
+
+                                            # Categorize failure from log content
+                                            if ($failureInfo -match 'Timed Out \(timeout') {
+                                                $jobDetail.errorCategory = "test-timeout"
+                                            } elseif ($failureInfo -match 'Exit Code:\s*(139|134|-4)' -or $failureInfo -match 'createdump') {
+                                                # Crash takes highest precedence — don't downgrade
+                                                if ($jobDetail.errorCategory -notin @("crash")) {
+                                                    $jobDetail.errorCategory = "crash"
+                                                }
+                                            } elseif ($failureInfo -match 'Traceback \(most recent call last\)' -and $helixLog -match 'Tests run:.*Failures:\s*0') {
+                                                # Work item failed (non-zero exit from reporter crash) but all tests passed.
+                                                # The Python traceback is from Helix infrastructure, not from the test itself.
+                                                if ($jobDetail.errorCategory -notin @("crash", "test-timeout")) {
+                                                    $jobDetail.errorCategory = "tests-passed-reporter-failed"
+                                                }
+                                            } elseif ($jobDetail.errorCategory -eq "unclassified") {
+                                                $jobDetail.errorCategory = "test-failure"
+                                            }
+                                            if (-not $jobDetail.errorSnippet) {
+                                                $jobDetail.errorSnippet = $failureInfo.Substring(0, [Math]::Min(200, $failureInfo.Length))
+                                            }
+
+                                            # Search for known issues
+                                            Show-KnownIssues -TestName $workItemName -ErrorMessage $failureInfo -IncludeMihuBot:$SearchMihuBot
+                                        }
+                                        else {
+                                            # No failure pattern matched — show tail of log
+                                            $lines = $helixLog -split "`n"
+                                            $lastLines = $lines | Select-Object -Last 20
+                                            $tailText = $lastLines -join "`n"
+                                            Write-Host $tailText -ForegroundColor White
+                                            if (-not $jobDetail.errorSnippet) {
+                                                $jobDetail.errorSnippet = $tailText.Substring(0, [Math]::Min(200, $tailText.Length))
+                                            }
+                                            Show-KnownIssues -TestName $workItemName -ErrorMessage $tailText -IncludeMihuBot:$SearchMihuBot
+                                        }
+                                    }
+                                }
+                            }
+                            elseif ($helixUrls.Count -gt 0) {
+                                Write-Host "`n  Helix logs available (use -ShowLogs to fetch):" -ForegroundColor Yellow
+                                foreach ($url in $helixUrls | Select-Object -First 3) {
+                                    Write-Host "    $url" -ForegroundColor Gray
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+                else {
+                    # No Helix tasks - this is a build failure, extract actual errors
+                    $buildTasks = $timeline.records | Where-Object {
+                        $_.parentId -eq $job.id -and $_.result -eq "failed"
+                    }
+
+                    foreach ($task in $buildTasks | Select-Object -First 3) {
+                        Write-Host "  Failed task: $($task.name)" -ForegroundColor Red
+
+                        # Fetch and parse the build log for actual errors
+                        if ($task.log) {
+                            $logUrl = "https://dev.azure.com/$Organization/$Project/_build/results?buildId=$currentBuildId&view=logs&j=$($job.id)&t=$($task.id)"
+                            Write-Host "  Log: $logUrl" -ForegroundColor Gray
+                            $logContent = Get-BuildLog -Build $currentBuildId -LogId $task.log.id
+
+                            if ($logContent) {
+                                $buildErrors = Extract-BuildErrors -LogContent $logContent
+
+                                if ($buildErrors.Count -gt 0) {
+                                    # Collect for PR correlation
+                                    $allFailuresForCorrelation += @{
+                                        TaskName = $task.name
+                                        JobName = $job.name
+                                        Errors = $buildErrors
+                                        HelixLogs = @()
+                                        FailedTests = @()
+                                    }
+                                    $jobDetail.errorCategory = "build-error"
+                                    if (-not $jobDetail.errorSnippet) {
+                                        $snippet = ($buildErrors | Select-Object -First 2) -join "; "
+                                        $jobDetail.errorSnippet = $snippet.Substring(0, [Math]::Min(200, $snippet.Length))
+                                    }
+
+                                    # Extract Helix log URLs from the full log content
+                                    $helixLogUrls = Extract-HelixLogUrls -LogContent $logContent
+
+                                    if ($helixLogUrls.Count -gt 0) {
+                                        Write-Host "  Helix failures ($($helixLogUrls.Count)):" -ForegroundColor Red
+                                        foreach ($helixLog in $helixLogUrls | Select-Object -First 5) {
+                                            Write-Host "    - $($helixLog.WorkItem)" -ForegroundColor White
+                                            Write-Host "      Log: $($helixLog.Url)" -ForegroundColor Gray
+                                        }
+                                        if ($helixLogUrls.Count -gt 5) {
+                                            Write-Host "    ... and $($helixLogUrls.Count - 5) more" -ForegroundColor Gray
+                                        }
+                                    }
+                                    else {
+                                        Write-Host "  Build errors:" -ForegroundColor Red
+                                        foreach ($err in $buildErrors | Select-Object -First 5) {
+                                            Write-Host "    $err" -ForegroundColor White
+                                        }
+                                        if ($buildErrors.Count -gt 5) {
+                                            Write-Host "    ... and $($buildErrors.Count - 5) more errors" -ForegroundColor Gray
+                                        }
+                                    }
+
+                                    # Search for known issues
+                                    Show-KnownIssues -ErrorMessage ($buildErrors -join "`n") -IncludeMihuBot:$SearchMihuBot
+                                }
+                                else {
+                                    Write-Host "  (No specific errors extracted from log)" -ForegroundColor Gray
+                                }
+                            }
+                        }
+                    }
+                }
+
+            $allFailedJobDetails += $jobDetail
+            $processedJobs++
+        }
+        catch {
+            $errorCount++
+            if ($ContinueOnError) {
+                Write-Warning "  Error processing job '$($job.name)': $_"
+            }
+            else {
+                throw [System.Exception]::new("Error processing job '$($job.name)': $($_.Exception.Message)", $_.Exception)
+            }
+        }
+    }
+
+    Write-Host "`n=== Build $currentBuildId Summary ===" -ForegroundColor Yellow
+    if ($allJobs.Count -gt 0) {
+        $parts = @()
+        if ($succeededJobs -gt 0) { $parts += "$succeededJobs passed" }
+        if ($warningJobs -gt 0) { $parts += "$warningJobs passed with warnings" }
+        if ($failedJobs.Count -gt 0) { $parts += "$($failedJobs.Count) failed" }
+        if ($canceledJobCount -gt 0) { $parts += "$canceledJobCount canceled" }
+        if ($skippedJobs -gt 0) { $parts += "$skippedJobs skipped" }
+        if ($pendingJobs -gt 0) { $parts += "$pendingJobs pending" }
+        $jobSummary = $parts -join ", "
+        $allSucceeded = ($failedJobs.Count -eq 0 -and $pendingJobs -eq 0 -and $canceledJobCount -eq 0 -and ($succeededJobs + $warningJobs + $skippedJobs) -eq $allJobs.Count)
+        $summaryColor = if ($allSucceeded) { "Green" } elseif ($failedJobs.Count -gt 0) { "Red" } else { "Cyan" }
+        Write-Host "Jobs: $($allJobs.Count) total ($jobSummary)" -ForegroundColor $summaryColor
+    }
+    else {
+        Write-Host "Failed jobs: $($failedJobs.Count)" -ForegroundColor Red
+    }
+    if ($localTestFailures.Count -gt 0) {
+        Write-Host "Local test failures: $($localTestFailures.Count)" -ForegroundColor Red
+    }
+    if ($errorCount -gt 0) {
+        Write-Host "API errors (partial results): $errorCount" -ForegroundColor Yellow
+    }
+    Write-Host "Build URL: https://dev.azure.com/$Organization/$Project/_build/results?buildId=$currentBuildId" -ForegroundColor Cyan
+}
+
+# Show PR change correlation if we have changed files
+if ($prChangedFiles.Count -gt 0 -and $allFailuresForCorrelation.Count -gt 0) {
+    Show-PRCorrelationSummary -ChangedFiles $prChangedFiles -AllFailures $allFailuresForCorrelation
+}
+
+# Overall summary if multiple builds
+if ($buildIds.Count -gt 1) {
+    Write-Host "`n=== Overall Summary ===" -ForegroundColor Magenta
+    Write-Host "Analyzed $($buildIds.Count) builds" -ForegroundColor White
+    Write-Host "Total failed jobs: $totalFailedJobs" -ForegroundColor Red
+    Write-Host "Total local test failures: $totalLocalFailures" -ForegroundColor Red
+
+    if ($knownIssuesFromBuildAnalysis.Count -gt 0) {
+        Write-Host "`nKnown Issues (from Build Analysis):" -ForegroundColor Yellow
+        foreach ($issue in $knownIssuesFromBuildAnalysis) {
+            Write-Host "  - #$($issue.Number): $($issue.Title)" -ForegroundColor Gray
+            Write-Host "    $($issue.Url)" -ForegroundColor DarkGray
+        }
+    }
+}
+
+# Build structured summary and emit as JSON
+$summary = [ordered]@{
+    mode = $PSCmdlet.ParameterSetName
+    repository = $Repository
+    prNumber = if ($PSCmdlet.ParameterSetName -eq 'PRNumber') { $PRNumber } else { $null }
+    builds = @($buildIds | ForEach-Object {
+        [ordered]@{
+            buildId = $_
+            url = "https://dev.azure.com/$Organization/$Project/_build/results?buildId=$_"
+        }
+    })
+    totalFailedJobs = $totalFailedJobs
+    totalLocalFailures = $totalLocalFailures
+    lastBuildJobSummary = if ($lastBuildJobSummary) { $lastBuildJobSummary } else { [ordered]@{
+        total = 0; succeeded = 0; failed = 0; canceled = 0; pending = 0; warnings = 0; skipped = 0
+    } }
+    failedJobNames = @($allFailedJobNames)
+    failedJobDetails = @($allFailedJobDetails)
+    failedJobDetailsTruncated = ($allFailedJobNames.Count -gt $allFailedJobDetails.Count)
+    canceledJobNames = @($allCanceledJobNames)
+    knownIssues = @($knownIssuesFromBuildAnalysis | ForEach-Object {
+        [ordered]@{ number = $_.Number; title = $_.Title; url = $_.Url }
+    })
+    prCorrelation = [ordered]@{
+        changedFileCount = $prChangedFiles.Count
+        hasCorrelation = $false
+        correlatedFiles = @()
+    }
+    recommendationHint = ""
+}
+
+# Compute PR correlation using shared helper
+if ($prChangedFiles.Count -gt 0 -and $allFailuresForCorrelation.Count -gt 0) {
+    $correlation = Get-PRCorrelation -ChangedFiles $prChangedFiles -AllFailures $allFailuresForCorrelation
+    $allCorrelated = @($correlation.CorrelatedFiles) + @($correlation.TestFiles) | Select-Object -Unique
+    $summary.prCorrelation.hasCorrelation = $allCorrelated.Count -gt 0
+    $summary.prCorrelation.correlatedFiles = @($allCorrelated)
+}
+
+# Compute recommendation hint
+# Priority: KNOWN_ISSUES wins over LIKELY_PR_RELATED intentionally.
+# When both exist, SKILL.md "Mixed signals" guidance tells the agent to separate them.
+if (-not $lastBuildJobSummary -and $buildIds.Count -gt 0) {
+    $summary.recommendationHint = "REVIEW_REQUIRED"
+} elseif ($knownIssuesFromBuildAnalysis.Count -gt 0) {
+    $summary.recommendationHint = "KNOWN_ISSUES_DETECTED"
+} elseif ($totalFailedJobs -eq 0 -and $totalLocalFailures -eq 0) {
+    $summary.recommendationHint = "BUILD_SUCCESSFUL"
+} elseif ($summary.prCorrelation.hasCorrelation) {
+    $summary.recommendationHint = "LIKELY_PR_RELATED"
+} elseif ($prChangedFiles.Count -gt 0 -and $allFailuresForCorrelation.Count -gt 0) {
+    $summary.recommendationHint = "POSSIBLY_TRANSIENT"
+} else {
+    $summary.recommendationHint = "REVIEW_REQUIRED"
+}
+
+Write-Host ""
+Write-Host "[CI_ANALYSIS_SUMMARY]"
+Write-Host ($summary | ConvertTo-Json -Depth 5)
+Write-Host "[/CI_ANALYSIS_SUMMARY]"
+
+}
+catch {
+    Write-Error "Error: $_"
+    exit 1
+}
+
+#endregion Main Execution

--- a/.github/skills/ci-analysis/scripts/Test-KnownIssuePattern.ps1
+++ b/.github/skills/ci-analysis/scripts/Test-KnownIssuePattern.ps1
@@ -1,0 +1,308 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Validates a Known Build Error (KBE) ErrorMessage or ErrorPattern against a failure log
+    using the same matching logic as Build Analysis.
+
+.DESCRIPTION
+    Tests whether an ErrorMessage (String.Contains, case-sensitive) or ErrorPattern
+    (Regex with Singleline | IgnoreCase | NonBacktracking, 50ms timeout) would match
+    against the provided log content. Supports single-string and multi-line array matching.
+
+    Outputs PASS/FAIL, matched lines with line numbers, and a validated JSON blob ready
+    to paste into a Known Build Error GitHub issue.
+
+.PARAMETER ErrorMessage
+    String or string array for String.Contains matching (case-sensitive).
+    Use for exact substring matching. Cannot be combined with -ErrorPattern.
+
+.PARAMETER ErrorPattern
+    String or string array for regex matching.
+    Uses RegexOptions: Singleline, IgnoreCase, NonBacktracking with 50ms timeout.
+    Cannot be combined with -ErrorMessage.
+
+.PARAMETER LogFile
+    Path to a log file to test against. Cannot be combined with -LogContent.
+
+.PARAMETER LogContent
+    Log text string to test against. Cannot be combined with -LogFile.
+
+.PARAMETER BuildRetry
+    Whether Build Analysis should retry the build on match. Default: false.
+
+.PARAMETER ExcludeConsoleLog
+    Whether to exclude console logs from matching. Default: false.
+
+.EXAMPLE
+    ./Test-KnownIssuePattern.ps1 -ErrorMessage "Failed to retrieve information" -LogFile ./build.log
+
+.EXAMPLE
+    ./Test-KnownIssuePattern.ps1 -ErrorPattern "The command .+ failed" -LogContent "The command 'dotnet build' failed"
+
+.EXAMPLE
+    ./Test-KnownIssuePattern.ps1 -ErrorMessage "Assert.True() Failure","Actual:   False" -LogFile ./test.log
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string[]]$ErrorMessage,
+
+    [Parameter(Mandatory = $false)]
+    [string[]]$ErrorPattern,
+
+    [Parameter(Mandatory = $false)]
+    [string]$LogFile,
+
+    [Parameter(Mandatory = $false)]
+    [string]$LogContent,
+
+    [switch]$BuildRetry,
+
+    [switch]$ExcludeConsoleLog
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# --- Input validation ---
+
+if ($ErrorMessage -and $ErrorPattern) {
+    throw "Specify either -ErrorMessage or -ErrorPattern, not both."
+}
+
+if (-not $ErrorMessage -and -not $ErrorPattern) {
+    throw "Specify either -ErrorMessage or -ErrorPattern."
+}
+
+if ($LogFile -and $LogContent) {
+    throw "Specify either -LogFile or -LogContent, not both."
+}
+
+if (-not $LogFile -and -not $LogContent) {
+    throw "Specify either -LogFile or -LogContent."
+}
+
+$useRegex = [bool]$ErrorPattern
+$patterns = @(if ($useRegex) { $ErrorPattern } else { $ErrorMessage })
+
+for ($i = 0; $i -lt $patterns.Count; $i++) {
+    if ([string]::IsNullOrWhiteSpace($patterns[$i])) {
+        $parameterName = if ($useRegex) { 'ErrorPattern' } else { 'ErrorMessage' }
+        throw "-$parameterName contains a null, empty, or whitespace-only entry at position $i."
+    }
+}
+
+$isMultiLine = $patterns.Count -gt 1
+
+# Load log lines - use streaming for file input to avoid high memory usage on large logs
+if ($LogFile) {
+    if (-not (Test-Path $LogFile)) {
+        throw "Log file not found: $LogFile"
+    }
+    $resolvedPath = (Resolve-Path $LogFile).Path
+    if ((Get-Item $resolvedPath).Length -eq 0) {
+        throw "Log file is empty."
+    }
+    $logLineSource = [System.IO.File]::ReadLines($resolvedPath)
+} else {
+    $logLineSource = @($LogContent -split "\r?\n")
+    if ($logLineSource.Count -eq 0) {
+        throw "Log content is empty."
+    }
+}
+
+Write-Host "`nKnown Build Error Pattern Validator" -ForegroundColor Cyan
+Write-Host "===================================" -ForegroundColor Cyan
+Write-Host "Mode: $(if ($useRegex) { 'Regex (ErrorPattern)' } else { 'String (ErrorMessage)' })"
+Write-Host "Pattern count: $($patterns.Count) $(if ($isMultiLine) { '(multi-line AND matching)' } else { '(single-line)' })"
+Write-Host ""
+
+# --- Validate regex patterns ---
+
+if ($useRegex) {
+    $regexOptions = [System.Text.RegularExpressions.RegexOptions]::Singleline -bor
+                    [System.Text.RegularExpressions.RegexOptions]::IgnoreCase -bor
+                    [System.Text.RegularExpressions.RegexOptions]::NonBacktracking
+    $timeout = [TimeSpan]::FromMilliseconds(50)
+
+    $compiledRegexes = @()
+    for ($i = 0; $i -lt $patterns.Count; $i++) {
+        try {
+            $regex = [System.Text.RegularExpressions.Regex]::new($patterns[$i], $regexOptions, $timeout)
+            $compiledRegexes += $regex
+        } catch {
+            Write-Host "FAIL: Invalid regex at position $($i): $($patterns[$i])" -ForegroundColor Red
+            Write-Host "  Error: $_" -ForegroundColor Red
+            exit 1
+        }
+    }
+    Write-Host "Regex validation: OK" -ForegroundColor Green
+}
+
+# --- Matching logic (replicates Build Analysis) ---
+
+function Test-SingleLineMatch {
+    param([string]$line, [int]$patternIndex)
+
+    if ($useRegex) {
+        try {
+            return $compiledRegexes[$patternIndex].IsMatch($line)
+        } catch [System.Text.RegularExpressions.RegexMatchTimeoutException] {
+            Write-Verbose "Regex timeout on line (50ms exceeded)"
+            return $false
+        }
+    } else {
+        return $line.IndexOf($patterns[$patternIndex], [System.StringComparison]::Ordinal) -ge 0
+    }
+}
+
+$matchResults = [System.Collections.Generic.List[hashtable]]::new()
+$overallMatch = $false
+$totalLineCount = 0
+
+if (-not $isMultiLine) {
+    # Single pattern: stream lines and match each independently
+    foreach ($line in $logLineSource) {
+        $totalLineCount++
+        if (Test-SingleLineMatch -line $line -patternIndex 0) {
+            $matchResults.Add(@{
+                LineNumber   = $totalLineCount
+                LineContent  = $line.Trim()
+                PatternIndex = 0
+            })
+            $overallMatch = $true
+        }
+    }
+} else {
+    # Multi-line: single-pass state machine matching patterns in order (O(N))
+    $patternIdx = 0
+    $currentMatches = [System.Collections.Generic.List[hashtable]]::new()
+    foreach ($line in $logLineSource) {
+        $totalLineCount++
+        if (-not $overallMatch -and (Test-SingleLineMatch -line $line -patternIndex $patternIdx)) {
+            $currentMatches.Add(@{
+                LineNumber   = $totalLineCount
+                LineContent  = $line.Trim()
+                PatternIndex = $patternIdx
+            })
+            $patternIdx++
+            if ($patternIdx -eq $patterns.Count) {
+                $overallMatch = $true
+                foreach ($m in $currentMatches) { $matchResults.Add($m) }
+            }
+        }
+    }
+}
+
+Write-Host "Log lines processed: $totalLineCount"
+
+# --- Output results ---
+
+Write-Host ""
+if ($overallMatch) {
+    Write-Host "RESULT: PASS - Pattern matches the log" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "Matched lines:" -ForegroundColor Yellow
+    foreach ($match in $matchResults) {
+        $patternLabel = if ($isMultiLine) { " [pattern $($match.PatternIndex)]" } else { "" }
+        Write-Host "  Line $($match.LineNumber)${patternLabel}: $($match.LineContent)" -ForegroundColor Gray
+    }
+} else {
+    Write-Host "RESULT: FAIL - Pattern does not match the log" -ForegroundColor Red
+    Write-Host ""
+    if ($isMultiLine) {
+        Write-Host "Matched $patternIdx of $($patterns.Count) patterns. Stuck on pattern[$patternIdx]:" -ForegroundColor Yellow
+        Write-Host "  ``$($patterns[$patternIdx])``" -ForegroundColor Yellow
+        if ($currentMatches.Count -gt 0) {
+            Write-Host ""
+            Write-Host "Partial matches before failure:" -ForegroundColor Yellow
+            foreach ($m in $currentMatches) {
+                Write-Host "  pattern[$($m.PatternIndex)] matched line $($m.LineNumber): $($m.LineContent)" -ForegroundColor Gray
+            }
+        }
+        Write-Host ""
+        Write-Host "Possible causes:" -ForegroundColor Yellow
+        Write-Host "  - The substring does not appear in any log line" -ForegroundColor Yellow
+        Write-Host "  - It appears on a line already consumed by an earlier pattern (each element must match a *different* line)" -ForegroundColor Yellow
+    } else {
+        Write-Host "No log line contains the specified $(if ($useRegex) { 'pattern' } else { 'substring' })." -ForegroundColor Yellow
+    }
+    Write-Host ""
+    exit 1
+}
+
+# --- Broadness warning ---
+
+if (-not $isMultiLine -and $totalLineCount -gt 0) {
+    $matchRatio = $matchResults.Count / $totalLineCount
+    if ($matchRatio -gt 0.5) {
+        Write-Host ""
+        Write-Host "WARNING: Pattern matches $($matchResults.Count)/$($totalLineCount) lines ($([math]::Round($matchRatio * 100))%)." -ForegroundColor Red
+        Write-Host "  This pattern is too broad and will cause false positives." -ForegroundColor Red
+        Write-Host "  Add more specific text or use multi-line matching to narrow it down." -ForegroundColor Red
+    } elseif ($matchRatio -gt 0.1) {
+        Write-Host ""
+        Write-Host "NOTE: Pattern matches $($matchResults.Count) lines. Review matches to ensure they all represent the same error." -ForegroundColor Yellow
+    }
+}
+
+# --- Output validated JSON blob ---
+
+Write-Host ""
+Write-Host "Validated JSON blob:" -ForegroundColor Cyan
+Write-Host "--------------------" -ForegroundColor Cyan
+
+$jsonObj = [ordered]@{}
+if ($useRegex) {
+    if ($isMultiLine) {
+        $jsonObj["ErrorPattern"] = $patterns
+    } else {
+        $jsonObj["ErrorPattern"] = $patterns[0]
+    }
+} else {
+    if ($isMultiLine) {
+        $jsonObj["ErrorMessage"] = $patterns
+    } else {
+        $jsonObj["ErrorMessage"] = $patterns[0]
+    }
+}
+$jsonObj["BuildRetry"] = [bool]$BuildRetry
+$jsonObj["ExcludeConsoleLog"] = [bool]$ExcludeConsoleLog
+
+$jsonBlob = $jsonObj | ConvertTo-Json -Depth 3
+Write-Host $jsonBlob -ForegroundColor White
+
+# --- Output full issue template ---
+
+Write-Host ""
+Write-Host "Issue body template:" -ForegroundColor Cyan
+Write-Host "--------------------" -ForegroundColor Cyan
+
+# Build a code fence longer than any backtick sequence in the JSON to prevent markdown breakout
+$fenceLen = 3
+$backtickRuns = [regex]::Matches($jsonBlob, '`+')
+foreach ($run in $backtickRuns) {
+    if ($run.Length -ge $fenceLen) { $fenceLen = $run.Length + 1 }
+}
+$fence = '`' * $fenceLen
+
+$template = @(
+    "## Build Information"
+    "Build: <!-- Add link to the AzDO build -->"
+    "Leg Name: <!-- Add failing job name -->"
+    ""
+    "## Error Details"
+    "<!-- Paste the full stack trace or exception output below -->"
+    '```'
+    "<!-- Replace this line with the full error output -->"
+    '```'
+    ""
+    "## Error Message"
+    "${fence}json"
+    $jsonBlob
+    $fence
+) -join "`n"
+
+Write-Host $template -ForegroundColor White
+Write-Host ""

--- a/.github/skills/ci-crash-dump/SKILL.md
+++ b/.github/skills/ci-crash-dump/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: ci-crash-dump
+description: >
+  Download and debug crash dumps from CI test failures in dotnet repositories.
+  Use when a CI test crashed (not just failed), when the user wants to debug a crash dump
+  from a PR or build, or when asked "debug dump", "download dump", "crash dump from CI",
+  "test crashed", "analyze crash in PR", or "why did the test crash".
+  DO NOT USE FOR: test failures that are not crashes (use ci-analysis),
+  build failures, performance analysis, or analyzing dumps you already have locally.
+---
+
+# CI Crash Dump Analysis
+
+Dotnet repositories run tests on a distributed test infrastructure called Helix. When a test
+process crashes, Helix captures a dump file and publishes it as an artifact. This skill
+covers finding those artifacts, downloading them, and analyzing the dump.
+
+## When to Use
+
+- A CI test crashed (not just failed with assertion errors)
+- User wants to debug a dump from a PR or build
+
+## When Not to Use
+
+- Test failed but didn't crash (normal assertion failure) — use `ci-analysis`
+- User already has a dump file locally
+- Build failures (no test execution occurred)
+
+## Step 1: Identify the Crashed Work Item
+
+**If pointed at a PR**, use this plugin's `ci-analysis` skill to find failing Helix jobs.
+The `ci-analysis` skill provides `Get-CIStatus.ps1`:
+```
+../ci-analysis/scripts/Get-CIStatus.ps1 -PRNumber <PR> -Repository "dotnet/runtime" -ShowLogs
+../ci-analysis/scripts/Get-CIStatus.ps1 -BuildId <BuildId> -ShowLogs
+```
+
+**If pointed at an issue** (not a PR), look at the issue body and comments for linked AzDO
+build URLs. Multiple builds may be listed — start with the most recent, as older builds may
+have expired from AzDO retention policies. Pass its build ID to
+`../ci-analysis/scripts/Get-CIStatus.ps1`.
+There is no associated PR in this scenario — skip PR correlation in your analysis.
+
+> **Stacks already in the issue/PR:** The issue or PR may already contain a pasted stack trace.
+> Do not simply repeat it — always perform your own independent analysis from the console log
+> and/or dump. You may get better symbol resolution, find additional threads, or identify
+> details the original poster missed. Use any existing stacks as a cross-reference, not a
+> substitute.
+
+Crashes are reported at the work item level. Look for work items that have dump files in
+their artifacts. Note that even individual test-name failures can be crashes (not just
+assertion failures) — for example, in dotnet/runtime test crashes are often attributed to
+individual tests. A single work item may also contain multiple crashes (e.g., tests using
+`RemoteExecutor` or process isolation). A PR may have many failures — look specifically
+for work items with dump files. If multiple work items crashed, list them and ask the user
+which one to investigate.
+
+## Step 2: Check the Console Log First
+
+Before downloading any dump files, check the work item's console log.
+`../ci-analysis/scripts/Get-CIStatus.ps1 -ShowLogs`
+reports the `ConsoleOutputUri`, or find it in the Helix work item Details response.
+In **dotnet/runtime**, the crash handler runs `cdb` (or equivalent) on the machine before
+uploading, so the console log may contain symbolicated native stacks (`~*k`) and
+managed stacks (`!clrstack -all`). Other repos may not have this — the console log may only
+show test output. If crash stacks are present and symbols are resolved (function names, not
+just hex addresses), use them as a starting point for analysis. However, stacks alone may
+not be sufficient — for corruption, heap issues, or cases where managed exceptions are
+caught by the test framework (common in libs tests using xunit), downloading and analyzing
+the dump provides deeper insight. If the stacks are missing, truncated, or show only
+unresolved addresses, proceed directly to download the dump.
+
+## Step 3: Query the Work Item for Crash Evidence
+
+Query the Helix API for work item details:
+```
+GET https://helix.dot.net/api/2019-06-17/jobs/{jobId}/workitems/{workItemName}
+```
+
+> The work item name often contains spaces, parentheses, or other special characters.
+> URL-encode it (e.g., `[uri]::EscapeDataString($workItemName)` in PowerShell) or the
+> request will 404.
+
+The response includes `ExitCode` and a `Files` array (each with `FileName` and `Uri`).
+However, the `Files` URIs from the Details endpoint can be broken for subdirectory or Unicode
+filenames. To get reliable download URIs, use the separate ListFiles endpoint:
+```
+GET https://helix.dot.net/api/2019-06-17/jobs/{jobId}/workitems/{workItemName}/files
+```
+
+**Crash vs. normal failure:** Crashes have a negative or large `ExitCode` and crash artifacts
+in the `Files` array: `.dmp` files (Windows) or `.crashreport.json` files (macOS/Linux).
+Normal failures have `ExitCode: 1` and no crash artifacts.
+**If there are no dump or crashreport files, stop here** — this is a normal test failure,
+not a crash. Report the failure details to the user and suggest using the `ci-analysis`
+skill instead.
+
+> **`.crashreport.json` files** are generated on macOS and Linux (there is no Windows
+> equivalent). They contain full native call stacks and are often the most useful starting
+> point for crash analysis — check these first before attempting to load the dump.
+
+Common crash exit codes:
+
+| Exit code | Meaning | Platform |
+|-----------|---------|----------|
+| `-1073740771` (`0xC000041D`) | Process abort | Windows |
+| `-1073741819` (`0xC0000005`) | Access violation | Windows |
+| `-532462766` (`0xE0434352`) | CLR unhandled exception | Windows |
+| `134` (128+6) | SIGABRT | Linux/macOS |
+| `139` (128+11) | SIGSEGV | Linux/macOS |
+
+## Step 4: Download Artifacts
+
+> **Check the console log first** (Step 2). If it already contains the crash stacks, you may
+> not need to download the dump at all. Only proceed with download if the console log doesn't
+> have sufficient detail.
+
+Download files using the ListFiles endpoint URIs. Start with `.crashreport.json` files
+(contain stack traces, especially useful for macOS) and `.dmp` files — these are directly
+downloadable and often sufficient for initial analysis without needing the full payload.
+
+> **Duplicate dumps:** Crashes often produce multiple dump files for the same crash.
+> On Windows you may see e.g. `dotnet.exe.6524.dmp` and `dotnet.exe(1).6524.dmp` — one from
+> Windows Error Reporting and one from `createdump`. Prefer the `createdump` variant (usually
+> the `(1)` file) as it is more reliable for SOS/`dotnet-dump`. On Linux you may see e.g.
+> `core.1000.33` and `coredump.33.dmp` for the same crash. Prefer the `coredump.*.dmp` file
+> (produced by `createdump`) over the `core.*` file (kernel core dump). In either case, only
+> analyze one and ignore the duplicate.
+
+Download the remaining payload files (runtime binaries, test binaries) only if you need to
+load the dump in a debugger. Do not use `runfo get-helix-payload` unless you actually need
+the full payload — it downloads everything including large runtime binaries. If the `Files`
+URIs are inaccessible (expired, 403, etc.) and you do need the payload, fall back to
+[runfo](https://github.com/jaredpar/runfo): `runfo get-helix-payload -j <jobId> -w <workItem> -o <dir>`.
+
+> **Internal Helix jobs** (identified by the org `dnceng` rather than `dnceng-public` in URLs,
+> or when the Helix API returns 401/403) require authentication that the agent does not have.
+> Report the job ID and work item name to the user and ask them to download manually.
+
+Extract any archive files (`.zip`, `.tar.gz`) in the downloaded payload.
+
+## Step 5: Debug the Dump
+
+The dump needs matching runtime binaries (DAC, SOS) from the payload at
+`shared/Microsoft.NETCore.App/<version>/`.
+
+> **`dotnet-dump` version must match the runtime version of the dump.** A .NET 9.0
+> `dotnet-dump` cannot load a .NET 11.0 DAC (fails with `0x80004002` or
+> `No CLR runtime found`). `dotnet-dump` is backwards compatible, so the simplest
+> approach is to install the latest version:
+> `dotnet tool install -g dotnet-dump --prerelease` (or `dotnet tool update -g dotnet-dump --prerelease`).
+> This usually comes from the `dotnet-tools` feed and works for all supported runtime versions.
+>
+> **If a matching dotnet-dump version is not available** (common for unreleased .NET versions
+> where no package exists on NuGet or dev feeds), **skip dotnet-dump and use `cdb` instead**
+> (see "Native crashes on Windows" below). `cdb` does not have the DAC version coupling
+> problem — its `!analyze -v` and `kn` commands produce native + managed stacks without
+> needing a matching SOS/DAC version.
+>
+> **When DAC loading fails**, run `modules -v` inside `dotnet-dump analyze` as a first
+> diagnostic step. This command works without the DAC and shows the full paths of all loaded
+> modules, including the exact `coreclr.dll` and `System.Private.CoreLib.dll` that were in
+> use. This tells you which runtime build produced the dump and where to find the matching
+> DAC. Use `setclrpath` to point to that directory.
+
+Determine the dump's platform from the CI job name (e.g., "windows-x64", "linux-arm64").
+
+### OS compatibility
+
+`dotnet-dump` can analyze managed state cross-platform. Native debuggers require a matching OS.
+
+| Dump OS | Agent on Windows | Agent on Linux | Agent on macOS |
+|---------|-----------------|----------------|----------------|
+| Windows | ✅ `dotnet-dump`, `cdb` | ⚠️ `dotnet-dump` managed-only | ⚠️ `dotnet-dump` managed-only |
+| Linux | ⚠️ `dotnet-dump` managed-only (needs Cross DAC — see below) | ✅ `dotnet-dump`, `lldb` | ⚠️ `dotnet-dump` managed-only |
+| macOS | ⚠️ Use `.crashreport.json` stacks only | ⚠️ Use `.crashreport.json` stacks only | ✅ `lldb` |
+
+> **Cross DAC for Linux dumps on Windows**: `dotnet-dump` needs the cross-DAC binaries to read
+> Linux ELF core dumps. Search the AzDO build artifacts for names containing `CrossDac` (the
+> exact artifact name varies by build — e.g., `CoreCLRCrossDacArtifacts`). Copy the matching
+> architecture's binaries into the runtime dir alongside the payload. If no cross-DAC artifact
+> is found, report this to the user.
+>
+> **macOS Mach-O core dumps** generally cannot be loaded by `dotnet-dump` even with cross-DAC.
+> The `.crashreport.json` files from the Helix `Files` array contain full native stacks and
+> are the primary analysis path for macOS crashes on non-macOS agents.
+
+If the agent cannot fully analyze the dump (OS mismatch), report the crash type, exit code,
+dump file path, and runtime binaries path, and suggest the user debug manually.
+
+### Managed crashes
+
+Use `dotnet-dump analyze`. The critical Helix-specific setup:
+- `setclrpath` — point to the runtime binaries from the payload
+- `setsymbolserver -directory` — same path, for symbols
+- `setsymbolserver` (no args) — also enables the Microsoft public symbol server for OS and framework symbols
+
+Start with `pe` (print exception) and `clrstack -all`. See [SOS command reference](https://learn.microsoft.com/dotnet/core/diagnostics/sos-debugging-extension) for further commands.
+
+### Native crashes on Windows
+
+Use `cdb.exe` (command-line debugger) for native crashes, or as a **fallback when
+`dotnet-dump` cannot load the DAC** (e.g., unreleased .NET versions). `cdb` does not depend
+on SOS/DAC version matching for native stacks and `!analyze -v`.
+
+`cdb.exe` may be at `C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe`
+(Windows SDK) or inside the WinDbg MSIX package (`winget install --id Microsoft.WinDbg`).
+To find it in the MSIX package:
+```powershell
+$pkg = Get-AppxPackage -Name "*WinDbg*"
+$cdb = Join-Path $pkg.InstallLocation "amd64\cdb.exe"
+```
+
+> **MSIX sandbox limitation:** `cdb.exe` from the WinDbg MSIX package may not be able to
+> access files at arbitrary paths (e.g., `C:\dumps`). If it reports "file not found" for a
+> dump that exists, copy the dump to `$env:TEMP` and open it from there.
+
+Set up the Microsoft public symbol server: `.symfix+ c:\symbols`. Key commands: `!analyze -v` (automatic crash analysis), `kP` / `~*kP` (native stacks).
+For mixed native+managed: `.loadby sos coreclr`, then `!setclrpath`, `!pe`, `!clrstack`.
+
+### Native crashes on Linux/macOS
+
+Use `lldb` with the SOS plugin for combined native + managed debugging. Point it at the dump
+and the dotnet host binary from the payload. Native commands: `bt` (backtrace), `bt all`
+(all threads), `frame variable` (locals). After loading the SOS plugin, use `setclrpath` /`setsymbolserver`, then `pe`, `clrstack -all`
+for managed state — these SOS commands work inside `lldb` the same as in `dotnet-dump`.
+
+For native symbol resolution: runtime binaries in CI are stripped (only `.dynsym` exports).
+Use `dotnet-symbol --host-only --debugging <path-to-libcoreclr.so>` to download the matching
+`.dbg` files, which resolve internal function names. Without these, native frames show only
+as offsets between exported symbols.
+
+Setup: [LLDB for .NET](https://github.com/dotnet/diagnostics/blob/main/documentation/lldb/linux-instructions.md).
+
+### NativeAOT crashes
+
+The CI job name will contain "NativeAOT" (e.g., "osx-arm64 Release NativeAOT_Libraries").
+SOS does not work with NativeAOT. Use `cdb` or `lldb` directly.
+
+## After Loading the Dump
+
+**Always include the following in your report to the user:**
+- A **link to the PR or build** that was analyzed
+- The **exit code** and its meaning (e.g., `0xC0000005` = access violation)
+- The **crashing thread's call stack** (and any other relevant threads), with symbols resolved
+  as far as possible — this is the most important output
+- Any **managed exception** type, message, and inner exception stack (use `pe`) if different
+  from the native crash stack
+- **Links to existing issues** that match this crash — search the repo for open issues (and
+  also closed issues) with matching crash signatures, stack frames, or error messages. If
+  found, link them so the user can see prior context and whether this is a known problem.
+
+Without these the user cannot verify your interpretation or dig deeper.
+
+Use the backtrace, exception info, heap state, etc. together with the PR's code changes to
+understand *why* the crash happened. Correlate the crash location with what was changed — a
+crash in code touched by the PR is likely caused by it; a crash elsewhere may be pre-existing
+or a side effect.
+
+If the crash is in a native binary not part of the PR, report its version metadata
+(`lm v m <module>` in cdb, `image list <module>` in lldb) — the version helps identify
+which build or package introduced it.
+
+Use your judgement and knowledge of the codebase to form a diagnosis and suggest a fix.
+
+## Common Pitfalls
+
+- **Helix artifacts expire after 20 days.** If downloads fail with 404, the artifacts have likely expired — tell the user.
+- **AzDO builds also expire** due to retention policies. If a build returns "not found", try a more recent build. When multiple builds are listed (e.g., in an issue), start with the newest.
+- **`dotnet-dump` only handles managed state.** For native crashes, use `cdb`/`lldb` on matching OS.
+- **32-bit dumps on 64-bit OS:** Use 32-bit dotnet SDK to install dotnet-dump.
+- **Mobile/WASM dumps** are not covered — report the dump location and hand off.
+- **Internal jobs** (`dnceng` org) require auth the agent doesn't have — report and hand off.
+
+## Further Reading
+
+- [dotnet-dump](https://learn.microsoft.com/dotnet/core/diagnostics/dotnet-dump)
+- [SOS debugging extension](https://learn.microsoft.com/dotnet/core/diagnostics/sos-debugging-extension)
+- [Debugging .NET core dumps](https://github.com/dotnet/diagnostics/blob/main/documentation/debugging-coredump.md)

--- a/.github/skills/flow-analysis/SKILL.md
+++ b/.github/skills/flow-analysis/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: flow-analysis
+description: >
+  Analyze VMR codeflow health using maestro MCP tools and GitHub MCP tools.
+  USE FOR: investigating stale codeflow PRs, checking if fixes have flowed
+  through the VMR pipeline, debugging dependency update issues, checking overall
+  flow status for a repo, diagnosing why backflow PRs are missing or blocked,
+  subscription health, build freshness, URLs containing dotnet-maestro or
+  "Source code updates from dotnet/dotnet".
+  DO NOT USE FOR: CI build failures (use ci-analysis skill), code review
+  (use code-review skill), general PR investigation without codeflow context,
+  tracing whether a specific commit/PR has reached another repo (use
+  flow-tracing skill).
+  INVOKES: maestro and GitHub MCP tools, flow-health.cs script.
+---
+
+# Flow Analysis
+
+Analyze VMR codeflow PR health using **scripts** for data collection and **MCP tools** for enrichment and remediation. For single-PR analysis, `Get-CodeflowStatus.ps1` does comprehensive data collection (VMR commit comparison, forward flow discovery, staleness detection); maestro MCP tools provide subscription triggering and build freshness. For repo-wide flow health, `flow-health.cs` handles batch GitHub scanning in parallel.
+
+> 🚨 **NEVER** use `gh pr review --approve` or `--request-changes`. Only `--comment` is allowed.
+
+## When to Use This Skill
+
+Use this skill when:
+- A codeflow PR (from `dotnet-maestro[bot]`) is stale or failing and you need to understand why
+- You need to check if a specific fix has flowed through the VMR pipeline
+- A PR has a Maestro staleness warning or conflict
+- You want to check overall flow health for a repo ("what's the flow status for the sdk?")
+- You need to diagnose why backflow PRs are missing or blocked
+- You're asked "is this codeflow PR up to date", "why is the codeflow blocked", "what's the flow status for net11"
+
+## Prerequisites
+
+- **Maestro MCP server** — provides subscription health, build freshness, and codeflow management. See [lewing/maestro.mcp](https://github.com/lewing/maestro.mcp) for setup.
+- **GitHub CLI (`gh`)** — must be installed and authenticated. Required by `flow-health.cs`.
+
+## Quick Start
+
+For **"is the backflow healthy for repo X on branch Y?"** — use PR Analysis (`Get-CodeflowStatus.ps1 -Repository -Branch`). The script finds the open backflow PR (if any), compares VMR commits, discovers forward flow, and extracts warnings — all in one call.
+
+For **"what's the flow status across all repos?"** or **multi-repo/multi-branch scanning** — use the Codeflow Overview (MCP tools for subscription health + build freshness across many repos simultaneously).
+
+For **investigating a specific PR** — use PR Analysis (`Get-CodeflowStatus.ps1 -PRNumber`). If **no open PR exists**, the script reports this; use MCP tools to check the subscription state.
+
+## Codeflow Concepts
+
+- **Backflow** (VMR → product repo): PRs titled `[branch] Source code updates from dotnet/dotnet`
+- **Forward flow** (product repo → VMR): PRs titled `[branch] Source code updates from dotnet/<repo>`
+- **Staleness**: Forward flow merging while backflow PR is open blocks further updates. **Merging `main` into the PR branch does NOT resolve staleness** — it only fixes git conflicts. The only resolutions are: merge the PR as-is, close it, or force trigger the subscription.
+- **VMR backflow vs dependency subs**: Don't confuse stuck dependency subscriptions (from product repos) with VMR backflow problems (from `dotnet/dotnet`). See [vmr-codeflow-reference.md](references/vmr-codeflow-reference.md#vmr-backflow-vs-dependency-subscriptions) for details.
+
+## Channel Resolution
+
+Users refer to channels with shorthand. **.NET major = year − 2015** (2026 → .NET 11, 2025 → .NET 10).
+
+| User says | Resolve to | Example exact channel name |
+|-----------|-----------|---------------------------|
+| `net11` | Filter channels for `11.0` | `.NET 11.0.1xx SDK` |
+| `11.0.1xx` | Use directly | `.NET 11.0.1xx SDK` |
+| `net10 3xx` | Version 10, band 3 | `.NET 10.0.3xx SDK` |
+| `release/10.0.3xx` | Strip `release/` → `10.0.3xx` | `.NET 10.0.3xx SDK` |
+| `main` | Current dev (major = year − 2015, band = `1xx`) | `.NET 11.0.1xx SDK` |
+
+> ⚠️ **Channel filter requires an exact substring match.** Use the full channel name (e.g., `.NET 11.0.1xx SDK`) when filtering codeflow PRs or subscriptions. Partial names like `.NET 11.0` may not match.
+
+### SDK Bands and Forward Flow
+
+The **1xx band** has full source-build with runtime forward flow. **2xx/3xx bands** consume runtime as prebuilts — missing runtime forward flow on these bands is expected, not broken. See [vmr-codeflow-reference.md](references/vmr-codeflow-reference.md#sdk-bands-and-forward-flow) for the full band table.
+
+## Analysis Modes
+
+| Question | Mode | Approach |
+|----------|------|----------|
+| "What's the flow status for X?" | **Codeflow overview** | Codeflow statuses → subscription health with validate → build freshness |
+| "Is backflow healthy for X on Y?" | **PR analysis** | `Get-CodeflowStatus.ps1 -Repository -Branch` → read output → MCP enrichment |
+| "Why is this PR stale/blocked?" | **PR analysis** | `Get-CodeflowStatus.ps1 -PrUrl` → read output → MCP enrichment |
+| "What's the flow status across all repos?" | **Codeflow overview** | Codeflow statuses for each repo → subscription health + build freshness |
+| "Full flow health report for X" | **Flow health** | `flow-health.cs` script for batch GitHub scanning + maestro enrichment |
+
+## Codeflow Overview Workflow
+
+When the user asks "what codeflow PRs are active?" or "what's the flow status?", start with **codeflow statuses** for the target repo/branch — one call shows per-mapping forward flow and backflow status with active PRs and build staleness. Then drill into problems with subscription health and scripts.
+
+> 🚨 **Trust "commits behind", don't trust "builds behind".** Subscription health returns two kinds of staleness numbers — **"N commits behind"** is real commit distance (trust it, report it directly) and **"~N builds behind"** (note the `~` prefix) is a meaningless BAR build ID delta that overstates staleness by 10x-300x. For any stale entry showing `~builds behind`, compute the real commit distance yourself (see Step 5).
+
+### Step 0: Quick Status via Codeflow Statuses
+
+For any repo or the VMR, get **codeflow statuses** for the repo and branch (defaults to `dotnet/dotnet` on `main`). This returns per-mapping forward flow and backflow status in one call — active PRs, build staleness, and subscription details. Use this as the initial triage to identify which mappings need investigation before drilling into subscription health.
+
+> 💡 **When to skip Step 0**: If you already have a specific PR URL or subscription ID, go directly to PR Analysis or subscription health. Codeflow statuses is for "what's the overall picture?" questions.
+
+### Step 1: Check Subscription Health
+
+Check subscription health for the target repository. This shows which subscriptions are stale and which are current. Entries showing "N commits behind" (no `~`) have real commit distances — use those directly. Entries showing "~N builds behind" (with `~`) need commit distance computation in Step 5.
+
+Use the `validate` option to enable **cross-validation** — this checks subscription state against GitHub PR state, detects state oscillation patterns, and traces source-manifest commits. Always use `validate` when investigating stuck subscriptions.
+
+> ⚠️ **Output includes ALL subscriptions** (all branches and channels). For a version-specific query like "net11 status", filter the results for channels containing your target version (e.g., `11.0`) and the relevant branch (`main` for current dev).
+
+### Step 2: Check Forward Flow
+
+**Before drilling into backflow problems**, check for open forward flow PRs from the product repo into `dotnet/dotnet`. An open forward flow PR is the #1 cause of backflow staleness — if forward flow is pending, backflow is blocked by design.
+
+If codeflow statuses (Step 0) shows a forward flow subscription with failures or high commit distance, investigate:
+
+1. **Check the subscription's update history** — look for consecutive `Failed` or state oscillation (e.g., repeating `ApplyingUpdates → MergingPullRequest → ApplyingUpdates`). State oscillation means Maestro keeps retrying but something prevents completion.
+2. **Check if a tracked PR exists** — a forward flow subscription may report failures but actually have a merged-then-reopened PR, or no PR at all. The tracked PR tells you what Maestro thinks is happening.
+3. **Cross-validate against GitHub** — if Maestro says the subscription is failing but a PR exists and is merged, the subscription has a **bookkeeping bug** (Maestro never updated `LastAppliedBuildId`). Use `validate` on subscription health to detect this automatically.
+
+> 🚨 **Forward flow bookkeeping bug**: When a forward flow subscription shows "N builds behind" with consecutive failures but GitHub shows PRs merging successfully, this is a known Maestro issue where `LastAppliedBuildId` doesn't update after merge. The subscription is stuck in an infinite retry loop. **Remedy**: force-trigger the subscription — this resets Maestro's state by creating a fresh PR branch.
+
+### Step 3: List Tracked PRs
+
+List all codeflow PRs currently tracked by Maestro, optionally filtering by channel name.
+
+> ⚠️ **Output is large** (200+ PRs across all repos). Filter by `channelName` parameter (use exact name like `.NET 11.0.1xx SDK`), or grep/search the output for your target repo.
+
+### Step 4: Drill Into Problems
+
+For subscriptions that are stale — whether they have a stuck PR or no PR at all:
+- Check the subscription's update history to find the failure point
+- Check build freshness to rule out VMR build failures (if builds are stale, it's a VMR issue, not Maestro)
+- For stuck PRs, check the PR's age and recent activity — a PR open >3 days with no progress needs attention
+
+### Step 5: Get Real Commit Distance
+
+For stale entries showing "~N builds behind", request **commit details** when checking subscription health. This returns the actual commit count and recent commit metadata (SHA, message, author, date) — no manual GitHub API calls needed.
+
+Report the commit count as "N commits behind". Use the recent commit list to explain *what* is behind (e.g., "3 commits behind — latest: Fix NuGet restore race condition").
+
+### Step 6: Enrich with GitHub Data
+
+Use GitHub PR details to check state, comments, and merge status for any PRs flagged as problematic.
+
+### Multi-Repo Health Check
+
+When asked about flow health across "all repos" or a major version (e.g., "net11 status"), check the core product repos. Subscription health calls are independent — run them in parallel.
+
+**Core repos**: `dotnet/runtime`, `dotnet/sdk`, `dotnet/aspnetcore`, `dotnet/roslyn`, `dotnet/efcore`, `dotnet/winforms`, `dotnet/wpf`, `dotnet/msbuild`
+
+**Branch names differ across repos** — `runtime`/`aspnetcore` use `release/X.0`, `sdk` uses `release/X.0.Nxx`, `msbuild` uses `vsNN.N`, `roslyn` uses `release/devNN.0` (VS major = .NET major + 8). Current dev is `main` for all. See [vmr-codeflow-reference.md](references/vmr-codeflow-reference.md#branch-naming-per-repo) for the full table.
+
+When asked about a major version, check **all branches** — don't ask for clarification. Present a consolidated cross-repo summary.
+
+## PR Analysis Workflow
+
+> 🚨 **Script-first.** Always run `Get-CodeflowStatus.ps1` first. It produces a `[CODEFLOW_SUMMARY]` JSON block with VMR commit comparison, forward flow discovery, and staleness detection that cannot be replicated by individual MCP calls. **Do NOT re-query the same data via MCP tools** — read and interpret the script output.
+
+### Step 1: Run the Script
+
+```powershell
+# Analyze a specific PR by number
+./scripts/Get-CodeflowStatus.ps1 -Repository "dotnet/runtime" -PRNumber 12345
+
+# Check if a PR exists for a repo/branch (finds the open backflow PR)
+./scripts/Get-CodeflowStatus.ps1 -Repository "dotnet/runtime" -CheckMissing -Branch "main"
+
+# Check for missing PRs across all branches
+./scripts/Get-CodeflowStatus.ps1 -Repository "dotnet/runtime" -CheckMissing
+```
+
+The script outputs a `[CODEFLOW_SUMMARY]` JSON block followed by a text summary. **Parse the JSON** — it contains:
+- **`status`**: MERGED / CLOSED / NO-OP / IN_PROGRESS / STALE / ACTIVE
+- **`vmrComparison.aheadBy`**: How many VMR commits behind (the *real* staleness number)
+- **`forwardFlow.prs[]`**: All open forward flow PRs with their state
+- **`warnings[]`**: Maestro staleness and conflict warnings extracted from PR comments
+- **`subscription.id`**: For use with MCP remediation tools
+- **`build.id`**: BAR build ID for triggering
+
+### Step 2: After the Script — Use Its Output
+
+🚨 The script already collected PR metadata, VMR commit distances, forward flow PRs, and Maestro warnings. **Do NOT re-query this data.** Instead:
+
+1. **Read the `[CODEFLOW_SUMMARY]` JSON** and extract key facts:
+   - `vmrComparison.aheadBy` = how far behind (this is VMR commits, NOT builds)
+   - `forwardFlow.prs` = what's blocking backflow (open forward flow = blocked by design)
+   - `warnings` = staleness/conflict details from Maestro comments
+   - `commits.mergeCommitDetails` = merge commits on the PR (who merged `main` and when — note: merging `main` does NOT resolve staleness)
+   - `status` = overall PR health classification
+
+2. **Use MCP tools only for enrichment** the script can't provide:
+   - Check **build freshness** — are VMR builds healthy? (channel-level, not per-PR)
+   - Check **subscription history** — timeline of when the subscription got stuck (if script shows STALE)
+   - **Trigger the subscription** — to remediate a stuck subscription (needs subscription ID + build ID from script output)
+
+3. **Synthesize** script data + MCP enrichment into a diagnosis and recommendation.
+
+> 💡 **No open PR?** If `-Repository`/`-Branch` finds no open backflow PR, the script reports this. Look up the **tracked PR for the subscription** to check Maestro's view, then check the most recently merged matching PR. A missing PR with a healthy subscription means flow is working normally.
+
+### Step 3: Trace a Fix (Optional)
+
+To check if a specific fix has reached the PR:
+1. Read `src/source-manifest.json` from the VMR at the PR's snapshot commit — find the product repo's `commitSha`
+2. Check if the fix commit is an ancestor of that SHA
+
+## Flow Health Workflow (Script + MCP)
+
+Flow health scanning uses a **hybrid approach**: the `flow-health.cs` script handles batch GitHub API calls in parallel, while maestro MCP tools provide subscription and build freshness data.
+
+> 💡 **Why a script for flow health?** Scanning all branches requires 10-30+ parallel GitHub API calls (PR searches, body fetches, VMR HEAD lookups, commit comparisons). The script fires these in parallel using `Task.Run`; sequential MCP calls would be prohibitively slow.
+
+### Step 1: Run the Script
+
+```shell
+# Scan all branches for a repo
+dotnet ./scripts/flow-health.cs -- dotnet/sdk
+
+# Scan a specific branch only
+dotnet ./scripts/flow-health.cs -- dotnet/sdk --branch main
+```
+
+The script outputs structured JSON with:
+- **`backflow.branches[]`**: Per-branch status (healthy/stale/conflict/missing/up-to-date/released-preview), PR numbers, VMR commit mapping, ahead-by counts, **CI status** (`ciStatus`: green/red/pending/none, `ciFailedCount`/`ciTotalCount` when red)
+- **`backflow.summary`**: Counts of healthy/upToDate/blocked/missing branches
+- **`forwardFlow.prs[]`**: Open forward flow PRs with health status
+- **`forwardFlow.summary`**: Counts of healthy/stale/conflicted forward PRs
+
+### Step 2: Enrich with Maestro MCP Data
+
+After the script runs, enrich with maestro data:
+
+1. **Build freshness**: For each `vmrBranch` found in the script output, check build freshness with the channel short name to verify official VMR builds are healthy.
+
+2. **Subscription health**: For branches with `status: "missing"`, check subscription health for the target repository to diagnose *why* — is the subscription stuck, disabled, or is the channel frozen?
+
+3. **Update history**: For stuck subscriptions, check the subscription's update history to see the timeline — when was the last successful application? Was there a failed attempt?
+
+4. **Tracked PRs**: Cross-reference script results with the codeflow PR list to see Maestro's view of tracked PRs — the script sees GitHub state while Maestro may have a different picture.
+
+5. **Latest builds**: For stuck subscriptions, find the latest build to get the buildId needed for triggering.
+
+### Step 3: Synthesize
+
+Combine script output (GitHub PR state) + MCP data (Maestro health) to produce the diagnosis:
+- If multiple branches show `missing` AND build freshness is stale → VMR build failure (not a Maestro issue)
+- If one branch is `missing` but builds are fresh → Maestro is stuck, suggest triggering
+- If a branch has `status: "conflict"` → suggest `darc vmr resolve-conflict`
+
+## Interpreting Results
+
+### Current State
+- **✅ MERGED**: No action needed
+- **✖️ CLOSED**: Maestro should create a replacement; check subscription health
+- **📭 NO-OP**: Empty diff — changes landed via other paths
+- **🔄 IN PROGRESS**: Recent force push within 24h — someone is working on it
+- **⏳ STALE**: No activity for >3 days — needs attention
+- **🔴 CI-RED**: CI is failing — investigate with ci-analysis even if codeflow is otherwise healthy
+- **✅ ACTIVE**: PR has content and recent activity
+
+### CI Status on Open PRs
+
+> 🚨 **Always report CI status for open PRs.** A "healthy" PR with red CI is NOT healthy — CI failure is a problem regardless of codeflow state. A stale PR with red CI is stale *because* CI is failing. Report `ciStatus` from the script output in every PR row.
+
+| ciStatus | Meaning | Action |
+|----------|---------|--------|
+| `green` | All checks passing | PR is mergeable if no conflicts |
+| `red` | CI failures (`ciFailedCount`/`ciTotalCount`) | **Always flag this** — even on "healthy" PRs. Suggest ci-analysis for deeper investigation. |
+| `pending` | Checks still running | Wait for completion |
+| `none` | No checks found | Unusual — may be freshly pushed |
+
+### Subscription Health Diagnostics
+- **`maestro-stuck`**: Subscription enabled, but last applied build is older than latest — Maestro isn't processing. Trigger the subscription to remediate.
+- **`subscription-disabled`**: Subscription turned off — intentional or oversight
+- **`channel-frozen`**: Latest build is `Released` — no action needed (preview shipped)
+- **`subscription-missing`**: No subscription exists — expected for shipped previews
+
+### Subscription History Patterns
+
+Check **subscription history** to understand failure timelines. Key patterns: one-off `ApplyingUpdates` failures are normal retry; **alternating failures spanning weeks** indicate systemic problems (conflict, CI, blocked forward flow). Long gaps mean disabled subscription or no new builds. See [vmr-codeflow-reference.md](references/vmr-codeflow-reference.md#subscription-history-patterns) for the full pattern catalog.
+
+> ❌ **Never assume "Unknown" means healthy.** API failures produce Unknown status — exclude from positive counts.
+
+## Generating Recommendations
+
+Check `isCodeflowPR` first — if the PR isn't from `dotnet-maestro[bot]`, skip codeflow advice.
+
+| State | Action |
+|-------|--------|
+| MERGED | Mention Maestro will create new PR if VMR has newer content |
+| CLOSED | Suggest triggering subscription if ID available |
+| NO-OP | Recommend closing/merging to clear state |
+| IN_PROGRESS | Wait, then check back |
+| STALE | Check warnings for what's blocking |
+| ACTIVE | Check freshness and warnings for nuance |
+
+### Remediation via Maestro
+
+| Action | When |
+|--------|------|
+| Trigger subscription | PR was closed or no PR exists for an enabled subscription |
+| Trigger with source repo + channel | Provide source repository URL and channel name to auto-resolve latest build (eliminates manual build lookup) |
+| Force-trigger subscription | Bookkeeping bug — subscription shows failures but PRs merge. Force-trigger overwrites the existing PR branch with fresh content, resetting Maestro's state |
+| Check subscription history | Diagnosing when a subscription got stuck or failed |
+| Check backflow status for a VMR build | Understanding which product repos received a VMR build |
+| Bypass cache after action | After triggering, verify state changed using noCache |
+
+> 💡 **Smart trigger**: When triggering a subscription, you can provide the source repository and channel name instead of looking up the latest build ID manually. The MCP server resolves the latest build automatically.
+
+> 💡 **Force trigger**: Force-trigger overwrites the existing PR branch with fresh content. Use this when the subscription has a bookkeeping bug (consecutive failures but PRs merge) or when the tracked PR is in a broken state. Force-trigger is available via MCP.
+
+### Darc Commands (When MCP Insufficient)
+
+```bash
+darc vmr resolve-conflict --subscription <subscription-id>   # Resolve conflicts locally
+```
+
+## Widespread Staleness Pattern
+
+When multiple repos are missing backflow simultaneously, the root cause is usually **VMR build failures**, not Maestro:
+
+1. Check **build freshness** across multiple channels — if all are stale, VMR builds are broken
+2. Check public VMR CI builds at `dnceng-public/public` pipeline 278 for failures
+3. Search `dotnet/dotnet` issues with `[Operational Issue]` label
+
+## References
+
+- **VMR codeflow concepts & darc commands**: [references/vmr-codeflow-reference.md](references/vmr-codeflow-reference.md)
+- **VMR build topology**: [references/vmr-build-topology.md](references/vmr-build-topology.md)
+- **Maestro MCP server**: [github.com/lewing/maestro.mcp](https://github.com/lewing/maestro.mcp)

--- a/.github/skills/flow-analysis/references/vmr-build-topology.md
+++ b/.github/skills/flow-analysis/references/vmr-build-topology.md
@@ -1,0 +1,257 @@
+# VMR Build Topology and Staleness Diagnosis
+
+## Overview
+
+When backflow PRs are missing across multiple repositories simultaneously, the root cause
+is usually not Maestro — it's that the VMR can't build successfully, so no new channel
+builds are produced, and subscriptions have nothing to trigger on.
+
+This reference explains how to diagnose that situation using publicly available signals.
+
+## Build Pipeline Structure
+
+The VMR (`dotnet/dotnet`) has two tiers of builds:
+
+### Public CI (validation only)
+- **AzDO org**: `dnceng-public`
+- **Project**: `public` (ID: `cbb18261-c48f-4abb-8651-8cdcb5474649`)
+- **Pipeline**: `dotnet-unified-build` (definition 278)
+- **Purpose**: Validates PRs and runs scheduled CI on `refs/heads/main` and release branches
+- **Does NOT publish** to Maestro channels — cannot trigger subscriptions
+
+### Official builds (channel publishing)
+- **AzDO org**: `dnceng` (internal, requires auth)
+- **Purpose**: Produces signed builds that publish to Maestro channels (e.g., `.NET 11.0.1xx SDK`)
+- **These are the builds that trigger Maestro subscriptions and create backflow PRs**
+- Not queryable without internal access
+
+### Key insight
+When investigating stale backflow, the **public CI builds are a useful proxy**. If the public
+scheduled build on `refs/heads/main` is failing, the official build is almost certainly
+failing too (they build the same source). A string of failed public builds strongly suggests
+the official pipeline is also broken.
+
+## Checking Official Build Freshness (aka.ms)
+
+The most direct way to check if official VMR builds are producing output is to query
+the SDK blob storage via `aka.ms` shortlinks. When official builds succeed, they publish
+SDK artifacts to `ci.dot.net`. We can check when the latest build was published.
+
+### How it works
+
+1. Resolve the aka.ms redirect (returns 301 with the blob URL):
+   ```
+   https://aka.ms/dotnet/{channel}/daily/dotnet-sdk-win-x64.zip
+   ```
+   Example channels: `11.0.1xx`, `11.0.1xx-preview1`, `10.0.3xx`, `10.0.1xx`
+
+2. The 301 Location header gives the actual blob URL on `ci.dot.net`, which includes
+   the version number in the path.
+
+3. HEAD the blob URL — the `Last-Modified` header tells you exactly when the build was
+   published.
+
+### Example (PowerShell)
+
+```powershell
+Add-Type -AssemblyName System.Net.Http
+$handler = [System.Net.Http.HttpClientHandler]::new()
+$handler.AllowAutoRedirect = $false
+$client = [System.Net.Http.HttpClient]::new($handler)
+
+# Step 1: Resolve aka.ms → ci.dot.net blob URL
+$resp = $client.GetAsync("https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-win-x64.zip").Result
+$blobUrl = $resp.Headers.Location.ToString()  # Only if StatusCode is 301
+$resp.Dispose()
+
+# Step 2: HEAD the blob for Last-Modified
+$headReq = [System.Net.Http.HttpRequestMessage]::new([System.Net.Http.HttpMethod]::Head, $blobUrl)
+$headResp = $client.SendAsync($headReq).Result
+$published = $headResp.Content.Headers.LastModified.Value.UtcDateTime
+$age = [DateTime]::UtcNow - $published
+
+$headReq.Dispose(); $headResp.Dispose()
+$client.Dispose(); $handler.Dispose()
+```
+
+### Interpreting results
+- **< 1 day old**: Official builds are healthy for this channel
+- **1-2 days old**: Normal for daily builds, especially over weekends
+- **3+ days old**: Official builds are likely failing — investigate further
+- **Multiple channels stale simultaneously**: Strong signal of a systemic VMR build problem
+
+### Validating with darc (when auth is available)
+
+The aka.ms approach is an auth-free proxy. When `darc` is installed and authenticated,
+you can get the authoritative answer directly from Maestro:
+
+```bash
+# Latest build on a channel (exact match for what triggers subscriptions)
+darc get-latest-build --repo dotnet/dotnet --channel ".NET 11.0.1xx SDK"
+
+# Check what build a subscription last acted on
+darc get-subscriptions --source-repo dotnet/dotnet --target-repo dotnet/aspnetcore
+```
+
+The `Date Produced` from `darc get-latest-build` will be ~6 hours earlier than the
+aka.ms blob `Last-Modified` (due to signing/publishing delay), but they refer to the
+same build. If the subscription's `Last Build` SHA matches the channel's latest build,
+then Maestro already fired — no newer builds exist.
+
+### Channel-to-branch mapping
+
+Channel names follow the pattern `{major}.0.{band}xx` where `{band}` is typically `1`, `2`, or `3`.
+The major version tracks .NET version = current year - 2015 (e.g., 2026 → .NET 11).
+
+| Channel Pattern | VMR branch | Notes |
+|---------|-----------|-----------------|
+| `{N}.0.1xx` | `main` (during development) | Primary SDK band, runtime + sdk + aspnetcore |
+| `{N}.0.1xx-preview{X}` | `release/{N}.0.1xx-preview{X}` | Preview branches |
+| `{N}.0.{band}xx` | `release/{N}.0.{band}xx` | Servicing bands (2xx, 3xx) |
+| `{N-1}.0.{band}xx` | `release/{N-1}.0.{band}xx` | Previous major servicing |
+
+Example (2026): `11.0.1xx` → `main`, `10.0.3xx` → `release/10.0.3xx`
+
+### Cross-referencing with Version.Details.xml and PR metadata
+
+There are two sources of truth for what VMR build a repo is synced to:
+
+**1. `eng/Version.Details.xml` in the target repo (authoritative):**
+```xml
+<Source Uri="https://github.com/dotnet/dotnet" Mapping="sdk"
+  Sha="ec846aee7f12180381c444dfeeba0c5022e1d110" BarId="297974" />
+```
+- `Sha` = the exact VMR commit the repo is synced to
+- `BarId` = the Maestro build ID (queryable via `darc get-build --id 297974` for date/channel)
+- Dependency version strings encode build dates (e.g., `26069.105` → year 26, day-code 069)
+
+**2. Backflow PR body (when a PR is open):**
+```
+- **Date Produced**: February 4, 2026 11:05:10 AM UTC
+- **Build**: [20260203.11](...) ([300217](https://maestro.dot.net/channel/8298/.../build/300217))
+```
+
+**Comparing against aka.ms build date:**
+- If they match → the backflow PR is based on the latest successful build
+- If the aka.ms build is newer → a newer build succeeded but hasn't triggered backflow yet
+- If the aka.ms build matches the PR but is old → no new successful builds since
+
+## Querying Public VMR CI Builds
+
+Public CI builds (separate from official builds) can confirm whether the VMR source is
+buildable. These don't publish to channels but use the same source.
+
+### AzDO REST API endpoints
+
+Recent scheduled builds on a branch:
+```
+GET https://dev.azure.com/dnceng-public/public/_apis/build/builds?definitions=278&branchName=refs/heads/main&$top=5&api-version=7.0
+```
+
+Last successful build:
+```
+GET https://dev.azure.com/dnceng-public/public/_apis/build/builds?definitions=278&branchName=refs/heads/main&resultFilter=succeeded&$top=1&api-version=7.0
+```
+
+Build timeline (to find failing jobs):
+```
+GET https://dev.azure.com/dnceng-public/public/_apis/build/builds/{buildId}/timeline?api-version=7.0
+```
+
+### Interpreting results
+- **`reason: schedule`** — Scheduled daily builds, closest proxy to official builds
+- **`reason: pullRequest`** — PR validation only
+- **`result: failed`** with consecutive scheduled builds — strong signal of broken VMR
+- Check the timeline for which jobs/stages failed to understand the root cause
+
+## Diagnosing Widespread Backflow Staleness
+
+### Pattern: Multiple repos missing backflow simultaneously
+
+When `CheckMissing` shows missing backflow across 3+ repos (e.g., runtime, SDK, aspnetcore
+all stale), this is almost always a VMR build problem, not a Maestro problem.
+
+**Diagnosis steps:**
+
+1. **Check public VMR builds**: Query the last 5 scheduled builds on the affected branch.
+   If all are failing, the VMR build is broken.
+
+2. **Find the failure**: Get the timeline of the most recent failed build. Look for failed
+   stages/jobs — common failures include:
+   - **macOS signing** (SignTool crashes on non-PE files)
+   - **Windows build** (individual repo build failures within the VMR)
+   - **Source-build validation** (packaging or dependency issues)
+
+3. **Check for known issues**: Search `dotnet/dotnet` issues with label `[Operational Issue]`
+   or search for the error message.
+
+4. **Check the last successful build date**: A gap of days or weeks confirms the VMR has been
+   broken for an extended period.
+
+### Pattern: Single repo missing backflow
+
+When only one repo is missing backflow but others are healthy, the issue is more likely:
+- Maestro subscription disabled or misconfigured
+- The specific repo's forward flow is blocking (conflict or staleness)
+- Channel mismatch
+
+Use `darc get-subscriptions --source-repo dotnet/dotnet --target-repo dotnet/<repo>` to check.
+
+## The Bootstrap / Chicken-and-Egg Problem
+
+The VMR builds arcade and other infrastructure from source. When an infrastructure fix
+(e.g., in `dotnet/arcade`) is needed to unblock the VMR build itself, a circular dependency
+can occur:
+
+1. Arcade fix merges in `dotnet/arcade`
+2. Arcade forward-flows to VMR (`dotnet/dotnet`)
+3. VMR now has the fix **in source**, but the build tooling used to build may still be the
+   old version (from a previous successful bootstrap)
+4. The build fails because the **bootstrap SDK** (cached from a prior build) doesn't have
+   the fix yet
+
+**Resolution** (by VMR maintainers):
+- Re-bootstrap: Build a new `source-built-sdks` package from a working state
+- Manual intervention: Patch the bootstrap or skip the failing step
+- Wait for a full re-bootstrap cycle after a milestone release
+
+This is not something that can be fixed by triggering subscriptions or resolving conflicts.
+When you see this pattern, flag it as needing VMR infrastructure team intervention.
+
+## Channels and Subscription Flow
+
+```
+dotnet/arcade ──forward flow──► dotnet/dotnet (VMR)
+dotnet/runtime ─forward flow──► dotnet/dotnet (VMR)
+dotnet/sdk ────forward flow──► dotnet/dotnet (VMR)
+    ...other repos...
+
+dotnet/dotnet (VMR)
+    │
+    ├── official build succeeds
+    │       │
+    │       ▼
+    │   publishes to channel (e.g., ".NET 11.0.1xx SDK")
+    │       │
+    │       ▼
+    │   Maestro fires subscriptions
+    │       │
+    │       ├──► dotnet/runtime backflow PR
+    │       ├──► dotnet/sdk backflow PR
+    │       ├──► dotnet/aspnetcore backflow PR
+    │       └──► ...etc
+    │
+    └── official build FAILS
+            │
+            ▼
+        nothing publishes → no subscriptions fire → all backflow stalls
+```
+
+## Quick Reference: Common VMR Build Failures
+
+| Failure | Symptom | Root cause |
+|---------|---------|------------|
+| SignTool crash | `Unknown file format` in Sign.proj on macOS | Non-PE file in signing input (e.g., tar.gz) |
+| Repo build failure | `error MSB...` in a specific repo's build | Source incompatibility within VMR |
+| Source-build validation | Packaging or prebuilt detection errors | New prebuilt dependency introduced |
+| Infrastructure timeout | Build exceeds time limit | Resource contention or build perf regression |

--- a/.github/skills/flow-analysis/references/vmr-codeflow-reference.md
+++ b/.github/skills/flow-analysis/references/vmr-codeflow-reference.md
@@ -1,0 +1,205 @@
+# VMR Codeflow Reference
+
+## Key Concepts
+
+### Codeflow Types
+- **Backflow** (VMR → product repo): Automated PRs created by Maestro that bring VMR source updates + dependency updates into product repos (e.g., `dotnet/sdk`). These are titled `[branch] Source code updates from dotnet/dotnet`.
+- **Forward flow** (product repo → VMR): Changes from product repos flowing into the VMR. These are titled `[branch] Source code updates from dotnet/<repo>`.
+
+### Staleness
+When a product repo pushes changes to the VMR (forward flow merges) while a backflow PR is already open, Maestro blocks further codeflow updates to that PR. The bot posts a warning comment with options:
+1. Merge the PR as-is, then Maestro creates a new PR with remaining changes
+2. Close the PR and let Maestro open a fresh one (loses manual commits)
+3. Force trigger: `darc trigger-subscriptions --id <subscription-id> --force` (manual commits may be reverted)
+
+### Key Files
+- **`src/source-manifest.json`** (in VMR): Tracks the exact commit SHA for each product repo synchronized into the VMR. This is the authoritative source of truth.
+- **`eng/Version.Details.xml`** (in product repos): Tracks dependencies and includes a `<Source>` tag for codeflow tracking.
+
+## PR Body Metadata Format
+
+Codeflow PRs have structured metadata in their body:
+
+```
+[marker]: <> (Begin:<subscription-id>)
+## From https://github.com/dotnet/dotnet
+- **Subscription**: [<subscription-id>](https://maestro.dot.net/subscriptions?search=<subscription-id>)
+- **Build**: [<build-number>](<azdo-build-url>) ([<bar-id>](<maestro-channel-url>))
+- **Date Produced**: <date>
+- **Commit**: [<vmr-commit-sha>](<vmr-commit-url>)
+- **Commit Diff**: [<from>...<to>](<compare-url>)
+- **Branch**: [<branch>](<branch-url>)
+[marker]: <> (End:<subscription-id>)
+```
+
+## Darc CLI Commands
+
+The `darc` tool (Dependency ARcade) manages dependency flow in the .NET ecosystem. Install via `eng\common\darc-init.ps1` in any arcade-enabled repo.
+
+### Essential Commands for Codeflow Analysis
+
+#### Get subscription details
+```bash
+# Find all subscriptions flowing to a repo
+darc get-subscriptions --target-repo dotnet/sdk --source-repo dotnet/dotnet
+
+# Output shows subscription ID, channel, update frequency, merge policies
+```
+
+#### Trigger a codeflow update
+```bash
+# Normal trigger (only works if not stale)
+darc trigger-subscriptions --id <subscription-id>
+
+# Force trigger (works even when stale, but may revert manual commits)
+darc trigger-subscriptions --id <subscription-id> --force
+
+# Trigger with a specific build
+darc trigger-subscriptions --id <subscription-id> --build <bar-build-id>
+```
+
+#### Get build information
+```bash
+# Get BAR build details by ID (found in PR body or AzDO logs)
+darc get-build --id <bar-build-id>
+
+# Get latest build for a repo on a channel
+darc get-latest-build --repo dotnet/dotnet --channel ".NET 11 Preview 1"
+```
+
+#### Check subscription health
+```bash
+# See if dependencies are missing subscriptions or have issues
+darc get-health --channel ".NET 11 Preview 1"
+```
+
+#### Simulate a subscription update locally
+```bash
+# Dry-run to see what a subscription would update
+darc update-dependencies --subscription <subscription-id> --dry-run
+```
+
+### VMR-Specific Commands
+
+```bash
+# Resolve codeflow conflicts locally
+darc vmr resolve-conflict --subscription <subscription-id> --build <bar-build-id>
+
+# Flow source from VMR → local repo
+darc vmr backflow --subscription <subscription-id>
+
+# Flow source from local repo → local VMR
+darc vmr forwardflow --subscription <subscription-id>
+
+# Get version (SHA) of a repo in the VMR
+darc vmr get-version
+
+# Diff VMR vs product repos
+darc vmr diff
+```
+
+### Halting and Restarting Dependency Flow
+
+- **Disable default channel**: `darc default-channel-status --disable --id <id>` — stops new builds from flowing
+- **Disable subscription**: `darc subscription-status --disable --id <id>` — stops flow between specific repos
+- **Pin dependency**: Add `Pinned="true"` to dependency in `Version.Details.xml` — prevents specific dependency from updating
+
+## API Endpoints
+
+### GitHub API
+- PR details: `GET /repos/{owner}/{repo}/pulls/{pr_number}`
+- PR comments: `GET /repos/{owner}/{repo}/issues/{pr_number}/comments`
+- PR commits: `GET /repos/{owner}/{repo}/pulls/{pr_number}/commits`
+- Compare commits: `GET /repos/{owner}/{repo}/compare/{base}...{head}`
+- File contents: `GET /repos/{owner}/{repo}/contents/{path}?ref={branch}`
+
+### VMR Source Manifest
+```
+GET /repos/dotnet/dotnet/contents/src/source-manifest.json?ref={branch}
+```
+Returns JSON with `repositories[]` array, each having `path`, `remoteUri`, `commitSha`.
+
+### Maestro/BAR REST API
+Base URL: https://maestro.dot.net
+- Swagger: https://maestro.dot.net/swagger
+- Get subscriptions: `GET /api/subscriptions`
+- Get builds: `GET /api/builds`
+- Get build by ID: `GET /api/builds/{id}`
+
+## VMR Backflow vs Dependency Subscriptions
+
+Product repos receive two kinds of subscriptions:
+- **VMR backflow** (source: `dotnet/dotnet`): Carries source code sync + dependency updates. PRs titled `[branch] Source code updates from dotnet/dotnet`.
+- **Dependency subscriptions** (source: another product repo, e.g., `dotnet/hot-reload-test-framework`): Carry only package version updates.
+
+Both target the same branch but have different failure patterns — don't confuse a stuck dependency subscription with a VMR backflow problem.
+
+## Branch Naming per Repo
+
+Different repos use different branch naming conventions for the same .NET version:
+
+| Repo group | Branch pattern | Example (.NET 10) |
+|-----------|---------------|-------------------|
+| `runtime`, `aspnetcore`, `efcore`, `winforms`, `wpf` | `release/X.0` | `release/10.0` |
+| `sdk` | `release/X.0.Nxx` | `release/10.0.1xx`, `release/10.0.3xx` |
+| `msbuild` | `vsNN.N` (VS version numbering) | `vs18.0` (.NET 10), `vs17.14` (servicing) |
+| `roslyn` | `release/devNN.0` | `release/dev18.0` (.NET 10). **Formula**: VS major = .NET major + 8. |
+| Current dev (all repos) | `main` | `main` |
+| **Preview** | `release/X.0-previewN` or `release/X.0.1xx-previewN` | `release/11.0-preview2` |
+
+## SDK Bands and Forward Flow
+
+The SDK band determines what flows where. The **1xx band** is the full source-build band; higher bands consume some components as prebuilt packages:
+
+| Band | VMR branch | runtime/aspnetcore forward flow? | Example |
+|------|-----------|----------------------------------|---------|
+| 1xx | `release/X.Y.1xx` or `main` | ✅ Yes — full source build | `.NET 11.0.1xx SDK` |
+| 2xx | `release/X.Y.2xx` | ❌ No — consumed as prebuilts from 1xx | `.NET 10.0.2xx SDK` |
+| 3xx | `release/X.Y.3xx` | ❌ No — consumed as prebuilts from 1xx | `.NET 10.0.3xx SDK` |
+
+**Missing runtime forward flow on a 2xx/3xx branch is expected, not broken.** Only SDK, roslyn, fsharp, nuget, and arcade have forward flow on higher bands.
+
+## Subscription History Patterns
+
+When checking subscription history, these patterns indicate specific problems:
+
+- **`ApplyingUpdates` failure**: Maestro couldn't create or update the PR branch — typically a git conflict or API error. If this is a one-off, Maestro will retry on the next build.
+- **`MergingPullRequest` failure**: PR exists but merge failed — usually CI checks blocking auto-merge, or branch protection rules preventing the merge.
+- **Alternating `ApplyingUpdates` / `MergingPullRequest` failures**: A chronic pattern spanning weeks or months indicates a systemic problem — not normal retry. Usually means: (a) an unresolved conflict that recurs on each attempt, (b) persistently failing CI checks, or (c) a forward flow PR blocking backflow. Investigate the PR directly.
+- **Long gap with no entries**: Either the subscription is disabled, the channel has no new builds (check build freshness), or the subscription is on a `None` (manual) update frequency.
+- **Single old failure then silence**: Subscription may have been disabled after a failure, or the channel was frozen after a preview shipped. Check the subscription's enabled/disabled state.
+
+## Common Scenarios
+
+### 1. Codeflow is stale — a fix landed but hasn't reached the PR
+**Symptoms**: Tests failing on the codeflow PR; the fix is merged in a product repo.
+**Diagnosis**: Compare `source-manifest.json` on VMR branch HEAD vs the PR's VMR snapshot commit.
+**Resolution**: Close PR + reopen, or force trigger the subscription.
+
+### 2. Opposite codeflow merged — staleness warning
+**Symptoms**: Maestro bot comment saying "codeflow cannot continue".
+**Diagnosis**: Check PR comments for the warning. Check if forward flow PRs merged after the backflow PR was opened.
+**Resolution**: Follow the options in the bot's comment.
+
+### 3. Manual commits on the codeflow PR
+**Symptoms**: Developers added manual fixes to unblock the PR (baseline updates, workarounds).
+**Diagnosis**: Analyze PR commits to identify non-maestro commits.
+**Risk**: Closing the PR loses these. Force-triggering may revert them.
+
+### 4. Script reports "Maestro may be stuck"
+**Symptoms**: Builds are fresh (aka.ms shows recent publish) but no backflow PR was created.
+**Diagnosis**:
+1. Check the subscription to find when it last consumed a build:
+   ```bash
+   darc get-subscriptions --target-repo <repo> --source-repo dotnet/dotnet
+   ```
+   Look at the `Last Build` field — if it's weeks old while the channel has newer builds, the subscription is stuck.
+2. Compare against the latest channel build:
+   ```bash
+   darc get-latest-build --repo dotnet/dotnet --channel "<channel-name>"
+   ```
+3. Trigger the subscription manually:
+   ```bash
+   darc trigger-subscriptions --id <subscription-id>
+   ```
+4. If triggering doesn't produce a PR within a few minutes, check Maestro health or open an issue on `dotnet/arcade`.

--- a/.github/skills/flow-analysis/scripts/Get-CodeflowStatus.ps1
+++ b/.github/skills/flow-analysis/scripts/Get-CodeflowStatus.ps1
@@ -1,0 +1,1991 @@
+﻿<#
+.SYNOPSIS
+    Analyzes VMR codeflow PR status for dotnet repositories.
+
+.DESCRIPTION
+    Checks whether a codeflow PR (backflow from dotnet/dotnet VMR) is up to date,
+    detects staleness warnings, traces specific fixes through the pipeline, and
+    provides actionable recommendations.
+
+    Can also check if a backflow PR is expected but missing for a given repo/branch.
+
+.PARAMETER PRNumber
+    GitHub PR number to analyze. Required unless -CheckMissing is used.
+
+.PARAMETER Repository
+    Target repository (required). Format: owner/repo.
+
+.PARAMETER TraceFix
+    Optional. A repo PR to trace through the pipeline (e.g., "dotnet/runtime#123974").
+    Checks if the fix has flowed through VMR into the codeflow PR.
+
+.PARAMETER ShowCommits
+    Show individual VMR commits between the PR snapshot and current branch HEAD.
+
+.PARAMETER CheckMissing
+    Check if backflow PRs are expected but missing for a repository. When used,
+    PRNumber is not required. Finds the most recent merged backflow PR for each branch,
+    extracts its VMR commit, and compares against current VMR branch HEAD.
+
+.PARAMETER Branch
+    Optional. When used with -CheckMissing, only check a specific branch instead of all.
+
+.EXAMPLE
+    ./Get-CodeflowStatus.ps1 -PRNumber 52727 -Repository "dotnet/sdk"
+
+.EXAMPLE
+    ./Get-CodeflowStatus.ps1 -PRNumber 52727 -Repository "dotnet/sdk" -TraceFix "dotnet/runtime#123974"
+
+.EXAMPLE
+    ./Get-CodeflowStatus.ps1 -Repository "dotnet/roslyn" -CheckMissing
+
+.EXAMPLE
+    ./Get-CodeflowStatus.ps1 -Repository "dotnet/roslyn" -CheckMissing -Branch "main"
+#>
+
+param(
+    [int]$PRNumber,
+
+    [Parameter(Mandatory=$true)]
+    [string]$Repository,
+
+    [string]$TraceFix,
+
+    [switch]$ShowCommits,
+
+    [switch]$CheckMissing,
+
+    [string]$Branch
+)
+
+# Use Continue for native command compat (PS 5.1 treats gh stderr as terminating with Stop)
+$ErrorActionPreference = "Continue"
+
+# --- Parallel support detection ---
+$script:canParallel = $null -ne (Get-Command Start-ThreadJob -ErrorAction SilentlyContinue)
+
+# --- Darc support detection ---
+$script:hasDarc = (-not $env:CODEFLOW_NO_DARC) -and ($null -ne (Get-Command darc -ErrorAction SilentlyContinue))
+
+# Start a background gh api call (returns Job if parallel, $null if not).
+# Caller collects result with Complete-AsyncJob.
+function Start-AsyncGitHubApi {
+    param([string]$Endpoint, [switch]$Raw)
+    if (-not $script:canParallel) { return $null }
+    return Start-ThreadJob -ScriptBlock {
+        param($ep, $isRaw)
+        $ghArgs = @($ep)
+        if ($isRaw) { $ghArgs += '-H'; $ghArgs += 'Accept: application/vnd.github.raw' }
+        $result = gh api @ghArgs 2>$null
+        if ($LASTEXITCODE -ne 0) { return $null }
+        return ($result -join "`n")
+    } -ArgumentList $Endpoint, [bool]$Raw
+}
+
+# Start a background gh CLI call with arbitrary arguments.
+function Start-AsyncGh {
+    param([string[]]$GhArgs)
+    if (-not $script:canParallel) { return $null }
+    return Start-ThreadJob -ScriptBlock {
+        param($args_)
+        $result = gh @args_ 2>$null
+        if ($LASTEXITCODE -ne 0) { return $null }
+        return ($result -join "`n")
+    } -ArgumentList (,@($GhArgs))
+}
+
+# Collect result from an async job, or run synchronously if parallel isn't available.
+# $FallbackBlock is invoked when $Job is $null (sequential fallback).
+function Complete-AsyncJob {
+    param($Job, [scriptblock]$FallbackBlock)
+    if ($Job) { return Receive-Job -Job $Job -Wait -AutoRemoveJob }
+    return & $FallbackBlock
+}
+
+# --- Helpers ---
+
+function Invoke-GitHubApi {
+    param(
+        [string]$Endpoint,
+        [switch]$Raw
+    )
+    try {
+        $ghArgs = @($Endpoint)
+        if ($Raw) {
+            $ghArgs += '-H'
+            $ghArgs += 'Accept: application/vnd.github.raw'
+        }
+        $result = gh api @ghArgs 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "GitHub API call failed: $Endpoint"
+            return $null
+        }
+        if ($Raw) { return $result -join "`n" }
+        return ($result -join "`n") | ConvertFrom-Json
+    }
+    catch {
+        Write-Warning "Error calling GitHub API: $_"
+        return $null
+    }
+}
+
+function Get-ShortSha {
+    param([string]$Sha, [int]$Length = 12)
+    if (-not $Sha) { return "(unknown)" }
+    return $Sha.Substring(0, [Math]::Min($Length, $Sha.Length))
+}
+
+function Write-Section {
+    param([string]$Title)
+    Write-Host ""
+    Write-Host "=== $Title ===" -ForegroundColor Cyan
+}
+
+function Write-Status {
+    param([string]$Label, [string]$Value, [string]$Color = "White")
+    Write-Host "  ${Label}: " -NoNewline
+    Write-Host $Value -ForegroundColor $Color
+}
+
+# Check an open codeflow PR for staleness/conflict warnings
+# Returns a hashtable with: Status, Color, HasConflict, HasStaleness, WasResolved
+function Get-CodeflowPRHealth {
+    param([int]$PRNumber, [string]$Repo = "dotnet/dotnet")
+
+    $result = @{ Status = "⚠️  Unknown"; Color = "Yellow"; HasConflict = $false; HasStaleness = $false; WasResolved = $false; Details = @() }
+
+    $prJson = gh pr view $PRNumber -R $Repo --json body,comments,updatedAt,mergeable,statusCheckRollup 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $prJson) { return $result }
+
+    try { $prDetail = ($prJson -join "`n") | ConvertFrom-Json } catch { return $result }
+
+    # If we got here, we can determine health
+    $result.Status = "✅ Healthy"
+    $result.Color = "Green"
+
+    $hasConflict = $false
+    $hasStaleness = $false
+    if ($prDetail.comments) {
+        foreach ($comment in $prDetail.comments) {
+            if ($comment.author.login -match '^dotnet-maestro') {
+                if ($comment.body -match 'codeflow cannot continue|the source repository has received code changes') { $hasStaleness = $true }
+                if ($comment.body -match 'Conflict detected') { $hasConflict = $true }
+            }
+        }
+    }
+
+    $wasConflict = $hasConflict
+    $wasStaleness = $hasStaleness
+
+    # If issues detected, check if they were resolved
+    # Two signals: (1) PR is mergeable (no git conflict), (2) Codeflow verification SUCCESS
+    # Either one clears the conflict flag. Staleness needs a newer commit after the warning.
+    if ($hasConflict -or $hasStaleness) {
+        # Check mergeable status — if PR has no git conflicts, clear the conflict flag
+        $isMergeable = $false
+        if ($prDetail.PSObject.Properties.Name -contains 'mergeable' -and $prDetail.mergeable -eq 'MERGEABLE') {
+            $isMergeable = $true
+        }
+        if ($isMergeable -and $hasConflict) {
+            $hasConflict = $false
+        }
+
+        $checksJson = gh pr checks $PRNumber -R $Repo --json name,state 2>$null
+        if ($LASTEXITCODE -eq 0 -and $checksJson) {
+            try {
+                $checks = ($checksJson -join "`n") | ConvertFrom-Json
+                $codeflowCheck = @($checks | Where-Object { $_.name -match 'Codeflow verification' }) | Select-Object -First 1
+                if ($codeflowCheck -and $codeflowCheck.state -eq 'SUCCESS') {
+                    # Codeflow verification SUCCESS means Maestro has pushed fresh content
+                    $hasConflict = $false
+                    $hasStaleness = $false
+                }
+                elseif ($isMergeable) {
+                    # PR is mergeable (no git conflicts) but staleness is a separate concern.
+                    # Merging main into the PR branch resolves git conflicts but does NOT
+                    # resolve codeflow staleness — only Maestro force-push does that.
+                    $hasConflict = $false
+                }
+            } catch { }
+        }
+    }
+
+    if ($hasConflict) {
+        $result.Status = "🔴 Conflict"
+        $result.Color = "Red"
+        $result.HasConflict = $true
+    }
+    elseif ($hasStaleness) {
+        $result.Status = "⚠️  Stale"
+        $result.Color = "Yellow"
+        $result.HasStaleness = $true
+    }
+    else {
+        if ($wasConflict) { $result.Status = "✅ Conflict resolved"; $result.WasResolved = $true }
+        elseif ($wasStaleness) { $result.Status = "✅ Updated since staleness warning"; $result.WasResolved = $true }
+    }
+
+    # CI status from statusCheckRollup (flat array with conclusion/status fields)
+    $rollup = $prDetail.statusCheckRollup
+    if ($rollup -and $rollup.Count -gt 0) {
+        $ciContexts = @($rollup)
+        $ciFailed = @($ciContexts | Where-Object { $_.conclusion -eq 'FAILURE' -or $_.conclusion -eq 'ERROR' -or $_.state -eq 'FAILURE' -or $_.state -eq 'ERROR' })
+        if ($ciFailed.Count -gt 0) {
+            $result.CIStatus = "red"
+            $result.CIFailed = $ciFailed.Count
+            $result.CITotal = $ciContexts.Count
+        } elseif (@($ciContexts | Where-Object { ($_.status -eq 'IN_PROGRESS' -or $_.status -eq 'QUEUED' -or $_.status -eq 'PENDING') -or $_.state -eq 'PENDING' }).Count -gt 0) {
+            $result.CIStatus = "pending"
+        } elseif ($ciContexts.Count -gt 0) {
+            $result.CIStatus = "green"
+        }
+    }
+
+    return $result
+}
+
+function Get-VMRBuildFreshness {
+    param([string]$VMRBranch)
+
+    # Try darc first — gives exact commit, build date, build link
+    if ($script:hasDarc) {
+        $result = Get-VMRBuildFreshnessDarc -VMRBranch $VMRBranch
+        if ($result) { return $result }
+    }
+    return Get-VMRBuildFreshnessAkaMs -VMRBranch $VMRBranch
+}
+
+function Get-VMRBuildFreshnessDarc {
+    param([string]$VMRBranch)
+
+    # Map VMR branch to channel name
+    # Channels: ".NET 11.0.1xx SDK", ".NET 11.0.1xx SDK Preview 1"
+    $channelName = $null
+    if ($VMRBranch -eq "main") {
+        $currentMajor = [DateTime]::UtcNow.Year - 2015
+        $channelName = ".NET $currentMajor.0.1xx SDK"
+    }
+    elseif ($VMRBranch -match 'release/(\d+\.\d+\.\d+xx)-preview\.?(\d+)') {
+        $channelName = ".NET $($Matches[1]) SDK Preview $($Matches[2])"
+    }
+    elseif ($VMRBranch -match 'release/(\d+\.\d+\.\d+xx)') {
+        $channelName = ".NET $($Matches[1]) SDK"
+    }
+    if (-not $channelName) { return $null }
+
+    try {
+        $output = darc get-latest-build --repo dotnet/dotnet --channel $channelName 2>$null
+        if ($LASTEXITCODE -ne 0 -or -not $output) { return $null }
+        $text = $output -join "`n"
+
+        $commit = if ($text -match 'Commit:\s+(\S+)') { $Matches[1] } else { $null }
+        $buildNum = if ($text -match 'Build Number:\s+(\S+)') { $Matches[1] } else { $null }
+        $buildLink = if ($text -match 'Build Link:\s+(\S+)') { $Matches[1] } else { $null }
+        $dateStr = if ($text -match 'Date Produced:\s+(.+)') { $Matches[1].Trim() } else { $null }
+
+        if (-not $dateStr) { return $null }
+        $published = [DateTime]::Parse($dateStr, [System.Globalization.CultureInfo]::InvariantCulture).ToUniversalTime()
+
+        # Extract channel short name for display (e.g., "11.0.1xx" or "11.0.1xx-preview1")
+        $channelShort = if ($VMRBranch -eq "main") { "$([DateTime]::UtcNow.Year - 2015).0.1xx" }
+                        elseif ($VMRBranch -match 'release/(\d+\.\d+\.\d+xx(?:-preview\.?\d+)?)') { $Matches[1] }
+                        else { $channelName }
+
+        $released = if ($text -match 'Released:\s+(True|False)') { $Matches[1] -eq 'True' } else { $false }
+
+        return @{
+            Channel   = $channelShort
+            Version   = $buildNum
+            Published = $published
+            Age       = [DateTime]::UtcNow - $published
+            Commit    = $commit
+            BuildLink = $buildLink
+            Released  = $released
+            Source    = "darc"
+        }
+    } catch { return $null }
+}
+
+function Get-SubscriptionHealth {
+    param(
+        [string]$TargetRepo,
+        [string]$TargetBranch,
+        [hashtable]$BuildFreshness  # optional — reuse if already fetched
+    )
+
+    if (-not $script:hasDarc) { return $null }
+
+    try {
+        # Get subscriptions for this repo from dotnet/dotnet
+        $subOutput = darc get-subscriptions --source-repo dotnet/dotnet --target-repo $TargetRepo 2>$null
+        if ($LASTEXITCODE -ne 0 -or -not $subOutput) { return $null }
+
+        # Parse subscription blocks — each starts with the header line
+        # "https://...dotnet/dotnet (channel) ==> 'target' ('branch')"
+        $subText = $subOutput -join "`n"
+        $blocks = $subText -split '(?=https://github\.com/dotnet/dotnet\s+\()'
+        $blocks = $blocks | Where-Object { $_.Trim() }
+
+        # Find the subscription matching our target branch
+        $matchedBlock = $null
+        foreach ($block in $blocks) {
+            if ($block -match "==>\s+'[^']+'\s+\('([^']+)'\)") {
+                $subBranch = $Matches[1]
+                if ($subBranch -eq $TargetBranch) {
+                    $matchedBlock = $block
+                    break
+                }
+            }
+        }
+
+        if (-not $matchedBlock) {
+            return @{
+                Diagnostic = "subscription-missing"
+                Message    = "No subscription found for $TargetRepo/$TargetBranch"
+            }
+        }
+
+        # Parse subscription fields
+        $subId = if ($matchedBlock -match 'Id:\s+(\S+)') { $Matches[1] } else { $null }
+        $enabled = if ($matchedBlock -match 'Enabled:\s+(True|False)') { $Matches[1] -eq 'True' } else { $true }
+        $updateFreq = if ($matchedBlock -match 'Update Frequency:\s+(\S+)') { $Matches[1] } else { "Unknown" }
+        $lastBuildNum = $null; $lastBuildCommit = $null
+        if ($matchedBlock -match 'Last Build:\s+(\S+)\s+\((\S+)\)') {
+            $lastBuildNum = $Matches[1]
+            $lastBuildCommit = $Matches[2]
+        }
+
+        # Extract channel name from header
+        $channelName = $null
+        if ($matchedBlock -match 'dotnet/dotnet\s+\(([^)]+)\)') {
+            $channelName = $Matches[1]
+        }
+
+        if (-not $enabled) {
+            return @{
+                Diagnostic     = "subscription-disabled"
+                SubscriptionId = $subId
+                Channel        = $channelName
+                UpdateFrequency = $updateFreq
+                Message        = "Subscription $subId is disabled"
+            }
+        }
+
+        # Get latest build for comparison (reuse if provided)
+        $latestBuild = $BuildFreshness
+        if (-not $latestBuild -and $channelName) {
+            $latestBuild = try {
+                $bOutput = darc get-latest-build --repo dotnet/dotnet --channel $channelName 2>$null
+                if ($LASTEXITCODE -eq 0 -and $bOutput) {
+                    $bText = $bOutput -join "`n"
+                    $bCommit = if ($bText -match 'Commit:\s+(\S+)') { $Matches[1] } else { $null }
+                    $bNum = if ($bText -match 'Build Number:\s+(\S+)') { $Matches[1] } else { $null }
+                    $bReleased = if ($bText -match 'Released:\s+(True|False)') { $Matches[1] -eq 'True' } else { $false }
+                    $bDateStr = if ($bText -match 'Date Produced:\s+(.+)') { $Matches[1].Trim() } else { $null }
+                    $bDate = if ($bDateStr) { [DateTime]::Parse($bDateStr, [System.Globalization.CultureInfo]::InvariantCulture).ToUniversalTime() } else { $null }
+                    @{ Commit = $bCommit; Version = $bNum; Released = $bReleased; Published = $bDate }
+                }
+            } catch { $null }
+        }
+
+        if (-not $latestBuild) {
+            return @{
+                Diagnostic     = "unknown"
+                SubscriptionId = $subId
+                Channel        = $channelName
+                UpdateFrequency = $updateFreq
+                LastBuild      = $lastBuildNum
+                Message        = "Could not fetch latest build for channel $channelName"
+            }
+        }
+
+        # Check if channel is frozen (released preview)
+        if ($latestBuild.Released -and $lastBuildCommit -and $latestBuild.Commit -and
+            $lastBuildCommit -eq $latestBuild.Commit) {
+            return @{
+                Diagnostic     = "channel-frozen"
+                SubscriptionId = $subId
+                Channel        = $channelName
+                UpdateFrequency = $updateFreq
+                LastBuild      = $lastBuildNum
+                LatestBuild    = $latestBuild.Version
+                Message        = "Channel frozen — latest build is released, subscription is up to date"
+            }
+        }
+
+        # Check if Maestro is stuck (last-flowed build != latest build)
+        if ($lastBuildCommit -and $latestBuild.Commit -and $lastBuildCommit -ne $latestBuild.Commit) {
+            $behindMsg = "LastBuild=$lastBuildNum but latest=$($latestBuild.Version)"
+            # Check if frequency-limited — only applies when the gap is small
+            # Build numbers are date-based (YYYYMMDD.N), so we can compare dates
+            if ($updateFreq -eq "EveryDay" -and $latestBuild.Published -and $lastBuildNum) {
+                $buildAge = [DateTime]::UtcNow - $latestBuild.Published
+                # Only frequency-limited if last-flowed build is from the previous day or two
+                $lastBuildDate = $null
+                if ($lastBuildNum -match '^(\d{4})(\d{2})(\d{2})\.') {
+                    try { $lastBuildDate = [DateTime]::SpecifyKind([DateTime]::new([int]$Matches[1], [int]$Matches[2], [int]$Matches[3]), [DateTimeKind]::Utc) } catch {}
+                }
+                $lastBuildAge = if ($lastBuildDate) { ([DateTime]::UtcNow - $lastBuildDate).TotalDays } else { 999 }
+                if ($buildAge.TotalHours -lt 24 -and $lastBuildAge -lt 3) {
+                    return @{
+                        Diagnostic     = "frequency-limited"
+                        SubscriptionId = $subId
+                        Channel        = $channelName
+                        UpdateFrequency = $updateFreq
+                        LastBuild      = $lastBuildNum
+                        LatestBuild    = $latestBuild.Version
+                        Message        = "EveryDay subscription — latest build is $([math]::Round($buildAge.TotalHours,1))h old, next update within 24h"
+                    }
+                }
+            }
+            return @{
+                Diagnostic     = "maestro-stuck"
+                SubscriptionId = $subId
+                Channel        = $channelName
+                UpdateFrequency = $updateFreq
+                LastBuild      = $lastBuildNum
+                LastBuildCommit = $lastBuildCommit
+                LatestBuild    = $latestBuild.Version
+                LatestCommit   = $latestBuild.Commit
+                Message        = "Maestro stuck — $behindMsg"
+            }
+        }
+
+        # No Last Build data — can't determine health
+        if (-not $lastBuildCommit) {
+            return @{
+                Diagnostic     = "unknown"
+                SubscriptionId = $subId
+                Channel        = $channelName
+                UpdateFrequency = $updateFreq
+                LastBuild      = $lastBuildNum
+                Message        = "No Last Build data — subscription health unknown"
+            }
+        }
+
+        # Subscription is healthy
+        return @{
+            Diagnostic     = "healthy"
+            SubscriptionId = $subId
+            Channel        = $channelName
+            UpdateFrequency = $updateFreq
+            LastBuild      = $lastBuildNum
+            LatestBuild    = $latestBuild.Version
+            Message        = "Subscription is up to date"
+        }
+    } catch { return $null }
+}
+
+function Get-VMRBuildFreshnessAkaMs {
+    param([string]$VMRBranch)
+
+    # Map VMR branch to aka.ms channel
+    $channel = $null
+    $blobUrl = $null
+
+    Add-Type -AssemblyName System.Net.Http -ErrorAction SilentlyContinue
+    $handler = [System.Net.Http.HttpClientHandler]::new()
+    $handler.AllowAutoRedirect = $false
+    $client = [System.Net.Http.HttpClient]::new($handler)
+    $client.Timeout = [TimeSpan]::FromSeconds(15)
+
+    try {
+        if ($VMRBranch -eq "main") {
+            # Dynamically generate candidate channels. Try current major first,
+            # then next (for early-year transitions), then previous as fallback.
+            # .NET version = current year - 2015 (e.g., 2026 → 11, 2027 → 12)
+            $currentMajor = [DateTime]::UtcNow.Year - 2015
+            $tryChannels = @("$currentMajor.0.1xx", "$($currentMajor+1).0.1xx", "$($currentMajor-1).0.1xx")
+            foreach ($ch in $tryChannels) {
+                try {
+                    $resp = $client.GetAsync("https://aka.ms/dotnet/$ch/daily/dotnet-sdk-win-x64.zip").Result
+                    if ([int]$resp.StatusCode -eq 301 -and $resp.Headers.Location) {
+                        $channel = $ch
+                        $blobUrl = $resp.Headers.Location.ToString()
+                        $resp.Dispose()
+                        break
+                    }
+                    $resp.Dispose()
+                } catch { }
+            }
+        }
+        elseif ($VMRBranch -match 'release/(\d+\.\d+\.\d+xx-preview\.?\d+)') {
+            # aka.ms uses "preview1" not "preview.1"
+            $channel = $Matches[1] -replace 'preview\.', 'preview'
+        }
+        elseif ($VMRBranch -match 'release/(\d+\.\d+)\.(\d)xx') {
+            $channel = "$($Matches[1]).$($Matches[2])xx"
+        }
+
+        if (-not $channel) { return $null }
+
+        if (-not $blobUrl) {
+            $resp = $client.GetAsync("https://aka.ms/dotnet/$channel/daily/dotnet-sdk-win-x64.zip").Result
+            if ([int]$resp.StatusCode -ne 301 -or -not $resp.Headers.Location) {
+                $resp.Dispose()
+                return $null
+            }
+            $blobUrl = $resp.Headers.Location.ToString()
+            $resp.Dispose()
+        }
+
+        $version = if ($blobUrl -match '/Sdk/([^/]+)/') { $Matches[1] } else { $null }
+
+        # Use HttpClient HEAD (consistent with above, avoids mixing Invoke-WebRequest)
+        # Need a separate client with auto-redirect enabled for the blob URL
+        $blobHandler = [System.Net.Http.HttpClientHandler]::new()
+        $blobClient = [System.Net.Http.HttpClient]::new($blobHandler)
+        $blobClient.Timeout = [TimeSpan]::FromSeconds(15)
+        $published = $null
+        try {
+            $request = [System.Net.Http.HttpRequestMessage]::new([System.Net.Http.HttpMethod]::Head, $blobUrl)
+            $headResp = $blobClient.SendAsync($request, [System.Net.Http.HttpCompletionOption]::ResponseHeadersRead).Result
+            # PowerShell unwraps Nullable<DateTimeOffset> — use cast, not .Value
+            $lastMod = $headResp.Content.Headers.LastModified
+            if ($null -eq $lastMod) { $lastMod = $headResp.Headers.LastModified }
+            if ($null -ne $lastMod) { $published = ([DateTimeOffset]$lastMod).UtcDateTime }
+        }
+        finally {
+            if ($headResp) { $headResp.Dispose() }
+            if ($request) { $request.Dispose() }
+            $blobClient.Dispose()
+            $blobHandler.Dispose()
+        }
+
+        if (-not $published) { return $null }
+        return @{
+            Channel   = $channel
+            Version   = $version
+            Published = $published
+            Age       = [DateTime]::UtcNow - $published
+        }
+    }
+    catch {
+        return $null
+    }
+    finally {
+        if ($client) { $client.Dispose() }
+    }
+}
+
+# --- Parse repo owner/name ---
+if ($Repository -notmatch '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$') {
+    Write-Error "Repository must be in format 'owner/repo' (e.g., 'dotnet/sdk')"
+    return
+}
+
+# --- CheckMissing mode: find expected but missing backflow PRs ---
+if ($CheckMissing) {
+    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+        Write-Error "GitHub CLI (gh) is not installed or not in PATH. Install from https://cli.github.com/"
+        return
+    }
+
+    Write-Section "Checking for missing backflow PRs in $Repository"
+
+    # dotnet/dotnet doesn't have backflow from itself — skip to forward flow + build freshness
+    if ($Repository -eq "dotnet/dotnet") {
+        Write-Host "  ℹ️  VMR (dotnet/dotnet) does not have backflow from itself" -ForegroundColor DarkGray
+
+        # Still show build freshness for the VMR
+        $vmrBranches = @{}
+        if ($Branch -eq "main" -or -not $Branch) { $vmrBranches["main"] = "main" }
+        if ($Branch -match 'release/' -or -not $Branch) {
+            # Try to detect release branches
+            $branchesJson = gh api "/repos/dotnet/dotnet/branches?per_page=30" --jq '.[].name' 2>$null
+            if ($LASTEXITCODE -eq 0 -and $branchesJson) {
+                foreach ($b in ($branchesJson -split "`n")) {
+                    if ($b -match '^release/') { $vmrBranches[$b] = $b }
+                }
+            }
+        }
+        $checkedChannels = @{}
+        $anyVeryStale = $false
+        if ($vmrBranches.Count -gt 0) {
+            $freshnessSource = if ($script:hasDarc) { "darc" } else { "aka.ms" }
+            Write-Section "Official Build Freshness (via $freshnessSource)"
+            foreach ($entry in $vmrBranches.GetEnumerator()) {
+                $freshness = Get-VMRBuildFreshness -VMRBranch $entry.Value
+                if ($freshness -and -not $checkedChannels.ContainsKey($freshness.Channel)) {
+                    $checkedChannels[$freshness.Channel] = $freshness
+                    $ageDays = $freshness.Age.TotalDays
+                    $ageStr = if ($ageDays -ge 1) { "$([math]::Round($ageDays, 1))d" } else { "$([math]::Round($freshness.Age.TotalHours, 1))h" }
+                    $color = if ($ageDays -gt 3) { 'Red' } elseif ($ageDays -gt 1) { 'Yellow' } else { 'Green' }
+                    $versionStr = if ($freshness.Version) { $freshness.Version } else { "unknown" }
+                    $branchLabel = "$($entry.Key) → $($freshness.Channel)"
+                    Write-Host "  $($branchLabel.PadRight(40)) $($versionStr.PadRight(48)) $($freshness.Published.ToString('yyyy-MM-dd HH:mm')) UTC  ($ageStr ago)" -ForegroundColor $color
+                    if ($ageDays -gt 3) { $anyVeryStale = $true }
+                }
+            }
+            if ($anyVeryStale) {
+                Write-Host ""
+                Write-Host "  ⚠️  Official builds appear stale — VMR may be failing to build" -ForegroundColor Yellow
+                Write-Host "    Check https://dev.azure.com/dnceng-public/public/_build?definitionId=278 for public CI failures" -ForegroundColor DarkGray
+                Write-Host "    See also: https://github.com/dotnet/dotnet/issues?q=is:issue+is:open+%22Operational+Issue%22" -ForegroundColor DarkGray
+            }
+        }
+
+        # Emit structured summary for dotnet/dotnet
+        $vmrSummary = [ordered]@{
+            mode        = "flow-health"
+            repository  = $Repository
+            backflow    = [ordered]@{ covered = 0; upToDate = 0; blocked = 0; missing = 0 }
+            forwardFlow = [ordered]@{ healthy = 0; stale = 0; conflicted = 0 }
+            buildFreshness = @($checkedChannels.Values | ForEach-Object {
+                $entry = [ordered]@{ channel = $_.Channel; version = $_.Version; ageDays = [math]::Round($_.Age.TotalDays, 1); published = $_.Published.ToString("o") }
+                if ($_.Commit) { $entry.commit = $_.Commit }
+                if ($_.BuildLink) { $entry.buildLink = $_.BuildLink }
+                if ($_.Source) { $entry.source = $_.Source }
+                $entry
+            })
+            buildsAreStale = $anyVeryStale
+        }
+        Write-Host ""
+        Write-Host "[CODEFLOW_SUMMARY]"
+        Write-Host ($vmrSummary | ConvertTo-Json -Depth 4 -Compress)
+        Write-Host "[/CODEFLOW_SUMMARY]"
+
+        return
+    }
+
+    # Find open backflow PRs (to know which branches are already covered)
+    # Use gh pr list (REST API, reliable) instead of gh search prs (search index, can lag)
+    # Use --search instead of --author to avoid PS 5.1 bracket-mangling with [bot]
+    $allOpenJson = gh pr list --repo $Repository --search "author:app/dotnet-maestro" --state open --json number,title --limit 100 2>$null
+    $openPRs = @()
+    $ghSearchFailed = $false
+    if ($LASTEXITCODE -eq 0 -and $allOpenJson) {
+        try {
+            $allOpen = ($allOpenJson -join "`n") | ConvertFrom-Json
+            $openPRs = @($allOpen | Where-Object { $_.title -match 'Source code updates from dotnet/dotnet' })
+        } catch { $openPRs = @() }
+    }
+    elseif ($LASTEXITCODE -ne 0) {
+        Write-Warning "gh pr list failed (exit code $LASTEXITCODE). Check authentication with 'gh auth status'."
+        $ghSearchFailed = $true
+    }
+    $openBranches = @{}
+    foreach ($opr in $openPRs) {
+        if ($opr.title -match '^\[([^\]]+)\]') {
+            $openBranches[$Matches[1]] = $opr.number
+        }
+    }
+
+    if ($openPRs.Count -gt 0) {
+        Write-Host "  Open backflow PRs already exist:" -ForegroundColor White
+        foreach ($opr in $openPRs) {
+            Write-Host "    #$($opr.number): $($opr.title)" -ForegroundColor Green
+        }
+        Write-Host ""
+    }
+
+    # Find recently merged backflow PRs to discover branches and VMR commit mapping
+    $mergedPRsJson = gh search prs --repo $Repository --author "app/dotnet-maestro" --state closed --merged "Source code updates from dotnet/dotnet" --limit 30 --sort updated --json number,title,closedAt 2>$null
+    $mergedPRs = @()
+    if ($LASTEXITCODE -eq 0 -and $mergedPRsJson) {
+        try { $mergedPRs = ($mergedPRsJson -join "`n") | ConvertFrom-Json } catch { $mergedPRs = @() }
+    }
+    elseif ($LASTEXITCODE -ne 0 -and -not $ghSearchFailed) {
+        Write-Warning "gh search for merged PRs failed (exit code $LASTEXITCODE). Results may be incomplete."
+    }
+
+    if ($mergedPRs.Count -eq 0 -and $openPRs.Count -eq 0) {
+        if ($ghSearchFailed) {
+            Write-Host "  ❌ Could not query GitHub. Check 'gh auth status' and rate limits." -ForegroundColor Red
+        }
+        else {
+            Write-Host "  No backflow PRs found (open or recently merged). This repo may not have backflow subscriptions." -ForegroundColor Yellow
+        }
+        return
+    }
+
+    # Group merged PRs by branch, keeping only the most recently merged per branch
+    $branchLastMerged = @{}
+    foreach ($mpr in $mergedPRs) {
+        if ($mpr.title -match '^\[([^\]]+)\]') {
+            $branchName = $Matches[1]
+            if ($Branch -and $branchName -ne $Branch) { continue }
+            if (-not $branchLastMerged.ContainsKey($branchName)) {
+                $branchLastMerged[$branchName] = $mpr
+            }
+            else {
+                # Keep the one with the later closedAt (actual merge time)
+                $existing = $branchLastMerged[$branchName]
+                if ($mpr.closedAt -and $existing.closedAt -and $mpr.closedAt -gt $existing.closedAt) {
+                    $branchLastMerged[$branchName] = $mpr
+                }
+            }
+        }
+    }
+
+    if ($Branch -and -not $branchLastMerged.ContainsKey($Branch) -and -not $openBranches.ContainsKey($Branch)) {
+        Write-Host "  No backflow PRs found for branch '$Branch'." -ForegroundColor Yellow
+        return
+    }
+
+    # For each branch without an open PR, check if VMR has moved past the last merged commit
+    $missingCount = 0
+    $coveredCount = 0
+    $upToDateCount = 0
+    $blockedCount = 0
+    $vmrBranchesFound = @{}
+    $cachedPRBodies = @{}
+    $subscriptionDiagnostics = @()
+
+    # First pass: collect VMR branch mappings from merged PRs (needed for build freshness)
+    # Fetch all PR bodies in parallel (falls back to sequential on PS 5.1)
+    $prBodyJobs = @{}
+    foreach ($branchName in ($branchLastMerged.Keys | Sort-Object)) {
+        if ($openBranches.ContainsKey($branchName)) { continue }
+        $lastPR = $branchLastMerged[$branchName]
+        $prBodyJobs[$branchName] = Start-AsyncGh @('pr', 'view', $lastPR.number.ToString(), '-R', $Repository, '--json', 'body')
+    }
+
+    foreach ($branchName in ($branchLastMerged.Keys | Sort-Object)) {
+        if ($openBranches.ContainsKey($branchName)) { continue }
+        $lastPR = $branchLastMerged[$branchName]
+        $result = Complete-AsyncJob $prBodyJobs[$branchName] {
+            try {
+                $json = gh pr view $lastPR.number -R $Repository --json body 2>$null
+                if ($LASTEXITCODE -ne 0) { return $null }
+                return ($json -join "`n")
+            } catch { return $null }
+        }
+        if (-not $result) { continue }
+        try { $prDetail = $result | ConvertFrom-Json } catch { continue }
+        $cachedPRBodies[$branchName] = $prDetail
+        $vmrBranchFromPR = $null
+        if ($prDetail.body -match '\*\*Branch\*\*:\s*\[([^\]]+)\]') { $vmrBranchFromPR = $Matches[1] }
+        if ($vmrBranchFromPR) { $vmrBranchesFound[$branchName] = $vmrBranchFromPR }
+    }
+
+    # --- Official build freshness check (shown first for context) ---
+    $buildsAreStale = $false
+    if ($vmrBranchesFound.Count -gt 0) {
+        $freshnessSource = if ($script:hasDarc) { "darc" } else { "aka.ms" }
+        Write-Section "Official Build Freshness (via $freshnessSource)"
+        $checkedChannels = @{}
+        foreach ($entry in $vmrBranchesFound.GetEnumerator()) {
+            $freshness = Get-VMRBuildFreshness -VMRBranch $entry.Value
+            if ($freshness -and -not $checkedChannels.ContainsKey($freshness.Channel)) {
+                $checkedChannels[$freshness.Channel] = $freshness
+                $ageDays = $freshness.Age.TotalDays
+                $ageStr = if ($ageDays -ge 1) { "$([math]::Round($ageDays, 1))d" } else { "$([math]::Round($freshness.Age.TotalHours, 1))h" }
+                $color = if ($ageDays -gt 3) { 'Red' } elseif ($ageDays -gt 1) { 'Yellow' } else { 'Green' }
+                $isPreviewChannel = $freshness.Channel -match 'preview'
+                # Preview channels with old builds are expected post-release — don't flag as stale
+                if ($isPreviewChannel -and $ageDays -gt 14) {
+                    $color = 'DarkGray'
+                    $ageStr = "$ageStr (preview likely released)"
+                }
+                elseif (-not $isPreviewChannel -and $ageDays -gt 3) {
+                    $buildsAreStale = $true
+                }
+                $versionStr = if ($freshness.Version) { $freshness.Version } else { "unknown" }
+                $branchLabel = "$($entry.Key) → $($freshness.Channel)"
+                Write-Host "  $($branchLabel.PadRight(40)) $($versionStr.PadRight(48)) $($freshness.Published.ToString('yyyy-MM-dd HH:mm')) UTC  ($ageStr ago)" -ForegroundColor $color
+            }
+        }
+        if ($buildsAreStale) {
+            Write-Host ""
+            Write-Host "  ⚠️  Official builds appear stale — VMR may be failing to build" -ForegroundColor Yellow
+            Write-Host "    Missing backflow PRs below are likely caused by this, not a Maestro issue" -ForegroundColor DarkGray
+            Write-Host "    Check https://dev.azure.com/dnceng-public/public/_build?definitionId=278 for public CI failures" -ForegroundColor DarkGray
+            Write-Host "    See also: https://github.com/dotnet/dotnet/issues?q=is:issue+is:open+%22Operational+Issue%22" -ForegroundColor DarkGray
+        }
+    }
+
+    # --- Per-branch backflow analysis ---
+    # Pre-fetch VMR branch HEADs in parallel for branches without open PRs
+    $vmrHeadJobs = @{}
+    $vmrHeadBranches = @{}  # Track which branches we need to fetch
+    foreach ($branchName in ($branchLastMerged.Keys | Sort-Object)) {
+        if ($openBranches.ContainsKey($branchName)) { continue }
+        $vmrBranchFromPR = $vmrBranchesFound[$branchName]
+        if (-not $vmrBranchFromPR) { continue }
+        $prDetail = $cachedPRBodies[$branchName]
+        if (-not $prDetail) { continue }
+        if ($prDetail.body -notmatch '\*\*Commit\*\*:\s*\[([a-fA-F0-9]+)\]') { continue }
+        $encodedVmrBranch = [uri]::EscapeDataString($vmrBranchFromPR)
+        $vmrHeadBranches[$branchName] = $encodedVmrBranch
+        $vmrHeadJobs[$branchName] = Start-AsyncGitHubApi -Endpoint "/repos/dotnet/dotnet/commits/$encodedVmrBranch"
+    }
+
+    # Also pre-fetch health for open backflow PRs in parallel
+    $healthJobs = @{}
+    foreach ($branchName in ($branchLastMerged.Keys | Sort-Object)) {
+        if ($openBranches.ContainsKey($branchName)) {
+            $healthJobs[$branchName] = Start-AsyncGh @('pr', 'view', $openBranches[$branchName].ToString(), '-R', $Repository, '--json', 'body,comments,updatedAt,mergeable,statusCheckRollup')
+        }
+    }
+
+    # Collect VMR HEAD results
+    $cachedVmrHeads = @{}
+    foreach ($branchName in $vmrHeadBranches.Keys) {
+        $result = Complete-AsyncJob $vmrHeadJobs[$branchName] {
+            try {
+                $json = gh api "/repos/dotnet/dotnet/commits/$($vmrHeadBranches[$branchName])" 2>$null
+                if ($LASTEXITCODE -ne 0) { return $null }
+                return ($json -join "`n")
+            } catch { return $null }
+        }
+        if ($result) {
+            try { $cachedVmrHeads[$branchName] = $result | ConvertFrom-Json } catch { }
+        }
+    }
+
+    # Collect health results
+    $cachedHealthData = @{}
+    foreach ($branchName in $healthJobs.Keys) {
+        $result = Complete-AsyncJob $healthJobs[$branchName] {
+            try {
+                $json = gh pr view $openBranches[$branchName] -R $Repository --json body,comments,updatedAt,mergeable,statusCheckRollup 2>$null
+                if ($LASTEXITCODE -ne 0) { return $null }
+                return ($json -join "`n")
+            } catch { return $null }
+        }
+        if ($result) { $cachedHealthData[$branchName] = $result }
+    }
+
+    Write-Section "Backflow status ($Repository ← dotnet/dotnet)"
+
+    foreach ($branchName in ($branchLastMerged.Keys | Sort-Object)) {
+        $lastPR = $branchLastMerged[$branchName]
+        Write-Host ""
+        Write-Host "  Branch: $branchName" -ForegroundColor White
+
+        if ($openBranches.ContainsKey($branchName)) {
+            # Use pre-fetched health data — simplified check (no mergeable/verification probes)
+            $bfHealth = @{ Status = "⚠️  Unknown"; Color = "Yellow"; HasConflict = $false; HasStaleness = $false; WasResolved = $false }
+            $healthJson = $cachedHealthData[$branchName]
+            if ($healthJson) {
+                try {
+                    $prDetailH = $healthJson | ConvertFrom-Json
+                    $bfHealth.Status = "✅ Healthy"; $bfHealth.Color = "Green"
+                    # Check mergeable state if available
+                    if ($prDetailH.mergeable -eq 'CONFLICTING') { $bfHealth.HasConflict = $true }
+                    if ($prDetailH.comments) {
+                        foreach ($comment in $prDetailH.comments) {
+                            if ($comment.author.login -match '^dotnet-maestro') {
+                                if ($comment.body -match 'codeflow cannot continue|the source repository has received code changes') { $bfHealth.HasStaleness = $true }
+                                if ($comment.body -match 'Conflict detected') { $bfHealth.HasConflict = $true }
+                            }
+                        }
+                    }
+                    if ($bfHealth.HasConflict) { $bfHealth.Status = "🔴 Conflict"; $bfHealth.Color = "Red" }
+                    elseif ($bfHealth.HasStaleness) { $bfHealth.Status = "⚠️  Stale"; $bfHealth.Color = "Yellow" }
+                    # CI status (flat array with conclusion/status fields)
+                    $rollupH = $prDetailH.statusCheckRollup
+                    if ($rollupH -and $rollupH.Count -gt 0) {
+                        $ciContexts = @($rollupH)
+                        $ciFailed = @($ciContexts | Where-Object { $_.conclusion -eq 'FAILURE' -or $_.conclusion -eq 'ERROR' -or $_.state -eq 'FAILURE' -or $_.state -eq 'ERROR' })
+                        if ($ciFailed.Count -gt 0) {
+                            $bfHealth.CIStatus = "red"
+                            $bfHealth.CIFailed = $ciFailed.Count
+                            $bfHealth.CITotal = $ciContexts.Count
+                        } elseif (@($ciContexts | Where-Object { ($_.status -eq 'IN_PROGRESS' -or $_.status -eq 'QUEUED' -or $_.status -eq 'PENDING') -or $_.state -eq 'PENDING' }).Count -gt 0) {
+                            $bfHealth.CIStatus = "pending"
+                        } elseif ($ciContexts.Count -gt 0) {
+                            $bfHealth.CIStatus = "green"
+                        }
+                    }
+                } catch { }
+            }
+            Write-Host "    Open backflow PR #$($openBranches[$branchName]): $($bfHealth.Status)" -ForegroundColor $bfHealth.Color
+            if ($bfHealth.CIStatus -eq 'red') {
+                Write-Host "    🔴 CI: $($bfHealth.CIFailed)/$($bfHealth.CITotal) checks failing" -ForegroundColor Red
+            } elseif ($bfHealth.CIStatus -eq 'pending') {
+                Write-Host "    ⏳ CI: checks still running" -ForegroundColor Yellow
+            } elseif ($bfHealth.CIStatus -eq 'green') {
+                Write-Host "    ✅ CI: all checks passing" -ForegroundColor Green
+            }
+            if ($bfHealth.HasConflict -or $bfHealth.HasStaleness) { $blockedCount++ }
+            elseif ($bfHealth.Status -notlike '*Unknown*') { $coveredCount++ }
+            continue
+        }
+
+        # Get the PR body to extract VMR commit (branch already collected above)
+        $vmrBranchFromPR = $vmrBranchesFound[$branchName]
+        if (-not $vmrBranchFromPR) {
+            Write-Host "    ⚠️  Could not determine VMR branch from last merged PR" -ForegroundColor Yellow
+            continue
+        }
+
+        # Use cached PR body from first pass
+        $prDetail = $cachedPRBodies[$branchName]
+        if (-not $prDetail) {
+            Write-Host "    ⚠️  Could not fetch PR details" -ForegroundColor Yellow
+            continue
+        }
+
+        $vmrCommitFromPR = $null
+        if ($prDetail.body -match '\*\*Commit\*\*:\s*\[([a-fA-F0-9]+)\]') {
+            $vmrCommitFromPR = $Matches[1]
+        }
+
+        if (-not $vmrCommitFromPR) {
+            Write-Host "    ⚠️  Could not parse VMR commit from last merged PR #$($lastPR.number)" -ForegroundColor Yellow
+            continue
+        }
+
+        Write-Host "    Last merged: PR #$($lastPR.number) on $($lastPR.closedAt)" -ForegroundColor DarkGray
+        Write-Host "    VMR branch: $vmrBranchFromPR" -ForegroundColor DarkGray
+        Write-Host "    VMR commit: $(Get-ShortSha $vmrCommitFromPR)" -ForegroundColor DarkGray
+
+        # Get current VMR branch HEAD (from pre-fetched cache)
+        $vmrHead = $cachedVmrHeads[$branchName]
+        if (-not $vmrHead) {
+            Write-Host "    ⚠️  Could not fetch VMR branch HEAD for $vmrBranchFromPR" -ForegroundColor Yellow
+            continue
+        }
+
+        $vmrHeadSha = $vmrHead.sha
+        $vmrHeadDate = $vmrHead.commit.committer.date
+
+        if ($vmrCommitFromPR -eq $vmrHeadSha -or $vmrHeadSha.StartsWith($vmrCommitFromPR) -or $vmrCommitFromPR.StartsWith($vmrHeadSha)) {
+            Write-Host "    ✅ VMR branch is at same commit — no backflow needed" -ForegroundColor Green
+            $upToDateCount++
+        }
+        else {
+            # Check if this is a released preview branch (expected to stop flowing)
+            $mergedTime = [DateTimeOffset]::Parse($lastPR.closedAt).UtcDateTime
+            $elapsed = [DateTime]::UtcNow - $mergedTime
+            $isReleasedPreview = $false
+            $vmrBranchFromPR = $vmrBranchesFound[$branchName]
+            if (($vmrBranchFromPR -match 'preview') -and ($elapsed.TotalDays -gt 14)) {
+                $isReleasedPreview = $true
+            }
+
+            if ($isReleasedPreview) {
+                Write-Host "    ℹ️  Preview likely released — no further backflow expected" -ForegroundColor DarkGray
+                if ($script:hasDarc) {
+                    $subHealth = Get-SubscriptionHealth -TargetRepo $Repository -TargetBranch $branchName
+                    if ($subHealth) {
+                        $subscriptionDiagnostics += [ordered]@{ branch = $branchName; diagnostic = $subHealth.Diagnostic; subscriptionId = $subHealth.SubscriptionId; channel = $subHealth.Channel; lastBuild = $subHealth.LastBuild; latestBuild = $subHealth.LatestBuild; message = $subHealth.Message }
+                        Write-Host "    📋 Subscription: $($subHealth.Message)" -ForegroundColor DarkGray
+                    }
+                }
+                $upToDateCount++
+            }
+            else {
+                # Check how far ahead
+                $compare = Invoke-GitHubApi "/repos/dotnet/dotnet/compare/$vmrCommitFromPR...$vmrHeadSha"
+                $ahead = if ($compare) { $compare.ahead_by } else { "?" }
+
+                Write-Host "    🔴 MISSING BACKFLOW PR" -ForegroundColor Red
+                Write-Host "    VMR is $ahead commit(s) ahead since last merged PR" -ForegroundColor Yellow
+                Write-Host "    VMR HEAD: $(Get-ShortSha $vmrHeadSha) ($vmrHeadDate)" -ForegroundColor DarkGray
+                Write-Host "    Last merged VMR commit: $(Get-ShortSha $vmrCommitFromPR)" -ForegroundColor DarkGray
+
+                if ($elapsed.TotalHours -gt 6) {
+                    if ($buildsAreStale) {
+                        Write-Host "    ℹ️  No new official build available — backflow blocked upstream" -ForegroundColor DarkGray
+                    }
+                    else {
+                        Write-Host "    ⚠️  Last PR merged $([math]::Round($elapsed.TotalHours, 1)) hours ago — Maestro may be stuck" -ForegroundColor Yellow
+                        # Cross-reference with darc subscription data
+                        if ($script:hasDarc) {
+                            $subHealth = Get-SubscriptionHealth -TargetRepo $Repository -TargetBranch $branchName
+                            if ($subHealth) {
+                                $subscriptionDiagnostics += [ordered]@{ branch = $branchName; diagnostic = $subHealth.Diagnostic; subscriptionId = $subHealth.SubscriptionId; channel = $subHealth.Channel; lastBuild = $subHealth.LastBuild; latestBuild = $subHealth.LatestBuild; message = $subHealth.Message }
+                                $diagColor = if ($subHealth.Diagnostic -in @("maestro-stuck","subscription-disabled","subscription-missing")) { "Yellow" } else { "DarkGray" }
+                                Write-Host "    📋 Subscription: $($subHealth.Message)" -ForegroundColor $diagColor
+                            }
+                        }
+                    }
+                }
+                else {
+                    Write-Host "    ℹ️  Last PR merged $([math]::Round($elapsed.TotalHours, 1)) hours ago — Maestro may still be processing" -ForegroundColor DarkGray
+                }
+                $missingCount++
+            }
+        }
+    }
+
+    # Also check open-only branches (that weren't in merged list)
+    foreach ($branchName in ($openBranches.Keys | Sort-Object)) {
+        if (-not $branchLastMerged.ContainsKey($branchName)) {
+            if ($Branch -and $branchName -ne $Branch) { continue }
+            Write-Host ""
+            Write-Host "  Branch: $branchName" -ForegroundColor White
+            $bfHealth = Get-CodeflowPRHealth -PRNumber $openBranches[$branchName] -Repo $Repository
+            Write-Host "    Open backflow PR #$($openBranches[$branchName]): $($bfHealth.Status)" -ForegroundColor $bfHealth.Color
+            if ($bfHealth.CIStatus -eq 'red') {
+                Write-Host "    🔴 CI: $($bfHealth.CIFailed)/$($bfHealth.CITotal) checks failing" -ForegroundColor Red
+            } elseif ($bfHealth.CIStatus -eq 'pending') {
+                Write-Host "    ⏳ CI: checks still running" -ForegroundColor Yellow
+            } elseif ($bfHealth.CIStatus -eq 'green') {
+                Write-Host "    ✅ CI: all checks passing" -ForegroundColor Green
+            }
+            if ($bfHealth.HasConflict -or $bfHealth.HasStaleness) { $blockedCount++ }
+            elseif ($bfHealth.Status -notlike '*Unknown*') { $coveredCount++ }
+        }
+    }
+
+    # --- Forward flow: check PRs from this repo into the VMR ---
+    $repoShortName = $Repository -replace '^dotnet/', ''
+    Write-Host ""
+    Write-Section "Forward flow PRs ($Repository → dotnet/dotnet)"
+
+    $fwdPRsJson = gh search prs --repo dotnet/dotnet --author "app/dotnet-maestro" --state open "Source code updates from dotnet/$repoShortName" --json number,title --limit 10 2>$null
+    $fwdPRs = @()
+    if ($LASTEXITCODE -eq 0 -and $fwdPRsJson) {
+        try { $fwdPRs = ($fwdPRsJson -join "`n") | ConvertFrom-Json } catch { $fwdPRs = @() }
+    }
+    # Filter to exact repo match (avoid dotnet/sdk matching dotnet/sdk-container-builds)
+    $fwdPRs = @($fwdPRs | Where-Object { $_.title -match "from dotnet/$([regex]::Escape($repoShortName))$" })
+
+    $fwdHealthy = 0
+    $fwdStale = 0
+    $fwdConflict = 0
+
+    if ($fwdPRs.Count -eq 0) {
+        Write-Host "  No open forward flow PRs found" -ForegroundColor DarkGray
+    }
+    else {
+        foreach ($fpr in $fwdPRs) {
+            $fprBranch = if ($fpr.title -match '^\[([^\]]+)\]') { $Matches[1] } else { "unknown" }
+            if ($Branch -and $fprBranch -ne $Branch) { continue }
+
+            $fwdHealth = Get-CodeflowPRHealth -PRNumber $fpr.number -Repo "dotnet/dotnet"
+
+            if ($fwdHealth.HasConflict) { $fwdConflict++ }
+            elseif ($fwdHealth.HasStaleness) { $fwdStale++ }
+            elseif ($fwdHealth.Status -notlike '*Unknown*') { $fwdHealthy++ }
+
+            Write-Host "  PR #$($fpr.number) [$fprBranch]: $($fwdHealth.Status)" -ForegroundColor $fwdHealth.Color
+            Write-Host "    https://github.com/dotnet/dotnet/pull/$($fpr.number)" -ForegroundColor DarkGray
+        }
+    }
+
+    Write-Section "Summary"
+    Write-Host "  Backflow ($Repository ← dotnet/dotnet):" -ForegroundColor White
+    if ($coveredCount -gt 0) { Write-Host "    Branches with healthy open PRs: $coveredCount" -ForegroundColor Green }
+    if ($upToDateCount -gt 0) { Write-Host "    Branches up to date: $upToDateCount" -ForegroundColor Green }
+    if ($blockedCount -gt 0) { Write-Host "    Branches with blocked open PRs: $blockedCount" -ForegroundColor Red }
+    if ($missingCount -gt 0) {
+        Write-Host "    Branches MISSING backflow PRs: $missingCount" -ForegroundColor Red
+    }
+    if ($missingCount -eq 0 -and $blockedCount -eq 0) {
+        Write-Host "    No missing backflow PRs ✅" -ForegroundColor Green
+    }
+    Write-Host "  Forward flow ($Repository → dotnet/dotnet):" -ForegroundColor White
+    if ($fwdPRs.Count -eq 0) {
+        Write-Host "    No open forward flow PRs" -ForegroundColor DarkGray
+    }
+    else {
+        if ($fwdHealthy -gt 0) { Write-Host "    Healthy: $fwdHealthy" -ForegroundColor Green }
+        if ($fwdStale -gt 0) { Write-Host "    Stale: $fwdStale" -ForegroundColor Yellow }
+        if ($fwdConflict -gt 0) { Write-Host "    Conflicted: $fwdConflict" -ForegroundColor Red }
+    }
+
+    # Emit structured summary for CheckMissing mode
+    $buildFreshnessData = @()
+    if ($checkedChannels) {
+        $buildFreshnessData = @($checkedChannels.Values | ForEach-Object {
+            $entry = [ordered]@{ channel = $_.Channel; version = $_.Version; ageDays = [math]::Round($_.Age.TotalDays, 1); published = $_.Published.ToString("o") }
+            if ($_.Commit) { $entry.commit = $_.Commit }
+            if ($_.BuildLink) { $entry.buildLink = $_.BuildLink }
+            if ($_.Source) { $entry.source = $_.Source }
+            $entry
+        })
+    }
+    $flowSummary = [ordered]@{
+        mode        = "flow-health"
+        repository  = $Repository
+        backflow    = [ordered]@{
+            covered   = $coveredCount
+            upToDate  = $upToDateCount
+            blocked   = $blockedCount
+            missing   = $missingCount
+        }
+        forwardFlow = [ordered]@{
+            healthy    = $fwdHealthy
+            stale      = $fwdStale
+            conflicted = $fwdConflict
+        }
+        buildsAreStale   = $buildsAreStale
+        buildFreshness   = $buildFreshnessData
+    }
+    if ($subscriptionDiagnostics.Count -gt 0) {
+        $flowSummary.subscriptionHealth = $subscriptionDiagnostics
+    }
+    Write-Host ""
+    Write-Host "[CODEFLOW_SUMMARY]"
+    Write-Host ($flowSummary | ConvertTo-Json -Depth 4 -Compress)
+    Write-Host "[/CODEFLOW_SUMMARY]"
+
+    return
+}
+
+# --- Validate PRNumber for non-CheckMissing mode ---
+if (-not $PRNumber) {
+    Write-Error "PRNumber is required unless -CheckMissing is used."
+    return
+}
+
+# --- Step 1: PR Overview ---
+Write-Section "Codeflow PR #$PRNumber in $Repository"
+
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    Write-Error "GitHub CLI (gh) is not installed or not in PATH. Install from https://cli.github.com/"
+    return
+}
+
+$prJson = gh pr view $PRNumber -R $Repository --json body,title,state,author,headRefName,baseRefName,createdAt,updatedAt,url,comments,commits,additions,deletions,changedFiles
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Could not fetch PR #$PRNumber from $Repository. Ensure you are authenticated (gh auth login)."
+    return
+}
+$pr = ($prJson -join "`n") | ConvertFrom-Json
+
+Write-Status "Title" $pr.title
+Write-Status "State" $pr.state
+Write-Status "Branch" "$($pr.headRefName) -> $($pr.baseRefName)"
+Write-Status "Created" $pr.createdAt
+Write-Status "Updated" $pr.updatedAt
+Write-Host "  URL: $($pr.url)"
+
+# Check if this is actually a codeflow PR and detect flow direction
+$isMaestroPR = $pr.author.login -eq "dotnet-maestro[bot]"
+$isBackflow = $pr.title -match "Source code updates from dotnet/dotnet"
+$isForwardFlow = $pr.title -match "Source code updates from (dotnet/\S+)" -and -not $isBackflow
+if (-not $isMaestroPR -and -not $isBackflow -and -not $isForwardFlow) {
+    Write-Warning "This does not appear to be a codeflow PR (author: $($pr.author.login), title: $($pr.title))"
+    Write-Warning "Expected author 'dotnet-maestro[bot]' and title containing 'Source code updates from'"
+}
+
+if ($isForwardFlow) {
+    $sourceRepo = $Matches[1]
+    Write-Status "Flow" "Forward ($sourceRepo → $Repository)" "Cyan"
+}
+elseif ($isBackflow) {
+    Write-Status "Flow" "Backflow (dotnet/dotnet → $Repository)" "Cyan"
+}
+
+# --- Step 2: Current State (independent assessment from primary signals) ---
+Write-Section "Current State"
+
+# Check for empty diff (0 changed files)
+$isEmptyDiff = ($pr.changedFiles -eq 0 -and $pr.additions -eq 0 -and $pr.deletions -eq 0)
+if ($isEmptyDiff) {
+    Write-Host "  📭 Empty diff: 0 changed files, 0 additions, 0 deletions" -ForegroundColor Yellow
+}
+
+# Kick off parallel fetches for timeline + Version.Details.xml (both independent of each other)
+$owner, $repo = $Repository -split '/'
+$timelineJob = Start-AsyncGh @('api', "repos/$owner/$repo/issues/$PRNumber/timeline", '--paginate', '--slurp', '--jq', 'map(.[] | select(.event == "head_ref_force_pushed"))')
+
+$vdJob = $null
+if (-not $isForwardFlow) {
+    $encodedRef = [System.Uri]::EscapeDataString($pr.headRefName)
+    $vdJob = Start-AsyncGitHubApi -Endpoint "/repos/$Repository/contents/eng/Version.Details.xml?ref=$encodedRef" -Raw
+}
+
+# Collect timeline results
+$forcePushEvents = @()
+try {
+    $timelineJson = Complete-AsyncJob $timelineJob {
+        try {
+            $json = gh api "repos/$owner/$repo/issues/$PRNumber/timeline" --paginate --slurp --jq 'map(.[] | select(.event == "head_ref_force_pushed"))' 2>$null
+            if ($LASTEXITCODE -ne 0 -or -not $json) { return "[]" }
+            return ($json -join "`n")
+        } catch { return "[]" }
+    }
+    if ($timelineJson -and $timelineJson -ne "[]") {
+        $forcePushEvents = @($timelineJson | ConvertFrom-Json)
+    }
+}
+catch {
+    Write-Verbose "Failed to parse timeline JSON for force push events: $($_.Exception.Message)"
+    $forcePushEvents = @()
+}
+
+if ($forcePushEvents.Count -gt 0) {
+    foreach ($fp in $forcePushEvents) {
+        $fpActor = if ($fp.actor) { $fp.actor.login } else { "unknown" }
+        $fpTime = $fp.created_at
+        $fpSha = if ($fp.commit_id) { Get-ShortSha $fp.commit_id } else { "unknown" }
+        Write-Host "  🔄 Force push by @$fpActor at $fpTime (→ $fpSha)" -ForegroundColor Cyan
+    }
+    $lastForcePush = $forcePushEvents[-1]
+    $lastForcePushTime = if ($lastForcePush.created_at) {
+        [DateTimeOffset]::Parse($lastForcePush.created_at).UtcDateTime
+    } else { $null }
+    $lastForcePushActor = if ($lastForcePush.actor) { $lastForcePush.actor.login } else { "unknown" }
+}
+
+# Synthesize current state assessment
+$prUpdatedTime = if ($pr.updatedAt) { [DateTimeOffset]::Parse($pr.updatedAt).UtcDateTime } else { $null }
+$prAgeDays = if ($prUpdatedTime) { ([DateTime]::UtcNow - $prUpdatedTime).TotalDays } else { 0 }
+$isClosed = $pr.state -eq "CLOSED"
+$isMerged = $pr.state -eq "MERGED"
+$currentState = if ($isMerged) {
+    "MERGED"
+} elseif ($isClosed) {
+    "CLOSED"
+} elseif ($isEmptyDiff) {
+    "NO-OP"
+} elseif ($forcePushEvents.Count -gt 0 -and $lastForcePushTime -and ([DateTime]::UtcNow - $lastForcePushTime).TotalHours -lt 24) {
+    "IN_PROGRESS"
+} elseif ($prAgeDays -gt 3) {
+    "STALE"
+} else {
+    "ACTIVE"
+}
+
+Write-Host ""
+switch ($currentState) {
+    "MERGED"      { Write-Host "  ✅ MERGED — PR has been merged" -ForegroundColor Green }
+    "CLOSED"      { Write-Host "  ✖️  CLOSED — PR was closed without merging" -ForegroundColor DarkGray }
+    "NO-OP"       { Write-Host "  📭 NO-OP — empty diff, likely already resolved" -ForegroundColor Yellow }
+    "IN_PROGRESS" { Write-Host "  🔄 IN PROGRESS — recent force push, awaiting update" -ForegroundColor Cyan }
+    "STALE"       { Write-Host "  ⏳ STALE — no recent activity" -ForegroundColor Yellow }
+    "ACTIVE"      { Write-Host "  ✅ ACTIVE — PR has content" -ForegroundColor Green }
+}
+
+# --- Step 3: Codeflow Metadata ---
+Write-Section "Codeflow Metadata"
+
+$body = $pr.body
+
+# Extract subscription ID
+$subscriptionId = $null
+if ($body -match '\(Begin:([a-f0-9-]+)\)') {
+    $subscriptionId = $Matches[1]
+    Write-Status "Subscription" $subscriptionId
+}
+
+# Extract source commit (VMR commit for backflow, repo commit for forward flow)
+$sourceCommit = $null
+if ($body -match '\*\*Commit\*\*:\s*\[([a-fA-F0-9]+)\]') {
+    $sourceCommit = $Matches[1]
+    $commitLabel = if ($isForwardFlow) { "Source Commit" } else { "VMR Commit" }
+    Write-Status $commitLabel $sourceCommit
+}
+# Keep $vmrCommit alias for backflow compatibility
+$vmrCommit = $sourceCommit
+
+# Extract build info
+if ($body -match '\*\*Build\*\*:\s*\[([^\]]+)\]\(([^\)]+)\)') {
+    Write-Status "Build" "$($Matches[1])"
+    Write-Status "Build URL" $Matches[2]
+}
+
+# Extract date produced
+if ($body -match '\*\*Date Produced\*\*:\s*(.+)') {
+    Write-Status "Date Produced" $Matches[1].Trim()
+}
+
+# Extract source branch
+$vmrBranch = $null
+if ($body -match '\*\*Branch\*\*:\s*\[([^\]]+)\]') {
+    $vmrBranch = $Matches[1]
+    $branchLabel = if ($isForwardFlow) { "Source Branch" } else { "VMR Branch" }
+    Write-Status $branchLabel $vmrBranch
+}
+
+# Extract commit diff
+if ($body -match '\*\*Commit Diff\*\*:\s*\[([^\]]+)\]\(([^\)]+)\)') {
+    Write-Status "Commit Diff" $Matches[1]
+}
+
+# Extract associated repo changes from footer
+$repoChanges = @()
+$changeMatches = [regex]::Matches($body, '- (https://github\.com/([^/]+/[^/]+)/compare/([a-fA-F0-9]+)\.\.\.([a-fA-F0-9]+))')
+foreach ($m in $changeMatches) {
+    $repoChanges += @{
+        URL      = $m.Groups[1].Value
+        Repo     = $m.Groups[2].Value
+        FromSha  = $m.Groups[3].Value
+        ToSha    = $m.Groups[4].Value
+    }
+}
+if ($repoChanges.Count -gt 0) {
+    Write-Status "Associated Repos" "$($repoChanges.Count) repos with source changes"
+}
+
+if (-not $vmrCommit -or -not $vmrBranch) {
+    Write-Warning "Could not parse VMR metadata from PR body. This may not be a codeflow PR."
+    if (-not $vmrBranch) {
+        # For backflow: infer from PR target (which is the product repo branch = VMR branch name)
+        # For forward flow: infer from PR head branch pattern or source repo context
+        if ($isForwardFlow) {
+            $vmrBranch = $pr.headRefName -replace '^darc-', '' -replace '-[a-f0-9-]+$', ''
+            if (-not $vmrBranch) { $vmrBranch = $pr.baseRefName }
+        }
+        else {
+            $vmrBranch = $pr.baseRefName
+        }
+        Write-Status "Inferred Branch" "$vmrBranch (from PR metadata)"
+    }
+}
+
+# For backflow: compare against VMR (dotnet/dotnet) branch HEAD
+# For forward flow: compare against product repo branch HEAD
+$freshnessRepo = if ($isForwardFlow) { $sourceRepo } else { "dotnet/dotnet" }
+$freshnessRepoLabel = if ($isForwardFlow) { $sourceRepo } else { "VMR" }
+
+# Pre-load PR commits for use in validation and later analysis
+$prCommits = $pr.commits
+
+# --- Step 4: Determine actual VMR snapshot on the PR branch ---
+# Priority: 1) Version.Details.xml (ground truth), 2) commit messages, 3) PR body
+$branchVmrCommit = $null
+$commitMsgVmrCommit = $null
+$versionDetailsVmrCommit = $null
+
+# First: check eng/Version.Details.xml on the PR branch (authoritative source)
+if (-not $isForwardFlow) {
+    $vdContent = Complete-AsyncJob $vdJob {
+        Invoke-GitHubApi "/repos/$Repository/contents/eng/Version.Details.xml?ref=$([System.Uri]::EscapeDataString($pr.headRefName))" -Raw
+    }
+    if ($vdContent) {
+        try {
+            [xml]$vdXml = $vdContent
+            $sourceNode = $vdXml.Dependencies.Source
+            if ($sourceNode -and $sourceNode.Sha -and $sourceNode.Sha -match '^[a-fA-F0-9]{40}$') {
+                $versionDetailsVmrCommit = $sourceNode.Sha
+                $branchVmrCommit = $versionDetailsVmrCommit
+            }
+        }
+        catch {
+            # Fall back to regex if XML parsing fails
+            if ($vdContent -match '<Source\s+[^>]*Sha="([a-fA-F0-9]{40})"') {
+                $versionDetailsVmrCommit = $Matches[1]
+                $branchVmrCommit = $versionDetailsVmrCommit
+            }
+        }
+    }
+}
+
+# Second: scan commit messages for "Backflow from" / "Forward flow from" SHAs
+if ($prCommits) {
+    $reversedCommits = @($prCommits)
+    [Array]::Reverse($reversedCommits)
+    foreach ($c in $reversedCommits) {
+        $msg = $c.messageHeadline
+        if ($msg -match '(?:Backflow|Forward flow) from .+ / ([a-fA-F0-9]+)') {
+            $commitMsgVmrCommit = $Matches[1]
+            break
+        }
+    }
+    # For forward flow (no Version.Details.xml source), commit messages are primary
+    if (-not $branchVmrCommit -and $commitMsgVmrCommit) {
+        $branchVmrCommit = $commitMsgVmrCommit
+    }
+}
+
+if ($branchVmrCommit -or $vmrCommit) {
+    Write-Section "Snapshot Validation"
+    $usedBranchSnapshot = $false
+
+    if ($branchVmrCommit) {
+        # We have a branch-derived snapshot (from Version.Details.xml or commit message)
+        $branchShort = Get-ShortSha $branchVmrCommit
+        $sourceLabel = if ($versionDetailsVmrCommit -and $branchVmrCommit -eq $versionDetailsVmrCommit) { "Version.Details.xml" } else { "branch commit" }
+
+        if ($vmrCommit) {
+            $bodyShort = Get-ShortSha $vmrCommit
+            if ($vmrCommit.StartsWith($branchVmrCommit, [StringComparison]::OrdinalIgnoreCase) -or $branchVmrCommit.StartsWith($vmrCommit, [StringComparison]::OrdinalIgnoreCase)) {
+                Write-Host "  ✅ $sourceLabel ($branchShort) matches PR body ($bodyShort)" -ForegroundColor Green
+            }
+            else {
+                Write-Host "  ⚠️  MISMATCH: $sourceLabel has $branchShort but PR body claims $bodyShort" -ForegroundColor Red
+                Write-Host "  PR body is stale — using $sourceLabel for freshness check" -ForegroundColor Yellow
+            }
+        }
+        else {
+            Write-Host "  ℹ️  PR body has no commit reference — using $sourceLabel ($branchShort)" -ForegroundColor Yellow
+        }
+
+        # Resolve to full SHA for accurate comparison (skip API call if already full-length)
+        if ($branchVmrCommit.Length -ge 40) {
+            $vmrCommit = $branchVmrCommit
+            $usedBranchSnapshot = $true
+        }
+        else {
+            $resolvedCommit = Invoke-GitHubApi "/repos/$freshnessRepo/commits/$branchVmrCommit"
+            if ($resolvedCommit) {
+                $vmrCommit = $resolvedCommit.sha
+                $usedBranchSnapshot = $true
+            }
+            elseif ($vmrCommit) {
+                Write-Host "  ⚠️  Could not resolve $sourceLabel SHA $branchShort — falling back to PR body ($(Get-ShortSha $vmrCommit))" -ForegroundColor Yellow
+            }
+            else {
+                Write-Host "  ⚠️  Could not resolve $sourceLabel SHA $branchShort" -ForegroundColor Yellow
+            }
+        }
+    }
+    else {
+        # No branch-derived snapshot — PR body only
+        $commitCount = if ($prCommits) { $prCommits.Count } else { 0 }
+        if ($commitCount -eq 1 -and $prCommits[0].messageHeadline -match "^Initial commit for subscription") {
+            Write-Host "  ℹ️  PR has only an initial subscription commit — PR body snapshot ($(Get-ShortSha $vmrCommit)) not yet verifiable" -ForegroundColor DarkGray
+        }
+        else {
+            Write-Host "  ⚠️  Could not verify PR body snapshot ($(Get-ShortSha $vmrCommit)) from branch" -ForegroundColor Yellow
+        }
+    }
+}
+
+# --- Step 5: Check source freshness ---
+$freshnessLabel = if ($isForwardFlow) { "Source Freshness" } else { "VMR Freshness" }
+Write-Section $freshnessLabel
+
+$sourceHeadSha = $null
+$aheadBy = 0
+$behindBy = 0
+$compareStatus = $null
+
+if ($vmrCommit -and $vmrBranch) {
+    # Get current branch HEAD (URL-encode branch name for path segments with /)
+    $encodedBranch = [uri]::EscapeDataString($vmrBranch)
+    $branchHead = Invoke-GitHubApi "/repos/$freshnessRepo/commits/$encodedBranch"
+    if ($branchHead) {
+        $sourceHeadSha = $branchHead.sha
+        $sourceHeadDate = $branchHead.commit.committer.date
+        $snapshotSource = if ($usedBranchSnapshot) {
+            if ($versionDetailsVmrCommit -and $vmrCommit.StartsWith($versionDetailsVmrCommit, [StringComparison]::OrdinalIgnoreCase)) { "from Version.Details.xml" }
+            elseif ($commitMsgVmrCommit) { "from branch commit" }
+            else { "from branch" }
+        } else { "from PR body" }
+        Write-Status "PR snapshot" "$(Get-ShortSha $vmrCommit) ($snapshotSource)"
+        Write-Status "$freshnessRepoLabel HEAD" "$(Get-ShortSha $sourceHeadSha) ($sourceHeadDate)"
+
+        if ($vmrCommit -eq $sourceHeadSha) {
+            Write-Host "  ✅ PR is up to date with $freshnessRepoLabel branch" -ForegroundColor Green
+        }
+        else {
+            # Compare to find how many commits differ
+            $compare = Invoke-GitHubApi "/repos/$freshnessRepo/compare/$vmrCommit...$sourceHeadSha"
+            if ($compare) {
+                $aheadBy = $compare.ahead_by
+                $behindBy = $compare.behind_by
+                $compareStatus = $compare.status
+
+                switch ($compareStatus) {
+                    'identical' {
+                        Write-Host "  ✅ PR is up to date with $freshnessRepoLabel branch" -ForegroundColor Green
+                    }
+                    'ahead' {
+                        Write-Host "  ⚠️  $freshnessRepoLabel is $aheadBy commit(s) ahead of the PR snapshot" -ForegroundColor Yellow
+                    }
+                    'behind' {
+                        Write-Host "  ⚠️  $freshnessRepoLabel is $behindBy commit(s) behind the PR snapshot" -ForegroundColor Yellow
+                    }
+                    'diverged' {
+                        Write-Host "  ⚠️  $freshnessRepoLabel and PR snapshot have diverged: $aheadBy commit(s) ahead and $behindBy commit(s) behind" -ForegroundColor Yellow
+                    }
+                    default {
+                        Write-Host "  ⚠️  $freshnessRepoLabel and PR snapshot differ (status: $compareStatus)" -ForegroundColor Yellow
+                    }
+                }
+
+                if ($compare.total_commits -and $compare.commits) {
+                    $returnedCommits = @($compare.commits).Count
+                    if ($returnedCommits -lt $compare.total_commits) {
+                        Write-Host "  ⚠️  Compare API returned $returnedCommits of $($compare.total_commits) commits; listing may be incomplete." -ForegroundColor Yellow
+                    }
+                }
+
+                if ($ShowCommits -and $compare.commits) {
+                    Write-Host ""
+                    $commitLabel = switch ($compareStatus) {
+                        'ahead'  { "Commits since PR snapshot:" }
+                        'behind' { "Commits in PR snapshot but not in $freshnessRepoLabel`:" }
+                        default  { "Commits differing:" }
+                    }
+                    Write-Host "  $commitLabel" -ForegroundColor Yellow
+                    foreach ($c in $compare.commits) {
+                        $msg = ($c.commit.message -split "`n")[0]
+                        if ($msg.Length -gt 100) { $msg = $msg.Substring(0, 97) + "..." }
+                        $date = $c.commit.committer.date
+                        Write-Host "    $(Get-ShortSha $c.sha 8) $date $msg"
+                    }
+                }
+
+                # Check which repos have updates in the missing commits
+                $missingRepoUpdates = @()
+                if ($compare.commits) {
+                    foreach ($c in $compare.commits) {
+                        $msg = ($c.commit.message -split "`n")[0]
+                        if ($msg -match 'Source code updates from ([^\s(]+)') {
+                            $missingRepoUpdates += $Matches[1]
+                        }
+                    }
+                }
+                if ($missingRepoUpdates.Count -gt 0) {
+                    $uniqueRepos = $missingRepoUpdates | Select-Object -Unique
+                    Write-Host ""
+                    Write-Host "  Missing updates from: $($uniqueRepos -join ', ')" -ForegroundColor Yellow
+                }
+
+                # --- For backflow PRs that are behind: check pending forward flow PRs ---
+                if ($isBackflow -and $compareStatus -eq 'ahead' -and $aheadBy -gt 0 -and $vmrBranch) {
+                    $forwardPRsJson = gh search prs --repo dotnet/dotnet --author "app/dotnet-maestro" --state open "Source code updates from" --base $vmrBranch --json number,title --limit 20 2>$null
+                    $pendingForwardPRs = @()
+                    if ($LASTEXITCODE -eq 0 -and $forwardPRsJson) {
+                        try {
+                            $allForward = ($forwardPRsJson -join "`n") | ConvertFrom-Json
+                            # Filter to forward flow PRs (not backflow) targeting this VMR branch
+                            $pendingForwardPRs = $allForward | Where-Object {
+                                $_.title -match "Source code updates from (dotnet/\S+)" -and
+                                $Matches[1] -ne "dotnet/dotnet"
+                            }
+                        }
+                        catch {
+                            Write-Warning "Failed to parse forward flow PR search results. Skipping forward flow analysis."
+                        }
+                    }
+
+                    if ($pendingForwardPRs.Count -gt 0) {
+                        Write-Host ""
+                        Write-Host "  Pending forward flow PRs into VMR ($vmrBranch):" -ForegroundColor Cyan
+
+                        $coveredRepos = @()
+                        foreach ($fpr in $pendingForwardPRs) {
+                            $fprSourceRepo = $null
+                            if ($fpr.title -match "Source code updates from (dotnet/\S+)") {
+                                $fprSourceRepo = $Matches[1]
+                            }
+                            $coveredLabel = ""
+                            if ($fprSourceRepo -and $uniqueRepos -contains $fprSourceRepo) {
+                                $coveredRepos += $fprSourceRepo
+                                $coveredLabel = " ← covers missing updates"
+                            }
+                            Write-Host "    dotnet/dotnet#$($fpr.number): $($fpr.title)$coveredLabel" -ForegroundColor DarkGray
+                        }
+
+                        if ($coveredRepos.Count -gt 0) {
+                            $uncoveredRepos = $uniqueRepos | Where-Object { $_ -notin $coveredRepos }
+                            $coveredCount = $coveredRepos.Count
+                            $totalMissing = $uniqueRepos.Count
+                            Write-Host ""
+                            Write-Host "  📊 Forward flow coverage: $coveredCount of $totalMissing missing repo(s) have pending forward flow PRs" -ForegroundColor Cyan
+                            if ($uncoveredRepos.Count -gt 0) {
+                                Write-Host "  Still waiting on: $($uncoveredRepos -join ', ')" -ForegroundColor Yellow
+                            }
+                            else {
+                                Write-Host "  ✅ All missing repos have pending forward flow — gap should close once they merge + new backflow triggers" -ForegroundColor Green
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+else {
+    Write-Warning "Cannot check freshness without source commit and branch info"
+}
+
+# Collect Maestro comment data (needed by PR Branch Analysis and Codeflow History)
+$stalenessWarnings = @()
+$lastStalenessComment = $null
+$conflictWarnings = @()
+$lastConflictComment = $null
+
+if ($pr.comments) {
+    foreach ($comment in $pr.comments) {
+        $commentAuthor = $comment.author.login
+        if ($commentAuthor -eq "dotnet-maestro[bot]" -or $commentAuthor -eq "dotnet-maestro") {
+            if ($comment.body -match "codeflow cannot continue" -or $comment.body -match "darc trigger-subscriptions") {
+                $stalenessWarnings += $comment
+                $lastStalenessComment = $comment
+            }
+            if ($comment.body -match "Conflict detected") {
+                $conflictWarnings += $comment
+                $lastConflictComment = $comment
+            }
+        }
+    }
+}
+
+# Extract conflicting files (used in History and Recommendations)
+$conflictFiles = @()
+if ($lastConflictComment) {
+    $fileMatches = [regex]::Matches($lastConflictComment.body, '-\s+`([^`]+)`\s*\r?\n')
+    foreach ($fm in $fileMatches) {
+        $conflictFiles += $fm.Groups[1].Value
+    }
+}
+
+# Cross-reference force push against conflict/staleness warnings (data only)
+$conflictMayBeResolved = $false
+$stalenessMayBeResolved = $false
+if ($lastForcePushTime) {
+    if ($conflictWarnings.Count -gt 0 -and $lastConflictComment) {
+        $lastConflictTime = [DateTimeOffset]::Parse($lastConflictComment.createdAt).UtcDateTime
+        if ($lastForcePushTime -gt $lastConflictTime) {
+            $conflictMayBeResolved = $true
+        }
+    }
+    if ($stalenessWarnings.Count -gt 0 -and $lastStalenessComment) {
+        $lastStalenessTime = [DateTimeOffset]::Parse($lastStalenessComment.createdAt).UtcDateTime
+        if ($lastForcePushTime -gt $lastStalenessTime) {
+            $stalenessMayBeResolved = $true
+        }
+    }
+}
+
+# --- Step 6: PR Branch Analysis ---
+Write-Section "PR Branch Analysis"
+
+if ($prCommits) {
+    $maestroCommits = @()
+    $manualCommits = @()
+    $mergeCommits = @()
+
+    foreach ($c in $prCommits) {
+        $msg = $c.messageHeadline
+        $authorLogin = if ($c.authors -and $c.authors.Count -gt 0) { $c.authors[0].login } else { $null }
+        $authorName = if ($c.authors -and $c.authors.Count -gt 0) { $c.authors[0].name } else { "unknown" }
+        $author = if ($authorLogin) { $authorLogin } else { $authorName }
+
+        if ($msg -match "^Merge branch") {
+            $mergeCommits += $c
+        }
+        elseif ($author -in @("dotnet-maestro[bot]", "dotnet-maestro") -or $msg -eq "Update dependencies") {
+            $maestroCommits += $c
+        }
+        else {
+            $manualCommits += $c
+        }
+    }
+
+    Write-Status "Total commits" $prCommits.Count
+    Write-Status "Maestro auto-updates" $maestroCommits.Count
+    Write-Status "Merge commits" $mergeCommits.Count
+    Write-Status "Manual commits" $manualCommits.Count "$(if ($manualCommits.Count -gt 0) { 'Yellow' } else { 'Green' })"
+
+    if ($manualCommits.Count -gt 0) {
+        Write-Host ""
+        Write-Host "  Manual commits (at risk if PR is closed/force-triggered):" -ForegroundColor Yellow
+        foreach ($c in $manualCommits) {
+            $msg = $c.messageHeadline
+            if ($msg.Length -gt 80) { $msg = $msg.Substring(0, 77) + "..." }
+            $authorName = if ($c.authors -and $c.authors.Count -gt 0) { $c.authors[0].name } else { "unknown" }
+            Write-Host "    $(Get-ShortSha $c.oid 8) [$authorName] $msg"
+        }
+    }
+
+    # Detect manual commits that look like codeflow-like changes (someone manually
+    # doing what Maestro would do while flow is paused)
+    $codeflowLikeManualCommits = @()
+    foreach ($c in $manualCommits) {
+        $msg = $c.messageHeadline
+        if ($msg -match 'Update dependencies' -or
+            $msg -match 'Version\.Details\.xml' -or
+            $msg -match 'Versions\.props' -or
+            $msg -match '[Bb]ackflow' -or
+            $msg -match '[Ff]orward flow' -or
+            $msg -match 'from dotnet/' -or
+            $msg -match '[a-f0-9]{7,40}' -or
+            $msg -match 'src/SourceBuild') {
+            $codeflowLikeManualCommits += $c
+        }
+    }
+
+    if ($codeflowLikeManualCommits.Count -gt 0 -and $stalenessWarnings.Count -gt 0) {
+        Write-Host ""
+        Write-Host "  ⚠️  $($codeflowLikeManualCommits.Count) manual commit(s) appear to contain codeflow-like changes while flow is paused" -ForegroundColor Yellow
+        Write-Host "     The freshness gap reported above may be partially covered by these manual updates" -ForegroundColor DarkGray
+    }
+}
+
+# --- Step 7: Codeflow History (Maestro comments as historical context) ---
+Write-Section "Codeflow History"
+Write-Host "  Maestro warnings (historical — see Current State for present status):" -ForegroundColor DarkGray
+
+if ($stalenessWarnings.Count -gt 0 -or $conflictWarnings.Count -gt 0) {
+    if ($conflictWarnings.Count -gt 0) {
+        Write-Host "  🔴 Conflict detected ($($conflictWarnings.Count) conflict warning(s))" -ForegroundColor Red
+        Write-Status "Latest conflict" $lastConflictComment.createdAt
+
+        if ($conflictFiles.Count -gt 0) {
+            Write-Host "  Conflicting files:" -ForegroundColor Yellow
+            foreach ($f in $conflictFiles) {
+                Write-Host "    - $f" -ForegroundColor Yellow
+            }
+        }
+
+        # Extract VMR commit from the conflict comment
+        if ($lastConflictComment.body -match 'sources from \[`([a-fA-F0-9]+)`\]') {
+            Write-Host "  Conflicting VMR commit: $($Matches[1])" -ForegroundColor DarkGray
+        }
+
+        # Extract resolve command
+        if ($lastConflictComment.body -match '(darc vmr resolve-conflict --subscription [a-fA-F0-9-]+(?:\s+--build [a-fA-F0-9-]+)?)') {
+            Write-Host ""
+            Write-Host "  Resolve command:" -ForegroundColor White
+            Write-Host "    $($Matches[1])" -ForegroundColor DarkGray
+        }
+    }
+
+    if ($stalenessWarnings.Count -gt 0) {
+        if ($conflictWarnings.Count -gt 0) { Write-Host "" }
+        Write-Host "  ⚠️  Staleness warning detected ($($stalenessWarnings.Count) warning(s))" -ForegroundColor Yellow
+        Write-Status "Latest warning" $lastStalenessComment.createdAt
+        $oppositeFlow = if ($isForwardFlow) { "backflow from VMR merged into $sourceRepo" } else { "forward flow merged into VMR" }
+        Write-Host "  Opposite codeflow ($oppositeFlow) while this PR was open." -ForegroundColor Yellow
+        Write-Host "  Maestro has blocked further codeflow updates to this PR." -ForegroundColor Yellow
+
+        # Extract darc commands from the warning
+        if ($lastStalenessComment.body -match 'darc trigger-subscriptions --id ([a-fA-F0-9-]+)(?:\s+--force)?') {
+            Write-Host ""
+            Write-Host "  Suggested commands from Maestro:" -ForegroundColor White
+            if ($lastStalenessComment.body -match '(darc trigger-subscriptions --id [a-fA-F0-9-]+)\s*\r?\n') {
+                Write-Host "    Normal trigger: $($Matches[1])"
+            }
+            if ($lastStalenessComment.body -match '(darc trigger-subscriptions --id [a-fA-F0-9-]+ --force)') {
+                Write-Host "    Force trigger:  $($Matches[1])"
+            }
+        }
+    }
+}
+else {
+    Write-Host "  ✅ No staleness or conflict warnings found" -ForegroundColor Green
+}
+
+# Cross-reference force push against conflict/staleness warnings (historical context)
+if ($lastForcePushTime) {
+    if ($conflictMayBeResolved) {
+        Write-Host ""
+        Write-Host "  ℹ️  Force push by @$lastForcePushActor at $($lastForcePush.created_at) is AFTER the last conflict warning" -ForegroundColor Cyan
+        Write-Host "     Conflict may have been resolved via darc vmr resolve-conflict" -ForegroundColor DarkGray
+    }
+    if ($stalenessMayBeResolved) {
+        Write-Host "  ℹ️  Force push is AFTER the staleness warning — someone may have acted on it" -ForegroundColor Cyan
+    }
+    if ($isEmptyDiff -and ($conflictMayBeResolved -or $stalenessMayBeResolved)) {
+        Write-Host ""
+        Write-Host "  📭 PR has empty diff after force push — codeflow changes may already be in target branch" -ForegroundColor Yellow
+        Write-Host "     This PR is likely a no-op. Consider merging to clear state or closing it." -ForegroundColor DarkGray
+    }
+}
+
+# --- Step 8: Trace a specific fix (optional) ---
+if ($TraceFix) {
+    Write-Section "Tracing Fix: $TraceFix"
+
+    # Parse TraceFix format: "owner/repo#number" or "repo#number"
+    $traceMatch = [regex]::Match($TraceFix, '(?:([^/]+)/)?([^#]+)#(\d+)')
+    if (-not $traceMatch.Success) {
+        Write-Warning "Could not parse TraceFix format. Expected: 'owner/repo#number' or 'repo#number'"
+    }
+    else {
+        $traceOwner = if ($traceMatch.Groups[1].Value) { $traceMatch.Groups[1].Value } else { "dotnet" }
+        $traceRepo = $traceMatch.Groups[2].Value
+        $traceNumber = $traceMatch.Groups[3].Value
+        $traceFullRepo = "$traceOwner/$traceRepo"
+
+        # Check if the fix PR is merged (use merged_at since REST may not include merged boolean)
+        $fixPR = Invoke-GitHubApi "/repos/$traceFullRepo/pulls/$traceNumber"
+        $fixIsMerged = $false
+        if ($fixPR) {
+            $fixIsMerged = $null -ne $fixPR.merged_at
+            Write-Status "Fix PR" "${traceFullRepo}#${traceNumber}: $($fixPR.title)"
+            Write-Status "State" $fixPR.state
+            Write-Status "Merged" "$(if ($fixIsMerged) { '✅ Yes' } else { '❌ No' })" "$(if ($fixIsMerged) { 'Green' } else { 'Red' })"
+            if ($fixIsMerged) {
+                Write-Status "Merged at" $fixPR.merged_at
+                Write-Status "Merge commit" $fixPR.merge_commit_sha
+                $fixMergeCommit = $fixPR.merge_commit_sha
+            }
+        }
+
+        # Check if the fix is in the VMR source-manifest.json on the target branch
+        # For forward flow, the VMR target is the PR base branch; for backflow, use $vmrBranch
+        $vmrManifestBranch = if ($isForwardFlow -and $pr.baseRefName) { $pr.baseRefName } else { $vmrBranch }
+        if ($fixIsMerged -and $vmrManifestBranch) {
+            Write-Host ""
+            Write-Host "  Checking VMR source-manifest.json on $vmrManifestBranch..." -ForegroundColor White
+
+            $encodedManifestBranch = [uri]::EscapeDataString($vmrManifestBranch)
+            $manifestUrl = "/repos/dotnet/dotnet/contents/src/source-manifest.json?ref=$encodedManifestBranch"
+            $manifestJson = Invoke-GitHubApi $manifestUrl -Raw
+            if ($manifestJson) {
+                try {
+                    $manifest = $manifestJson | ConvertFrom-Json
+                }
+                catch {
+                    Write-Warning "Could not parse VMR source-manifest.json: $_"
+                    $manifest = $null
+                }
+
+                # Find the repo in the manifest
+                $escapedRepo = [regex]::Escape($traceRepo)
+                $repoEntry = $manifest.repositories | Where-Object {
+                    $_.remoteUri -match "${escapedRepo}(\.git)?$" -or $_.path -eq $traceRepo
+                }
+
+                if ($repoEntry) {
+                    $manifestCommit = $repoEntry.commitSha
+                    Write-Status "VMR manifest commit" "$(Get-ShortSha $manifestCommit) for $($repoEntry.path)"
+
+                    # Check if the fix merge commit is an ancestor of the manifest commit
+                    if ($fixMergeCommit -eq $manifestCommit) {
+                        Write-Host "  ✅ Fix merge commit IS the VMR manifest commit" -ForegroundColor Green
+                    }
+                    else {
+                        # Check if fix is an ancestor of the manifest commit
+                        $ancestorCheck = Invoke-GitHubApi "/repos/$traceFullRepo/compare/$fixMergeCommit...$manifestCommit"
+                        if ($ancestorCheck) {
+                            if ($ancestorCheck.status -eq "ahead" -or $ancestorCheck.status -eq "identical") {
+                                Write-Host "  ✅ Fix is included in VMR manifest (manifest is ahead or identical)" -ForegroundColor Green
+                            }
+                            elseif ($ancestorCheck.status -eq "behind") {
+                                Write-Host "  ❌ Fix is NOT in VMR manifest yet (manifest is behind the fix)" -ForegroundColor Red
+                            }
+                            else {
+                                Write-Host "  ⚠️  Fix and manifest have diverged (status: $($ancestorCheck.status))" -ForegroundColor Yellow
+                            }
+                        }
+                    }
+
+                    # Now check if the PR's VMR snapshot includes this
+                    # For backflow: $vmrCommit is a VMR SHA, use it directly
+                    # For forward flow: $vmrCommit is a source repo SHA, use PR head commit in dotnet/dotnet instead
+                    $snapshotRef = $vmrCommit
+                    if ($isForwardFlow -and $pr.commits -and $pr.commits.Count -gt 0) {
+                        $snapshotRef = $pr.commits[-1].oid
+                    }
+                    if ($snapshotRef) {
+                        Write-Host ""
+                        Write-Host "  Checking if fix is in the PR's snapshot..." -ForegroundColor White
+
+                        $snapshotManifestUrl = "/repos/dotnet/dotnet/contents/src/source-manifest.json?ref=$snapshotRef"
+                        $snapshotJson = Invoke-GitHubApi $snapshotManifestUrl -Raw
+                        if ($snapshotJson) {
+                            try {
+                                $snapshotData = $snapshotJson | ConvertFrom-Json
+                            }
+                            catch {
+                                Write-Warning "Could not parse snapshot manifest: $_"
+                                $snapshotData = $null
+                            }
+
+                            $snapshotEntry = $snapshotData.repositories | Where-Object {
+                                $_.remoteUri -match "${escapedRepo}(\.git)?$" -or $_.path -eq $traceRepo
+                            }
+
+                            if ($snapshotEntry) {
+                                $snapshotCommit = $snapshotEntry.commitSha
+                                Write-Status "PR snapshot commit" "$(Get-ShortSha $snapshotCommit) for $($snapshotEntry.path)"
+
+                                if ($snapshotCommit -eq $fixMergeCommit) {
+                                    Write-Host "  ✅ Fix IS in the PR's VMR snapshot" -ForegroundColor Green
+                                }
+                                else {
+                                    $snapshotCheck = Invoke-GitHubApi "/repos/$traceFullRepo/compare/$fixMergeCommit...$snapshotCommit"
+                                    if ($snapshotCheck) {
+                                        if ($snapshotCheck.status -eq "ahead" -or $snapshotCheck.status -eq "identical") {
+                                            Write-Host "  ✅ Fix is included in PR snapshot" -ForegroundColor Green
+                                        }
+                                        else {
+                                            Write-Host "  ❌ Fix is NOT in the PR's VMR snapshot" -ForegroundColor Red
+                                            Write-Host "  The PR needs a codeflow update to pick up this fix." -ForegroundColor Yellow
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                else {
+                    Write-Warning "Could not find $traceRepo in VMR source-manifest.json"
+                }
+            }
+        }
+    }
+}
+
+# --- Step 9: Structured Summary ---
+# Emit a JSON summary for the agent to reason over when generating recommendations.
+# The agent should use SKILL.md guidance to synthesize contextual recommendations.
+
+$summary = [ordered]@{
+    prNumber        = $PRNumber
+    repository      = $Repository
+    prState         = $pr.state
+    currentState    = $currentState
+    isCodeflowPR    = ($isBackflow -or $isForwardFlow)
+    isMaestroAuthored = $isMaestroPR
+    flowDirection   = if ($isForwardFlow) { "forward" } elseif ($isBackflow) { "backflow" } else { "unknown" }
+    isEmptyDiff     = $isEmptyDiff
+    changedFiles    = [int]$pr.changedFiles
+    additions       = [int]$pr.additions
+    deletions       = [int]$pr.deletions
+    subscriptionId  = $subscriptionId
+    vmrCommit       = if ($vmrCommit) { Get-ShortSha $vmrCommit } else { $null }
+    vmrBranch       = $vmrBranch
+}
+
+# Freshness
+$hasFreshnessData = ($null -ne $vmrCommit -and $null -ne $sourceHeadSha)
+$summary.freshness = [ordered]@{
+    sourceHeadSha   = if ($sourceHeadSha) { Get-ShortSha $sourceHeadSha } else { $null }
+    compareStatus   = $compareStatus
+    aheadBy         = $aheadBy
+    behindBy        = $behindBy
+    isUpToDate      = if ($hasFreshnessData) { ($vmrCommit -eq $sourceHeadSha -or $compareStatus -eq 'identical') } else { $null }
+}
+
+# Force pushes
+$summary.forcePushes = [ordered]@{
+    count           = $forcePushEvents.Count
+    lastActor       = if ($lastForcePushActor) { $lastForcePushActor } else { $null }
+    lastTime        = if ($lastForcePushTime) { $lastForcePushTime.ToString("o") } else { $null }
+}
+
+# Warnings
+$summary.warnings = [ordered]@{
+    conflictCount           = $conflictWarnings.Count
+    conflictFiles           = $conflictFiles
+    conflictMayBeResolved   = $conflictMayBeResolved
+    stalenessCount          = $stalenessWarnings.Count
+    stalenessMayBeResolved  = $stalenessMayBeResolved
+}
+
+# Commits
+$manualCommitCount = if ($manualCommits) { $manualCommits.Count } else { 0 }
+$codeflowLikeCount = if ($codeflowLikeManualCommits) { $codeflowLikeManualCommits.Count } else { 0 }
+$mergeCommitCount = if ($mergeCommits) { $mergeCommits.Count } else { 0 }
+$mergeCommitDetails = @()
+if ($mergeCommits) {
+    foreach ($mc in $mergeCommits) {
+        $mcAuthor = if ($mc.authors -and $mc.authors.Count -gt 0) {
+            if ($mc.authors[0].login) { $mc.authors[0].login } else { $mc.authors[0].name }
+        } else { "unknown" }
+        $mergeCommitDetails += [ordered]@{
+            sha     = Get-ShortSha $mc.oid 8
+            author  = $mcAuthor
+            date    = $mc.committedDate
+            message = $mc.messageHeadline
+        }
+    }
+}
+$summary.commits = [ordered]@{
+    total                   = if ($prCommits) { $prCommits.Count } else { 0 }
+    manual                  = $manualCommitCount
+    mergeCommits            = $mergeCommitCount
+    mergeCommitDetails      = $mergeCommitDetails
+    codeflowLikeManual      = $codeflowLikeCount
+}
+
+# PR age
+$summary.age = [ordered]@{
+    daysSinceUpdate = [math]::Max(0, [math]::Round($prAgeDays, 1))
+    createdAt       = $pr.createdAt
+    updatedAt       = $pr.updatedAt
+}
+
+Write-Host ""
+Write-Host "[CODEFLOW_SUMMARY]"
+Write-Host ($summary | ConvertTo-Json -Depth 4 -Compress)
+Write-Host "[/CODEFLOW_SUMMARY]"
+
+# Ensure clean exit code (gh api failures may leave $LASTEXITCODE = 1)
+exit 0

--- a/.github/skills/flow-analysis/scripts/Get-FlowHealth.ps1
+++ b/.github/skills/flow-analysis/scripts/Get-FlowHealth.ps1
@@ -1,0 +1,462 @@
+<#
+.SYNOPSIS
+    Batch-scan codeflow PR health across branches for a repository.
+
+.DESCRIPTION
+    Scans all backflow and forward flow PRs for a repository, gathering
+    health signals in parallel. Designed to complement the flow-analysis
+    skill which uses maestro MCP tools for subscription/build data.
+
+    This script handles the GitHub-side batch operations that require
+    many parallel API calls - something an agent cannot do efficiently
+    with sequential MCP tool calls.
+
+    Maestro-side data (subscriptions, builds, channels, freshness) should
+    be gathered separately using maestro MCP tools.
+
+.PARAMETER Repository
+    Target repository in owner/repo format (e.g., dotnet/sdk).
+
+.PARAMETER Branch
+    Optional. Only scan a specific branch instead of all discovered branches.
+
+.EXAMPLE
+    ./Get-FlowHealth.ps1 -Repository "dotnet/sdk"
+
+.EXAMPLE
+    ./Get-FlowHealth.ps1 -Repository "dotnet/sdk" -Branch "main"
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Repository,
+
+    [string]$Branch
+)
+
+$ErrorActionPreference = "Continue"
+
+# Threshold for considering a closed preview PR as "released" rather than "missing"
+$ReleasedPreviewThresholdDays = 14
+
+# --- Parallel support detection ---
+$script:canParallel = $null -ne (Get-Command Start-ThreadJob -ErrorAction SilentlyContinue)
+
+function Start-AsyncGh {
+    param([string[]]$GhArgs)
+    if (-not $script:canParallel) { return $null }
+    return Start-ThreadJob -ScriptBlock {
+        param($args_)
+        $result = gh @args_ 2>$null
+        if ($LASTEXITCODE -ne 0) { return $null }
+        return ($result -join "`n")
+    } -ArgumentList (,@($GhArgs))
+}
+
+function Complete-AsyncJob {
+    param($Job, [scriptblock]$FallbackBlock)
+    if ($Job) { return Receive-Job -Job $Job -Wait -AutoRemoveJob }
+    return & $FallbackBlock
+}
+
+function Get-ShortSha {
+    param([string]$Sha, [int]$Length = 12)
+    if (-not $Sha) { return "(unknown)" }
+    return $Sha.Substring(0, [Math]::Min($Length, $Sha.Length))
+}
+
+# --- Validate ---
+if ($Repository -notmatch '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$') {
+    Write-Error "Repository must be in format 'owner/repo'"
+    return
+}
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    Write-Error "GitHub CLI (gh) is required. Install from https://cli.github.com/"
+    return
+}
+
+# --- Search for codeflow PRs ---
+Write-Host "🔍 Searching for codeflow PRs in $Repository..." -ForegroundColor Cyan
+
+# Use gh pr list (REST API, reliable) instead of gh search prs (search index, can lag)
+# Then filter client-side for codeflow PRs (title contains "Source code updates from dotnet/dotnet")
+# Use --search instead of --author to avoid PS 5.1 bracket-mangling with [bot]
+$allOpenJson = gh pr list --repo $Repository --search "author:app/dotnet-maestro" --state open --json number,title --limit 100 2>$null
+$openPRs = @()
+if ($LASTEXITCODE -eq 0 -and $allOpenJson) {
+    try {
+        $allOpen = ($allOpenJson -join "`n") | ConvertFrom-Json
+        $openPRs = @($allOpen | Where-Object { $_.title -match 'Source code updates from dotnet/dotnet' })
+    } catch { $openPRs = @() }
+}
+
+# For merged PRs, gh pr list doesn't support --merged directly, so use gh search prs
+# (search lag is less critical for merged PRs since they're historical context)
+# Use app/ author syntax to avoid PS 5.1 bracket-mangling with [bot]
+$mergedPRsJson = gh search prs --repo $Repository --author "app/dotnet-maestro" --state closed --merged "Source code updates from dotnet/dotnet" --limit 30 --sort updated --json number,title,closedAt 2>$null
+$mergedPRs = @()
+if ($LASTEXITCODE -eq 0 -and $mergedPRsJson) {
+    try { $mergedPRs = ($mergedPRsJson -join "`n") | ConvertFrom-Json } catch { $mergedPRs = @() }
+}
+
+Write-Host "  ✅ Found $($openPRs.Count) open, $($mergedPRs.Count) merged codeflow PRs" -ForegroundColor Green
+
+# --- Map open PRs by branch ---
+$openBranches = @{}
+foreach ($opr in $openPRs) {
+    if ($opr.title -match '^\[([^\]]+)\]') {
+        $openBranches[$Matches[1]] = $opr.number
+    }
+}
+
+# --- Group merged PRs by branch (most recent per branch) ---
+$branchLastMerged = @{}
+foreach ($mpr in $mergedPRs) {
+    if ($mpr.title -match '^\[([^\]]+)\]') {
+        $branchName = $Matches[1]
+        if ($Branch -and $branchName -ne $Branch) { continue }
+        if (-not $branchLastMerged.ContainsKey($branchName) -or
+            ($mpr.closedAt -and $branchLastMerged[$branchName].closedAt -and $mpr.closedAt -gt $branchLastMerged[$branchName].closedAt)) {
+            $branchLastMerged[$branchName] = $mpr
+        }
+    }
+}
+
+# --- Parallel fetch: PR bodies for merged PRs (extract VMR metadata) ---
+Write-Host "📦 Fetching PR metadata and VMR branch data..." -ForegroundColor Cyan
+$prBodyJobs = @{}
+foreach ($branchName in ($branchLastMerged.Keys | Sort-Object)) {
+    if ($openBranches.ContainsKey($branchName)) { continue }
+    $lastPR = $branchLastMerged[$branchName]
+    $prBodyJobs[$branchName] = Start-AsyncGh @('pr', 'view', $lastPR.number.ToString(), '-R', $Repository, '--json', 'body')
+}
+
+# --- Parallel fetch: open PR health data ---
+$healthJobs = @{}
+foreach ($branchName in ($openBranches.Keys | Sort-Object)) {
+    if ($Branch -and $branchName -ne $Branch) { continue }
+    $healthJobs[$branchName] = Start-AsyncGh @('pr', 'view', $openBranches[$branchName].ToString(), '-R', $Repository, '--json', 'body,comments,updatedAt,mergeable,statusCheckRollup')
+}
+
+# --- Collect PR body results and extract VMR metadata ---
+$vmrBranches = @{}
+$vmrCommits = @{}
+foreach ($branchName in ($branchLastMerged.Keys | Sort-Object)) {
+    if ($openBranches.ContainsKey($branchName)) { continue }
+    $result = Complete-AsyncJob $prBodyJobs[$branchName] {
+        $json = gh pr view $branchLastMerged[$branchName].number -R $Repository --json body 2>$null
+        if ($LASTEXITCODE -ne 0) { return $null }
+        return ($json -join "`n")
+    }
+    if (-not $result) { continue }
+    try { $prDetail = $result | ConvertFrom-Json } catch { continue }
+    if ($prDetail.body -match '\*\*Branch\*\*:\s*\[([^\]]+)\]') {
+        $vmrBranches[$branchName] = $Matches[1]
+    }
+    if ($prDetail.body -match '\*\*Commit\*\*:\s*\[([a-fA-F0-9]+)\]') {
+        $vmrCommits[$branchName] = $Matches[1]
+    }
+}
+
+# --- Parallel fetch: VMR branch HEADs ---
+Write-Host "🔗 Comparing VMR branch HEADs..." -ForegroundColor Cyan
+$vmrHeadJobs = @{}
+foreach ($branchName in $vmrBranches.Keys) {
+    if (-not $vmrCommits.ContainsKey($branchName)) { continue }
+    $encodedBranch = [uri]::EscapeDataString($vmrBranches[$branchName])
+    $vmrHeadJobs[$branchName] = Start-AsyncGh @('api', "/repos/dotnet/dotnet/commits/$encodedBranch")
+}
+
+$vmrHeads = @{}
+foreach ($branchName in $vmrHeadJobs.Keys) {
+    $result = Complete-AsyncJob $vmrHeadJobs[$branchName] {
+        $encoded = [uri]::EscapeDataString($vmrBranches[$branchName])
+        $json = gh api "/repos/dotnet/dotnet/commits/$encoded" 2>$null
+        if ($LASTEXITCODE -ne 0) { return $null }
+        return ($json -join "`n")
+    }
+    if ($result) {
+        try { $vmrHeads[$branchName] = ($result | ConvertFrom-Json) } catch { }
+    }
+}
+
+# --- Collect open PR health ---
+$openPRHealth = @{}
+foreach ($branchName in $healthJobs.Keys) {
+    $result = Complete-AsyncJob $healthJobs[$branchName] {
+        $json = gh pr view $openBranches[$branchName] -R $Repository --json body,comments,updatedAt,mergeable,statusCheckRollup 2>$null
+        if ($LASTEXITCODE -ne 0) { return $null }
+        return ($json -join "`n")
+    }
+    if (-not $result) { continue }
+    try {
+        $prDetail = $result | ConvertFrom-Json
+        $health = @{ status = "healthy"; hasConflict = $false; hasStaleness = $false }
+        if ($prDetail.mergeable -eq 'CONFLICTING') { $health.hasConflict = $true }
+        if ($prDetail.comments) {
+            foreach ($comment in $prDetail.comments) {
+                if ($comment.author.login -match '^dotnet-maestro') {
+                    if ($comment.body -match 'codeflow cannot continue|the source repository has received code changes') { $health.hasStaleness = $true }
+                    if ($comment.body -match 'Conflict detected') { $health.hasConflict = $true }
+                }
+            }
+        }
+        # CI status from statusCheckRollup
+        # gh pr view returns a flat array; CheckRun items have conclusion+status, StatusContext items have state
+        $rollup = $prDetail.statusCheckRollup
+        if ($rollup -and $rollup.Count -gt 0) {
+            $contexts = @($rollup)
+            $failed = @($contexts | Where-Object { $_.conclusion -eq 'FAILURE' -or $_.conclusion -eq 'ERROR' -or $_.state -eq 'FAILURE' -or $_.state -eq 'ERROR' })
+            $pending = @($contexts | Where-Object { ($_.status -eq 'IN_PROGRESS' -or $_.status -eq 'QUEUED' -or $_.status -eq 'PENDING') -or $_.state -eq 'PENDING' })
+            $total = $contexts.Count
+            if ($failed.Count -gt 0) {
+                $health.ciStatus = "red"
+                $health.ciFailedCount = $failed.Count
+                $health.ciTotalCount = $total
+            } elseif ($pending.Count -gt 0) {
+                $health.ciStatus = "pending"
+            } elseif ($total -gt 0) {
+                $health.ciStatus = "green"
+            } else {
+                $health.ciStatus = "none"
+            }
+        } else {
+            $health.ciStatus = "none"
+        }
+
+        if ($health.hasConflict) { $health.status = "conflict" }
+        elseif ($health.hasStaleness) { $health.status = "stale" }
+        elseif ($health.ciStatus -eq "red") { $health.status = "ci-red" }
+
+        if ($prDetail.body -match '\(Begin:([a-f0-9-]+)\)'){
+            $health.subscriptionId = $Matches[1]
+        }
+        if ($prDetail.body -match '\*\*Branch\*\*:\s*\[([^\]]+)\]') {
+            $health.vmrBranch = $Matches[1]
+        }
+
+        $openPRHealth[$branchName] = $health
+    } catch { }
+}
+
+# --- Parallel fetch: commit comparisons for branches missing PRs ---
+$compareJobs = @{}
+foreach ($branchName in $vmrCommits.Keys) {
+    if ($openBranches.ContainsKey($branchName)) { continue }
+    if (-not $vmrHeads.ContainsKey($branchName)) { continue }
+    $vmrCommit = $vmrCommits[$branchName]
+    $vmrHeadSha = $vmrHeads[$branchName].sha
+    if ($vmrCommit -eq $vmrHeadSha -or $vmrHeadSha.StartsWith($vmrCommit) -or $vmrCommit.StartsWith($vmrHeadSha)) { continue }
+    $compareJobs[$branchName] = Start-AsyncGh @('api', "/repos/dotnet/dotnet/compare/$vmrCommit...$vmrHeadSha")
+}
+
+$compareResults = @{}
+foreach ($branchName in $compareJobs.Keys) {
+    $vmrCommit = $vmrCommits[$branchName]
+    $vmrHeadSha = $vmrHeads[$branchName].sha
+    $result = Complete-AsyncJob $compareJobs[$branchName] {
+        $json = gh api "/repos/dotnet/dotnet/compare/$vmrCommit...$vmrHeadSha" 2>$null
+        if ($LASTEXITCODE -ne 0) { return $null }
+        return ($json -join "`n")
+    }
+    if ($result) {
+        try { $compareResults[$branchName] = ($result | ConvertFrom-Json) } catch { }
+    }
+}
+
+# --- Forward flow scan ---
+Write-Host "↔️ Scanning forward flow PRs..." -ForegroundColor Cyan
+$repoShortName = $Repository -replace '^dotnet/', ''
+$fwdPRsJson = gh search prs --repo dotnet/dotnet --author "app/dotnet-maestro" --state open "Source code updates from dotnet/$repoShortName" --json number,title --limit 10 2>$null
+$fwdPRs = @()
+if ($LASTEXITCODE -eq 0 -and $fwdPRsJson) {
+    try {
+        $all = ($fwdPRsJson -join "`n") | ConvertFrom-Json
+        $fwdPRs = @($all | Where-Object { $_.title -match "from dotnet/$([regex]::Escape($repoShortName))$" })
+    } catch { }
+}
+
+# Forward flow health (parallel)
+$fwdHealthJobs = @{}
+foreach ($fpr in $fwdPRs) {
+    $fwdHealthJobs[$fpr.number] = Start-AsyncGh @('pr', 'view', $fpr.number.ToString(), '-R', 'dotnet/dotnet', '--json', 'comments,mergeable,statusCheckRollup')
+}
+$fwdHealth = @{}
+foreach ($fpr in $fwdPRs) {
+    $result = Complete-AsyncJob $fwdHealthJobs[$fpr.number] {
+        $json = gh pr view $fpr.number -R dotnet/dotnet --json comments,mergeable,statusCheckRollup 2>$null
+        if ($LASTEXITCODE -ne 0) { return $null }
+        return ($json -join "`n")
+    }
+    if (-not $result) { continue }
+    try {
+        $detail = $result | ConvertFrom-Json
+        $h = @{ status = "healthy"; hasConflict = $false; hasStaleness = $false }
+        if ($detail.mergeable -eq 'CONFLICTING') { $h.hasConflict = $true }
+        if ($detail.comments) {
+            foreach ($c in $detail.comments) {
+                if ($c.author.login -match '^dotnet-maestro') {
+                    if ($c.body -match 'codeflow cannot continue|the source repository has received code changes') { $h.hasStaleness = $true }
+                    if ($c.body -match 'Conflict detected') { $h.hasConflict = $true }
+                }
+            }
+        }
+        if ($h.hasConflict) { $h.status = "conflict" }
+        elseif ($h.hasStaleness) { $h.status = "stale" }
+
+        # CI status from statusCheckRollup (flat array with conclusion/status fields)
+        $h.ciStatus = "none"
+        $rollup = $detail.statusCheckRollup
+        if ($rollup -and $rollup.Count -gt 0) {
+            $ctx = @($rollup)
+            $fail = @($ctx | Where-Object { $_.conclusion -eq 'FAILURE' -or $_.conclusion -eq 'ERROR' -or $_.state -eq 'FAILURE' -or $_.state -eq 'ERROR' })
+            $pend = @($ctx | Where-Object { ($_.status -eq 'IN_PROGRESS' -or $_.status -eq 'QUEUED' -or $_.status -eq 'PENDING') -or $_.state -eq 'PENDING' })
+            if ($fail.Count -gt 0) {
+                $h.ciStatus = "red"; $h.ciFailedCount = $fail.Count; $h.ciTotalCount = $ctx.Count
+            } elseif ($pend.Count -gt 0) { $h.ciStatus = "pending" }
+            elseif ($ctx.Count -gt 0) { $h.ciStatus = "green" }
+        }
+        if ($h.status -eq "healthy" -and $h.ciStatus -eq "red") { $h.status = "ci-red" }
+
+        $fwdHealth[$fpr.number] = $h
+    } catch { }
+}
+
+# --- Build structured JSON output ---
+$backflowBranches = @()
+
+# Open PR branches
+foreach ($branchName in ($openBranches.Keys | Sort-Object)) {
+    if ($Branch -and $branchName -ne $Branch) { continue }
+    $entry = [ordered]@{
+        branch       = $branchName
+        prNumber     = $openBranches[$branchName]
+        prState      = "open"
+    }
+    $health = $openPRHealth[$branchName]
+    if ($health) {
+        $entry.status = $health.status
+        $entry.hasConflict = $health.hasConflict
+        $entry.hasStaleness = $health.hasStaleness
+        $entry.ciStatus = $health.ciStatus
+        if ($health.ciFailedCount) { $entry.ciFailedCount = $health.ciFailedCount; $entry.ciTotalCount = $health.ciTotalCount }
+        if ($health.subscriptionId) { $entry.subscriptionId = $health.subscriptionId }
+        if ($health.vmrBranch) { $entry.vmrBranch = $health.vmrBranch }
+    } else {
+        $entry.status = "unknown"
+    }
+    $backflowBranches += $entry
+}
+
+# Branches without open PRs (from merged PR history)
+foreach ($branchName in ($branchLastMerged.Keys | Sort-Object)) {
+    if ($Branch -and $branchName -ne $Branch) { continue }
+    if ($openBranches.ContainsKey($branchName)) { continue }
+    $lastPR = $branchLastMerged[$branchName]
+    $entry = [ordered]@{
+        branch         = $branchName
+        lastMergedPR   = $lastPR.number
+        lastMergedAt   = $lastPR.closedAt
+    }
+    if ($vmrBranches.ContainsKey($branchName)) { $entry.vmrBranch = $vmrBranches[$branchName] }
+    if ($vmrCommits.ContainsKey($branchName)) { $entry.lastVmrCommit = Get-ShortSha $vmrCommits[$branchName] }
+
+    $vmrHead = $vmrHeads[$branchName]
+    if ($vmrHead) {
+        $entry.vmrHeadSha = Get-ShortSha $vmrHead.sha
+        $entry.vmrHeadDate = $vmrHead.commit.committer.date
+    }
+
+    $vmrCommit = $vmrCommits[$branchName]
+    if ($vmrHead -and $vmrCommit) {
+        if ($vmrCommit -eq $vmrHead.sha -or $vmrHead.sha.StartsWith($vmrCommit) -or $vmrCommit.StartsWith($vmrHead.sha)) {
+            $entry.status = "up-to-date"
+            $entry.aheadBy = 0
+        } else {
+            $compare = $compareResults[$branchName]
+            $entry.aheadBy = if ($compare) { $compare.ahead_by } else { -1 }
+            $isReleasedPreview = ($vmrBranches[$branchName] -match 'preview') -and
+                $lastPR.closedAt -and
+                (([DateTime]::UtcNow - [DateTimeOffset]::Parse($lastPR.closedAt).UtcDateTime).TotalDays -gt $ReleasedPreviewThresholdDays)
+            if ($isReleasedPreview) {
+                $entry.status = "released-preview"
+            } else {
+                $entry.status = "missing"
+                $elapsed = if ($lastPR.closedAt) { [DateTime]::UtcNow - [DateTimeOffset]::Parse($lastPR.closedAt).UtcDateTime } else { $null }
+                $entry.hoursSinceLastMerge = if ($elapsed) { [math]::Round($elapsed.TotalHours, 1) } else { $null }
+            }
+        }
+    } else {
+        $entry.status = "unknown"
+    }
+    $backflowBranches += $entry
+}
+
+$forwardFlowPRs = @()
+foreach ($fpr in $fwdPRs) {
+    $fprBranch = if ($fpr.title -match '^\[([^\]]+)\]') { $Matches[1] } else { "unknown" }
+    if ($Branch -and $fprBranch -ne $Branch) { continue }
+    $fEntry = [ordered]@{
+        prNumber = $fpr.number
+        branch   = $fprBranch
+        title    = $fpr.title
+    }
+    $fh = $fwdHealth[$fpr.number]
+    if ($fh) {
+        $fEntry.status = $fh.status
+        $fEntry.hasConflict = $fh.hasConflict
+        $fEntry.hasStaleness = $fh.hasStaleness
+        $fEntry.ciStatus = $fh.ciStatus
+        if ($fh.ciFailedCount) { $fEntry.ciFailedCount = $fh.ciFailedCount; $fEntry.ciTotalCount = $fh.ciTotalCount }
+    } else {
+        $fEntry.status = "unknown"
+    }
+    $forwardFlowPRs += $fEntry
+}
+
+# --- Compute summary counts ---
+$healthy = @($backflowBranches | Where-Object { $_.status -eq "healthy" }).Count
+$upToDate = @($backflowBranches | Where-Object { $_.status -eq "up-to-date" -or $_.status -eq "released-preview" }).Count
+$blocked = @($backflowBranches | Where-Object { $_.status -in @("conflict", "stale", "ci-red") }).Count
+$missing = @($backflowBranches | Where-Object { $_.status -eq "missing" }).Count
+
+$fwdHealthy = @($forwardFlowPRs | Where-Object { $_.status -eq "healthy" }).Count
+$fwdStale = @($forwardFlowPRs | Where-Object { $_.status -eq "stale" }).Count
+$fwdConflict = @($forwardFlowPRs | Where-Object { $_.status -eq "conflict" }).Count
+$fwdCiRed = @($forwardFlowPRs | Where-Object { $_.status -eq "ci-red" }).Count
+
+$output = [ordered]@{
+    repository  = $Repository
+    backflow    = [ordered]@{
+        branches  = $backflowBranches
+        summary   = [ordered]@{
+            healthy   = $healthy
+            upToDate  = $upToDate
+            blocked   = $blocked
+            missing   = $missing
+        }
+    }
+    forwardFlow = [ordered]@{
+        prs     = $forwardFlowPRs
+        summary = [ordered]@{
+            healthy    = $fwdHealthy
+            stale      = $fwdStale
+            conflicted = $fwdConflict
+            ciRed      = $fwdCiRed
+        }
+    }
+}
+
+# --- Summary ---
+$totalBranches = $backflowBranches.Count
+$totalFwd = $forwardFlowPRs.Count
+$problemCount = $blocked + $missing
+if ($problemCount -eq 0 -and $fwdStale -eq 0 -and $fwdConflict -eq 0 -and $fwdCiRed -eq 0) {
+    Write-Host "✅ ${Repository}: $totalBranches branches healthy, $totalFwd forward flow PRs" -ForegroundColor Green
+} else {
+    Write-Host "⚠️ ${Repository}: $problemCount backflow issues ($blocked blocked, $missing missing), $($fwdStale + $fwdConflict) forward flow issues" -ForegroundColor Yellow
+}
+
+# Output as JSON for the agent to consume
+$output | ConvertTo-Json -Depth 5

--- a/.github/skills/flow-analysis/scripts/flow-health.cs
+++ b/.github/skills/flow-analysis/scripts/flow-health.cs
@@ -1,0 +1,589 @@
+#!/usr/bin/env dotnet
+
+#pragma warning disable CS8600, CS8602, CS8604, IL2026, IL3050
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+
+// =============================================================================
+// flow-health.cs — Batch-scan codeflow PR health across branches
+//
+// Usage: dotnet <path>/flow-health.cs -- dotnet/runtime [--branch main]
+//
+// Replaces Get-FlowHealth.ps1 to avoid PowerShell 5.1 compatibility issues
+// (bracket-mangling in [bot] author filters, regex parsing in -File mode).
+// =============================================================================
+
+var repository = args.Length > 0 ? args[0] : null;
+var branch = args.Length > 1 && args[1] == "--branch" && args.Length > 2 ? args[2] : null;
+
+if (string.IsNullOrEmpty(repository) || !Regex.IsMatch(repository, @"^[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+$"))
+{
+    Console.Error.WriteLine("Usage: flow-health.cs -- <owner/repo> [--branch <name>]");
+    return 1;
+}
+
+const int ReleasedPreviewThresholdDays = 14;
+const int MergedRetries = 3;
+const int MaxConcurrentGhCalls = 20;
+
+// =============================================================================
+// gh CLI helper — properly async with error tracking
+// =============================================================================
+
+var ghSemaphore = new SemaphoreSlim(MaxConcurrentGhCalls);
+int ghFailureCount = 0;
+
+async Task<(string? output, string? error)> RunGhCoreAsync(string arguments, int timeoutSeconds = 30)
+{
+    await ghSemaphore.WaitAsync();
+    try
+    {
+        var psi = new ProcessStartInfo("gh", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        using var proc = Process.Start(psi);
+        if (proc == null)
+        {
+            Interlocked.Increment(ref ghFailureCount);
+            return (null, "Failed to start gh process");
+        }
+        var outputTask = proc.StandardOutput.ReadToEndAsync();
+        var errorTask = proc.StandardError.ReadToEndAsync();
+        var exited = true;
+        try { await proc.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(timeoutSeconds)); }
+        catch (TimeoutException) { exited = false; }
+        if (!exited)
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            Interlocked.Increment(ref ghFailureCount);
+            return (null, $"gh timed out after {timeoutSeconds}s: {arguments}");
+        }
+        var output = await outputTask;
+        var stderr = await errorTask;
+        if (proc.ExitCode != 0)
+        {
+            Interlocked.Increment(ref ghFailureCount);
+            return (null, stderr);
+        }
+        return (output, null);
+    }
+    catch (Exception ex)
+    {
+        Interlocked.Increment(ref ghFailureCount);
+        return (null, ex.Message);
+    }
+    finally
+    {
+        ghSemaphore.Release();
+    }
+}
+
+async Task<string?> RunGhAsync(string arguments, int timeoutSeconds = 30)
+{
+    var (output, _) = await RunGhCoreAsync(arguments, timeoutSeconds);
+    return output;
+}
+
+async Task<JsonArray?> RunGhJsonAsync(string arguments, int timeoutSeconds = 30)
+{
+    var output = await RunGhAsync(arguments, timeoutSeconds);
+    if (string.IsNullOrWhiteSpace(output)) return null;
+    try { return JsonNode.Parse(output) as JsonArray; }
+    catch { return null; }
+}
+
+async Task<JsonObject?> RunGhJsonObjectAsync(string arguments, int timeoutSeconds = 60)
+{
+    var output = await RunGhAsync(arguments, timeoutSeconds);
+    if (string.IsNullOrWhiteSpace(output)) return null;
+    try { return JsonNode.Parse(output) as JsonObject; }
+    catch { return null; }
+}
+
+// Verify gh is available before starting
+var (ghCheck, ghCheckErr) = await RunGhCoreAsync("auth status", 10);
+if (ghCheck == null)
+{
+    Console.Error.WriteLine($"❌ gh CLI is not available or not authenticated: {ghCheckErr}");
+    return 1;
+}
+ghFailureCount = 0; // reset after auth check
+
+// =============================================================================
+// Phase 1: Find codeflow PRs
+// =============================================================================
+
+Console.Error.WriteLine($"🔍 Searching for codeflow PRs in {repository}...");
+
+// Open backflow PRs — uses --search to embed author filter (avoids PS 5.1 --author [bot] bug)
+var allOpen = await RunGhJsonAsync($"pr list --repo {repository} --search \"author:app/dotnet-maestro\" --state open --json number,title --limit 100");
+var openPRs = new List<(int number, string title, string branch)>();
+if (allOpen != null)
+{
+    foreach (var pr in allOpen)
+    {
+        var title = pr?["title"]?.ToString() ?? "";
+        if (!title.Contains("Source code updates from dotnet/dotnet")) continue;
+        var num = pr?["number"]?.GetValue<int>() ?? 0;
+        var m = Regex.Match(title, @"^\[([^\]]+)\]");
+        if (m.Success && num > 0)
+            openPRs.Add((num, title, m.Groups[1].Value));
+    }
+}
+
+// Merged backflow PRs — retry up to 3 times (GitHub search index eventual consistency)
+var mergedPRs = new List<(int number, string title, string branch, string? closedAt)>();
+for (int retry = 0; retry < MergedRetries && mergedPRs.Count == 0; retry++)
+{
+    if (retry > 0) await Task.Delay(1000);
+    var allMerged = await RunGhJsonAsync($"pr list --repo {repository} --search \"author:app/dotnet-maestro Source code updates from dotnet/dotnet\" --state merged --json number,title,closedAt --limit 30");
+    if (allMerged != null)
+    {
+        foreach (var pr in allMerged)
+        {
+            var title = pr?["title"]?.ToString() ?? "";
+            var num = pr?["number"]?.GetValue<int>() ?? 0;
+            var closedAt = pr?["closedAt"]?.ToString();
+            var m = Regex.Match(title, @"^\[([^\]]+)\]");
+            if (m.Success && num > 0)
+            {
+                var brName = m.Groups[1].Value;
+                if (branch != null && brName != branch) continue;
+                mergedPRs.Add((num, title, brName, closedAt));
+            }
+        }
+    }
+}
+
+Console.Error.WriteLine($"  ✅ Found {openPRs.Count} open, {mergedPRs.Count} merged codeflow PRs");
+
+// Map open PRs by branch
+var openBranches = new Dictionary<string, int>();
+foreach (var pr in openPRs)
+    openBranches[pr.branch] = pr.number;
+
+// Group merged PRs by branch (most recent per branch)
+var branchLastMerged = new Dictionary<string, (int number, string? closedAt)>();
+foreach (var pr in mergedPRs)
+{
+    if (!branchLastMerged.TryGetValue(pr.branch, out var existing) ||
+        string.Compare(pr.closedAt, existing.closedAt, StringComparison.Ordinal) > 0)
+    {
+        branchLastMerged[pr.branch] = (pr.number, pr.closedAt);
+    }
+}
+
+// =============================================================================
+// Phase 2: Parallel fetch — PR bodies, health data, VMR metadata
+// =============================================================================
+
+Console.Error.WriteLine("📦 Fetching PR metadata and VMR branch data...");
+
+// Fetch merged PR bodies (to extract VMR branch/commit)
+var bodyTasks = new Dictionary<string, Task<string?>>();
+foreach (var kv in branchLastMerged.OrderBy(k => k.Key))
+{
+    if (openBranches.ContainsKey(kv.Key)) continue;
+    bodyTasks[kv.Key] = RunGhAsync($"pr view {kv.Value.number} -R {repository} --json body");
+}
+
+// Fetch open PR health data
+var healthTasks = new Dictionary<string, Task<string?>>();
+foreach (var kv in openBranches.OrderBy(k => k.Key))
+{
+    if (branch != null && kv.Key != branch) continue;
+    healthTasks[kv.Key] = RunGhAsync($"pr view {kv.Value} -R {repository} --json body,comments,updatedAt,mergeable,statusCheckRollup", 60);
+}
+
+// Await all body tasks, extract VMR metadata
+var vmrBranches = new Dictionary<string, string>();
+var vmrCommits = new Dictionary<string, string>();
+foreach (var kv in bodyTasks)
+{
+    var json = await kv.Value;
+    if (json == null) continue;
+    try
+    {
+        var obj = JsonNode.Parse(json);
+        var body = obj?["body"]?.ToString() ?? "";
+        var branchMatch = Regex.Match(body, @"\*\*Branch\*\*:\s*\[([^\]]+)\]");
+        if (branchMatch.Success) vmrBranches[kv.Key] = branchMatch.Groups[1].Value;
+        var commitMatch = Regex.Match(body, @"\*\*Commit\*\*:\s*\[([a-fA-F0-9]+)\]");
+        if (commitMatch.Success) vmrCommits[kv.Key] = commitMatch.Groups[1].Value;
+    }
+    catch { }
+}
+
+// =============================================================================
+// Phase 3: VMR branch HEAD comparisons
+// =============================================================================
+
+Console.Error.WriteLine("🔗 Comparing VMR branch HEADs...");
+
+var vmrHeadTasks = new Dictionary<string, Task<JsonObject?>>();
+foreach (var kv in vmrBranches)
+{
+    if (!vmrCommits.ContainsKey(kv.Key)) continue;
+    var encoded = Uri.EscapeDataString(kv.Value);
+    vmrHeadTasks[kv.Key] = RunGhJsonObjectAsync($"api /repos/dotnet/dotnet/commits/{encoded}");
+}
+
+var vmrHeads = new Dictionary<string, JsonObject>();
+foreach (var kv in vmrHeadTasks)
+{
+    var result = await kv.Value;
+    if (result != null) vmrHeads[kv.Key] = result;
+}
+
+// Compare commits for branches without open PRs
+var compareTasks = new Dictionary<string, Task<JsonObject?>>();
+foreach (var kv in vmrCommits)
+{
+    if (openBranches.ContainsKey(kv.Key)) continue;
+    if (!vmrHeads.TryGetValue(kv.Key, out var head)) continue;
+    var headSha = head["sha"]?.ToString() ?? "";
+    if (headSha.StartsWith(kv.Value) || kv.Value.StartsWith(headSha) || headSha == kv.Value) continue;
+    compareTasks[kv.Key] = RunGhJsonObjectAsync($"api /repos/dotnet/dotnet/compare/{kv.Value}...{headSha}");
+}
+
+var compareResults = new Dictionary<string, JsonObject>();
+foreach (var kv in compareTasks)
+{
+    var result = await kv.Value;
+    if (result != null) compareResults[kv.Key] = result;
+}
+
+// =============================================================================
+// Phase 4: Open PR health analysis
+// =============================================================================
+
+var openPRHealth = new Dictionary<string, Dictionary<string, object>>();
+foreach (var kv in healthTasks)
+{
+    var json = await kv.Value;
+    if (json == null) continue;
+    try
+    {
+        var detail = JsonNode.Parse(json);
+        if (detail == null) continue;
+        var health = new Dictionary<string, object>
+        {
+            ["status"] = "healthy",
+            ["hasConflict"] = false,
+            ["hasStaleness"] = false
+        };
+
+        if (detail["mergeable"]?.ToString() == "CONFLICTING")
+            health["hasConflict"] = true;
+
+        var comments = detail["comments"]?.AsArray();
+        if (comments != null)
+        {
+            foreach (var c in comments)
+            {
+                var login = c?["author"]?["login"]?.ToString() ?? "";
+                if (!login.StartsWith("dotnet-maestro")) continue;
+                var body = c?["body"]?.ToString() ?? "";
+                if (body.Contains("codeflow cannot continue") || body.Contains("the source repository has received code changes"))
+                    health["hasStaleness"] = true;
+                if (body.Contains("Conflict detected"))
+                    health["hasConflict"] = true;
+            }
+        }
+
+        // CI status
+        var rollup = detail["statusCheckRollup"]?.AsArray();
+        if (rollup != null && rollup.Count > 0)
+        {
+            int failed = 0, pending = 0, total = rollup.Count;
+            foreach (var ctx in rollup)
+            {
+                var conclusion = ctx?["conclusion"]?.ToString() ?? "";
+                var status = ctx?["status"]?.ToString() ?? "";
+                var state = ctx?["state"]?.ToString() ?? "";
+                if (conclusion is "FAILURE" or "ERROR" || state is "FAILURE" or "ERROR") failed++;
+                else if (status is "IN_PROGRESS" or "QUEUED" or "PENDING" || state == "PENDING") pending++;
+            }
+            if (failed > 0) { health["ciStatus"] = "red"; health["ciFailedCount"] = failed; health["ciTotalCount"] = total; }
+            else if (pending > 0) health["ciStatus"] = "pending";
+            else health["ciStatus"] = "green";
+        }
+        else health["ciStatus"] = "none";
+
+        if ((bool)health["hasConflict"]) health["status"] = "conflict";
+        else if ((bool)health["hasStaleness"]) health["status"] = "stale";
+        else if (health["ciStatus"].ToString() == "red") health["status"] = "ci-red";
+
+        // Extract subscription ID and VMR branch from body
+        var prBody = detail["body"]?.ToString() ?? "";
+        var subMatch = Regex.Match(prBody, @"\(Begin:([a-f0-9\-]+)\)");
+        if (subMatch.Success) health["subscriptionId"] = subMatch.Groups[1].Value;
+        var vmrBrMatch = Regex.Match(prBody, @"\*\*Branch\*\*:\s*\[([^\]]+)\]");
+        if (vmrBrMatch.Success) health["vmrBranch"] = vmrBrMatch.Groups[1].Value;
+
+        openPRHealth[kv.Key] = health;
+    }
+    catch { }
+}
+
+// =============================================================================
+// Phase 5: Forward flow scan
+// =============================================================================
+
+Console.Error.WriteLine("↔️ Scanning forward flow PRs...");
+var repoShortName = Regex.Replace(repository, @"^dotnet/", "");
+
+var fwdJson = await RunGhJsonAsync($"pr list --repo dotnet/dotnet --search \"author:app/dotnet-maestro Source code updates from dotnet/{repoShortName}\" --state open --json number,title --limit 10");
+var fwdPRs = new List<(int number, string title, string branch)>();
+if (fwdJson != null)
+{
+    var escapedName = Regex.Escape(repoShortName);
+    foreach (var pr in fwdJson)
+    {
+        var title = pr?["title"]?.ToString() ?? "";
+        var num = pr?["number"]?.GetValue<int>() ?? 0;
+        if (num > 0 && Regex.IsMatch(title, $"from dotnet/{escapedName}$"))
+        {
+            var m = Regex.Match(title, @"^\[([^\]]+)\]");
+            fwdPRs.Add((num, title, m.Success ? m.Groups[1].Value : "unknown"));
+        }
+    }
+}
+
+// Fetch forward flow health in parallel
+var fwdHealthTasks = new Dictionary<int, Task<string?>>();
+foreach (var fpr in fwdPRs)
+    fwdHealthTasks[fpr.number] = RunGhAsync($"pr view {fpr.number} -R dotnet/dotnet --json comments,mergeable,statusCheckRollup", 60);
+
+var fwdHealth = new Dictionary<int, Dictionary<string, object>>();
+foreach (var fpr in fwdPRs)
+{
+    var json = await fwdHealthTasks[fpr.number];
+    if (json == null) continue;
+    try
+    {
+        var detail = JsonNode.Parse(json);
+        if (detail == null) continue;
+        var h = new Dictionary<string, object>
+        {
+            ["status"] = "healthy",
+            ["hasConflict"] = false,
+            ["hasStaleness"] = false,
+            ["ciStatus"] = "none"
+        };
+
+        if (detail["mergeable"]?.ToString() == "CONFLICTING") h["hasConflict"] = true;
+
+        var comments = detail["comments"]?.AsArray();
+        if (comments != null)
+        {
+            foreach (var c in comments)
+            {
+                var login = c?["author"]?["login"]?.ToString() ?? "";
+                if (!login.StartsWith("dotnet-maestro")) continue;
+                var body = c?["body"]?.ToString() ?? "";
+                if (body.Contains("codeflow cannot continue") || body.Contains("the source repository has received code changes"))
+                    h["hasStaleness"] = true;
+                if (body.Contains("Conflict detected"))
+                    h["hasConflict"] = true;
+            }
+        }
+
+        if ((bool)h["hasConflict"]) h["status"] = "conflict";
+        else if ((bool)h["hasStaleness"]) h["status"] = "stale";
+
+        var rollup = detail["statusCheckRollup"]?.AsArray();
+        if (rollup != null && rollup.Count > 0)
+        {
+            int failed = 0, pending = 0;
+            foreach (var ctx in rollup)
+            {
+                var conclusion = ctx?["conclusion"]?.ToString() ?? "";
+                var status = ctx?["status"]?.ToString() ?? "";
+                var state = ctx?["state"]?.ToString() ?? "";
+                if (conclusion is "FAILURE" or "ERROR" || state is "FAILURE" or "ERROR") failed++;
+                else if (status is "IN_PROGRESS" or "QUEUED" or "PENDING" || state == "PENDING") pending++;
+            }
+            if (failed > 0) { h["ciStatus"] = "red"; h["ciFailedCount"] = failed; h["ciTotalCount"] = rollup.Count; }
+            else if (pending > 0) h["ciStatus"] = "pending";
+            else h["ciStatus"] = "green";
+        }
+
+        if (h["status"].ToString() == "healthy" && h["ciStatus"].ToString() == "red")
+            h["status"] = "ci-red";
+
+        fwdHealth[fpr.number] = h;
+    }
+    catch { }
+}
+
+// =============================================================================
+// Phase 6: Build structured JSON output
+// =============================================================================
+
+string ShortSha(string? sha) => sha == null ? "(unknown)" : sha[..Math.Min(12, sha.Length)];
+
+var backflowBranches = new List<Dictionary<string, object?>>();
+
+// Open PR branches
+foreach (var kv in openBranches.OrderBy(k => k.Key))
+{
+    if (branch != null && kv.Key != branch) continue;
+    var entry = new Dictionary<string, object?>
+    {
+        ["branch"] = kv.Key,
+        ["prNumber"] = kv.Value,
+        ["prState"] = "open"
+    };
+    if (openPRHealth.TryGetValue(kv.Key, out var health))
+    {
+        entry["status"] = health["status"];
+        entry["hasConflict"] = health["hasConflict"];
+        entry["hasStaleness"] = health["hasStaleness"];
+        entry["ciStatus"] = health["ciStatus"];
+        if (health.ContainsKey("ciFailedCount")) { entry["ciFailedCount"] = health["ciFailedCount"]; entry["ciTotalCount"] = health["ciTotalCount"]; }
+        if (health.ContainsKey("subscriptionId")) entry["subscriptionId"] = health["subscriptionId"];
+        if (health.ContainsKey("vmrBranch")) entry["vmrBranch"] = health["vmrBranch"];
+    }
+    else entry["status"] = "unknown";
+    backflowBranches.Add(entry);
+}
+
+// Branches without open PRs
+foreach (var kv in branchLastMerged.OrderBy(k => k.Key))
+{
+    if (branch != null && kv.Key != branch) continue;
+    if (openBranches.ContainsKey(kv.Key)) continue;
+    var entry = new Dictionary<string, object?>
+    {
+        ["branch"] = kv.Key,
+        ["lastMergedPR"] = kv.Value.number,
+        ["lastMergedAt"] = kv.Value.closedAt
+    };
+    if (vmrBranches.TryGetValue(kv.Key, out var vmrBr)) entry["vmrBranch"] = vmrBr;
+    if (vmrCommits.TryGetValue(kv.Key, out var vmrC)) entry["lastVmrCommit"] = ShortSha(vmrC);
+
+    if (vmrHeads.TryGetValue(kv.Key, out var head))
+    {
+        var headSha = head["sha"]?.ToString() ?? "";
+        entry["vmrHeadSha"] = ShortSha(headSha);
+        entry["vmrHeadDate"] = head["commit"]?["committer"]?["date"]?.ToString();
+
+        if (vmrCommits.TryGetValue(kv.Key, out var vc) && (headSha.StartsWith(vc) || vc.StartsWith(headSha) || headSha == vc))
+        {
+            entry["status"] = "up-to-date";
+            entry["aheadBy"] = 0;
+        }
+        else
+        {
+            var aheadBy = compareResults.TryGetValue(kv.Key, out var cmp) ? cmp["ahead_by"]?.GetValue<int>() ?? -1 : -1;
+            entry["aheadBy"] = aheadBy;
+
+            var isReleasedPreview = (vmrBr?.Contains("preview") ?? false)
+                && kv.Value.closedAt != null
+                && (DateTime.UtcNow - DateTimeOffset.Parse(kv.Value.closedAt).UtcDateTime).TotalDays > ReleasedPreviewThresholdDays;
+
+            if (isReleasedPreview)
+                entry["status"] = "released-preview";
+            else
+            {
+                entry["status"] = "missing";
+                if (kv.Value.closedAt != null)
+                    entry["hoursSinceLastMerge"] = Math.Round((DateTime.UtcNow - DateTimeOffset.Parse(kv.Value.closedAt).UtcDateTime).TotalHours, 1);
+            }
+        }
+    }
+    else entry["status"] = "unknown";
+    backflowBranches.Add(entry);
+}
+
+var forwardFlowPRs = new List<Dictionary<string, object?>>();
+foreach (var fpr in fwdPRs)
+{
+    if (branch != null && fpr.branch != branch) continue;
+    var entry = new Dictionary<string, object?>
+    {
+        ["prNumber"] = fpr.number,
+        ["branch"] = fpr.branch,
+        ["title"] = fpr.title
+    };
+    if (fwdHealth.TryGetValue(fpr.number, out var fh))
+    {
+        entry["status"] = fh["status"];
+        entry["hasConflict"] = fh["hasConflict"];
+        entry["hasStaleness"] = fh["hasStaleness"];
+        entry["ciStatus"] = fh["ciStatus"];
+        if (fh.ContainsKey("ciFailedCount")) { entry["ciFailedCount"] = fh["ciFailedCount"]; entry["ciTotalCount"] = fh["ciTotalCount"]; }
+    }
+    else entry["status"] = "unknown";
+    forwardFlowPRs.Add(entry);
+}
+
+// Summary counts
+int healthy = backflowBranches.Count(b => b["status"]?.ToString() == "healthy");
+int upToDate = backflowBranches.Count(b => b["status"]?.ToString() is "up-to-date" or "released-preview");
+int blocked = backflowBranches.Count(b => b["status"]?.ToString() is "conflict" or "stale" or "ci-red");
+int missing = backflowBranches.Count(b => b["status"]?.ToString() == "missing");
+
+int fwdHealthy = forwardFlowPRs.Count(b => b["status"]?.ToString() == "healthy");
+int fwdStale = forwardFlowPRs.Count(b => b["status"]?.ToString() == "stale");
+int fwdConflict = forwardFlowPRs.Count(b => b["status"]?.ToString() == "conflict");
+int fwdCiRed = forwardFlowPRs.Count(b => b["status"]?.ToString() == "ci-red");
+int fwdIssues = fwdStale + fwdConflict + fwdCiRed;
+
+var output = new Dictionary<string, object>
+{
+    ["repository"] = repository,
+    ["backflow"] = new Dictionary<string, object>
+    {
+        ["branches"] = backflowBranches,
+        ["summary"] = new Dictionary<string, int>
+        {
+            ["healthy"] = healthy,
+            ["upToDate"] = upToDate,
+            ["blocked"] = blocked,
+            ["missing"] = missing
+        }
+    },
+    ["forwardFlow"] = new Dictionary<string, object>
+    {
+        ["prs"] = forwardFlowPRs,
+        ["summary"] = new Dictionary<string, int>
+        {
+            ["healthy"] = fwdHealthy,
+            ["stale"] = fwdStale,
+            ["conflicted"] = fwdConflict,
+            ["ciRed"] = fwdCiRed
+        }
+    }
+};
+
+if (ghFailureCount > 0)
+    output["ghFailures"] = ghFailureCount;
+
+// Summary to stderr
+int problemCount = blocked + missing;
+if (problemCount == 0 && fwdIssues == 0)
+    Console.Error.WriteLine($"✅ {repository}: {backflowBranches.Count} branches healthy, {forwardFlowPRs.Count} forward flow PRs");
+else
+    Console.Error.WriteLine($"⚠️ {repository}: {problemCount} backflow issues ({blocked} blocked, {missing} missing), {fwdIssues} forward flow issues ({fwdCiRed} ci-red, {fwdConflict} conflict, {fwdStale} stale)");
+
+if (ghFailureCount > 0)
+    Console.Error.WriteLine($"⚠️ {ghFailureCount} gh CLI call(s) failed — results may be incomplete");
+
+// JSON to stdout
+var options = new JsonSerializerOptions
+{
+    WriteIndented = true,
+    TypeInfoResolver = new System.Text.Json.Serialization.Metadata.DefaultJsonTypeInfoResolver()
+};
+Console.WriteLine(JsonSerializer.Serialize(output, options));
+return ghFailureCount > 0 ? 2 : 0;

--- a/.github/skills/flow-tracing/SKILL.md
+++ b/.github/skills/flow-tracing/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: flow-tracing
+description: >
+  Trace dependency flow across .NET repos through the VMR pipeline.
+  USE FOR: checking if a PR/commit from repo A has reached repo B,
+  finding what runtime SHA is in an SDK build, tracing dependency
+  versions through the VMR, checking if a commit is included in an
+  SDK build, decoding SDK version strings, "has my fix reached runtime",
+  "did roslyn#80873 flow to runtime", "what SHA is in SDK version X",
+  cross-repo dependency tracing, mapping SDK versions to VMR commits.
+  DO NOT USE FOR: codeflow PR health or staleness (use flow-analysis
+  skill), CI build failures (use ci-analysis skill).
+  INVOKES: maestro and GitHub MCP tools, Get-SdkVersionTrace.ps1 script.
+---
+
+# Flow Tracing
+
+Trace dependency flow across .NET repositories through the VMR pipeline. Two workflows:
+
+1. **Cross-repo flow trace**: Has a change from repo A reached repo B? → Use Steps 1-4 below (reads GitHub files + maestro MCP directly)
+2. **SDK version trace**: What component SHA is in a specific SDK version? → **Run `Get-SdkVersionTrace.ps1`** (handles version decoding, build lookup, and servicing topology automatically)
+
+## Cross-Repo Flow Trace
+
+**Question**: "Has change X from repo A reached repo B?"
+
+### Step 1: Resolve the Source Change
+
+Identify the merge commit SHA in repo A from the PR number, issue number, commit SHA, or description the user provides. If the PR isn't merged yet, stop — the change hasn't entered the pipeline.
+
+### Step 2: Check VMR Intake (source-manifest.json)
+> ⚠️ **Internal branches** (`internal/release/*`) exist only on AzDO, not GitHub. Use the AzDO REST API to read files. See [references/internal-vmr.md](references/internal-vmr.md).
+
+Read `src/source-manifest.json` from `dotnet/dotnet` on the target VMR branch (usually `main` or `release/*`). This file is the authoritative record of what the VMR has actually consumed — subscription status reflects Maestro's bookkeeping, but the manifest reflects reality. Find the entry for repo A — the `commitSha` field shows the latest commit the VMR has consumed.
+
+**Determine if the change is included** (try in order):
+1. **Date comparison** (fastest): If the VMR commit date is months after the PR merge date, it's included.
+2. **Compare API**: Use GitHub compare endpoint if dates are close.
+3. **Commit history walk**: List recent commits if compare is unavailable.
+
+If repo A's SHA in source-manifest is not past the merge commit → the change hasn't reached the VMR yet. Check for an open forward flow PR from repo A into `dotnet/dotnet`.
+
+> ⚠️ **2xx/3xx bands**: Only the **1xx branch** source-builds all components. If tracing to a 2xx/3xx branch, runtime/aspnetcore won't appear in source-manifest — they're consumed as prebuilts from 1xx. See [references/servicing-topology.md](references/servicing-topology.md).
+
+### Step 3: Check Downstream Delivery (repo B)
+
+If the VMR has the change, check if it has flowed to repo B:
+
+> ⚠️ **`eng/Version.Details.xml`** is the file you want — it contains source dependency entries with `Sha` fields. Do NOT use `eng/Versions.props` (that has NuGet package versions, not source SHAs).
+
+1. **Check subscription health** for repo B using maestro MCP.
+2. **If current**: The change has reached repo B. Confirm by reading `eng/Version.Details.xml` in repo B.
+3. **If stale**: Read `eng/Version.Details.xml` in repo B — the `dotnet/dotnet` entry's `Sha` is the VMR commit repo B last consumed. Check `src/source-manifest.json` at *that SHA* for repo A's commitSha. If it's past the merge commit, the change reached repo B despite the stale subscription.
+4. **If stale AND change not in consumed VMR SHA**: Change is in the VMR but hasn't flowed to repo B. Suggest flow-analysis skill for diagnosis.
+
+### Step 4: Report
+
+Summarize the trace chain:
+- "✅ roslyn#80873 merged at `abc123` → VMR consumed it → runtime backflow current"
+- "⚠️ Change in VMR → but runtime backflow is 3 builds behind"
+- "❌ PR hasn't merged yet — not in pipeline"
+
+## SDK Version Trace
+
+Run the script to trace from an SDK version string to a component commit SHA:
+
+```powershell
+# Trace runtime SHA in a specific SDK version
+./scripts/Get-SdkVersionTrace.ps1 -SdkVersion "10.0.300-preview.26117.103"
+
+# Trace a specific component
+./scripts/Get-SdkVersionTrace.ps1 -SdkVersion "10.0.300-preview.26117.103" -Component "aspnetcore"
+
+# Check if specific commits are included
+./scripts/Get-SdkVersionTrace.ps1 -SdkVersion "10.0.300-preview.26117.103" -CheckCommit "b226ba1f77a4","f3bc0212e637"
+
+# Just decode the version string
+./scripts/Get-SdkVersionTrace.ps1 -SdkVersion "10.0.300-preview.26117.103" -DecodeOnly
+```
+
+The script decodes the SDK version, maps to a VMR branch, finds the build in AzDO, and walks the dependency chain through `source-manifest.json` (and `Version.Details.xml` for servicing branches that don't source-build all components).
+
+> ⚠️ **SDK version dates use Arcade's SHORT_DATE formula**: `YY*1000 + MM*50 + DD` (NOT YYDDD day-of-year). `26117` = Feb 17, 2026, NOT April 27. See [references/sdk-version-format.md](references/sdk-version-format.md).
+
+> ⚠️ **Servicing branches (2xx, 3xx)** do NOT source-build runtime. The script automatically follows the dependency chain through `Version.Details.xml` to the 1xx branch. See [references/servicing-topology.md](references/servicing-topology.md).
+
+## References
+
+- **Internal VMR branches**: See [references/internal-vmr.md](references/internal-vmr.md)
+- **SDK version format**: See [references/sdk-version-format.md](references/sdk-version-format.md)
+- **Servicing branch topology**: See [references/servicing-topology.md](references/servicing-topology.md)
+- **AzDO pipeline IDs and queries**: See [references/azdo-pipelines.md](references/azdo-pipelines.md)

--- a/.github/skills/flow-tracing/references/azdo-pipelines.md
+++ b/.github/skills/flow-tracing/references/azdo-pipelines.md
@@ -1,0 +1,83 @@
+# AzDO Pipeline Reference for VMR Builds
+
+## Pipeline Overview
+
+The VMR (`dotnet/dotnet`) is built by two pipeline tiers:
+
+### Official Builds (produces SDK artifacts)
+
+| Property | Value |
+|----------|-------|
+| **AzDO org** | `dnceng` (internal, requires auth) |
+| **Project** | `internal` |
+| **Pipeline** | `dotnet-unified-build` (definition 1330) |
+| **Branches** | `main`, `release/X.Y.Nxx`, `release/X.Y.Nxx-previewN` |
+| **Publishes to** | Maestro channels + blob storage (`ci.dot.net`) |
+
+### Public CI (validation only)
+
+| Property | Value |
+|----------|-------|
+| **AzDO org** | `dnceng-public` |
+| **Project** | `public` (ID: `cbb18261-c48f-4abb-8651-8cdcb5474649`) |
+| **Pipeline** | `dotnet-unified-build` (definition 278) |
+| **Purpose** | PR validation + scheduled CI |
+| **Does NOT publish** | to Maestro channels |
+
+## Querying Official Builds
+
+### Via AzDO MCP Tools
+
+Use the `azure-devops-pipelines_get_builds` tool:
+- `project`: `internal`
+- `definitions`: `[1330]`
+- `branchName`: `refs/heads/release/X.Y.Nxx`
+
+> ⚠️ The AzDO MCP tools connect to the `dnceng` org by default. If builds return empty, verify the org configuration.
+
+### Filtering by Date
+
+To find a build for a specific SDK version:
+1. Decode the SDK version date (see [sdk-version-format.md](sdk-version-format.md))
+2. Use `minTime`/`maxTime` to narrow the search window to ±1 day of the decoded date
+3. Match on `result: succeeded` or `result: partiallySucceeded` (some SDK builds succeed partially)
+
+### Build Properties
+
+Key fields in build results:
+
+| Field | Meaning |
+|-------|---------|
+| `sourceVersion` | The VMR commit SHA that was built |
+| `buildNumber` | Format `YYYYMMDD.N` (e.g., `20260217.3`) |
+| `result` | `succeeded`, `partiallySucceeded`, `failed` |
+| `sourceBranch` | Full ref (e.g., `refs/heads/release/10.0.3xx`) |
+
+### Via aka.ms SDK Blob URLs
+
+When you only need the latest SDK for a channel (not a specific version):
+
+```powershell
+# Resolve aka.ms → ci.dot.net blob URL (301 redirect)
+# Channel examples: 11.0.1xx, 10.0.3xx, 10.0.1xx
+$url = "https://aka.ms/dotnet/{channel}/daily/dotnet-sdk-win-x64.zip"
+```
+
+The blob URL contains the SDK version string, and `HEAD` gives the `Last-Modified` date.
+
+## Channel-to-Branch Mapping
+
+| Channel | VMR Branch | SDK Band |
+|---------|-----------|----------|
+| `.NET 11.0.1xx SDK` | `main` | 11.0.1xx |
+| `.NET 11.0.1xx-preview1 SDK` | `release/11.0.1xx-preview1` | 11.0.1xx-preview1 |
+| `.NET 10.0.3xx SDK` | `release/10.0.3xx` | 10.0.3xx |
+| `.NET 10.0.2xx SDK` | `release/10.0.2xx` | 10.0.2xx |
+| `.NET 10.0.1xx SDK` | `release/10.0.1xx` | 10.0.1xx |
+
+## Common Pitfalls
+
+1. **Wrong org**: SDK official builds are in `dnceng` (internal), NOT `dnceng-public`
+2. **Pipeline name collision**: Both orgs have a `dotnet-unified-build` pipeline but with different definition IDs (278 public, 1330 internal)
+3. **Date mismatch**: The aka.ms blob `Last-Modified` can differ from the AzDO build finish time by hours (signing/publishing delay). Use ±1 day search windows.
+4. **Partially succeeded builds**: Some SDK builds publish artifacts even when individual platform legs fail. Don't filter to only `succeeded`.

--- a/.github/skills/flow-tracing/references/internal-vmr.md
+++ b/.github/skills/flow-tracing/references/internal-vmr.md
@@ -1,0 +1,27 @@
+# Internal VMR Branches
+
+## Branch Routing
+
+| Branch pattern | Location | How to access |
+|----------------|----------|---------------|
+| `main`, `release/*` | GitHub `dotnet/dotnet` | `gh api` / GitHub MCP tools |
+| `internal/*` | AzDO (internal repo, requires auth) | AzDO Git Items REST API via `az` CLI auth |
+
+> ⚠️ **If the target branch starts with `internal/`**, do NOT try GitHub — it will 404. Go directly to AzDO.
+
+## Reading Files from AzDO
+
+Authenticate with `az account get-access-token`, then use the AzDO Git Items REST API to download file content. Key points:
+
+- `az devops invoke` for Git items returns metadata, not file content — use the REST API directly with `$format=text` to get raw content
+- Without `$format=text`, the API returns JSON metadata about the blob instead of the file itself
+- Use `versionDescriptor.version` and `versionDescriptor.versionType=branch` to target a specific branch
+
+## Internal Release Branch Semantics
+
+`internal/release/X.Y.NNN` branches (e.g., `internal/release/10.0.106`) are **point-in-time snapshots** cut from `release/X.Y.1xx` for a specific servicing release.
+
+- They are **frozen** after the cut — no continuous forward flow
+- Changes reach them only through explicit cherry-picks or merges
+- If a change landed in `release/X.Y.1xx` after the branch was cut, it missed the release
+- To determine if a change made the cut, compare the component SHA in the internal branch's `source-manifest.json` against the change's merge commit

--- a/.github/skills/flow-tracing/references/sdk-version-format.md
+++ b/.github/skills/flow-tracing/references/sdk-version-format.md
@@ -1,0 +1,77 @@
+# SDK Version Format
+
+## Version String Structure
+
+.NET SDK versions follow this format:
+
+```
+{major}.{minor}.{band}xx-{prerelease}.{SHORT_DATE}.{revision}
+```
+
+### Example: `10.0.300-preview.26117.103`
+
+| Component | Value | Meaning |
+|-----------|-------|---------|
+| Major.Minor | `10.0` | .NET version |
+| Band | `3` | SDK feature band (1xx, 2xx, 3xx) |
+| Prerelease | `preview` | Preview/RC/GA label (absent for GA) |
+| Build date code | `26117` | SHORT_DATE encoding (see below) → February 17, 2026 |
+| Revision | `103` | Build revision within that day |
+
+### Date Decoding (SHORT_DATE)
+
+The build date is encoded using Arcade's SHORT_DATE formula, defined in
+`dotnet/arcade` at `src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets`:
+
+```
+SHORT_DATE = YY * 1000 + MM * 50 + DD
+```
+
+Where `YY`, `MM`, `DD` come from the `OfficialBuildId` (format `YYYYMMDD.revision`).
+
+To **decode** a SHORT_DATE back to a calendar date:
+
+```
+YY = SHORT_DATE / 1000           (integer division)
+MM = (SHORT_DATE % 1000) / 50    (integer division)
+DD = (SHORT_DATE % 1000) % 50
+```
+
+### Examples
+
+```
+26117 → YY=26, remainder=117 → MM=117/50=2, DD=117%50=17 → 2026-02-17
+26048 → YY=26, remainder=48  → MM=48/50=0, DD=48%50=48   → invalid (MM=0!)
+25652 → YY=25, remainder=652 → MM=652/50=13, DD=652%50=2 → 2025-13-02 → invalid
+26563 → YY=26, remainder=563 → MM=563/50=11, DD=563%50=13 → 2026-11-13
+```
+
+> ⚠️ **Common mistake**: Do NOT interpret SHORT_DATE as YYDDD (day-of-year). `26117` is NOT day 117 of 2026 (April 27). It is `26*1000 + 02*50 + 17` = February 17, 2026. The formula uses `MM*50` to leave room for days up to 31 within each month slot.
+
+### Extracting the SDK Band
+
+The SDK band determines which VMR branch produced the build:
+
+| Version pattern | SDK band | VMR branch |
+|----------------|----------|------------|
+| `X.Y.1xx-*` | 1xx | `main` or `release/X.Y.1xx` or `release/X.Y.1xx-previewN` |
+| `X.Y.2xx-*` | 2xx | `release/X.Y.2xx` |
+| `X.Y.3xx-*` | 3xx | `release/X.Y.3xx` |
+
+The band digit is the **hundreds digit** of the patch version: `10.0.300` → band `3` → `release/10.0.3xx`.
+
+### AzDO Build Number Correlation
+
+AzDO unified builds use `YYYYMMDD.N` format (e.g., `20260217.3`). To correlate with an SDK version:
+
+1. Decode the SDK's SHORT_DATE to get the calendar date
+2. Search for AzDO builds on the matching VMR branch around that date
+3. The AzDO build's `sourceVersion` is the VMR commit that produced the SDK
+
+### Source of Truth
+
+The SHORT_DATE formula is defined in Arcade:
+- **MSBuild targets**: `src/Microsoft.DotNet.Arcade.Sdk/tools/Version.BeforeCommonTargets.targets`
+- **C# task**: `src/Microsoft.DotNet.Build.Tasks.Installers/src/GenerateCurrentVersion.cs`
+
+The C# `GenerateCurrentVersion` task uses a different formula (`months since base date * 100 + day`) for installer versions, but SDK prerelease suffixes use the MSBuild SHORT_DATE formula.

--- a/.github/skills/flow-tracing/references/servicing-topology.md
+++ b/.github/skills/flow-tracing/references/servicing-topology.md
@@ -1,0 +1,70 @@
+# Servicing Branch Dependency Topology
+
+## Overview
+
+Not all VMR branches build all components from source. The **1xx band** is the "full source build" band for each major version, while higher bands (2xx, 3xx) consume runtime and other components as **prebuilt packages** from the 1xx band.
+
+## Branch Hierarchy
+
+```
+release/X.Y.1xx  ← Full source build: runtime + SDK + all components
+    │
+    │  runtime packages flow as prebuilts
+    ▼
+release/X.Y.2xx  ← Source builds: SDK, roslyn, fsharp, nuget, arcade
+    │               Consumes: runtime, aspnetcore as packages from 1xx
+    │
+    │  inherits the same runtime prebuilts
+    ▼
+release/X.Y.3xx  ← Source builds: SDK, roslyn, fsharp, nuget, arcade
+                    Consumes: runtime, aspnetcore as packages from 1xx
+```
+
+## What This Means for Version Tracing
+
+When tracing a component SHA through a **1xx branch** build:
+- Check `source-manifest.json` at the VMR commit — runtime will be listed directly
+
+When tracing through a **2xx or 3xx branch** build:
+- `source-manifest.json` will NOT list runtime (it's not source-built)
+- Instead, check `eng/Version.Details.xml` for `MicrosoftNETCoreAppRefPackageVersion`
+- That dependency's `<Sha>` element points to the **1xx VMR commit** that produced the runtime packages
+- Then check `source-manifest.json` at THAT 1xx VMR commit for the actual runtime SHA
+
+### Example Chain (10.0.300 SDK)
+
+```
+10.0.300-preview.26117.103
+    → VMR branch: release/10.0.3xx
+    → VMR commit: 120a956a...
+    → Version.Details.xml: MicrosoftNETCoreAppRefPackageVersion = 10.0.2
+        → Source: dotnet-dotnet SHA 44525024...  (this is a release/10.0.1xx commit)
+        → source-manifest.json at 44525024...:
+            → dotnet/runtime: 9ffface2f3fa...
+```
+
+## Source-Build vs Prebuilt Components by Branch
+
+| Component | 1xx band | 2xx band | 3xx band |
+|-----------|----------|----------|----------|
+| runtime | ✅ Source | 📦 Prebuilt | 📦 Prebuilt |
+| aspnetcore | ✅ Source | 📦 Prebuilt | 📦 Prebuilt |
+| SDK | ✅ Source | ✅ Source | ✅ Source |
+| roslyn | ✅ Source | ✅ Source | ✅ Source |
+| fsharp | ✅ Source | ✅ Source | ✅ Source |
+| nuget | ✅ Source | ✅ Source | ✅ Source |
+| arcade | ✅ Source | ✅ Source | ✅ Source |
+
+## Forward Flow Implications
+
+- The `release/X.Y.1xx` branch receives forward flows from **all** component repos (including runtime)
+- The `release/X.Y.2xx` and `release/X.Y.3xx` branches receive forward flows from SDK, roslyn, fsharp, nuget, arcade — but **NOT** runtime or aspnetcore
+- Runtime version updates in 2xx/3xx branches come through **Version.Details.xml** updates, not forward flow PRs
+
+## Key Files in the VMR
+
+| File | Purpose | Location |
+|------|---------|----------|
+| `src/source-manifest.json` | Lists all source-built component SHAs | Root of VMR repo |
+| `eng/Version.Details.xml` | Lists package dependencies with source SHAs | Root of VMR repo |
+| `eng/Versions.props` | Package version properties | Root of VMR repo |

--- a/.github/skills/flow-tracing/scripts/Get-SdkVersionTrace.ps1
+++ b/.github/skills/flow-tracing/scripts/Get-SdkVersionTrace.ps1
@@ -1,0 +1,487 @@
+<#
+.SYNOPSIS
+    Traces which component commit SHA is included in a specific .NET SDK version.
+
+.DESCRIPTION
+    Given an SDK version string (e.g., 10.0.300-preview.26117.103), this script:
+    1. Decodes the version to extract band, build date, and revision
+    2. Maps to the correct VMR branch
+    3. Finds the AzDO unified build that produced it
+    4. Walks source-manifest.json and/or Version.Details.xml to find the component SHA
+
+.PARAMETER SdkVersion
+    Full SDK version string (e.g., "10.0.300-preview.26117.103").
+
+.PARAMETER Component
+    Component to trace. Default: "runtime". Options: runtime, aspnetcore, roslyn, sdk, fsharp, nuget.
+
+.PARAMETER DecodeOnly
+    Only decode the version string; don't trace the full dependency chain.
+
+.PARAMETER CheckCommit
+    One or more commit SHAs to check whether they are included (ancestors of) the
+    resolved component SHA. Requires a local clone of the component repo.
+
+.EXAMPLE
+    ./Get-SdkVersionTrace.ps1 -SdkVersion "10.0.300-preview.26117.103"
+
+.EXAMPLE
+    ./Get-SdkVersionTrace.ps1 -SdkVersion "10.0.300-preview.26117.103" -Component "aspnetcore"
+
+.EXAMPLE
+    ./Get-SdkVersionTrace.ps1 -SdkVersion "10.0.300-preview.26117.103" -DecodeOnly
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$SdkVersion,
+
+    [string]$Component = "runtime",
+
+    [switch]$DecodeOnly,
+
+    [string[]]$CheckCommit
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Section($title) {
+    Write-Host ""
+    Write-Host "=== $title ===" -ForegroundColor Cyan
+}
+
+function Write-Status($emoji, $message, $color) {
+    Write-Host "  $emoji $message" -ForegroundColor $color
+}
+
+function Get-GitHubFileContent {
+    param([string]$Repo, [string]$Path, [string]$Ref)
+    # GitHub Contents API returns base64 content. For files >1MB it uses download_url instead.
+    # gh api --jq '.content' can return the string with surrounding quotes or whitespace.
+    $response = gh api "repos/$Repo/contents/${Path}?ref=$Ref" 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $response) { return $null }
+    $obj = $response | ConvertFrom-Json
+    if ($obj.content) {
+        $raw = $obj.content -replace '"', '' -replace '\s', ''
+        try {
+            return [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($raw))
+        } catch {
+            Write-Status "⚠️" "Base64 decode failed, trying download_url" Yellow
+        }
+    }
+    # Fallback: download raw content via download_url
+    if ($obj.download_url) {
+        try {
+            return (Invoke-RestMethod -Uri $obj.download_url)
+        } catch {
+            return $null
+        }
+    }
+    return $null
+}
+
+# Component matching is data-driven from source-manifest.json — no hardcoded map needed.
+# The user's -Component value is matched against the manifest's "path" field or repo name in "remoteUri".
+function Find-ComponentInManifest {
+    param($Manifest, [string]$Component)
+    $lower = $Component.ToLower()
+    # Try exact path match first
+    $matches = @($manifest.repositories | Where-Object { $_.path -eq $lower })
+    if ($matches.Count -eq 1) { return $matches[0] }
+    # Try matching the repo name portion of remoteUri (e.g., "runtime" matches "https://github.com/dotnet/runtime")
+    $matches = @($manifest.repositories | Where-Object { $_.remoteUri -match "/$lower(\.\w+)?$" })
+    if ($matches.Count -eq 1) { return $matches[0] }
+    # Try partial match on path (e.g., "nuget" matches "nuget-client")
+    $matches = @($manifest.repositories | Where-Object { $_.path -like "*$lower*" })
+    if ($matches.Count -eq 1) { return $matches[0] }
+    if ($matches.Count -gt 1) {
+        Write-Status "⚠️" "Ambiguous component '$Component' — matched $($matches.Count) entries: $(($matches | ForEach-Object { $_.path }) -join ', ')" Yellow
+        return $null
+    }
+    return $null
+}
+
+# ─── Step 1: Decode SDK version ───
+
+Write-Section "Step 1: Decode SDK Version"
+
+# Parse: {major}.{minor}.{patch}-{prerelease}.{SHORT_DATE}.{revision}
+# Prerelease can be multi-part: preview.3, rc.1, alpha.1, etc.
+# or: {major}.{minor}.{patch}.{SHORT_DATE}.{revision} (GA)
+# Use non-greedy (.+?) so SHORT_DATE and revision are captured from the end.
+$versionRegex = '^(\d+)\.(\d+)\.(\d+)(?:-(.+?))?\.(\d{4,5})\.(\d+)$'
+if ($SdkVersion -notmatch $versionRegex) {
+    Write-Status "🔴" "Cannot parse SDK version: $SdkVersion" Red
+    Write-Host "  Expected format: X.Y.ZZZ[-prerelease].SHORT_DATE.revision" -ForegroundColor DarkGray
+    exit 1
+}
+
+$major = [int]$Matches[1]
+$minor = [int]$Matches[2]
+$patch = [int]$Matches[3]
+$prerelease = $Matches[4]
+$shortDate = [int]$Matches[5]
+$revision = [int]$Matches[6]
+
+$band = [int][math]::Floor($patch / 100)
+$bandStr = "${band}xx"
+
+# Decode SHORT_DATE using Arcade formula: SHORT_DATE = YY * 1000 + MM * 50 + DD
+$yy = [int][math]::Floor($shortDate / 1000)
+$remainder = $shortDate % 1000
+$mm = [int][math]::Floor($remainder / 50)
+$dd = $remainder % 50
+
+if ($mm -lt 1 -or $mm -gt 12 -or $dd -lt 1 -or $dd -gt 31) {
+    Write-Status "🔴" "Invalid SHORT_DATE $shortDate decodes to month=$mm day=$dd" Red
+    Write-Host "  The SHORT_DATE formula is YY*1000 + MM*50 + DD. Check the version string." -ForegroundColor DarkGray
+    exit 1
+}
+
+$year = 2000 + $yy
+$buildDate = Get-Date -Year $year -Month $mm -Day $dd
+$buildDateStr = $buildDate.ToString("yyyy-MM-dd")
+
+# Determine VMR branch — 1xx preview/rc branches use a suffix, all others use just the band
+# For 1xx GA: current dev major builds from 'main', released majors from 'release/X.Y.1xx'
+if ($band -eq 1 -and $prerelease) {
+    # VMR preview/rc branches use preview1/rc1 (no dot before N)
+    $normalizedPrerelease = $prerelease -replace '\\.(\d+)$', '$1'
+    $vmrBranch = "release/$major.$minor.${bandStr}-$normalizedPrerelease"
+} elseif ($band -eq 1 -and -not $prerelease) {
+    # GA 1xx — if the release branch doesn't exist, this is the current dev major (use main)
+    $vmrBranch = "release/$major.$minor.${bandStr}"
+    $encodedBranch = [uri]::EscapeDataString($vmrBranch)
+    $branchCheck = gh api "repos/dotnet/dotnet/branches/$encodedBranch" 2>$null | ConvertFrom-Json -ErrorAction SilentlyContinue
+    if (-not $branchCheck -or -not $branchCheck.name) {
+        $vmrBranch = "main"
+    }
+} else {
+    $vmrBranch = "release/$major.$minor.${bandStr}"
+}
+
+Write-Host "  SDK Version:  $SdkVersion"
+Write-Host "  Major.Minor:  $major.$minor"
+Write-Host "  Band:         ${bandStr} (patch=$patch)"
+Write-Host "  Prerelease:   $(if ($prerelease) { $prerelease } else { '(none - GA)' })"
+Write-Host "  SHORT_DATE:   $shortDate (YY=$yy MM=$mm DD=$dd)"
+Write-Host "  Build Date:   $buildDateStr"
+Write-Host "  Revision:     $revision"
+Write-Host "  VMR Branch:   $vmrBranch"
+
+if ($DecodeOnly) {
+    Write-Host ""
+    Write-Host "[SKILL_SUMMARY]"
+    $summary = [ordered]@{
+        sdkVersion = $SdkVersion
+        major = $major; minor = $minor; band = $bandStr; patch = $patch
+        prerelease = $prerelease
+        shortDate = $shortDate; buildDate = $buildDateStr
+        year = $year; month = $mm; day = $dd
+        revision = $revision
+        vmrBranch = $vmrBranch
+    }
+    Write-Host ($summary | ConvertTo-Json -Depth 4 -Compress)
+    Write-Host "[/SKILL_SUMMARY]"
+    exit 0
+}
+
+# ─── Step 2: Find the AzDO build ───
+
+Write-Section "Step 2: Find AzDO Build"
+
+Write-Host "  Searching internal builds on branch: $vmrBranch" -ForegroundColor DarkGray
+Write-Host "  Looking for builds around: $buildDateStr" -ForegroundColor DarkGray
+
+# Search ±2 days around the build date
+$minDate = $buildDate.AddDays(-2).ToString("yyyy-MM-ddT00:00:00Z")
+$maxDate = $buildDate.AddDays(2).ToString("yyyy-MM-ddT23:59:59Z")
+
+# Use az CLI to query internal builds
+# Pipeline 1330 = dotnet-unified-build in dnceng/internal
+$buildsJson = az pipelines runs list `
+    --org "https://dev.azure.com/dnceng" `
+    --project "internal" `
+    --pipeline-ids 1330 `
+    --branch "refs/heads/$vmrBranch" `
+    --top 20 `
+    --query "[?finishTime >= '$minDate' && finishTime <= '$maxDate' && (result == 'succeeded' || result == 'partiallySucceeded')]" `
+    --output json 2>$null
+
+if ($LASTEXITCODE -ne 0 -or -not $buildsJson) {
+    Write-Status "⚠️" "Could not query dnceng/internal builds (az CLI auth may be needed)." Yellow
+    Write-Host ""
+    Write-Host "[SKILL_SUMMARY]"
+    $summary = [ordered]@{
+        status = "azdo_query_failed"
+        sdkVersion = $SdkVersion
+        vmrBranch = $vmrBranch
+        buildDate = $buildDateStr
+        searchWindow = [ordered]@{ minDate = $minDate; maxDate = $maxDate }
+        note = "az CLI auth to dnceng org required for internal build lookup. Try 'az login' if not authenticated."
+    }
+    Write-Host ($summary | ConvertTo-Json -Depth 4 -Compress)
+    Write-Host "[/SKILL_SUMMARY]"
+    exit 0
+}
+
+$builds = $buildsJson | ConvertFrom-Json
+if ($builds.Count -eq 0) {
+    Write-Status "⚠️" "No successful builds found in date range $minDate to $maxDate" Yellow
+
+    Write-Host ""
+    Write-Host "[SKILL_SUMMARY]"
+    $summary = [ordered]@{
+        status = "no_builds_found"
+        sdkVersion = $SdkVersion
+        vmrBranch = $vmrBranch
+        buildDate = $buildDateStr
+        band = $bandStr
+        searchWindow = [ordered]@{ minDate = $minDate; maxDate = $maxDate }
+        note = "Decoded version data above is valid. Try widening the search window or checking the AzDO pipeline directly."
+    }
+    Write-Host ($summary | ConvertTo-Json -Depth 4 -Compress)
+    Write-Host "[/SKILL_SUMMARY]"
+    exit 0
+}
+
+# Pick the build closest to the target date
+$targetBuild = $builds | Sort-Object { [math]::Abs(([DateTime]$_.finishTime - $buildDate).TotalSeconds) } | Select-Object -First 1
+$vmrCommit = $targetBuild.sourceVersion
+$buildNumber = $targetBuild.buildNumber
+$buildResult = $targetBuild.result
+
+Write-Status "✅" "Found build: $buildNumber ($buildResult)" Green
+Write-Host "  VMR Commit: $vmrCommit"
+Write-Host "  Finished:   $($targetBuild.finishTime)"
+
+# ─── Step 3: Check source-manifest.json ───
+
+Write-Section "Step 3: Check source-manifest.json"
+
+$manifestContent = Get-GitHubFileContent -Repo "dotnet/dotnet" -Path "src/source-manifest.json" -Ref $vmrCommit
+if (-not $manifestContent) {
+    Write-Status "⚠️" "Cannot fetch source-manifest.json from VMR at $vmrCommit" Yellow
+    Write-Host "  The agent should fetch this file via gh api or raw.githubusercontent.com." -ForegroundColor DarkGray
+
+    Write-Host ""
+    Write-Host "[SKILL_SUMMARY]"
+    $summary = [ordered]@{
+        status = "manifest_fetch_failed"
+        sdkVersion = $SdkVersion
+        vmrBranch = $vmrBranch
+        vmrCommit = $vmrCommit
+        buildNumber = $buildNumber
+        component = $Component
+        fallback = "Fetch via: gh api repos/dotnet/dotnet/contents/src/source-manifest.json?ref=$vmrCommit"
+    }
+    Write-Host ($summary | ConvertTo-Json -Depth 4 -Compress)
+    Write-Host "[/SKILL_SUMMARY]"
+    exit 0
+}
+
+$manifest = $manifestContent | ConvertFrom-Json
+
+# Search for the component using data-driven matching
+$entry = Find-ComponentInManifest -Manifest $manifest -Component $Component
+
+if (-not $entry) {
+    # Show available components so the user/agent can pick the right one
+    $available = ($manifest.repositories | ForEach-Object { $_.path }) -join ', '
+    Write-Status "⚠️" "'$Component' not found in source-manifest.json at this VMR commit" Yellow
+    Write-Host "  Available components: $available" -ForegroundColor DarkGray
+}
+
+if ($entry) {
+    Write-Status "✅" "Found $Component in source-manifest.json" Green
+    Write-Host "  Repository: $($entry.remoteUri)"
+    Write-Host "  Commit SHA: $($entry.commitSha)"
+
+    $resolvedSha = $entry.commitSha
+    $resolvedRepo = $entry.remoteUri
+    $traceType = "source-built (direct)"
+} else {
+
+# ─── Step 4: Follow Version.Details.xml (servicing branches) ───
+
+Write-Section "Step 4: Follow Version.Details.xml (component is prebuilt)"
+
+Write-Status "⚠️" "$Component is NOT source-built on $vmrBranch — following dependency chain" Yellow
+
+$vdxContent = Get-GitHubFileContent -Repo "dotnet/dotnet" -Path "eng/Version.Details.xml" -Ref $vmrCommit
+if (-not $vdxContent) {
+    Write-Status "⚠️" "Cannot fetch Version.Details.xml. Agent should trace manually." Yellow
+
+    Write-Host ""
+    Write-Host "[SKILL_SUMMARY]"
+    $summary = [ordered]@{
+        status = "vdx_fetch_failed"
+        sdkVersion = $SdkVersion
+        vmrBranch = $vmrBranch
+        vmrCommit = $vmrCommit
+        buildNumber = $buildNumber
+        component = $Component
+        fallback = "Fetch eng/Version.Details.xml from dotnet/dotnet at $vmrCommit and inspect the <Dependency> entry for MicrosoftNETCoreAppRefPackageVersion, then use its <Sha> element as the component commit."
+    }
+    Write-Host ($summary | ConvertTo-Json -Depth 4 -Compress)
+    Write-Host "[/SKILL_SUMMARY]"
+    exit 0
+}
+
+[xml]$vdx = $vdxContent
+
+# Find the dependency that points to the upstream VMR commit (dotnet-dotnet source).
+# VDX uses <Uri> and <Sha> as child elements. Check both ProductDependencies and ToolsetDependencies.
+$upstreamSha = $null
+$allDeps = @()
+if ($vdx.Dependencies.ProductDependencies.Dependency) {
+    $allDeps += $vdx.Dependencies.ProductDependencies.Dependency
+}
+if ($vdx.Dependencies.ToolsetDependencies.Dependency) {
+    $allDeps += $vdx.Dependencies.ToolsetDependencies.Dependency
+}
+foreach ($dep in $allDeps) {
+    $uri = $dep.Uri
+    if ($uri -and $uri -match 'dotnet-dotnet|dotnet/dotnet') {
+        $upstreamSha = $dep.Sha
+        Write-Host "  Upstream VMR SHA: $upstreamSha"
+        Write-Host "  From package: $($dep.Name) v$($dep.Version)"
+        break
+    }
+}
+
+if (-not $upstreamSha) {
+    Write-Status "🔴" "Could not find upstream VMR reference in Version.Details.xml" Red
+    Write-Host "  The agent should manually inspect eng/Version.Details.xml at $vmrCommit" -ForegroundColor DarkGray
+
+    Write-Host ""
+    Write-Host "[SKILL_SUMMARY]"
+    $summary = [ordered]@{
+        status = "upstream_not_found"
+        sdkVersion = $SdkVersion
+        vmrBranch = $vmrBranch
+        vmrCommit = $vmrCommit
+        component = $Component
+    }
+    Write-Host ($summary | ConvertTo-Json -Depth 4 -Compress)
+    Write-Host "[/SKILL_SUMMARY]"
+    exit 0
+}
+
+# Now check source-manifest.json at the upstream SHA
+Write-Section "Step 5: Check source-manifest.json at upstream VMR commit"
+
+$upstreamManifestContent = Get-GitHubFileContent -Repo "dotnet/dotnet" -Path "src/source-manifest.json" -Ref $upstreamSha
+if (-not $upstreamManifestContent) {
+    Write-Status "⚠️" "Cannot fetch source-manifest.json at upstream SHA $upstreamSha" Yellow
+
+    Write-Host ""
+    Write-Host "[SKILL_SUMMARY]"
+    $summary = [ordered]@{
+        status = "upstream_manifest_failed"
+        sdkVersion = $SdkVersion
+        vmrBranch = $vmrBranch
+        vmrCommit = $vmrCommit
+        upstreamVmrSha = $upstreamSha
+        component = $Component
+        fallback = "Fetch source-manifest.json from dotnet/dotnet at $upstreamSha"
+    }
+    Write-Host ($summary | ConvertTo-Json -Depth 4 -Compress)
+    Write-Host "[/SKILL_SUMMARY]"
+    exit 0
+}
+
+$upstreamManifest = $upstreamManifestContent | ConvertFrom-Json
+
+$upstreamEntry = Find-ComponentInManifest -Manifest $upstreamManifest -Component $Component
+
+if ($upstreamEntry) {
+    Write-Status "✅" "Found $Component in upstream source-manifest.json" Green
+    Write-Host "  Repository: $($upstreamEntry.remoteUri)"
+    Write-Host "  Commit SHA: $($upstreamEntry.commitSha)"
+    Write-Host ""
+    Write-Host "  Trace chain:"
+    Write-Host "    SDK $SdkVersion"
+    Write-Host "    → VMR branch: $vmrBranch (commit: $vmrCommit)"
+    Write-Host "    → Version.Details.xml → upstream VMR: $upstreamSha"
+    Write-Host "    → source-manifest.json → $($upstreamEntry.remoteUri): $($upstreamEntry.commitSha)"
+
+    $resolvedSha = $upstreamEntry.commitSha
+    $resolvedRepo = $upstreamEntry.remoteUri
+    $traceType = "prebuilt (via Version.Details.xml → upstream 1xx branch)"
+} else {
+    Write-Status "🔴" "$Component not found in upstream source-manifest.json either" Red
+    Write-Host "  Component may not be tracked in source-manifest.json for this branch configuration." -ForegroundColor DarkGray
+
+    Write-Host ""
+    Write-Host "[SKILL_SUMMARY]"
+    $summary = [ordered]@{
+        status = "not_found"
+        sdkVersion = $SdkVersion
+        vmrBranch = $vmrBranch
+        vmrCommit = $vmrCommit
+        upstreamVmrSha = $upstreamSha
+        component = $Component
+    }
+    Write-Host ($summary | ConvertTo-Json -Depth 4 -Compress)
+    Write-Host "[/SKILL_SUMMARY]"
+    exit 0
+}
+
+} # end of else (component not in direct source-manifest)
+
+# ─── Step 6 (optional): Check if specific commits are included ───
+
+$commitResults = @()
+if ($CheckCommit -and $resolvedSha) {
+    Write-Section "Step 6: Check Commits Against Resolved SHA ($($resolvedSha.Substring(0, 12)))"
+
+    foreach ($commit in $CheckCommit) {
+        $shortCommit = $commit.Substring(0, [Math]::Min(12, $commit.Length))
+
+        $commitMsg = git log --oneline -1 $commit 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Status "⚠️" "$shortCommit — not found in local repo (fetch may be needed)" Yellow
+            $commitResults += [ordered]@{ commit = $commit; included = "unknown"; reason = "not in local repo" }
+            continue
+        }
+
+        # Check ancestry — distinguish "not ancestor" from "error"
+        $mergeBaseOutput = git merge-base --is-ancestor $commit $resolvedSha 2>&1
+        $mergeBaseExit = $LASTEXITCODE
+
+        if ($mergeBaseExit -eq 0) {
+            Write-Status "✅" "$shortCommit — INCLUDED ($commitMsg)" Green
+            $commitResults += [ordered]@{ commit = $commit; included = $true; message = $commitMsg }
+        } elseif ($mergeBaseExit -eq 1) {
+            # Exit code 1 = not an ancestor (definitive answer)
+            Write-Status "🔴" "$shortCommit — NOT included ($commitMsg)" Red
+            $commitResults += [ordered]@{ commit = $commit; included = $false; message = $commitMsg }
+        } else {
+            # Exit code > 1 = error (disconnected history, bad object, etc.)
+            Write-Status "⚠️" "$shortCommit — UNKNOWN (merge-base error: $mergeBaseOutput)" Yellow
+            $commitResults += [ordered]@{ commit = $commit; included = "unknown"; reason = "merge-base error"; message = $commitMsg }
+        }
+    }
+}
+
+# ─── Final Summary ───
+
+Write-Host ""
+Write-Host "[SKILL_SUMMARY]"
+$summary = [ordered]@{
+    status = if ($resolvedSha) { if ($traceType -match 'direct') { "found_direct" } else { "found_via_upstream" } } else { "not_found" }
+    sdkVersion = $SdkVersion
+    vmrBranch = $vmrBranch
+    vmrCommit = $vmrCommit
+    buildNumber = $buildNumber
+    component = $Component
+    componentRepo = $resolvedRepo
+    componentSha = $resolvedSha
+    traceType = $traceType
+}
+if ($upstreamSha) { $summary.upstreamVmrSha = $upstreamSha }
+if ($commitResults.Count -gt 0) { $summary.commitChecks = $commitResults }
+Write-Host ($summary | ConvertTo-Json -Depth 4 -Compress)
+Write-Host "[/SKILL_SUMMARY]"

--- a/.github/skills/helix-investigation/SKILL.md
+++ b/.github/skills/helix-investigation/SKILL.md
@@ -1,0 +1,332 @@
+---
+name: helix-investigation
+description: >
+  Deep-dive investigation of Helix test failures starting from AzDO build legs.
+  USE FOR: investigating recurring Helix test failures, downloading and analyzing
+  Helix console logs, comparing passing vs failing runs, identifying machine-specific
+  issues, XHarness timeout analysis, Android emulator DEVICE_NOT_FOUND errors,
+  bulk failure aggregation across legs, "why does this test fail on some machines",
+  "top 5 failing tests in the last 2 days", "download helix logs for build X",
+  "compare passing and failing helix runs", "what are the most common failures".
+  DO NOT USE FOR: high-level CI status checks (use ci-analysis), codeflow PRs
+  (use flow-analysis).
+  INVOKES: Helix and AzDO MCP tools, curl, gh CLI.
+---
+
+# Helix Investigation
+
+Deep-dive into Helix test failures starting from an AzDO build leg. Goes beyond CI status checks to download raw console logs, compare passing vs failing runs, and identify root causes at the machine/device level.
+
+## When to Use This Skill
+
+- User has an AzDO build URL with a failing test leg and wants to understand why
+- User wants to see raw Helix console logs for a specific work item
+- User notices a test fails intermittently and wants pass/fail comparison
+- User asks "why does this test only fail on some machines?"
+- User wants to correlate AzDO build → Helix job → work item → console output
+- User mentions XHarness, device tests, or Helix timeouts
+- User asks for a "top N" list of failures across a pipeline or time range
+- User wants to know if failures are machine-specific or systemic
+- User sees Android DEVICE_NOT_FOUND or emulator boot failures
+
+## Prerequisites
+
+- Helix MCP tools (hlx-* prefix) for querying jobs, work items, and logs
+- AzDO MCP tools (ado-* prefix) for querying builds and timelines
+- `curl` for downloading raw log files when MCP search is insufficient
+- Access to `https://helix.dot.net/` API endpoints
+
+## Workflow
+
+### Step 1: Start from the AzDO build
+
+Given an AzDO build URL or pipeline definition + build ID:
+
+1. Query the build timeline to find the failing job/leg
+2. Identify the Helix job ID from the timeline records — look for `HelixJobId` in record properties or Helix URLs in the log output
+3. Note the job name, queue, and failure category
+
+```
+AzDO Build → Timeline API → Failing job record → Helix job ID
+```
+
+> ⚠️ AzDO MCP tools may become unavailable mid-session. Fall back to the REST API: `https://dev.azure.com/{org}/{project}/_apis/build/builds/{buildId}/timeline?api-version=7.1`
+
+### Step 2: Enumerate Helix work items
+
+Query the Helix job for its work items. Each work item is a test group that ran on a specific machine.
+
+Key fields to capture per work item:
+- **Work item name** (e.g., `iOS.CoreCLR.R2R.Test`, `System.Runtime.Tests`)
+- **Exit code** (0 = pass, 143 = SIGTERM/timeout, 71 = infra error)
+- **Machine name** (e.g., `DNCENGMAC036`, `DNCENGTVOS-106`)
+- **Duration** — long durations with exit 143 indicate timeout kills
+- **Failure category** — `Crash`, `InfrastructureError`, etc.
+
+### Step 3: Download console logs
+
+The Helix console log URL pattern:
+
+```
+https://helix.dot.net/api/2019-06-17/jobs/{jobId}/workitems/{workItemName}/console
+```
+
+Download with curl for local analysis — this is often more reliable than Helix MCP search tools for finding specific patterns:
+
+```bash
+curl -s "https://helix.dot.net/api/2019-06-17/jobs/{jobId}/workitems/{workItemName}/console" > /tmp/{jobIdPrefix}-console.log
+```
+
+Also check for additional log files (test output, device logs):
+
+```
+https://helix.dot.net/api/2019-06-17/jobs/{jobId}/workitems/{workItemName}/files
+```
+
+**testResults.xml**: Many work items produce xUnit/NUnit result XML. Download it for structured failure data — test names, failure messages, stack traces, and pass/fail counts — especially when console logs lack detail:
+
+```bash
+# List files to find the results XML
+curl -s "https://helix.dot.net/api/2019-06-17/jobs/{jobId}/workitems/{workItemName}/files" | python3 -c "import sys,json; [print(f['Name']) for f in json.load(sys.stdin)]"
+# Download (path varies: testResults.xml, xharness-output/testResults.xml, etc.)
+curl -sL "https://helix.dot.net/api/2019-06-17/jobs/{jobId}/workitems/{workItemName}/files/{fileName}" > /tmp/test-results.xml
+# Quick failure summary
+grep -c 'result="Fail"' /tmp/test-results.xml
+grep 'result="Fail"' -A5 /tmp/test-results.xml | grep 'name='
+```
+
+> 💡 Helix MCP search tools (`hlx_search_log`, `hlx_search_file`) may miss patterns — they can be case-sensitive or have limited regex support. When searching for specific strings, download the file and use local `grep` for reliability.
+
+### Step 4: Analyze the console log
+
+Look for these key patterns in order:
+
+1. **Setup phase** — machine name, queue, environment (OS version, Xcode version, device model)
+2. **Test execution** — command line used (e.g., XHarness `apple run` with flags), app launch, test output
+3. **Completion signals** — exit codes, timeout messages, crash reports
+4. **Helix wrapper** — `WORKLOAD TIMED OUT`, `exit_code=`, `Command exited with`
+
+Common failure signatures:
+
+| Pattern | Meaning |
+|---------|---------|
+| `exit_code=143` + `WORKLOAD TIMED OUT` | Helix killed the process after timeout (SIGTERM) |
+| `exit_code=71` | Infrastructure error |
+| `exit_code=81` / `DEVICE_NOT_FOUND` | Android emulator not running or not responding |
+| `exit_code=80` / `APP_CRASH` | XHarness device error — **may be false** (see below) |
+| `Run timed out after N seconds` | XHarness hit its own timeout before Helix |
+| `TIMED_OUT` (XHarness) | XHarness-level timeout (distinct from Helix timeout) |
+| `mlaunch exited with {code}` | App completed — check if XHarness noticed |
+| `Detected test end tag` then `APP_CRASH` | **False failure** — tests passed but device communication failed afterward |
+| `Mercury error 1000` / `RSD error 0xE8000003` | devicectl file copy failure (tvOS/iOS) |
+| Device log file empty/removed | Device communication issue (tvOS/iOS) |
+| `emulator-5554` found but not `emulator-5556` | Wrong emulator architecture booted |
+| `Attempt.3` in work item name | All retries exhausted |
+| `Expected 0 exit code but got 1` (dotnet build) | SDK/MSBuild build failure — 100% fail rate, not a test bug |
+| `System.TimeoutException: Timeout 30000ms exceeded` | Playwright browser automation timeout (Blazor) |
+| `exit_code=133` (128+5=SIGTRAP) + `ASSERT FAILED` | Runtime assertion failure / core dump — every test suite crashes |
+
+> ⚠️ **False failure detection is critical.** XHarness can report APP_CRASH (exit 80) or TIMED_OUT (exit 143) even when **all tests pass**. Always check for `"Detected test end tag"` or `"Test run completed"` in the log before trusting the exit code. If tests completed successfully but XHarness still reports failure, the issue is post-completion device communication, not a test bug.
+
+### Step 5: Compare passing vs failing runs
+
+This is the highest-value step for intermittent failures. Find a passing run of the same work item and download its console log too.
+
+Compare side-by-side:
+1. **Machine/device** — are failures concentrated on specific machines?
+2. **Environment** — OS version, SDK version, device model differences
+3. **Log divergence point** — where does the passing run succeed and the failing run hang or crash?
+4. **File artifacts** — does the passing run produce files (device logs, test results) that the failing run doesn't?
+
+Use a SQL table to track findings across multiple runs:
+
+```sql
+CREATE TABLE helix_runs (
+  job_id TEXT, work_item TEXT, machine TEXT, exit_code INT,
+  duration_sec INT, queue TEXT, os_version TEXT, passed BOOLEAN,
+  notes TEXT
+);
+```
+
+### Step 6: Identify root cause pattern
+
+Common root cause categories:
+
+| Category | Signal | Action |
+|----------|--------|--------|
+| **False failure** | Tests pass (`"Test run completed"`) but exit 80/143 reported | Device communication failed post-completion — file/update on dotnet/xharness |
+| **Machine-specific** | Same test, same code, different outcomes by machine | Report machine name, suggest pool removal |
+| **Device communication** | Empty device logs, log stream hangs, `Mercury error 1000`, `RSD error 0xE8000003` | USB/connectivity issue on host |
+| **Emulator failure** | DEVICE_NOT_FOUND (exit 81), wrong emulator arch | Systemic if spread across machines; file on dotnet/xharness for recovery logic |
+| **Test infrastructure** | XHarness/Helix wrapper bug | File issue on dotnet/xharness or dotnet/arcade |
+| **Deterministic test bug** | 100% failure rate, same assertion, every run | Test expectation is wrong, not infra — file on dotnet/runtime, check for `blocking-clean-ci` label |
+| **Genuine test failure** | Test code exercises broken runtime behavior | File issue on dotnet/runtime |
+| **Timeout misconfiguration** | Test passes but harness timeout too short | Adjust timeout parameter |
+| **Retry exhaustion** | `Attempt.3` still failing, retries hit same broken machine | Helix retries on same machine before reboot takes effect |
+| **XML truncation** | All tests pass but app killed mid-result-write → truncated XML → crash reported | Large test suites on constrained devices (tvOS memory limits) |
+| **SDK/build break** | `dotnet build` exit 1, 100% fail rate, error in SDK targets | Not a test bug — file on dotnet/aspnetcore or dotnet/sdk |
+| **Browser automation** | Playwright timeout on UI element, app builds fine | Resource contention or Blazor rendering regression |
+| **Poison PR** | Exit 133 (SIGTRAP), ALL suites fail on same build, 1x per platform per suite | Runtime assertion failure — single bad commit crashes before tests run. Filter out this build; failures are misleading |
+
+### Step 7: Report findings
+
+Provide:
+1. **Summary table** — all analyzed runs with machine, exit code, pass/fail, key observation
+2. **Root cause** — which category, with evidence from the logs
+3. **Direct links** — Helix console log URLs, AzDO build URLs
+4. **Recommended action** — machine removal, issue to file, timeout adjustment, etc.
+
+## Fix Verification
+
+When a PR is merged to fix a test failure, verify it's working by checking builds **queued after** the merge — not builds that **finished** after it.
+
+### Why queue time matters
+
+A build queued 10 minutes before a PR merges runs against the **old** source, even if it finishes hours later. Only builds queued after the merge include the fix.
+
+### Workflow
+
+1. Find the fix PR and its merge timestamp: `gh pr view {number} --repo {owner/repo} --json mergedAt`
+2. Query recent builds for the pipeline — **include all statuses** (completed, inProgress, notStarted). If you only check completed builds, you'll miss active builds currently testing the fix.
+3. For each build with the relevant failure, check its **queueTime** (not finishTime)
+4. Partition into pre-merge and post-merge builds
+5. If post-merge builds still show the failure → fix didn't work or there's a second issue
+6. If only pre-merge builds fail → fix is confirmed clean
+
+> ⚠️ **Common mistake**: Seeing a failure "after the merge" and concluding the fix didn't work. Always check queue time — the build may have started before the merge landed.
+
+### Ancestry check shortcut
+
+When queue time is ambiguous (merge happened mid-build), use commit ancestry:
+
+```bash
+gh api repos/{owner}/{repo}/compare/{merge_commit}...{build_source_version} --jq '.status'
+# "ahead" or "identical" = fix is included; "behind" = fix is NOT included
+```
+
+## Bulk Failure Aggregation
+
+When the user asks "what are the top N failures" across a pipeline or time range, use a different approach than single-build investigation.
+
+### Approach
+
+1. Query AzDO for all failed builds in the time range (e.g., last 2 days)
+2. For each failed build, query the timeline to find which jobs/legs failed
+3. For Helix-based legs, query work item results to get test names, exit codes, machines
+4. Aggregate into a SQL table for analysis:
+
+```sql
+CREATE TABLE failure_survey (
+  build_id INT, leg TEXT, work_item TEXT, exit_code INT,
+  machine TEXT, failure_category TEXT, helix_job TEXT,
+  is_pr_specific BOOLEAN, notes TEXT
+);
+```
+
+5. Group by work item to find the most frequent failures
+6. Separate PR-specific build errors (hit all legs at once) from recurring test failures
+
+### Classification
+
+| Type | Signal | Priority |
+|------|--------|----------|
+| **Recurring test failure** | Same work item fails across many PRs | High — investigate root cause |
+| **PR-specific build error** | Multiple legs fail on same build only | Low — PR author's problem |
+| **Poison PR** | ALL suites fail on one build, exit 133, 1x per platform | Low — filter out; single bad commit crashes runtime before tests run |
+| **Infrastructure error** | exit 71, exit 81, DEVICE_NOT_FOUND | Medium — systemic infra issue |
+| **Sporadic infra** | Single occurrence, no pattern | Ignore — noise |
+
+### Rolling Builds vs PR Builds
+
+When assessing **main branch health**, filter to rolling (scheduled) builds using `reasonFilter=schedule`. PR builds include broken PR branches that dominate failure counts and obscure systemic issues.
+
+Real-world example: over the same 2-day window, PR builds produced **423 work item failures** (dominated by a single poison PR with 119 failures). Rolling builds had only **46 failures** — all genuine systemic issues.
+
+```bash
+# Rolling builds only (scheduled, typically 2x daily on main)
+curl -s "https://dev.azure.com/{org}/{project}/_apis/build/builds?definitions={defId}&reasonFilter=schedule&resultFilter=failed&minTime={iso8601}&$top=50&api-version=7.1"
+```
+
+Use rolling builds to:
+- Assess current main branch health
+- Identify systemic test failures vs PR-introduced regressions
+- Verify fix impact (compare rolling failure counts before/after merge)
+
+### Cross-Leg View
+
+Some tests fail on multiple platforms. When reporting top-N, group by test name but break out by leg to show which platforms are affected:
+
+```
+System.Runtime.Tests: 61 total
+  → ios-arm64 Mono (13), tvos-arm64 Mono (20), android (9), ...
+```
+
+This reveals whether a failure is platform-specific or cross-platform.
+
+## Machine Distribution Analysis
+
+After identifying a recurring failure, determine whether it's **machine-specific** or **systemic**:
+
+1. Collect the machine name from each failing work item
+2. Count failures per machine
+3. Compare to the pool size
+
+| Distribution | Diagnosis | Action |
+|-------------|-----------|--------|
+| 1-2 machines account for most failures | **Machine-specific** — hardware/config issue | Report machines, suggest pool removal |
+| Failures spread evenly across many machines | **Systemic** — software/infra issue | File infrastructure bug |
+| Slight concentration on a few + spread | **Mixed** — systemic with some worse machines | File bug + flag worst offenders |
+
+Example from real investigation: tvOS failures concentrated on DNCENGTVOS-036 and DNCENGTVOS-022 = machine-specific. Android DEVICE_NOT_FOUND spread across 17 machines = systemic emulator issue.
+
+## Filing Issues from Investigation
+
+When investigation reveals a clear root cause, file issues on the appropriate repo:
+
+| Root Cause | File On | Include |
+|------------|---------|---------|
+| XHarness bug (timeout handling, exit code detection, device recovery) | [dotnet/xharness](https://github.com/dotnet/xharness) | Pass/fail comparison evidence, console log URLs, affected machines |
+| Helix infrastructure (retry behavior, machine management) | [dotnet/arcade](https://github.com/dotnet/arcade) or dnceng issue tracker | Failure counts, machine distribution, retry logs |
+| Test code bug | [dotnet/runtime](https://github.com/dotnet/runtime) | Failing test name, stack trace, repro steps |
+| Machine hardware | dnceng infrastructure team | Machine names, failure frequency, environment details |
+
+Always include:
+- **Evidence**: Helix console log URLs and AzDO build URLs
+- **Failure count**: How many times this occurred in the analysis window
+- **Machine list**: Which machines are affected
+- **Pass/fail comparison**: If intermittent, what differs between passing and failing runs
+
+## Stop Signals
+
+- **Stop downloading logs** after you have 1 clear failing run + 1 clear passing run for comparison. Don't download all 50 builds.
+- **Stop analyzing** when you can explain why the test fails on machine A but passes on machine B. That's the root cause.
+- **Stop if no passing runs exist** — the failure is 100% reproducible, not intermittent. Shift to analyzing the test code itself.
+
+## Anti-Patterns
+
+> 🚨 **Don't rely solely on Helix MCP search tools for log analysis.** Download the console log with curl and use local grep — it's faster and more reliable for pattern matching.
+
+> 🚨 **Don't assume "flaky" without evidence.** If the same machine fails every time, it's machine-specific, not flaky. Capture the machine name.
+
+> 🚨 **Don't ignore the "Exit code detection" warning as the root cause.** On tvOS/iOS 15+, XHarness logs this warning but it may be a red herring — the real issue can be device log streaming, not exit code detection itself.
+
+> 🚨 **Don't analyze all builds in a pipeline.** Filter to the specific job/leg first, then look at 3-5 recent runs maximum.
+
+## Reference: Known Helix Queue Patterns
+
+| Queue Pattern | Platform |
+|---------------|----------|
+| `osx.*.amd64.appletv.open` | Apple TV devices (tvOS) |
+| `osx.*.amd64.iphone.open` | iPhone devices (iOS) |
+| `ubuntu.*.amd64.android.*.open` | Android emulators |
+| `ubuntu.*` | Linux |
+| `windows.*` | Windows |
+| `browser-wasm.*` | WASM (Chrome/Firefox) |
+
+Queue name is in the first line of every Helix console log: `workitem ... ({queue}) executed on machine {machine}`.
+
+## Reference: Platform-Specific Resources
+
+- [references/xharness-patterns.md](references/xharness-patterns.md) — tvOS/iOS XHarness exit code detection, device log streaming, timeout chain
+- [references/android-patterns.md](references/android-patterns.md) — Android emulator DEVICE_NOT_FOUND, retry/reboot flow, common test failures
+- [references/wasm-patterns.md](references/wasm-patterns.md) — WASM/browser SDK build errors, Playwright timeouts, work item naming

--- a/.github/skills/helix-investigation/references/android-patterns.md
+++ b/.github/skills/helix-investigation/references/android-patterns.md
@@ -1,0 +1,65 @@
+# Android Emulator Patterns
+
+Domain knowledge for investigating Android emulator test failures on Helix, captured from real investigations.
+
+## DEVICE_NOT_FOUND (Exit 81)
+
+When XHarness can't find the expected Android emulator, the work item fails with exit code 81 (`DEVICE_NOT_FOUND`).
+
+### Emulator Architecture
+
+Helix machines run two emulators:
+- `emulator-5554` — x86 emulator
+- `emulator-5556` — x86_64 emulator (started via `systemctl start android-emulator@android_emu_86_64`)
+
+When a test targets x86_64, XHarness calls `GetDevice()` looking for the x86_64 emulator. If only `emulator-5554` (x86) is found, the test fails with DEVICE_NOT_FOUND.
+
+### Retry and Reboot Flow
+
+```
+Work item fails (exit 81)
+  → xharness-event-processor.py catches it
+  → Requests infra retry + sets reboot file
+  → Retry runs on SAME machine (up to 3 attempts)
+  → Machine reboots AFTER all attempts exhausted
+```
+
+**The gap**: Retries run back-to-back on the same broken machine before the reboot fires. If the emulator crashed, all 3 attempts see the same dead emulator.
+
+You'll see this in logs as `Attempt.3` work items still failing with exit 81.
+
+### Machine Distribution
+
+Unlike tvOS device failures (which concentrate on specific hardware), Android DEVICE_NOT_FOUND errors are typically **spread across many machines** in the pool. This indicates a systemic emulator stability issue, not a hardware problem.
+
+From a real investigation: 29 DEVICE_NOT_FOUND failures across 17 different machines over 2 days, with no single machine dominating.
+
+### Diagnosis Questions
+
+1. Is the x86_64 emulator running? Check `adb devices` output in the console log
+2. Did the emulator crash? Look for emulator crash logs before the XHarness invocation
+3. Are retries helping? If `Attempt.3` still fails with exit 81, the reboot-between-retries gap is the blocker
+4. Is this concentrated or spread? Count failures per machine to determine machine-specific vs systemic
+
+### Known Issues
+
+- [dotnet/xharness#1549](https://github.com/dotnet/xharness/issues/1549) — Proposal: try emulator restart before DEVICE_NOT_FOUND exit
+- [dotnet/runtime#112633](https://github.com/dotnet/runtime/issues/112633) — Android JIT test DEVICE_NOT_FOUND failures
+
+## Common Android Test Failures
+
+| Test | Pattern | Root Cause |
+|------|---------|------------|
+| System.Net.Http.Functional.Tests | XHarness TIMED_OUT (30min) | Tests too slow on emulator |
+| System.Net.WebSockets.Client.Tests | `TaskCanceledException` in `ReceiveAsync` | Known flaky — [#119520](https://github.com/dotnet/runtime/issues/119520) |
+| System.Security.Cryptography.Tests | DEVICE_NOT_FOUND (exit 81) | Emulator crash |
+| Android.Device_Emulator.JIT tests | DEVICE_NOT_FOUND (exit 81) | Emulator crash |
+
+## Android Helix Queue Patterns
+
+| Queue Pattern | Platform |
+|---------------|----------|
+| `ubuntu.*.amd64.android.29.open` | Android API 29 emulator |
+| `ubuntu.*.amd64.android.34.open` | Android API 34 emulator |
+
+Machine names in Android pools use alphanumeric IDs (e.g., `a003B8R`, `a003B94`) rather than the `DNCENG*` naming used for Apple devices.

--- a/.github/skills/helix-investigation/references/wasm-patterns.md
+++ b/.github/skills/helix-investigation/references/wasm-patterns.md
@@ -1,0 +1,55 @@
+# WASM / Browser Failure Patterns
+
+Failure patterns specific to `browser-wasm` Helix queues. These run in Docker containers (`mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-helix-webassembly`) on Linux AMD64.
+
+## Work Item Naming
+
+WASM build tests use the pattern: `WBT-{Config}-{Runtime}-ST-{TestClass}`
+
+| Segment | Values |
+|---------|--------|
+| Config | `NoWebcil`, `NoWorkload`, `Workloads`, `NoFingerprint` |
+| Runtime | `CLR` (CoreCLR), `Mono` |
+| TestClass | e.g., `Wasm.Build.Tests.DebugLevelTests` |
+
+## Failure Mode 1: SDK / MSBuild Errors
+
+**Signal**: `dotnet build` or `dotnet publish` returns exit code 1. 100% failure rate across all tests in the work item.
+
+**Example**: `System.InvalidOperationException: Unknown source type 'Framework'` in `Microsoft.NET.Sdk.WebAssembly.Browser.targets` — the `DefineStaticWebAssets` MSBuild task doesn't recognize a new sourceType value.
+
+**Key indicators**:
+- Every test in the work item fails with same assertion: `Expected 0 exit code but got 1`
+- The error is in SDK targets, not test code
+- `NoWorkload` config uses `dotnet-none` SDK (no WASM workload installed) — most susceptible to SDK-level breaks
+
+**Diagnosis**: Download `testResults.xml` and look at the failure message. Then download the `.binlog` from the Helix files endpoint for MSBuild-level diagnosis.
+
+**Root cause owner**: Typically dotnet/aspnetcore (StaticWebAssets) or dotnet/sdk depending on the failing target.
+
+## Failure Mode 2: Playwright Timeouts
+
+**Signal**: `System.TimeoutException: Timeout 30000ms exceeded` waiting for a Blazor UI element (e.g., `Locator("text=Counter")`).
+
+**Key indicators**:
+- The app builds and launches successfully
+- Playwright connects to the browser
+- Timeout occurs waiting for a specific DOM element
+- Intermittent — some runs pass, some don't
+
+**Diagnosis**: This is a browser automation timing issue, not a build failure. The Blazor app starts but doesn't render fast enough for the 30-second timeout.
+
+**Possible causes**:
+- Resource contention on the Helix machine (container CPU/memory limits)
+- Blazor rendering regression (app takes longer to hydrate)
+- Playwright version mismatch or browser startup delay
+
+**Root cause owner**: dotnet/runtime (test infrastructure or Blazor runtime).
+
+## Distinguishing Build vs Runtime Failures
+
+When investigating a `Wasm.Build.Tests` work item:
+
+1. **Check pass/fail ratio**: If 100% of tests fail → likely build infrastructure. If a few fail → likely runtime/timing.
+2. **Check failure message**: `Expected 0 exit code but got 1` = build failure. `TimeoutException` = runtime.
+3. **Check the config**: `NoWorkload` builds are more fragile because they lack the full WASM toolchain.

--- a/.github/skills/helix-investigation/references/xharness-patterns.md
+++ b/.github/skills/helix-investigation/references/xharness-patterns.md
@@ -1,0 +1,129 @@
+# XHarness Device Test Patterns
+
+Domain knowledge for investigating XHarness test failures on iOS/tvOS devices, captured from real investigations.
+
+## XHarness Command Structure
+
+Typical XHarness invocation for device tests:
+
+```
+xharness apple run --target tvos-device --timeout 00:12:00 --signal-app-end --expected-exit-code 42
+```
+
+Key flags:
+- `--target tvos-device` / `ios-device` — physical device (not simulator)
+- `--timeout 00:12:00` — XHarness-level timeout (720 seconds)
+- `--signal-app-end` — mechanism for detecting app completion
+- `--expected-exit-code 42` — what the test app returns on success
+
+## Exit Code Detection on tvOS/iOS 15+
+
+XHarness explicitly warns:
+
+```
+warn: Exit code detection is not working on iOS/tvOS 15+
+      so the run will fail to match it with the expected value
+```
+
+**This warning is often a red herring.** The real issue is typically device log streaming:
+
+### Pass/Fail Divergence Pattern
+
+| Aspect | Passing Machine | Failing Machine |
+|--------|----------------|-----------------|
+| mlaunch exit code | 42 ✅ | 42 ✅ |
+| Device log file | Non-empty | **Empty** (removed) |
+| XHarness reads logs | Yes | **No** — hangs waiting |
+| Uses mlaunch exit code? | Yes → success | **No** — blocked on log reader |
+| Result | Success in ~2 sec | **Timeout after 720 sec** |
+
+**Root cause**: When `devicectl` can't stream console output from the device (USB/connectivity issue), XHarness blocks on the log-reading task and never reaches the fallback code path that would use `mlaunch`'s exit code.
+
+## Timeout Chain
+
+Device test timeouts involve multiple layers:
+
+```
+XHarness timeout (--timeout, e.g., 720s)
+  ↓ if exceeded
+Helix workload timeout (~21 min total)
+  ↓ sends SIGTERM
+Process exit code = 143
+```
+
+When you see `exit_code=143`, the timeline is:
+1. App launched and exited in <1 second with expected exit code
+2. XHarness didn't detect completion → waited 720 seconds
+3. XHarness timed out → "Run timed out after 720 seconds"
+4. Helix workload timeout reached → "WORKLOAD TIMED OUT - Killing user command"
+5. SIGTERM → exit 143
+
+## Machine Naming Conventions
+
+| Pattern | Role |
+|---------|------|
+| `DNCENGMAC###` | macOS host machine |
+| `DNCENGTVOS-###` | Apple TV device attached to host |
+| `DNCENGIPHONE-###` | iPhone device attached to host |
+
+A macOS host (e.g., DNCENGMAC036) has a physical device attached (e.g., DNCENGTVOS-036). If the device's log streaming is broken, ALL tests on that host/device pair will fail with timeouts.
+
+## Failure Rate Correlation
+
+If a test fails ~10% of the time:
+- It's likely machine-specific, not a test bug
+- Calculate: (broken machines in pool) / (total machines in pool) ≈ failure rate
+- Example: 1 broken Apple TV out of ~10 in the pool → ~10% failure rate
+
+## Known Issues
+
+- [dotnet/xharness#1548](https://github.com/dotnet/xharness/issues/1548) — tvOS: Device communication failures cause false TIMED_OUT and APP_CRASH results after successful test runs
+- [dotnet/runtime#60713](https://github.com/dotnet/runtime/issues/60713) — iOS/tvOS test suite timeouts on devices (open since 2021)
+- [dotnet/runtime#124069](https://github.com/dotnet/runtime/issues/124069) — System.Runtime.Tests APP_CRASH on tvOS
+- [dotnet/runtime#117807](https://github.com/dotnet/runtime/issues/117807) — AppleTV queue includes machines with higher OS version
+
+## False Failure: APP_CRASH After Successful Tests
+
+XHarness can report `APP_CRASH` (exit 80) even when **all tests passed**. This is a distinct manifestation from the timeout issue above but shares the same root cause: device communication failure.
+
+### The Sequence
+
+```
+1. ✅ Tests launch and ALL pass (e.g., 67,000+ tests, 0 failures)
+2. ✅ "Detected test end tag in application's output" — XHarness knows tests finished
+3. ✅ "Test run completed" — mlaunch exits (SIGKILL, expected)
+4. ❌ XHarness tries to copy result XML from device via devicectl
+5. ❌ devicectl fails: "Mercury error 1000" / "RSD error 0xE8000003"
+6. ❌ XHarness reports APP_CRASH (exit 80) despite knowing tests completed
+```
+
+### Two Manifestations, Same Root Cause
+
+| | TIMED_OUT (exit 143) | APP_CRASH (exit 80) |
+|---|---|---|
+| **Tests pass?** | Yes | Yes |
+| **XHarness knows?** | No — blocks before checking | **Yes** — logs "Test run completed" |
+| **What breaks** | Device log stream empty | Device file copy fails (devicectl) |
+| **Device error** | Log file 0 bytes | `Mercury error 1000` / `RSD error 0xE8000003` |
+
+Both are tracked in [xharness#1548](https://github.com/dotnet/xharness/issues/1548). The fix: XHarness should honor its own completion detection rather than overriding the result when post-completion device communication fails.
+
+### How to Detect
+
+When investigating an APP_CRASH, always search the console log for:
+- `"Detected test end tag"` — if present, tests actually completed
+- `"Test run completed"` — confirms XHarness saw the completion
+- `"Mercury error"` or `"RSD error"` — device communication failure after completion
+
+If all three are present, it's a false failure, not a real crash.
+
+## XML Truncation Pattern
+
+Large test suites (e.g., System.Runtime.Tests with 67K+ tests) can trigger another false failure mode:
+
+1. All tests pass
+2. App starts writing results XML
+3. App is killed mid-write (tvOS memory pressure / EXC_RESOURCE)
+4. Truncated XML → XHarness can't parse → reports crash
+
+Signal: Exit code 1, very large test count (60K+), look for truncated XML in the work item files.

--- a/.github/skills/known-issue-history/SKILL.md
+++ b/.github/skills/known-issue-history/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: known-issue-history
+description: >
+  Analyze historical failure rates for Known Build Error issues by mining the
+  edit history of issue bodies. Use when asked "when did this last fail",
+  "failure history", "failure rate", "is this issue still active",
+  "flaky test history", "known issue activity", or "most active known issues".
+---
+
+# Known Build Error History Analysis
+
+Reconstruct failure timelines for "Known Build Error" issues by analyzing the edit history of the issue body's hit count table. The `build-analysis` bot periodically edits these issues to update rolling hit counts (24h/7d/1mo) — this skill mines those edits to recover the full failure history.
+
+## When to Use This Skill
+
+Use this skill when:
+- Investigating whether a known issue is still actively failing ("when did this last fail?")
+- Checking failure frequency and trends for a flaky test
+- Triaging known issues — identifying which are dormant vs actively hitting
+- Deciding whether to close a known issue that appears inactive
+- Scanning all open known issues to find the most problematic ones
+
+## Workflow Steps
+
+### Single Issue Analysis
+
+1. Determine the issue number and repository from the user's request
+2. Run the script: `./scripts/Get-KnownIssueHistory.ps1 -IssueNumber <N> -Repository <owner/repo>`
+3. Add `-Since <date>` if the user only wants recent failures, or `-Json` for structured output
+4. Summarize the results: total failure events, failure periods, last failure date, and days since last failure
+5. If posting results to an issue or PR, include a link to this skill (see Posting Results below)
+
+### Scanning All Active Known Issues
+
+1. Run the script: `./scripts/Get-KnownIssueHistory.ps1 -ListActive -Repository <owner/repo>`
+2. Add `-MaxIssues <N>` to limit scope (default 50, max 100)
+3. Summarize the ranked table highlighting the most actively failing issues and any dormant candidates for closing
+
+## Quick Start
+
+```powershell
+# Analyze a single known issue
+./scripts/Get-KnownIssueHistory.ps1 -IssueNumber 100088
+
+# Only show recent failures
+./scripts/Get-KnownIssueHistory.ps1 -IssueNumber 100088 -Since 2025-01-01
+
+# JSON output for programmatic use
+./scripts/Get-KnownIssueHistory.ps1 -IssueNumber 100088 -Json
+
+# Scan all open Known Build Error issues, ranked by activity
+./scripts/Get-KnownIssueHistory.ps1 -ListActive
+
+# Different repository
+./scripts/Get-KnownIssueHistory.ps1 -IssueNumber 12345 -Repository dotnet/aspnetcore
+```
+
+## Key Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `-IssueNumber` | Known Build Error issue number to analyze |
+| `-Repository` | Target repo in `owner/repo` format (default: `dotnet/runtime`) |
+| `-ListActive` | Scan all open Known Build Error issues and rank by recent activity |
+| `-MaxIssues` | Max issues to scan in ListActive mode (default: 50) |
+| `-Since` | Only show failures after this date (ISO 8601, e.g. `2025-01-01`) |
+| `-Json` | Output structured JSON (`[KNOWN_ISSUE_HISTORY]` block) instead of table |
+
+## Modes
+
+### Single Issue Mode (`-IssueNumber`)
+
+Queries the GitHub GraphQL `userContentEdits` API for the issue, parses each edit's hit count table, and detects failure events by tracking when the 24-hour count transitions from 0 to a positive value.
+
+**Output includes:**
+- **Failure summary** — total failure events, failure periods, last failure date, days since last failure
+- **Failure periods** — clusters of failures grouped by the gap between all-clear events, with peak hit counts
+- **Edit timeline** — chronological table of every hit count snapshot with failure event markers
+
+### List Active Mode (`-ListActive`)
+
+Scans all open issues with the "Known Build Error" label in the repository and analyzes each one's edit history. Outputs a ranked table sorted by most recent failure.
+
+Use this to find:
+- Which known issues are still actively failing
+- Which known issues haven't failed in months (candidates for closing)
+- Overall flaky test health of the repository
+
+## Interpreting Results
+
+### Failure Events
+
+| Marker | Meaning |
+|--------|---------|
+| `<-- NEW FAILURE` | 24h count went from 0 to N — a build just matched this known issue |
+| `<-- ADDITIONAL FAILURE` | 24h count increased — another build matched within 24 hours |
+| `(cleared)` | All counts returned to 0 — no recent matches |
+
+### Failure Periods
+
+Consecutive failure events are grouped into periods. A period starts when 24h goes from 0→N and ends when all counts return to 0.
+
+- **Many short periods** → intermittently flaky test
+- **One long period** → sustained regression
+- **Peak 24h count** → severity indicator (1 = occasional, higher = frequent across builds)
+
+### Triage Guidelines
+
+| Days Since Last Failure | Status | Action |
+|------------------------|--------|--------|
+| 0-7 | Actively failing | Needs investigation |
+| 7-30 | Recently active | Monitor |
+| 30-90 | Dormant | Consider closing |
+| 90+ | Likely fixed | Recommend closing |
+
+### Posting Results
+
+When posting results to an issue or PR comment, always include a link back to this skill so readers know where the analysis came from:
+
+```
+Analysis generated by [known-issue-history](https://github.com/dotnet/arcade-skills/tree/main/plugins/dotnet-dnceng/skills/known-issue-history)
+```
+
+## How It Works
+
+The `build-analysis` bot edits Known Build Error issue bodies whenever hit counts change. GitHub stores the revision history via the GraphQL `userContentEdits` API. Each edit includes a diff showing what changed in the issue body. The script parses hit-count table rows from these diffs to reconstruct snapshots:
+
+```markdown
+|24-Hour Hit Count|7-Day Hit Count|1-Month Count|
+|---|---|---|
+|0|0|0|
+```
+
+The script extracts these snapshots chronologically and detects state transitions to reconstruct when failures actually occurred — recovering historical data that the rolling windows would otherwise hide.
+
+### Limitations
+
+- **Edit retention**: GitHub may not retain edits indefinitely for very old issues
+- **Polling frequency**: Edits occur when hit counts change, not on a fixed schedule — timestamps show when the bot detected changes, not the exact test failure time
+- **Rolling windows**: A single failure appears across multiple snapshots as it moves through the 24h→7d→1mo windows
+
+## References
+
+- **Detailed approach and interpretation**: See [references/known-issue-history.md](references/known-issue-history.md)
+- **Known Issues documentation**: See [dotnet/arcade Known Issues guide](https://github.com/dotnet/arcade/blob/main/Documentation/Projects/Build%20Analysis/KnownIssues.md)
+- **Build Analysis website**: https://helix.dot.net/BuildAnalysis
+- **Known Issues board**: https://github.com/orgs/dotnet/projects/111

--- a/.github/skills/known-issue-history/references/known-issue-history.md
+++ b/.github/skills/known-issue-history/references/known-issue-history.md
@@ -1,0 +1,77 @@
+# Known Issue History Analysis
+
+## Overview
+
+The `Get-KnownIssueHistory.ps1` script reconstructs failure timelines for "Known Build Error" issues by analyzing the edit history of the issue body.
+
+## How It Works
+
+### Data Source
+
+The dotnet Build Analysis bot periodically edits Known Build Error issue bodies to update a rolling hit count table:
+
+```
+|24-Hour Hit Count|7-Day Hit Count|1-Month Count|
+|---|---|---|
+|0|0|0|
+```
+
+GitHub stores the revision history via the GraphQL `userContentEdits` API. Each edit includes a diff showing what changed in the issue body; the script parses hit-count table rows from these diffs to reconstruct snapshots over time.
+
+### Failure Detection
+
+The script detects failure events by tracking transitions in the 24-hour hit count:
+
+| Transition | Meaning |
+|---|---|
+| 24h: 0 → N (N>0) | **New failure event** — a build just matched this known issue |
+| 24h: N → M (M>N) | **Additional failure** — another build matched within 24 hours |
+| All counts → 0 | **Cleared** — issue hasn't matched any builds recently |
+
+### Failure Periods
+
+Consecutive failure events are grouped into "failure periods" — a period starts when 24h goes from 0→N and ends when all counts return to 0. Each period tracks:
+- Start/end dates
+- Peak 24h and 1-month hit counts (indicating severity)
+
+## Limitations
+
+- **Edit retention**: GitHub may not retain edits indefinitely for very old issues. The script works with whatever edit history is available.
+- **Polling frequency**: The Build Analysis bot doesn't edit on a fixed schedule. Edits occur when hit counts change, so the timeline shows when the bot detected changes, not the exact moment a test failed.
+- **Rolling windows**: The 24h/7d/1mo counts are rolling windows. A single failure may appear in multiple snapshots as it moves through the windows.
+- **Multiple matches per edit**: If the bot updates multiple sections of the issue body in one edit, only the hit count table is extracted.
+
+## Usage Examples
+
+### Single issue analysis
+```powershell
+# Full history
+./scripts/Get-KnownIssueHistory.ps1 -IssueNumber 100088
+
+# Recent failures only
+./scripts/Get-KnownIssueHistory.ps1 -IssueNumber 100088 -Since 2025-01-01
+
+# JSON output for programmatic use
+./scripts/Get-KnownIssueHistory.ps1 -IssueNumber 100088 -Json
+```
+
+### Scan all active known issues
+```powershell
+# Find most actively failing known issues
+./scripts/Get-KnownIssueHistory.ps1 -ListActive
+
+# Different repo
+./scripts/Get-KnownIssueHistory.ps1 -ListActive -Repository dotnet/aspnetcore
+```
+
+### Interpreting Output
+
+**Failure periods** show clusters of failures. A test with many short periods is intermittently flaky. A test with one long period had a sustained regression.
+
+**Days since last failure** is the key metric for triage:
+- 0-7 days: Actively failing, needs attention
+- 7-30 days: Recently active, monitor
+- 30-90 days: Dormant, consider closing the known issue
+- 90+ days: Likely fixed, recommend closing
+
+**Peak 24h count** indicates severity — a peak of 1 means occasional flakiness, while higher counts mean the test is failing frequently across many builds.

--- a/.github/skills/known-issue-history/scripts/Get-KnownIssueHistory.ps1
+++ b/.github/skills/known-issue-history/scripts/Get-KnownIssueHistory.ps1
@@ -1,0 +1,599 @@
+<#
+.SYNOPSIS
+    Retrieves historical failure timeline for Known Build Error issues by analyzing
+    the edit history of the issue body's hit count table.
+
+.DESCRIPTION
+    The dotnet Build Analysis bot periodically edits Known Build Error issues to update
+    rolling hit count tables (24-hour, 7-day, 1-month). This script queries the GitHub
+    GraphQL API for the edit history (userContentEdits) and reconstructs a failure
+    timeline by detecting when the 24-hour count transitions from 0 to a positive value.
+
+    Can analyze a single issue or scan all open Known Build Error issues in a repository
+    to find the most actively failing tests.
+
+.PARAMETER IssueNumber
+    The GitHub issue number of a Known Build Error to analyze.
+
+.PARAMETER Repository
+    The GitHub repository (owner/repo format). Default: dotnet/runtime
+
+.PARAMETER ListActive
+    Scan all open "Known Build Error" issues and rank by recent failure activity.
+
+.PARAMETER MaxIssues
+    Maximum number of issues to scan when using -ListActive. Default: 50
+
+.PARAMETER Since
+    Only show failure events and periods on or after this date (ISO 8601 format,
+    e.g. 2025-01-01). Failure periods are included if their End date is on or after
+    the filter date, even if their Start date is earlier.
+
+.PARAMETER Json
+    Output structured JSON summary instead of human-readable table.
+
+.EXAMPLE
+    .\Get-KnownIssueHistory.ps1 -IssueNumber 100088
+
+.EXAMPLE
+    .\Get-KnownIssueHistory.ps1 -IssueNumber 100088 -Since 2025-01-01
+
+.EXAMPLE
+    .\Get-KnownIssueHistory.ps1 -IssueNumber 100088 -Json
+
+.EXAMPLE
+    .\Get-KnownIssueHistory.ps1 -ListActive -Repository dotnet/runtime
+#>
+
+[CmdletBinding(DefaultParameterSetName = 'SingleIssue')]
+param(
+    [Parameter(Mandatory, ParameterSetName = 'SingleIssue', Position = 0)]
+    [ValidateRange(1, [int]::MaxValue)]
+    [int]$IssueNumber,
+
+    [Parameter()]
+    [string]$Repository = "dotnet/runtime",
+
+    [Parameter(Mandatory, ParameterSetName = 'ListActive')]
+    [switch]$ListActive,
+
+    [Parameter(ParameterSetName = 'ListActive')]
+    [ValidateRange(1,100)]
+    [int]$MaxIssues = 50,
+
+    [Parameter()]
+    [string]$Since,
+
+    [Parameter()]
+    [switch]$Json
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Split-Repository {
+    param([string]$Repo)
+    if ($Repo -notmatch '^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$') {
+        throw "Invalid repository format '$Repo'. Expected 'owner/repo' (alphanumeric, dots, hyphens, underscores only)."
+    }
+    $parts = $Repo -split '/'
+    return @{ Owner = $parts[0]; Name = $parts[1] }
+}
+
+function Get-IssueEditHistory {
+    param(
+        [string]$Owner,
+        [string]$RepoName,
+        [int]$Number,
+        [int]$MaxPages = 50
+    )
+
+    $allNodes = [System.Collections.Generic.List[object]]::new()
+    $totalCount = 0
+    $hasNextPage = $true
+    $endCursor = $null
+    $pageCount = 0
+    $truncated = $false
+
+    # Paginate through edits (API returns max 100 per page)
+    while ($hasNextPage) {
+        $afterClause = if ($endCursor) { ", after: `"$endCursor`"" } else { "" }
+        $query = @"
+{
+  repository(owner: "$Owner", name: "$RepoName") {
+    issue(number: $Number) {
+      title
+      createdAt
+      state
+      labels(first: 100) { nodes { name } }
+      userContentEdits(first: 100$afterClause) {
+        totalCount
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          editedAt
+          editor { login }
+          diff
+        }
+      }
+    }
+  }
+}
+"@
+        $result = gh api graphql -f "query=$query" 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "GraphQL query failed: $result"
+        }
+
+        $data = ($result -join "`n") | ConvertFrom-Json
+
+        if ($data.errors) {
+            $msgs = ($data.errors | ForEach-Object { $_.message }) -join '; '
+            throw "GraphQL errors for issue #$Number in ${Owner}/${RepoName}: $msgs"
+        }
+
+        $issue = $data.data.repository.issue
+
+        if (-not $issue) {
+            throw "Issue #$Number not found in $Owner/$RepoName"
+        }
+
+        $edits = $issue.userContentEdits
+        if ($totalCount -eq 0) { $totalCount = $edits.totalCount }
+        $allNodes.AddRange(@($edits.nodes))
+        $hasNextPage = $edits.pageInfo.hasNextPage
+        $endCursor = $edits.pageInfo.endCursor
+        $pageCount++
+
+        if ($hasNextPage -and $pageCount -ge $MaxPages) {
+            $hasNextPage = $false
+            $truncated = $true
+            Write-Warning "Issue #$Number has more than $($pageCount * 100) edits; results truncated to $($allNodes.Count) edits."
+        }
+    }
+
+    return @{
+        Title      = $issue.title
+        CreatedAt  = $issue.createdAt
+        State      = $issue.state
+        Labels     = @($issue.labels.nodes | ForEach-Object { $_.name })
+        Edits      = @($allNodes | Sort-Object { $_.editedAt })
+        TotalEdits = $totalCount
+        Truncated  = $truncated
+    }
+}
+
+function Parse-HitCounts {
+    param([array]$Edits)
+
+    $timeline = [System.Collections.Generic.List[object]]::new()
+    $prev24h = $null
+
+    foreach ($edit in $Edits) {
+        $date = $edit.editedAt
+        $editor = if ($edit.editor) { $edit.editor.login } else { "unknown" }
+        $diff = if ($edit.diff) { $edit.diff } else { "" }
+
+        # Match hit count data rows, optionally prefixed with a unified diff marker (+, -, or space).
+        # Skip removed (-) rows so each edit contributes only the current/added snapshot.
+        $matches = [regex]::Matches($diff, '(?m)^([+ -])?\|(\d+)\|(\d+)\|(\d+)\|\s*$')
+
+        foreach ($m in $matches) {
+            $prefix = $m.Groups[1].Value
+            if ($prefix -eq '-') { continue }
+
+            $h24 = [int]$m.Groups[2].Value
+            $h7d = [int]$m.Groups[3].Value
+            $h1mo = [int]$m.Groups[4].Value
+
+            $event = "update"
+            if ($null -eq $prev24h -and $h24 -gt 0) {
+                # First edit with hit counts and 24h > 0 — treat as initial failure
+                $event = "new_failure"
+            }
+            elseif ($null -ne $prev24h -and $h24 -gt 0 -and $prev24h -eq 0) {
+                $event = "new_failure"
+            }
+            elseif ($null -ne $prev24h -and $h24 -gt $prev24h) {
+                $event = "additional_failure"
+            }
+            elseif ($h24 -eq 0 -and $h7d -eq 0 -and $h1mo -eq 0) {
+                $event = "all_clear"
+            }
+
+            $entry = [PSCustomObject]@{
+                Date    = $date
+                Editor  = $editor
+                Hit24h  = $h24
+                Hit7d   = $h7d
+                Hit1mo  = $h1mo
+                Event   = $event
+            }
+
+            $prev24h = $h24
+            $timeline.Add($entry)
+        }
+    }
+
+    return $timeline
+}
+
+function ConvertTo-UtcDateTime {
+    param([object]$Value)
+    if ($Value -is [datetime]) { return $Value.ToUniversalTime() }
+    return [DateTime]::Parse(
+        $Value,
+        [System.Globalization.CultureInfo]::InvariantCulture,
+        [System.Globalization.DateTimeStyles]::AssumeUniversal -bor [System.Globalization.DateTimeStyles]::AdjustToUniversal
+    )
+}
+
+function Filter-Since {
+    param([array]$Items, [string]$SinceDate, [string]$DateProperty = 'Date')
+    if (-not $SinceDate) { return $Items }
+    $sinceDateTime = ConvertTo-UtcDateTime $SinceDate
+    return @($Items | Where-Object { (ConvertTo-UtcDateTime $_.$DateProperty) -ge $sinceDateTime })
+}
+
+function Get-FailureEvents {
+    param([array]$Timeline)
+
+    return @($Timeline | Where-Object { $_.Event -eq 'new_failure' -or $_.Event -eq 'additional_failure' })
+}
+
+function Get-FailurePeriods {
+    param([array]$Timeline)
+
+    $periods = @()
+    $inFailure = $false
+    $currentPeriod = $null
+
+    foreach ($entry in $Timeline) {
+        if (($entry.Event -eq 'new_failure' -or $entry.Event -eq 'additional_failure') -and -not $inFailure) {
+            # Start of a new failure period
+            $inFailure = $true
+            $currentPeriod = @{
+                Start      = $entry.Date
+                End        = $entry.Date
+                PeakHit24h = $entry.Hit24h
+                PeakHit1mo = $entry.Hit1mo
+                Events     = @($entry)
+            }
+        }
+        elseif ($inFailure -and ($entry.Event -eq 'new_failure' -or $entry.Event -eq 'additional_failure')) {
+            # Continuation of existing period (another failure before all_clear)
+            $currentPeriod.Events += $entry
+            $currentPeriod.End = $entry.Date
+            if ($entry.Hit24h -gt $currentPeriod.PeakHit24h) {
+                $currentPeriod.PeakHit24h = $entry.Hit24h
+            }
+            if ($entry.Hit1mo -gt $currentPeriod.PeakHit1mo) {
+                $currentPeriod.PeakHit1mo = $entry.Hit1mo
+            }
+        }
+        elseif ($inFailure -and $entry.Event -ne 'all_clear') {
+            # Non-failure update within a period — track peak counts as they decay
+            $currentPeriod.End = $entry.Date
+            if ($entry.Hit1mo -gt $currentPeriod.PeakHit1mo) {
+                $currentPeriod.PeakHit1mo = $entry.Hit1mo
+            }
+        }
+        elseif ($entry.Event -eq 'all_clear' -and $inFailure) {
+            $inFailure = $false
+            $currentPeriod.End = $entry.Date
+            $periods += [PSCustomObject]$currentPeriod
+            $currentPeriod = $null
+        }
+    }
+
+    # Close any open period
+    if ($inFailure -and $currentPeriod) {
+        $periods += [PSCustomObject]$currentPeriod
+    }
+
+    return $periods
+}
+
+function Format-ShortDate {
+    param([object]$Value)
+    $dt = ConvertTo-UtcDateTime $Value
+    return $dt.ToString("yyyy-MM-dd")
+}
+
+function Format-Timeline {
+    param(
+        [hashtable]$IssueData,
+        [array]$Timeline,
+        [array]$FailureEvents,
+        [array]$FailurePeriods,
+        [int]$IssueNum,
+        [string]$Repo,
+        [string]$SinceFilter,
+        [int]$TotalFailureEvents,
+        [int]$TotalFailurePeriods
+    )
+
+    $sb = [System.Text.StringBuilder]::new()
+    $suffix = if ($SinceFilter) { " (since $SinceFilter)" } else { "" }
+
+    [void]$sb.AppendLine("=" * 70)
+    [void]$sb.AppendLine("KNOWN ISSUE FAILURE HISTORY")
+    [void]$sb.AppendLine("=" * 70)
+    [void]$sb.AppendLine("")
+    [void]$sb.AppendLine("Issue:      #$IssueNum - $($IssueData.Title)")
+    [void]$sb.AppendLine("Repository: $Repo")
+    [void]$sb.AppendLine("State:      $($IssueData.State)")
+    [void]$sb.AppendLine("Created:    $($IssueData.CreatedAt)")
+    [void]$sb.AppendLine("Edits:      $($IssueData.TotalEdits) total ($($Timeline.Count) with hit counts)")
+    [void]$sb.AppendLine("")
+
+    # Summary
+    [void]$sb.AppendLine("-" * 70)
+    [void]$sb.AppendLine("FAILURE SUMMARY$suffix")
+    [void]$sb.AppendLine("-" * 70)
+    [void]$sb.AppendLine("")
+    [void]$sb.AppendLine("Failure events:        $($FailureEvents.Count)$suffix")
+    [void]$sb.AppendLine("Failure periods:       $($FailurePeriods.Count)$suffix")
+    if ($SinceFilter) {
+        [void]$sb.AppendLine("Total failure events:  $TotalFailureEvents (all time)")
+        [void]$sb.AppendLine("Total failure periods:  $TotalFailurePeriods (all time)")
+    }
+
+    if ($FailureEvents.Count -gt 0) {
+        $lastFailure = $FailureEvents[-1]
+        [void]$sb.AppendLine("Last failure:          $(Format-ShortDate $lastFailure.Date)")
+
+        $lastDate = ConvertTo-UtcDateTime $lastFailure.Date
+        $daysSince = [math]::Floor(([DateTime]::UtcNow - $lastDate).TotalDays)
+        [void]$sb.AppendLine("Days since last:       $daysSince")
+    }
+    else {
+        [void]$sb.AppendLine("Last failure:          (none detected in edit history)")
+    }
+
+    [void]$sb.AppendLine("")
+
+    # Failure periods
+    if ($FailurePeriods.Count -gt 0) {
+        [void]$sb.AppendLine("-" * 70)
+        [void]$sb.AppendLine("FAILURE PERIODS")
+        [void]$sb.AppendLine("-" * 70)
+        [void]$sb.AppendLine("")
+        [void]$sb.AppendLine(("{0,-4} {1,-14} {2,-14} {3,10} {4,10}" -f "#", "Start", "End", "Peak 24h", "Peak 1mo"))
+        [void]$sb.AppendLine(("{0,-4} {1,-14} {2,-14} {3,10} {4,10}" -f "---", "---", "---", "---", "---"))
+
+        $i = 1
+        foreach ($p in $FailurePeriods) {
+            [void]$sb.AppendLine(("{0,-4} {1,-14} {2,-14} {3,10} {4,10}" -f $i, (Format-ShortDate $p.Start), (Format-ShortDate $p.End), $p.PeakHit24h, $p.PeakHit1mo))
+            $i++
+        }
+        [void]$sb.AppendLine("")
+    }
+
+    # Full timeline
+    [void]$sb.AppendLine("-" * 70)
+    [void]$sb.AppendLine("EDIT TIMELINE")
+    [void]$sb.AppendLine("-" * 70)
+    [void]$sb.AppendLine("")
+    [void]$sb.AppendLine(("{0,-28} {1,5} {2,5} {3,5}  {4}" -f "Date", "24h", "7d", "1mo", "Event"))
+    [void]$sb.AppendLine(("{0,-28} {1,5} {2,5} {3,5}  {4}" -f "---", "---", "---", "---", "---"))
+
+    foreach ($entry in $Timeline) {
+        $marker = switch ($entry.Event) {
+            'new_failure'        { "<-- NEW FAILURE" }
+            'additional_failure' { "<-- ADDITIONAL FAILURE" }
+            'all_clear'          { "(cleared)" }
+            default              { "" }
+        }
+        [void]$sb.AppendLine(("{0,-28} {1,5} {2,5} {3,5}  {4}" -f $entry.Date, $entry.Hit24h, $entry.Hit7d, $entry.Hit1mo, $marker))
+    }
+
+    return $sb.ToString()
+}
+
+function Build-JsonSummary {
+    param(
+        [hashtable]$IssueData,
+        [array]$FullTimeline,
+        [array]$FailureEvents,
+        [array]$FailurePeriods,
+        [int]$IssueNum,
+        [string]$Repo,
+        [string]$SinceFilter,
+        [int]$TotalFailureEvents,
+        [int]$TotalFailurePeriods
+    )
+
+    $lastFailure = if ($FailureEvents.Count -gt 0) { $FailureEvents[-1].Date } else { $null }
+    $daysSince = if ($lastFailure) {
+        $lastDate = ConvertTo-UtcDateTime $lastFailure
+        [math]::Floor(([DateTime]::UtcNow - $lastDate).TotalDays)
+    } else { $null }
+
+    # Current counts from most recent entry in full (unfiltered) timeline
+    $current = if ($FullTimeline.Count -gt 0) { $FullTimeline[-1] } else { $null }
+
+    $summary = [ordered]@{
+        issueNumber            = $IssueNum
+        repository             = $Repo
+        title                  = $IssueData.Title
+        state                  = $IssueData.State
+        createdAt              = $IssueData.CreatedAt
+        totalEdits             = $IssueData.TotalEdits
+        sinceFilter            = $SinceFilter
+        failureEvents          = $FailureEvents.Count
+        failurePeriodCount     = $FailurePeriods.Count
+        totalFailureEvents     = $TotalFailureEvents
+        totalFailurePeriods    = $TotalFailurePeriods
+        lastFailureDate        = $lastFailure
+        daysSinceLastFailure   = $daysSince
+        currentHitCounts       = if ($current) {
+            [ordered]@{ h24 = $current.Hit24h; h7d = $current.Hit7d; h1mo = $current.Hit1mo }
+        } else { $null }
+        failureTimeline        = @($FailureEvents | ForEach-Object {
+            [ordered]@{ date = $_.Date; hit24h = $_.Hit24h; hit7d = $_.Hit7d; hit1mo = $_.Hit1mo }
+        })
+        periods                = @($FailurePeriods | ForEach-Object {
+            [ordered]@{ start = $_.Start; end = $_.End; peakHit24h = $_.PeakHit24h; peakHit1mo = $_.PeakHit1mo }
+        })
+    }
+
+    return $summary
+}
+
+# --- ListActive mode ---
+function Invoke-ListActive {
+    param(
+        [string]$Owner,
+        [string]$RepoName,
+        [int]$Max,
+        [string]$SinceDate
+    )
+
+    Write-Host "Scanning open 'Known Build Error' issues in $Owner/$RepoName..."
+    Write-Host ""
+
+    $issues = gh api "repos/$Owner/$RepoName/issues?labels=Known+Build+Error&state=open&per_page=$Max&sort=updated&direction=desc" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to list issues: $issues"
+    }
+
+    $issueList = ($issues -join "`n") | ConvertFrom-Json
+
+    if ($issueList.Count -eq 0) {
+        Write-Host "No open 'Known Build Error' issues found."
+        return
+    }
+
+    Write-Host "Found $($issueList.Count) open issues. Analyzing edit history..."
+    Write-Host ""
+
+    $results = @()
+
+    foreach ($issue in $issueList) {
+        # REST issues endpoint can return PRs; skip them
+        if ($issue.pull_request) { continue }
+
+        $num = $issue.number
+        $title = $issue.title
+        if ($title.Length -gt 60) { $title = $title.Substring(0, 57) + "..." }
+
+        try {
+            $issueData = Get-IssueEditHistory -Owner $Owner -RepoName $RepoName -Number $num -MaxPages 5
+            if (-not $issueData) { continue }
+
+            $timeline = Parse-HitCounts -Edits $issueData.Edits
+            $failureEvents = Get-FailureEvents -Timeline $timeline
+            $failureEvents = Filter-Since -Items $failureEvents -SinceDate $SinceDate
+
+            $lastFailure = if ($failureEvents.Count -gt 0) { $failureEvents[-1].Date } else { $null }
+            $daysSince = if ($lastFailure) {
+                $lastDate = ConvertTo-UtcDateTime $lastFailure
+                [math]::Floor(([DateTime]::UtcNow - $lastDate).TotalDays)
+            } else { 99999 }
+
+            $lastFailureDisplay = if ($lastFailure) {
+                $d = ConvertTo-UtcDateTime $lastFailure
+                $d.ToString("yyyy-MM-dd")
+            } elseif ($SinceDate) { "none since $SinceDate" } else { "never" }
+
+            $results += [PSCustomObject]@{
+                Number        = $num
+                Title         = $title
+                FailureCount  = $failureEvents.Count
+                LastFailure   = $lastFailureDisplay
+                DaysSince     = $daysSince
+            }
+        }
+        catch {
+            Write-Warning "  Skipping #$num ($($_.Exception.Message))"
+        }
+    }
+
+    # Sort by most recent failure
+    $results = $results | Sort-Object DaysSince
+
+    Write-Host ("=" * 70)
+    Write-Host "KNOWN BUILD ERROR ACTIVITY REPORT"
+    Write-Host ("=" * 70)
+    Write-Host ""
+    Write-Host ("{0,-8} {1,8} {2,12} {3,-12} {4}" -f "Issue", "Failures", "Last Failure", "Days Ago", "Title")
+    Write-Host ("{0,-8} {1,8} {2,12} {3,-12} {4}" -f "---", "---", "---", "---", "---")
+
+    foreach ($r in $results) {
+        $daysLabel = if ($r.DaysSince -eq 99999) { "n/a" } else { $r.DaysSince.ToString() }
+        Write-Host ("{0,-8} {1,8} {2,12} {3,-12} {4}" -f "#$($r.Number)", $r.FailureCount, $r.LastFailure, $daysLabel, $r.Title)
+    }
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+$repo = Split-Repository -Repo $Repository
+
+# Verify GitHub CLI is available and authenticated
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    throw "GitHub CLI (gh) is not installed. See https://cli.github.com/ for installation instructions."
+}
+$null = gh auth status 2>&1
+if ($LASTEXITCODE -ne 0) {
+    throw "GitHub CLI is not authenticated. Run 'gh auth login' first."
+}
+
+if ($ListActive) {
+    Invoke-ListActive -Owner $repo.Owner -RepoName $repo.Name -Max $MaxIssues -SinceDate $Since
+    return
+}
+
+# Single issue mode
+Write-Host "Fetching edit history for issue #$IssueNumber in $Repository..."
+Write-Host ""
+
+$issueData = Get-IssueEditHistory -Owner $repo.Owner -RepoName $repo.Name -Number $IssueNumber
+
+if (-not $issueData) { return }
+
+# Verify it's a Known Build Error
+if ($issueData.Labels -notcontains 'Known Build Error') {
+    Write-Warning "Issue #$IssueNumber does not have the 'Known Build Error' label. Results may not be meaningful."
+}
+
+$fullTimeline = Parse-HitCounts -Edits $issueData.Edits
+$allFailureEvents = Get-FailureEvents -Timeline $fullTimeline
+$allFailurePeriods = Get-FailurePeriods -Timeline $fullTimeline
+
+# Apply -Since filter after analysis so periods are computed on full data
+$timeline = Filter-Since -Items $fullTimeline -SinceDate $Since
+$failureEvents = Filter-Since -Items $allFailureEvents -SinceDate $Since
+$failurePeriods = Filter-Since -Items $allFailurePeriods -SinceDate $Since -DateProperty 'End'
+
+if ($Json) {
+    $summary = Build-JsonSummary `
+        -IssueData $issueData `
+        -FullTimeline $fullTimeline `
+        -FailureEvents $failureEvents `
+        -FailurePeriods $failurePeriods `
+        -IssueNum $IssueNumber `
+        -Repo $Repository `
+        -SinceFilter $Since `
+        -TotalFailureEvents $allFailureEvents.Count `
+        -TotalFailurePeriods $allFailurePeriods.Count
+
+    Write-Host ""
+    Write-Host "[KNOWN_ISSUE_HISTORY]"
+    Write-Host ($summary | ConvertTo-Json -Depth 5)
+    Write-Host "[/KNOWN_ISSUE_HISTORY]"
+}
+else {
+    $output = Format-Timeline `
+        -IssueData $issueData `
+        -Timeline $timeline `
+        -FailureEvents $failureEvents `
+        -FailurePeriods $failurePeriods `
+        -IssueNum $IssueNumber `
+        -Repo $Repository `
+        -SinceFilter $Since `
+        -TotalFailureEvents $allFailureEvents.Count `
+        -TotalFailurePeriods $allFailurePeriods.Count
+
+    Write-Host $output
+}

--- a/.github/skills/maestro-cli/SKILL.md
+++ b/.github/skills/maestro-cli/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: maestro-cli
+description: >
+  Query Maestro/BAR dependency flow data using the mstro CLI tool via bash.
+  USE FOR: subscription health checks, build flow tracing, codeflow status,
+  channel discovery, triggering subscription updates — when MCP tools aren't
+  loaded or when scripting with JSON output and jq. Also use when investigating
+  "is this subscription stale", "what's the latest build", "check backflow status".
+  DO NOT USE FOR: tasks where maestro MCP tools are already available in context
+  (prefer flow-analysis or flow-tracing skills when MCP server is loaded).
+  INVOKES: bash (mstro CLI commands with --json output).
+---
+
+# Maestro CLI
+
+Query Maestro/BAR data via the `mstro` CLI tool instead of loading MCP tools into context. Same data, same caching, zero context tax — agents discover capabilities progressively through `--help` and `mstro guide`.
+
+## When to Use This Skill
+
+Use this skill when:
+- You need Maestro/BAR data but the maestro MCP server isn't configured
+- You're scripting or chaining commands with `jq`, `grep`, or other CLI tools
+- You want structured JSON output for downstream processing
+- The task is one-shot (not a multi-turn conversational investigation)
+
+**Prefer MCP-based skills (flow-analysis, flow-tracing) when:**
+- The maestro MCP server is already loaded in your tool list
+- You're doing multi-turn conversational investigation
+- You need markdown-formatted output with visual indicators
+
+## Installation
+
+```bash
+dotnet tool install -g lewing.maestro.mcp
+```
+
+After installation, `mstro` is available globally. Verify: `mstro --help`
+
+> Note: The same package (`lewing.maestro.mcp`) serves as both a .NET global tool (providing the `mstro` CLI) and an MCP server (via `dotnet dnx`). The CLI is what this skill uses.
+
+## Authentication
+
+Three-tier cascade (automatic fallback):
+1. **`MAESTRO_BAR_TOKEN`** env var — explicit PAT
+2. **Cached Entra ID** — reuses `darc authenticate` credentials from `~/.darc/.auth-record-*`
+3. **Anonymous** — read-only fallback (may be rate-limited)
+
+Run `darc authenticate` once for persistent credentials.
+
+## Progressive Discovery
+
+Don't memorize commands. Discover them:
+
+```bash
+mstro --help              # All commands, one line each
+mstro <command> --help    # Parameters for a specific command
+mstro <command> --schema  # JSON response field names (for jq pipelines)
+mstro guide               # Workflow-organized guide (~3KB)
+```
+
+Before writing jq queries, run `--schema` to see the response shape:
+```bash
+mstro subscription-health --schema   # → shows StaleSubs[].Id, .BuildsBehind, etc.
+mstro latest-build --schema          # → shows Id, Repository, Commit, etc.
+```
+
+## Common Patterns
+
+All query commands support `--json` (structured output) and `--no-cache` (fresh data).
+
+### Check subscription health
+```bash
+mstro subscription-health --target-repository https://github.com/dotnet/dotnet --json
+```
+
+### Find latest build
+```bash
+mstro latest-build https://github.com/dotnet/runtime --channel-name ".NET 10.0.1xx SDK" --json
+```
+
+### Check codeflow status
+```bash
+mstro codeflow-statuses --json
+```
+
+### Trace a build graph
+```bash
+mstro build-graph <build-id> --json
+```
+
+### Trigger a stale subscription
+```bash
+# Provide --source-repository + --channel-name (auto-resolves latest build)
+mstro trigger-subscription <guid> --source-repository https://github.com/dotnet/runtime --channel-name ".NET 10.0.1xx SDK"
+# Or provide --build-id directly. Add --force to overwrite stale PR branch.
+```
+
+## Chaining with jq
+
+Use `mstro <command> --schema` to see all response fields before writing jq queries.
+
+```bash
+# Count stale subscriptions (StaleSubs[].Id, .BuildsBehind, .SourceRepository, .ChannelName)
+mstro subscription-health --target-repository https://github.com/dotnet/dotnet --json | jq '.StaleSubs | length'
+
+# Filter channels by name
+mstro channels --json | jq '.[] | select(.Name | contains("10.0"))'
+
+# Get build ID then trace graph
+BUILD_ID=$(mstro latest-build https://github.com/dotnet/runtime --json | jq -r '.Id')
+mstro build-graph $BUILD_ID --json
+```
+
+## Cache
+
+Shared SQLite cache at `~/.mstro/cache.db` (WAL mode). Cache is shared between CLI and MCP server instances — using the CLI warms the cache for MCP and vice versa.
+
+- `mstro cache status` — show cache stats
+- `mstro cache clear` — clear all cached data
+- `--no-cache` on any command bypasses cache

--- a/.github/skills/pipeline-investigation/SKILL.md
+++ b/.github/skills/pipeline-investigation/SKILL.md
@@ -1,0 +1,312 @@
+---
+name: pipeline-investigation
+description: >
+  Investigate AzDO pipeline failures beyond Helix — build errors, infra tooling
+  crashes, validation test flakiness, artifact cascade failures.
+  USE FOR: "why did the unified-build fail", "what's breaking the pipeline",
+  "how often does this failure occur", "drill into build task logs",
+  "1ES scan failures", "SourcelinkTests flaky", "NetAnalyzers build error",
+  analyzing AzDO build timelines and task logs, failure frequency/trend analysis.
+  DO NOT USE FOR: Helix test failures (use helix-investigation), CI status
+  overview (use ci-analysis), codeflow PRs (use flow-analysis).
+  INVOKES: AzDO, Helix, and binlog MCP tools, az CLI for internal auth, gh CLI.
+---
+
+# Pipeline Investigation
+
+Investigate AzDO pipeline failures that aren't Helix test failures — build errors, infrastructure tooling crashes, validation test flakiness, and artifact cascade failures. Complements helix-investigation by covering everything else in the pipeline.
+
+## When to Use This Skill
+
+- User has an AzDO build URL with a non-Helix failure (build step, validation, infra task)
+- User asks "why did the pipeline fail" and the failure is in a build/scan/validation task
+- User wants to know how often a specific failure occurs (frequency/trend analysis)
+- User sees `exit code null`, 1ES PT errors, or MSBuild failures
+- User wants to understand artifact cascade failures ("missing artifacts from prior build")
+- User asks about SourcelinkTests, Binary Analysis Scan, or installer validation failures
+
+## Output Formats
+
+This skill produces two distinct report types. Match the format to the request:
+
+### Health Assessment ("pipeline health", "are builds passing", "pipeline status")
+
+Follow [references/health-assessment-format.md](references/health-assessment-format.md). Output MUST include these two tables:
+
+1. **Failed Builds Table** — every failed build, classified and investigated:
+   | Build | Type | Source | Failure Detail |
+   - **Type**: Rolling, Forward Flow, or Other PR (classify via `gh pr view`)
+   - **Source**: Rolling → branch name. Forward Flow → `target ← source-repo`. Other PR → short description.
+
+2. **Summary Table** — pass/fail breakdown by build type:
+   | Type | Completed | ✅ Pass | ❌ Fail | Pass Rate |
+
+3. **Failure Trends Table** (conditional — include when 3+ builds in scope and at least one pattern recurs; cap at top 5):
+   | Pattern | Hits | Window | Status |
+   - **Status**: ❌ No issue filed, ✅ Fix merged, 🔄 Known issue (link), ⏳ Fix in progress
+
+See the reference for build classification rules, branch filtering, and codeflow analysis methodology.
+
+**Save the report:** After presenting the health assessment, save it to `reviews/pipeline-health-<slug>-YYYY-MM-DD-HHMM.md` in the repo, where `<slug>` identifies the pipeline or scope (e.g., `unified-build`, `runtime-ci`). Include the timestamp to ensure uniqueness across multiple investigations per day. Include a Methodology section at the end documenting data sources and classification approach.
+
+### Individual Failure Investigation ("why did this build fail", single build URL)
+
+Use Step 7's numbered format: failure category, frequency, root cause, affected branches, owner, existing issues, recommended action.
+
+## Prerequisites
+
+- AzDO MCP tools (ado-* prefix) for querying builds and timelines on public projects
+- Binlog MCP tools (mcp-binlog-tool-*) for analyzing MSBuild binary logs from build artifacts
+- `az account get-access-token` or `azureauth ado token` for authenticated REST API access to `dnceng/internal`
+- `curl` for downloading task logs and build artifacts
+- `gh` CLI for searching related issues and source code
+
+## Authentication
+
+The `dnceng/internal` project requires authentication. Two methods:
+
+```bash
+# Method 1: Azure CLI (preferred — works in most environments)
+TOKEN=$(az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
+
+# Method 2: azureauth tool
+TOKEN=$(azureauth ado token --output token --prompt-hint "copilot-cli")
+
+# Usage
+curl -s -H "Authorization: Bearer $TOKEN" "https://dev.azure.com/dnceng/internal/_apis/build/builds/{buildId}/timeline?api-version=7.1"
+```
+
+> ⚠️ Tokens expire. Re-acquire if you get a 401 or redirect to a sign-in page.
+> ⚠️ AzDO MCP tools do NOT work against `dnceng/internal`. Use curl with Bearer token for all internal queries.
+
+## Workflow
+
+### Step 1: Get the build timeline
+
+Given a build ID or URL, query the timeline to find all failed records:
+
+```
+https://dev.azure.com/{org}/{project}/_apis/build/builds/{buildId}/timeline?api-version=7.1
+```
+
+Filter records by `result == "failed"` or `result == "succeededWithIssues"`, with `type == "Task"`. Don't skip `succeededWithIssues` — these contain real failures (signing validation errors, Component Governance warnings) that didn't block the overall job. For health assessments, also include builds with overall result `partiallySucceeded`.
+
+Each failed or warning task has:
+- **name** — the task that failed
+- **parentId** — links to the parent Job record (tells you which leg)
+- **issues** — error messages with type and message fields
+- **log.url** — URL to download the full task log
+
+### Step 2: Categorize the failure
+
+| Pattern | Category | Owner |
+|---------|----------|-------|
+| `Binary Analysis Scan` task, `exit code null` | 1ES infra tooling crash | 1ES PT team |
+| `MSB3073` / `NetAnalyzers.Package.csproj` error | Build error | Source code / SDK |
+| `Validate installer packages` — expected vs actual package list mismatch | Installer validation regex | dotnet/installer |
+| `Run Tests` with `SourcelinkTests.VerifySourcelinks` | Sourcelink validation | dotnet/dotnet |
+| `Run Tests` with `The task has timed out` across many `SB_*_Validation_*` legs | Run Tests timeout epidemic | dotnet/dotnet |
+| `Run Tests` with locale test failure (e.g., `tr-TR`) | Scenario test bug | dotnet/templating |
+| `Build` with `IBCMerge` / PGO error in `Windows_Pgo_*` | PGO optimization failure | dotnet/runtime |
+| `Download Previous Build` with "Artifact not found" | Artifact cascade failure | Prior build failed first |
+| `Build` with `curl` / `tar` / download failure (exit code 2, "not recoverable") | External resource fetch failure | Retry first; if persistent, check URL/version |
+| `Build` with `npm ci` ETIMEDOUT / ECONNREFUSED | npm network timeout | Transient; shell retry wrapper needed |
+| `Build` task with compilation errors | Source code build break | Varies by component |
+| `Crossgen.targets` with `exit code 57005` (0xDEAD) | crossgen2 fatal crash | dotnet/runtime (area-crossgen2-coreclr) |
+| ESRP `MacSignFailed` / `FailDoNotRetry` / notarization errors | Signing/notarization failure | dotnet/sdk or ESRP team |
+| `exit code null` on cross-compilation legs in containers | Container OOM kill | Infrastructure — pool/container config |
+| Build start == finish, HTTP 204 timeline, `validationResults` has errors | YAML pre-flight rejection | PR author — pipeline YAML invalid |
+
+> **Routing: AzDO tests vs Helix tests.** If the test runs directly as an AzDO task (e.g., `Run Tests` in `SB_*_Validation_*` legs — SourcelinkTests, scenario tests), it's pipeline-investigation. If the test is submitted to Helix (has a Helix job ID, work items, console logs at helix.dot.net), use helix-investigation.
+
+### Step 3: Download and analyze task logs
+
+```bash
+TOKEN=$(azureauth ado token --output token --prompt-hint "copilot-cli")
+curl -s -H "Authorization: Bearer $TOKEN" "{log_url}" > /tmp/task-{buildId}.log
+```
+
+Key patterns to search for:
+- **`exit code null`** — process terminated by signal (OOM, timeout). Check for memory-related warnings before the crash.
+- **`exit code 57005`** (0xDEAD) — crossgen2 fatal error. Check which assembly was being compiled. Intermittent crashes need crash dumps for diagnosis.
+- **`[ERROR]`** / **`##[error]`** — explicit error messages from the task
+- **`[WARNING]` floods** — excessive warnings (e.g., 1000+ hardlink failures) indicate resource exhaustion
+- **MSBuild error codes** — `MSB3073` (command failed), `NETSDK*` (SDK errors), `NU1105` (invalid target framework — often transient forward flow)
+- **`MacSignFailed`** / **`FailDoNotRetry`** — ESRP signing rejection. `FailDoNotRetry` means deterministic content failure, not transient.
+- **Stack traces** — .NET exceptions in test output
+- **`ETIMEDOUT`** / **`ECONNREFUSED`** — TCP-level network failures in npm/curl that aren't retried by default
+
+### Step 4: Determine if it's a one-off or recurring
+
+Query failed builds over a time range and count how many hit the same failure:
+
+```bash
+# Get failed builds for a pipeline definition
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://dev.azure.com/{org}/{project}/_apis/build/builds?definitions={defId}&resultFilter=failed&minTime={iso8601}&$top=200&api-version=7.1"
+```
+
+> 💡 **Rolling builds give cleaner signal.** Add `&reasonFilter=schedule` to filter to scheduled builds only. PR builds include broken branches that inflate failure counts and obscure systemic trends.
+
+For each build, check its timeline for the same failure pattern. Track in a SQL table:
+
+```sql
+CREATE TABLE pipeline_failures (
+  build_id INT, branch TEXT, queued TEXT, failure_category TEXT, 
+  failed_task TEXT, notes TEXT
+);
+```
+
+Look for:
+- **Burst pattern** — many occurrences in a short window → something changed (tooling update, artifact size growth)
+- **Steady trickle** — consistent low rate → chronic issue
+- **Single occurrence** — likely transient, not worth investigating further
+
+### Step 5: Check for known issues
+
+Search the relevant repo for existing issues:
+
+```bash
+gh search issues "{failure_pattern}" --repo dotnet/dotnet --limit 5
+```
+
+If found, check if the issue is being worked on. If not found and the failure is recurring, consider filing one.
+
+### Step 6: Root cause analysis
+
+For non-obvious failures, pull up the source code of the failing test or tool:
+
+```bash
+gh api "repos/{owner}/{repo}/contents/{path}" --jq '.content' | base64 -d
+```
+
+Look for:
+- **Unbounded parallelism** — `Parallel.ForEach` without `MaxDegreeOfParallelism`
+- **Tight timeouts** — processes timing out under contention
+- **Resource assumptions** — disk space, memory, network that may not hold in CI
+- **Non-determinism** — race conditions, order-dependent assertions
+
+### Step 6b: Binlog analysis for deep investigation
+
+When task logs don't reveal enough, download the build's binlog artifacts for detailed MSBuild analysis:
+
+```bash
+# List build artifacts to find binlogs
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://dev.azure.com/{org}/{project}/_apis/build/builds/{buildId}/artifacts?api-version=7.1"
+
+# Download the artifact zip
+curl -s -H "Authorization: Bearer $TOKEN" -o /tmp/logs.zip "{downloadUrl}"
+unzip -o /tmp/logs.zip "*/Build.binlog" -d /tmp/binlogs/
+```
+
+Then use the binlog MCP tools:
+- `load_binlog` → `get_diagnostics` for errors/warnings
+- `search_binlog` to find specific patterns (e.g., `MacSignFailed`, `crossgen2`)
+- `get_task_info` to see exact command lines and parameters for failed tasks
+- `list_tasks_in_target` to see all tasks in a target (e.g., 126 Crossgen tasks, which one failed?)
+
+> 💡 Binlogs capture the full MSBuild execution including command lines, environment variables, and interleaved output that task logs lose. Essential for signing, crossgen2, and SBRP failures.
+
+### Step 7: Report findings (individual failure investigations only)
+
+For health assessments, use the Output Formats section above instead.
+
+Provide:
+1. **Failure category** — which pattern from the table above
+2. **Frequency** — how often in the last N days, trending up/down/stable
+3. **Root cause** — with evidence from logs and/or source code
+4. **Affected branches** — main only, or also release branches
+5. **Owner** — who should fix it (1ES, dotnet/dotnet, SDK team, etc.)
+6. **Existing issues** — links to any filed issues
+7. **Recommended action** — file issue, retry, wait for fix, etc.
+
+## Artifact Cascade Failures
+
+When a build leg fails, downstream legs that depend on its artifacts will also fail with "Artifact not found." This creates a cascade:
+
+```
+SB_CentOS_Build (fails: NetAnalyzers error)
+  → SB_CentOS_Validation (fails: missing artifacts)
+  → SB_Fedora_Offline (fails: missing artifacts)
+```
+
+**Don't investigate the cascade — find the root failure.** Look for the first failed task chronologically, or filter out "Download Previous Build" failures to find the real cause.
+
+## Category-Specific Investigation Techniques
+
+For detailed investigation techniques for each failure category in the table above, see [references/investigation-techniques.md](references/investigation-techniques.md). Covers: ESRP signing/notarization, container OOM, crossgen2 crashes, YAML pre-flight rejections, and network transient failures.
+
+## Fix Verification
+
+When a fix is merged, verify it's tested by checking builds queued **after** the merge — not builds that finished after it.
+
+### Query all build statuses
+
+**Always include in-progress and not-started builds**, not just completed ones. The AzDO builds API requires explicit `statusFilter` to return active builds.
+
+> ⚠️ **The AzDO API rejects combining `completed` with `inProgress`/`notStarted` in a single `statusFilter`.** You must make separate calls and merge the results:
+
+```bash
+# Completed builds
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://dev.azure.com/{org}/{project}/_apis/build/builds?definitions={defId}&branchName=refs/heads/{branch}&statusFilter=completed&api-version=7.1"
+
+# Active builds (in-progress and queued)
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://dev.azure.com/{org}/{project}/_apis/build/builds?definitions={defId}&branchName=refs/heads/{branch}&statusFilter=inProgress,notStarted&api-version=7.1"
+```
+
+If you only query completed builds, you'll miss active builds that are currently testing the fix and incorrectly conclude "not tested yet."
+
+### Multi-branch fixes
+
+Fixes often need backporting to multiple release branches. For each branch:
+
+1. Find the fix PR (or backport PR) and its merge time
+2. Query builds on that branch with **all statuses**
+3. Compare each build's `queueTime` to the merge time
+4. Partition into pre-merge (doesn't have fix) and post-merge (has fix)
+
+> ⚠️ **batchedCI builds pick up source at queue time.** A build queued before a PR merges runs against old source, even if it finishes hours later.
+
+## Stop Signals
+
+- **Stop after categorizing** if it's a known issue with an existing bug. Link to it and move on.
+- **Stop frequency analysis** after 14 days of data. Longer trends are rarely actionable.
+- **Stop investigating cascades** — always trace back to the root failure.
+- **Present single-occurrence failures** — even one-offs deserve a summary. Let the user decide whether to dig deeper or move on.
+
+## Anti-Patterns
+
+> 🚨 **Don't confuse cascade failures with root causes.** "Missing artifacts" means a prior leg failed — find that leg.
+
+> 🚨 **Don't assume `exit code null` is a code bug.** It usually means the process was terminated externally (OOM, signal). Look for resource exhaustion in the log. In containers, check memory limits.
+
+> 🚨 **Don't investigate all 100+ failed builds.** Sample 3-5 spread across the time range to confirm the pattern, then count occurrences.
+
+> 🚨 **Don't assume ESRP `FailDoNotRetry` is transient.** It means the binary content is deterministically invalid. Investigate the source commits, don't retry the build.
+
+> 🚨 **Don't skip infrastructure failures.** Container OOM, agent timeouts, signing failures, and network issues deserve the same depth of investigation as code failures. They often have actionable fixes (memory tuning, retry wrappers, pool changes).
+
+## Discovering Pipeline Definitions
+
+Never hardcode definition IDs — they vary across projects and can change. Discover them at runtime:
+
+```bash
+# Public pipelines (AzDO MCP tools work here too)
+curl -s "https://dev.azure.com/dnceng-public/public/_apis/build/definitions?name=dotnet-unified-build&api-version=7.1" | jq '.value[] | {id, name, project: .project.name}'
+
+# Internal pipelines (requires auth)
+TOKEN=$(az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://dev.azure.com/dnceng/internal/_apis/build/definitions?name=dotnet-unified-build&api-version=7.1" \
+  | jq '.value[] | {id, name, project: .project.name}'
+```
+
+If querying internal fails (401/redirect), fall back to public-only analysis and note the limitation in the report.
+
+### Health Assessment Report Format
+
+**Required format** for pipeline health assessments. See Output Formats section above for routing, and [references/health-assessment-format.md](references/health-assessment-format.md) for the complete specification including build classification rules, branch filtering, and codeflow analysis methodology.
+

--- a/.github/skills/pipeline-investigation/references/health-assessment-format.md
+++ b/.github/skills/pipeline-investigation/references/health-assessment-format.md
@@ -1,0 +1,123 @@
+# Health Assessment Report Format
+
+Standard format for pipeline health assessments. Use when asked "how healthy is the pipeline" or similar.
+
+## Default Time Window
+
+Since the last rolling build (scheduled/manual build on main or release/*). This gives the most meaningful snapshot — everything since the last full pipeline validation.
+
+## Build Classification
+
+Classify every build into one of three types:
+
+| Type | How to Identify |
+|------|----------------|
+| **Rolling** | `sourceBranch` starts with `refs/heads/` (main, release/*). No PR trigger. Requested by `Microsoft.VisualStudio.Services.TFS`. |
+| **Forward Flow** | PR title matches `[branch] Source code updates from *`. These are maestro codeflow PRs. |
+| **Other PR** | All remaining PRs — developer changes, release updates, infrastructure fixes. |
+
+To classify PR builds, extract the PR number from `sourceBranch` (`refs/pull/{number}/merge`) and query GitHub for the title:
+
+```bash
+gh pr view {number} --repo dotnet/dotnet --json title -q '.title'
+```
+
+## Failed Builds Table
+
+List only failed builds in chronological order:
+
+```
+| Build | Type | Source | Failure Detail |
+|-------|------|--------|---------------|
+| 1332308 | Rolling | main (scheduled) | Razor race (#5391) on 3 arm legs |
+| 1333526 | Forward Flow | release/10.0.3xx ← sdk | PR Validation (modified protected file) |
+```
+
+- **Build**: AzDO build ID
+- **Type**: Rolling, Forward Flow, or Other PR
+- **Source**: For Rolling: branch name. For Forward Flow: `target ← source-repo`. For Other PR: short description of the PR.
+- **Failure Detail**: Short category + root cause. Investigate before displaying; use `(not yet investigated)` only as a temporary placeholder.
+
+## Summary Table
+
+Follow the build list with a breakdown by type:
+
+```
+| Type | Completed | ✅ Pass | ❌ Fail | Pass Rate |
+|------|-----------|---------|---------|-----------|
+| Rolling | 1 | 0 | 1 | 0% |
+| Forward Flow | 31 | 23 | 8 | 74% |
+| Other PR | 15 | 6 | 9 | 40% |
+| **Total** | **47** | **29** | **18** | **62%** |
+```
+
+Note any temporal patterns (failure clusters, recent green streaks, etc.).
+
+## Failure Trends Table
+
+When 3+ builds are in scope and at least one failure pattern recurs across builds, add a trends table after the summary. Cap at top 5 patterns — one-offs don't get rows.
+
+```
+| Pattern | Hits | Window | Status |
+|---------|------|--------|--------|
+| Razor file-lock race | 3/5 rolling | Mar 12-14 | ❌ No issue filed |
+| SDK CS8602 | 2/5 rolling | Mar 13-14 | ✅ Fix merged PR #5471 |
+| SourcelinkTests flaky | 2/3 internal | Mar 14 | 🔄 Known #5259 |
+```
+
+- **Pattern**: Short name for the recurring failure
+- **Hits**: Count of affected builds / total builds in that category (e.g., "3/5 rolling")
+- **Window**: Date range of occurrences
+- **Status**: Triage state — one of:
+  - ❌ No issue filed — needs action
+  - ✅ Fix merged (link PR) — verify in next build
+  - 🔄 Known issue (link) — tracked but not yet fixed
+  - ⏳ Fix in progress (link PR) — someone is working on it
+
+This table transforms the report from "what's broken" to "what needs action." The Failed Builds Table is a per-build log; this is per-pattern triage.
+
+## Branch Filtering
+
+Not all builds are equally interesting when assessing pipeline health.
+
+**Internal (dnceng/internal):** Requires authentication (see SKILL.md Authentication section). If authenticated, include `main`, `release/*`, and `internal/release/*` branches. All three carry batchedCI builds that represent the shipping product. `internal/release/*` branches are **not** duplicates — they are the internal-only counterparts used for signing and secure build steps, and their health matters for release readiness. Ignore `dev/*` branches — those are experiments. If authentication fails, skip internal and note the limitation.
+
+When reporting, group `internal/release/*` builds separately from `release/*` builds so their distinct failure patterns (e.g., signing, feed auth) are visible.
+
+```bash
+# AzDO API: filter to a specific branch
+&branchName=refs/heads/main
+```
+
+**Public (dnceng-public/public):** Three categories of interest:
+
+| Category | Branch Pattern | Reason | Signal |
+|----------|---------------|--------|--------|
+| **Main & release** | `main`, `release/*` | Same as internal — product health | batchedCI reason |
+| **Codeflow PRs** | PR branches from `dotnet-maestro[bot]` | Automated dependency updates flowing between repos | pullRequest reason, author = `dotnet-maestro[bot]` |
+| **Developer PRs** | All other PR branches | Individual contributor changes | pullRequest reason |
+
+Codeflow PRs are especially useful — they test dependency updates before merge. A codeflow PR failing repeatedly signals a cross-repo integration break, not a one-off contributor mistake.
+
+> ⚠️ **AzDO shows "GitHub" as the requester for ALL GitHub PRs.** You cannot distinguish codeflow from developer PRs using AzDO data alone. Extract the PR number from `sourceBranch` (`refs/pull/{number}/merge`) and query GitHub:
+
+```bash
+# Get PR author to classify codeflow vs developer
+gh pr view {number} --repo dotnet/dotnet --json author,title --jq '{author: .author.login, title: .title}'
+# Codeflow: author = "app/dotnet-maestro"
+# Bot: author starts with "app/" (copilot-swe-agent, github-actions)
+# Developer: all other authors
+```
+
+## Branch Health via Codeflow Analysis
+
+When assessing overall pipeline health, group codeflow PRs by **target branch** to reveal which branches are healthy vs blocked:
+
+1. Collect all PR builds in the time range
+2. Query GitHub for each unique PR to get the author and target branch
+3. Classify: codeflow (maestro) / bot / developer
+4. Group codeflow PRs by target branch, count pass/fail
+
+A codeflow PR failing **repeatedly** (e.g., 5 consecutive failures) is a stronger signal than any single build failure — it means dependency flow into that branch is blocked.
+
+> 💡 **When asked about "pipeline health", default to main + release branches.** Only include PR builds if the user specifically asks or if looking for codeflow integration issues.

--- a/.github/skills/pipeline-investigation/references/investigation-techniques.md
+++ b/.github/skills/pipeline-investigation/references/investigation-techniques.md
@@ -1,0 +1,85 @@
+# Investigation Techniques by Failure Category
+
+Deep-dive investigation techniques for specific pipeline failure categories. Referenced from the categorization table in SKILL.md Step 2.
+
+## ESRP Signing and Notarization Failures
+
+ESRP (Enterprise Security Response Platform) handles code signing for all .NET shipping builds, including Apple notarization for macOS packages.
+
+### Interpreting ESRP status codes
+
+- **`FailDoNotRetry`** — Deterministic content failure. The binary content is wrong (unhardened, unsigned inner components, corrupt). Retrying won't help. Investigate which commit introduced the bad binary.
+- **`FailCanRetry`** — Transient service issue. Retry the build.
+- **`MacSignFailed: "Archive contains critical validation errors"`** — Apple rejected the .pkg because inner binaries lack hardened runtime or proper code signatures.
+
+### Investigation technique
+
+1. Download the signing binlog from the build artifacts (look for `NotarizationRound*.binlog`)
+2. Search for `MacSignFailed`, `FailDoNotRetry`, or `notarization` to find the failing operation
+3. If `FailDoNotRetry`: compare the source commits between a succeeding and failing build — a forward flow likely introduced an unhardened binary
+4. If transient: check ESRP service health, retry the build
+
+> ⚠️ ESRP cert catalog IDs (e.g., cert 8020) are internal identifiers. Omit them from public issues — they add no diagnostic value.
+
+## Container OOM and Resource Exhaustion
+
+Cross-compilation legs running in containers (e.g., `azurelinux-3.0-net11.0-cross-arm64`) can OOM when NuGet restore, build, or test phases exceed the container's memory limits.
+
+### Signals
+
+- **`exit code null`** on a Build task inside a container leg
+- No explicit error in the log — process simply vanishes
+- Often hits arm64 cross-compilation (high memory usage for cross-toolchain)
+
+### Investigation technique
+
+1. Check the container options in `vmr-build.yml` — look for `$(defaultContainerOptions)` which may only be `--privileged` with no memory tuning
+2. Check the pool — `NetCore1ESPool-Internal` vs `NetCore-Public-XL` (different VM SKUs)
+3. Look for restore/build parallelism that could spike memory
+4. Options: larger VM SKU, `--memory` container limits, reduced restore parallelism (`NUGET_CONCURRENCY_LIMIT`), GC heap limits
+
+### Key files in dotnet/dotnet
+
+- `eng/pipelines/templates/variables/vmr-build.yml` — container images, pool names, variable defaults
+- `eng/pipelines/templates/stages/vmr-verticals.yml` — vertical build job definitions
+- `eng/pipelines/templates/jobs/vmr-build.yml` — job template where container options are applied
+
+## crossgen2 Crash Investigation
+
+crossgen2 produces ReadyToRun (R2R) images of SDK assemblies during the SDK layout step. Exit code 57005 (0xDEAD) is crossgen2's hardcoded fatal error sentinel.
+
+### Investigation technique
+
+1. Download the SDK build binlog from the build artifacts
+2. Find the `CrossgenLayout` target and its `Crossgen` tasks — there are typically 100+ tasks
+3. Identify which task failed and what assembly it was crossgen'ing
+4. Check if crossgen2's stderr was captured (often it isn't — MSBuild Exec only records the exit code)
+5. Without a crash dump or stack trace, diagnosis is limited. Check if runtime#124181 or similar tracking issues exist.
+
+> The VMR build does not currently produce crash dumps for crossgen2 failures. Getting dump collection enabled is a prerequisite for root-causing these crashes.
+
+## YAML Pre-Flight Failures
+
+When a build fails with `startTime == finishTime` and the timeline returns HTTP 204 (No Content), the build was rejected during YAML validation before any agent was allocated.
+
+### Investigation technique
+
+1. Check `build.validationResults` in the build API response — it contains the YAML parsing error
+2. Common causes: incompatible 1ES pipeline template parameters, container configuration the template doesn't support
+3. These are always PR-specific — the PR author needs to fix their YAML
+
+## Network Transient Failures
+
+External resource downloads (wasi-sdk, NuGet packages, npm registries) can fail transiently due to network issues.
+
+### curl / tar failures
+
+- curl downloads a truncated response → tar fails with "not in gzip format"
+- Fix: add `--retry 3 --retry-delay 5` to curl commands
+- On Linux, curl may not have retry flags — check the script
+
+### npm ci failures
+
+- `ETIMEDOUT` / `ECONNREFUSED` are TCP-level failures
+- npm's `--fetch-retries` only covers HTTP-level errors, not TCP connection timeouts
+- Fix: shell-level retry wrapper around `npm ci` (try up to 3 times with delay)

--- a/.github/skills/test-arcade/SKILL.md
+++ b/.github/skills/test-arcade/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: test-arcade
+description: >
+  Build the Arcade SDK from source, configure a local NuGet feed with the artifacts,
+  and validate the build by running a test repository against the locally-built packages.
+  Use when testing local Arcade changes against a consuming repo, validating Arcade SDK
+  changes before merging, or verifying that a repo can build with a new Arcade version.
+  Use when asked "test arcade", "build and test arcade", "validate arcade changes",
+  "try arcade locally", "test arcade SDK", "build arcade packages", or
+  "run a repo against local arcade".
+  DO NOT USE FOR: CI analysis, Helix test investigation, codeflow/dependency-flow issues,
+  or production Arcade SDK publishing.
+---
+
+# Build and Test Arcade SDK Locally
+
+Build the Arcade SDK from a local checkout, publish the artifacts to a local NuGet feed, and validate by building a test repository against those packages.
+
+**Workflow**: Gather paths (Step 0) → run the script (Step 1) → interpret results (Step 2) → present summary (Step 3). The script handles repo resets, building, feed configuration, `global.json` updates, and test repo builds end-to-end.
+
+## When to Use This Skill
+
+- Testing local Arcade SDK changes against a consuming repository
+- Validating that a repo builds with a modified Arcade version before submitting a PR
+- Reproducing build issues with specific Arcade changes
+- Questions like "does my arcade change break runtime?", "test arcade locally", "validate arcade SDK"
+
+**Not for**: CI/CD pipeline analysis, Helix test failures, publishing Arcade packages to official feeds, or dependency flow troubleshooting.
+
+## Prerequisites
+
+Before running this skill, ensure the following are available:
+
+- **PowerShell 7+** (`pwsh`): the script is implemented in PowerShell Core for cross-platform portability
+- **Git**: repos must be cloned locally
+- **Network access**: Azure DevOps package feeds (dev.azure.com/dnceng) must be reachable for NuGet restore
+- **Local clones**: both the `dotnet/arcade` repo and a test repo (e.g., `arcade-validation`, `runtime`, `sdk`) must be cloned locally.
+
+### Optional: Binlog MCP Tool
+
+For investigating build failures, the `mcp-binlog-tool` MCP server can parse `.binlog` files produced during builds.
+
+## Quick Start
+
+```powershell
+# Full build-and-test
+pwsh ./scripts/Test-Arcade.ps1 -Arcade /path/to/arcade -TestRepo /path/to/test-repo
+
+# Clean the local feed before running (e.g., after switching arcade branches)
+pwsh ./scripts/Test-Arcade.ps1 -Arcade /path/to/arcade -TestRepo /path/to/test-repo -CleanFeed
+
+# Build and run Signing Validation (SignCheck) on test repo output
+pwsh ./scripts/Test-Arcade.ps1 -Arcade /path/to/arcade -TestRepo /path/to/test-repo -SignCheck
+
+# Run SignCheck against a custom directory
+pwsh ./scripts/Test-Arcade.ps1 -Arcade /path/to/arcade -TestRepo /path/to/test-repo -SignCheck -SignCheckDir /path/to/files
+```
+
+## Step 0: Verify Repos Are Cloned
+
+Both the Arcade repo and the test repo must be cloned locally. The test repo can be any .NET repo that consumes the Arcade SDK (e.g., `arcade-validation`, `runtime`, `sdk`, `aspnetcore`).
+
+- The `-Arcade` argument points to the local `dotnet/arcade` checkout with the changes to test
+- The `-TestRepo` argument points to any Arcade-consuming repo to validate against
+
+The local NuGet feed is stored at `arcade-local-feed/` inside the system temp directory (e.g., `$env:TEMP/arcade-local-feed` on Windows, `/tmp/arcade-local-feed` on Linux/macOS). It is **not cleaned up** between runs — use `-CleanFeed` to explicitly clear it when needed (e.g., after switching branches or testing a different Arcade change). Because this is a shared path, stale packages from previous runs may persist; always use `-CleanFeed` when switching Arcade branches.
+
+## Step 1: Run the Script
+
+Run `scripts/Test-Arcade.ps1` with the required `-Arcade` and `-TestRepo` arguments. The script performs these phases in order:
+
+1. **Validate** — confirms the arcade and test repo directories exist
+2. **Reset repos** — deletes `.packages` and `artifacts` directories in both repos to ensure a clean state
+3. **Create feed** — creates the feed directory if it doesn't exist (only cleans it when `-CleanFeed` is passed)
+4. **Build Arcade** — runs the repo's build script (`build.sh` on Linux/macOS, `Build.cmd` on Windows) with `--configuration Release --pack` and an auto-generated future-dated `OfficialBuildId`
+5. **Configure local NuGet feed** — uses `dotnet nuget push` to populate a flat local feed from `artifacts/packages/Release/NonShipping`, clears all NuGet caches, and adds the feed as a named source (`ArcadeLocalFeed`) to the test repo's `NuGet.config` using `--configfile`
+6. **Update global.json** — finds the built `Microsoft.DotNet.Arcade.Sdk` package, extracts its version, and updates existing `Microsoft.DotNet.Arcade.Sdk` and `Microsoft.DotNet.Helix.Sdk` entries in the test repo's `global.json` (only keys already present are modified)
+7. **Build test repo** — runs the repo's build script
+8. **Signing Validation** *(optional, `-SignCheck`)* — runs the SDK task `SigningValidation` against the test repo's output packages. Defaults to `artifacts/packages/<config>/NonShipping`; override with `-SignCheckDir`
+
+### Script Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `-Arcade <path>` | ✅ | Path to the local `dotnet/arcade` checkout |
+| `-TestRepo <path>` | ✅ | Path to the Arcade-consuming repo to test against |
+| `-CleanFeed` | ❌ | Delete and recreate the local feed directory before running. Use when switching branches or testing a different Arcade change |
+| `-SignCheck` | ❌ | Run Signing Validation (SignCheck) after building the test repo. Checks files in `artifacts/packages/<config>/NonShipping` by default |
+| `-SignCheckDir <path>` | ❌ | Directory to validate with SignCheck. Implies `-SignCheck`. Use to check a custom directory instead of the default |
+| `-SkipArcadeBuild` | ❌ | Skip the Arcade build step and reuse existing artifacts. Only resets the test repo |
+
+## Step 2: Interpret Results
+
+The script streams build output to stdout/stderr in real time. It exits on the first failure (`$ErrorActionPreference = 'Stop'`). Check the exit code and output to determine success or failure.
+
+### Common Failure Scenarios
+
+| Failure | Likely Cause | Remediation |
+|---------|-------------|-------------|
+| Arcade build fails | Code error in Arcade changes | Check `artifacts/log/` for `.binlog` files; fix the code |
+| `Arcade package not found` | Build didn't produce expected packages | Verify build completed with `--pack`; check `artifacts/packages/Release/NonShipping/` |
+| `Could not extract Arcade version` | Package filename doesn't match expected pattern | Check `.nupkg` filenames in NonShipping directory |
+| Test repo restore fails | NuGet feed not configured correctly or cache is stale | Run `dotnet nuget locals all --clear`; verify feed path contains `.nupkg` files |
+| Test repo build fails | Arcade changes broke compatibility | Compare with a build against official Arcade; check for breaking API changes |
+| SignCheck: no packages directory | Test repo didn't produce packages | Build with `--pack`, or specify `-SignCheckDir` pointing to existing files |
+| SignCheck: signing validation fails | Unsigned or incorrectly signed files found | Review SignCheck log in `artifacts/log/`; update `eng/Signing.props` or exclusions as needed |
+| Network errors during restore | Azure DevOps feeds unreachable | Check network/VPN; verify feed URLs in NuGet.config |
+
+## Step 3: Present Results
+
+Lead with a 1-2 sentence verdict, then a summary.
+
+Example output format:
+
+```
+## Arcade Test Results
+
+**Verdict**: All phases passed. The test repo builds successfully against local Arcade changes.
+
+| # | Phase | Result |
+|---|-------|--------|
+| 1 | Reset repos | ✅ |
+| 2 | Build Arcade | ✅ |
+| 3 | Configure feed | ✅ |
+| 4 | Update global.json | ✅ |
+| 5 | Build test repo | ✅ |
+| 6 | Signing Validation | ✅ *(if -SignCheck)* |
+
+Arcade SDK version: {VersionPrefix}-beta.<OfficialBuildId>
+Packages published to: <temp-dir>/arcade-local-feed/
+```
+
+When `-SignCheck` is used, also include the SignCheck results. Read the per-file outcomes from `artifacts/log/Debug/signcheck.xml` and the summary from `signcheck.log`:
+
+```
+**SignCheck results** (from `signcheck.xml`):
+
+| File | Outcome | Details |
+|------|---------|---------|
+| `dotnet-sdk-source-10.0.104.tar.gz` | Signed | Timestamp: 02/23/26 17:13:46 (RSA) |
+| `release.json` | Skipped | — |
+| `dotnet-sdk-source-10.0.104.tar.gz.sig` | Skipped | — |
+
+Summary: 3 files total — 1 signed, 0 unsigned, 2 skipped, 1 not unpacked. No signing issues found.
+```
+
+Possible `Outcome` values in the XML: `Signed`, `Unsigned` (error), `Skipped`, `Excluded`, `SkippedAndExcluded`. Any `Unsigned` file is an error — include it prominently in the results.
+
+If any phase fails, include the error details and remediation guidance from the table above.
+
+## Anti-Patterns
+
+> ❌ **Don't reuse a stale feed directory.** The script only resets the feed when run with `-CleanFeed`. If you're re-running without that flag or running steps manually, always clear the feed and NuGet caches before re-testing with new Arcade changes.
+
+> ❌ **Don't assume build failures are Arcade's fault.** The test repo may have its own issues. Compare with a build against the official Arcade SDK to isolate the cause.
+
+> ❌ **Don't manually modify NuGet.config or global.json** when the script handles it. Manual edits risk inconsistency and are harder to reproduce.
+
+> ❌ **Don't test against a dirty repo.** Ensure both the Arcade and test repos have committed or stashed changes before running. Uncommitted changes in build infrastructure files can cause misleading results.
+
+> ❌ **Don't install a .NET SDK manually.** The build process installs its own SDK via `eng/common/dotnet.sh`. Manual SDK installations can cause version conflicts.
+
+## References
+
+- **Signing Validation (SignCheck)**: [references/signing-validation.md](references/signing-validation.md)
+- **Building Arcade**: [references/building-arcade.md](references/building-arcade.md)
+- **NuGet feed setup**: [references/nuget-feed-setup.md](references/nuget-feed-setup.md)
+- **global.json version pinning**: [references/global-json-pinning.md](references/global-json-pinning.md)
+- **Build artifacts**: [references/build-artifacts.md](references/build-artifacts.md)
+- **Troubleshooting**: [references/troubleshooting.md](references/troubleshooting.md)

--- a/.github/skills/test-arcade/references/build-artifacts.md
+++ b/.github/skills/test-arcade/references/build-artifacts.md
@@ -1,0 +1,110 @@
+# Build Artifacts
+
+Understanding the Arcade build artifact layout is essential for troubleshooting feed configuration and package resolution issues.
+
+## Arcade Build Output
+
+After building Arcade with `--pack`, artifacts are produced under `artifacts/`:
+
+```
+arcade/artifacts/
+├── bin/                              # Compiled binaries by project/configuration
+│   ├── Microsoft.DotNet.Arcade.Sdk/
+│   ├── Microsoft.DotNet.Helix.Sdk/
+│   ├── Microsoft.DotNet.SignTool/
+│   └── ...
+├── packages/                         # NuGet packages
+│   └── Release/                      # (or Debug/)
+│       ├── NonShipping/              # ← Primary source for local feed
+│       │   ├── Microsoft.DotNet.Arcade.Sdk.{version}.nupkg
+│       │   ├── Microsoft.DotNet.Helix.Sdk.{version}.nupkg
+│       │   ├── Microsoft.DotNet.Build.Tasks.Feed.{version}.nupkg
+│       │   ├── Microsoft.DotNet.SignTool.{version}.nupkg
+│       │   └── ...
+│       └── Shipping/                 # Packages intended for public feeds
+│           └── ...
+├── log/                              # Build logs
+│   └── Release/
+│       ├── Build.binlog              # MSBuild binary log (use for diagnostics)
+│       └── ...
+├── TestResults/                      # Test output (if tests were run)
+├── tmp/                              # Temporary build artifacts
+└── toolset/                          # Downloaded build tools
+```
+
+## Key Packages
+
+These are the primary packages consumed by repos using Arcade:
+
+| Package | Purpose |
+|---------|---------|
+| `Microsoft.DotNet.Arcade.Sdk` | Core MSBuild SDK — the main package that controls the build |
+| `Microsoft.DotNet.Helix.Sdk` | Helix distributed testing SDK |
+| `Microsoft.DotNet.Build.Tasks.Feed` | NuGet feed publishing tasks |
+| `Microsoft.DotNet.Build.Tasks.Packaging` | Package creation and validation |
+| `Microsoft.DotNet.Build.Tasks.Installers` | MSI/PKG installer generation |
+| `Microsoft.DotNet.SignTool` | Code signing tasks |
+| `Microsoft.DotNet.XUnitExtensions` | Enhanced XUnit test capabilities |
+| `Microsoft.DotNet.RemoteExecutor` | Cross-platform process execution for tests |
+
+## Version Format
+
+The Arcade SDK version is determined by the `OfficialBuildId` property and the `VersionPrefix` from `eng/Versions.props`:
+
+```
+{VersionPrefix}-beta.{OfficialBuildId}
+```
+
+For example, with `VersionPrefix=11.0.0` and `OfficialBuildId=31216.1`:
+```
+11.0.0-beta.31216.1
+```
+
+The version is embedded in the `.nupkg` filename:
+```
+Microsoft.DotNet.Arcade.Sdk.11.0.0-beta.31216.1.nupkg
+```
+
+## Local Feed Structure
+
+The script uses `dotnet nuget push` to copy packages into a flat local feed under the system temp directory (`<temp-dir>/arcade-local-feed/`):
+
+```
+arcade-local-feed/
+├── Microsoft.DotNet.Arcade.Sdk.{version}.nupkg
+├── Microsoft.DotNet.Helix.Sdk.{version}.nupkg
+├── Microsoft.DotNet.SignCheckTask.{version}.nupkg
+└── ... (40+ packages)
+```
+
+This flat folder format is a valid [local NuGet feed](https://learn.microsoft.com/en-us/nuget/hosting-packages/local-feeds) that NuGet can restore from directly. It is registered as a NuGet source named `ArcadeLocalFeed` in the test repo's `NuGet.config` via `--configfile`.
+
+## global.json Updates
+
+The script updates the test repo's `global.json` to reference the locally-built version:
+
+**Before:**
+```json
+{
+  "tools": {
+    "dotnet": "11.0.100"
+  },
+  "msbuild-sdks": {
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26100.1",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26100.1"
+  }
+}
+```
+
+**After:**
+```json
+{
+  "tools": {
+    "dotnet": "11.0.100"
+  },
+  "msbuild-sdks": {
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.31216.1",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.31216.1"
+  }
+}
+```

--- a/.github/skills/test-arcade/references/building-arcade.md
+++ b/.github/skills/test-arcade/references/building-arcade.md
@@ -1,0 +1,109 @@
+# Building Arcade for CI
+
+How Arcade is built by the script and the key build parameters that control package versioning and output.
+
+## Build Command
+
+The script builds Arcade with:
+
+```powershell
+# OfficialBuildId is auto-generated as a future date (current date + 5 years)
+$OfficialBuildId = "{0}.1" -f (Get-Date).AddYears(5).ToString('yyyyMMdd')
+./build.sh --configuration Release --pack /p:OfficialBuildId=$OfficialBuildId
+```
+
+### Flags Explained
+
+| Flag | Purpose |
+|------|---------|
+| `--configuration Release` | Builds in Release mode (optimized, no debug symbols in packages) |
+| `--pack` | Produces NuGet packages in addition to compiled binaries |
+| `/p:OfficialBuildId=<future-date>.1` | Sets the build ID used for package versioning — must be a future date (see below) |
+
+### What `build.sh` Does Internally
+
+1. Invokes `eng/common/build.sh` (shared Arcade build infrastructure)
+2. Auto-installs the correct .NET SDK from `global.json` via `eng/common/dotnet.sh` into `.dotnet/`
+3. Runs MSBuild restore, build, and pack targets
+4. Outputs packages to `artifacts/packages/{Configuration}/`
+
+## OfficialBuildId and Package Versioning
+
+The `OfficialBuildId` property controls the prerelease version suffix of all packages. Format: `YYYYMMDD.N` where N is the build number for that day.
+
+**Version formula:**
+```
+{VersionPrefix}-beta.{OfficialBuildId}
+```
+
+**Example:**
+- `VersionPrefix` in Arcade is `11.0.0` (from `eng/Versions.props`)
+- `OfficialBuildId` = `31216.1` (auto-generated future date)
+- Resulting version: `11.0.0-beta.31216.1`
+
+The script **auto-generates a future-dated OfficialBuildId** (current date + 5 years) to ensure the locally-built version is **always newer** than any officially published version. This prevents package version conflicts — a real official build may have already used a past or present date, so the ID must always be in the future.
+
+> 🚨 **The OfficialBuildId must be a future date.** Using today's date or a past date risks colliding with a real official build's ID, causing NuGet to resolve the wrong package or fail with version conflicts.
+
+> ⚠️ If you need a specific version to match an official build, change the OfficialBuildId to match. Find the official build's ID from its Azure DevOps pipeline run. Only do this for reproduction — never for general testing.
+
+## Build Outputs
+
+After a successful build with `--pack`:
+
+```
+arcade/artifacts/
+├── packages/
+│   └── Release/
+│       ├── NonShipping/          ← Used by the script for local feed
+│       │   ├── Microsoft.DotNet.Arcade.Sdk.*.nupkg
+│       │   ├── Microsoft.DotNet.Helix.Sdk.*.nupkg
+│       │   └── ... (50+ packages)
+│       └── Shipping/             ← Not copied by the script (add manually if needed)
+│           └── ...
+├── bin/                          ← Compiled binaries (not used by feed)
+├── log/
+│   └── Release/
+│       └── Build.binlog          ← MSBuild binary log for diagnostics
+└── tmp/                          ← Temporary build files
+```
+
+### NonShipping vs Shipping
+
+- **NonShipping**: SDK packages, build tasks, internal tooling — these are what consuming repos resolve via `global.json` MSBuild SDK references
+- **Shipping**: Packages intended for public NuGet.org feeds (e.g., `Microsoft.DotNet.XUnitExtensions`)
+
+The script initializes the local feed from **NonShipping** packages because that's where the MSBuild SDK packages live. Shipping packages are **not** copied by default — if specific Shipping packages are needed, they can be added manually.
+
+## Build Configurations
+
+| Configuration | Use Case |
+|--------------|----------|
+| `Release` | Default. Optimized build, used for package validation. Most closely matches official builds |
+| `Debug` | Faster build, includes debug symbols. Useful for stepping through Arcade code in a debugger |
+
+## Platform-Specific Build Commands
+
+| Platform | Build Command | Configuration Flag | Pack Flag |
+|----------|--------------|-------------------|-----------|
+| Linux | `./build.sh` | `--configuration` | `--pack` |
+| macOS | `./build.sh` | `--configuration` | `--pack` |
+| Windows | `Build.cmd` | `-configuration` | `-pack` |
+
+The script auto-detects the platform-appropriate build script (`build.sh` on Linux/macOS, `Build.cmd` on Windows) and adjusts flag syntax automatically (e.g., `--configuration` vs `-configuration`, `--pack` vs `-pack`). On Windows, `Build.cmd` invokes `eng/common/build.ps1` via Windows PowerShell, which requires single-dash (`-`) parameter prefixes — double-dash (`--`) prefixes are not recognized as named parameters and cause `MSB1001: Unknown switch` errors.
+
+## Reproducing Official CI Builds
+
+To exactly reproduce an official CI build locally, you need:
+
+1. **Same commit**: checkout the exact commit from the official build
+2. **Same OfficialBuildId**: find it from the Azure DevOps pipeline run parameters
+3. **Same configuration**: typically `Release`
+4. **Same platform**: official builds run on specific OS/architecture
+
+```bash
+git checkout <commit-sha>
+./build.sh --configuration Release --pack /p:OfficialBuildId=<YYYYMMDD.N>
+```
+
+The main difference from CI: official builds also run signing, validation, and publishing steps that aren't needed for local testing.

--- a/.github/skills/test-arcade/references/global-json-pinning.md
+++ b/.github/skills/test-arcade/references/global-json-pinning.md
@@ -1,0 +1,91 @@
+# global.json Version Pinning
+
+How the script updates the test repo's `global.json` to consume locally-built Arcade packages.
+
+## What global.json Controls
+
+In .NET repos that use Arcade, `global.json` has an `msbuild-sdks` section that pins the versions of MSBuild SDK packages:
+
+```json
+{
+  "tools": {
+    "dotnet": "11.0.100-preview.3.26170.106"
+  },
+  "msbuild-sdks": {
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26100.1",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26100.1"
+  }
+}
+```
+
+When the repo builds, MSBuild resolves these SDK packages from configured NuGet sources at the pinned version.
+
+## What the Script Does
+
+The script replaces existing version pins with the exact version of the locally-built Arcade SDK:
+
+```
+# Before (exact version pin — most repos)
+"Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26100.1"
+
+# After
+"Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.31216.1"
+```
+
+The script updates any existing value (not just wildcards). Both `Microsoft.DotNet.Arcade.Sdk` and `Microsoft.DotNet.Helix.Sdk` are updated to the same version, since they are always released together from the same Arcade build. Only keys that already exist in `global.json` are modified — the script does not add new entries.
+
+### Version Extraction
+
+The version is extracted from the package filename:
+
+```
+Microsoft.DotNet.Arcade.Sdk.{version}.nupkg
+                           └──────────────────────┘
+                                    version
+```
+
+Using:
+```powershell
+$arcadeVersion = $arcadeSdkPkg.Name -replace '^Microsoft\.DotNet\.Arcade\.Sdk\.', '' -replace '\.nupkg$', ''
+```
+
+## Repos with Exact Version Pins
+
+Most repos pin to an exact version:
+
+```json
+"Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26100.1"
+```
+
+The script handles this automatically — it replaces whatever version value is currently present with the locally-built version using `ConvertFrom-Json`/`ConvertTo-Json`.
+
+## Which SDKs to Update
+
+The two primary SDKs from Arcade referenced in `global.json`:
+
+| SDK | Purpose |
+|-----|---------|
+| `Microsoft.DotNet.Arcade.Sdk` | Core build infrastructure — targets, props, tasks |
+| `Microsoft.DotNet.Helix.Sdk` | Helix distributed testing — only needed if the test repo runs Helix tests |
+
+Some repos also reference additional Arcade SDKs:
+- `Microsoft.DotNet.SharedFramework.Sdk` — shared framework packaging
+- `Microsoft.DotNet.CMake.Sdk` — CMake integration
+
+If the test repo uses these, they should also be updated to the locally-built version.
+
+## Verifying the Update
+
+After the script runs, confirm the update:
+
+```powershell
+Get-Content /path/to/test-repo/global.json | Select-String 'msbuild-sdks' -Context 0,3
+```
+
+Expected output should show the locally-built version (matching the OfficialBuildId used):
+```json
+"msbuild-sdks": {
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.31216.1",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.31216.1"
+}
+```

--- a/.github/skills/test-arcade/references/nuget-feed-setup.md
+++ b/.github/skills/test-arcade/references/nuget-feed-setup.md
@@ -1,0 +1,107 @@
+# Local NuGet Feed Configuration
+
+How the script sets up a local NuGet feed from Arcade build artifacts and configures a test repo to consume from it.
+
+## Overview
+
+After Arcade is built with `--pack`, NuGet packages are output to `artifacts/packages/Release/NonShipping/`. The script uses `dotnet nuget push` to copy these packages into a flat local feed directory, then registers the feed as a NuGet source for the test repo.
+
+## Feed Initialization with `dotnet nuget push`
+
+The `dotnet nuget push` command, when targeting a local folder source, copies each `.nupkg` file directly into the target directory (flat layout):
+
+```powershell
+$ArcadePackagesPath = Join-Path $ArcadePath 'artifacts/packages/Release/NonShipping'
+Get-ChildItem -Path $ArcadePackagesPath -Filter '*.nupkg' | ForEach-Object {
+    dotnet nuget push $_.FullName --source $FeedPath --skip-duplicate
+}
+```
+
+**Flat input** (what Arcade produces):
+```
+artifacts/packages/Release/NonShipping/
+├── Microsoft.DotNet.Arcade.Sdk.{version}.nupkg
+├── Microsoft.DotNet.Helix.Sdk.{version}.nupkg
+├── Microsoft.DotNet.SignCheckTask.{version}.nupkg
+└── ...
+```
+
+**Flat output** (what `dotnet nuget push` creates in the feed directory):
+```
+arcade-local-feed/
+├── Microsoft.DotNet.Arcade.Sdk.{version}.nupkg
+├── Microsoft.DotNet.Helix.Sdk.{version}.nupkg
+├── Microsoft.DotNet.SignCheckTask.{version}.nupkg
+└── ... (40+ packages)
+```
+
+The flat folder format is a valid [local NuGet feed](https://learn.microsoft.com/en-us/nuget/hosting-packages/local-feeds) that NuGet can restore from directly.
+
+The `--skip-duplicate` flag prevents errors when a package already exists in the feed (e.g., when re-running without `-CleanFeed`).
+
+## Registering the Feed
+
+After creating the feed, the script registers it as a named NuGet source in the test repo's `NuGet.config` using `--configfile`:
+
+```powershell
+# The script uses --configfile to target the repo's NuGet.config explicitly
+dotnet nuget add source $FeedPath --name ArcadeLocalFeed --configfile "$TestPath/NuGet.config"
+```
+
+This adds a `<packageSource>` entry to the test repo's `NuGet.config`. The `--configfile` flag ensures the user-level NuGet config is not modified. The local feed operates alongside other configured sources (e.g., Azure DevOps feeds, nuget.org).
+
+## Clearing NuGet Caches
+
+Before adding the source, the script clears all NuGet caches:
+
+```bash
+dotnet nuget locals all --clear
+```
+
+This is **critical** because NuGet aggressively caches resolved packages. Without clearing:
+- A previously-cached official Arcade SDK version may be used instead of the locally-built one
+- Version resolution may silently pick the wrong package
+- Symptoms: test repo builds successfully but uses the old Arcade, not your changes
+
+### Cache Locations
+
+`dotnet nuget locals all --list` shows:
+- **http-cache**: HTTP response cache
+- **global-packages**: `~/.nuget/packages/` — extracted packages
+- **temp**: temporary extraction directory
+- **plugins-cache**: credential plugin cache
+
+All are cleared by `--clear all`.
+
+## Feed Precedence
+
+NuGet resolves packages by checking sources in the order listed in `NuGet.config`. When the local feed is added:
+1. NuGet checks the local feed first (if listed first)
+2. Falls back to Azure DevOps feeds and nuget.org for packages not in the local feed
+
+The locally-built Arcade packages will be found because:
+- The exact version (e.g., `11.0.0-beta.31216.1`) only exists in the local feed
+- `global.json` is updated to request this exact version
+- NuGet caches are cleared, so no stale cached version can interfere
+
+## Manual Feed Setup
+
+If you need to configure the feed manually (e.g., the script failed partway through):
+
+```powershell
+# 1. Create feed from packages
+$feedPath = Join-Path ([System.IO.Path]::GetTempPath()) 'arcade-local-feed'
+New-Item -ItemType Directory -Path $feedPath -Force | Out-Null
+Get-ChildItem /path/to/arcade/artifacts/packages/Release/NonShipping/*.nupkg | ForEach-Object {
+    dotnet nuget push $_.FullName --source $feedPath --skip-duplicate
+}
+
+# 2. Clear caches
+dotnet nuget locals all --clear
+
+# 3. Add source (explicitly targeting the test repo's NuGet.config)
+dotnet nuget add source $feedPath --name ArcadeLocalFeed --configfile /path/to/test-repo/NuGet.config
+
+# 4. Verify
+dotnet nuget list source --configfile /path/to/test-repo/NuGet.config
+```

--- a/.github/skills/test-arcade/references/signing-validation.md
+++ b/.github/skills/test-arcade/references/signing-validation.md
@@ -1,0 +1,231 @@
+# Signing Validation (SignCheck)
+
+How the script validates file signatures using the Arcade SDK's SigningValidation task, and how to configure and troubleshoot it.
+
+## Overview
+
+SignCheck is a tool that scans files, archives, and packages to ensure their contents have valid signatures. It is bundled as part of the Arcade SDK (`Microsoft.DotNet.SignCheckTask`) and invoked via the shared SDK task entry point (`sdk-task.sh` on Linux/macOS, `sdk-task.ps1` on Windows).
+
+The `-SignCheck` flag in the test script runs SignCheck against the test repo's build output after the build completes. This validates that Arcade's signing infrastructure (including any local changes to SignCheck itself) works correctly end-to-end.
+
+## Invocation
+
+The script runs (on Linux/macOS; on Windows it uses `eng/common/sdk-task.ps1`):
+
+```bash
+cd "$TEST_PATH" && ./eng/common/sdk-task.sh --task SigningValidation --restore \
+    /p:PackageBasePath="$SIGNCHECK_DIR"
+```
+
+### What the SDK task script Does Internally
+
+1. Initializes the Arcade toolset via `eng/common/tools.sh`
+2. Locates `SigningValidation.proj` inside the resolved Arcade SDK package
+3. Runs MSBuild Restore target (when `--restore` is passed)
+4. Runs MSBuild Execute target, which invokes `Microsoft.DotNet.SignCheckTask.SignCheckTask`
+5. Produces a binary log at `artifacts/log/Debug/SigningValidation.binlog`
+
+Because the test repo's `global.json` has been pinned to the locally-built Arcade SDK version, SignCheck runs from the **local build artifacts** — not from a published feed. This is what makes it useful for testing SignCheck code changes.
+
+> ⚠️ **The `SigningValidation.proj` restore needs the local feed.** SignCheck resolves `Microsoft.DotNet.SignCheckTask` at the same version as the pinned Arcade SDK. Since this version only exists in the local feed, the local feed path must be passed via `/p:RestoreAdditionalProjectSources` so that the SDK task's restore can find it. The script handles this automatically.
+
+## Default Directory
+
+When `-SignCheck` is passed without `-SignCheckDir`, the script auto-detects the test repo's package output:
+
+```
+$TEST_PATH/artifacts/packages/<config>/NonShipping
+```
+
+It checks `Debug` first, then `Release`, using whichever exists. If neither is found, the script exits with an error suggesting `--pack` or `-SignCheckDir`.
+
+> ⚠️ Some repos (e.g., arcade-validation) do not produce packages with the default `./build.sh`. If you need packages in the default location, build with `./build.sh --pack`. Alternatively, point `-SignCheckDir` at any directory containing files to validate.
+
+## MSBuild Properties
+
+The `SigningValidation.proj` task accepts these properties via `/p:` arguments:
+
+| Property | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `PackageBasePath` | ✅ | — | Directory containing files to validate |
+| `SignCheckExclusionsFile` | ❌ | — | Path to a text file listing exclusions |
+| `EnableJarSigningCheck` | ❌ | `false` | Verify `.jar` file signatures |
+| `EnableStrongNameCheck` | ❌ | `false` | Verify strong names for `.exe`/`.dll` files |
+| `BuildManifestFile` | ❌ | — | If set, uses `ItemsToSign` from manifest instead of scanning `PackageBasePath` |
+| `SignCheckLog` | ❌ | `$(ArtifactsLogDir)/signcheck.log` | Output log file |
+| `SignCheckErrorLog` | ❌ | `$(ArtifactsLogDir)/signcheck.errors.log` | Error log file |
+| `SignCheckResultsXmlFile` | ❌ | `$(ArtifactsLogDir)/signcheck.xml` | XML results file |
+
+Additional properties can be passed by appending `/p:Key=Value` arguments to the script invocation.
+
+## Supported File Types
+
+SignCheck validates signatures on a wide range of file types:
+
+| Category | Extensions |
+|----------|-----------|
+| Managed code | `.dll`, `.exe` |
+| Native binaries | `.so`, `.dylib`, `.a` |
+| NuGet/VSIX | `.nupkg`, `.vsix` |
+| Installers | `.msi`, `.msp`, `.pkg`, `.deb`, `.rpm` |
+| Archives | `.zip`, `.tar`, `.tgz`, `.tar.gz`, `.gz`, `.cab` |
+| Scripts | `.ps1`, `.psd1`, `.psm1`, `.js` |
+| macOS | `.app`, `.pkg`, `.dylib` |
+| Optional | `.jar` (requires `EnableJarSigningCheck`), `.xml` |
+
+SignCheck recursively inspects containers (archives, packages) to validate signatures on their contents.
+
+## Exclusions
+
+To skip specific files from validation, create an exclusions file and pass it via `SignCheckExclusionsFile`. The file is typically referenced in a repo's CI pipeline as `eng/SignCheckExclusionsFile.txt`.
+
+## Signing Configuration in the Test Repo
+
+The test repo's signing configuration is defined in `eng/Signing.props`:
+
+```xml
+<ItemGroup>
+  <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.deb" />
+  <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.rpm" />
+  <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.dll" />
+  <!-- ... additional file types ... -->
+</ItemGroup>
+
+<ItemGroup>
+  <FileSignInfo Include="ProjectOne.dll" CertificateName="3PartySHA2" />
+  <!-- ... per-file certificate assignments ... -->
+</ItemGroup>
+```
+
+This file controls which files are **signed** during a build. `SignCheck` then validates that the signing was applied correctly.
+
+## Output and Logs
+
+After a SignCheck run, look for these files in the test repo:
+
+```
+<test-repo>/artifacts/log/
+├── Debug/
+│   ├── SigningValidation.binlog    ← MSBuild binary log
+│   ├── signcheck.log              ← Full validation output
+│   ├── signcheck.errors.log       ← Errors only (empty on success)
+│   └── signcheck.xml              ← Structured XML results (per-file)
+```
+
+The task **fails the build** if `signcheck.errors.log` contains any content. An empty error log means all scanned files passed validation.
+
+### Reading Results from `signcheck.xml`
+
+The XML file contains one `<File>` element per scanned file with per-file outcomes:
+
+```xml
+<SignCheckResults>
+  <File Name="dotnet-sdk-source-10.0.104.tar.gz" Outcome="Signed" Misc="Timestamp: 02/23/26 17:13:46 (RSA)" />
+  <File Name="release.json" Outcome="Skipped" />
+  <File Name="dotnet-sdk-source-10.0.104.tar.gz.sig" Outcome="Skipped" />
+</SignCheckResults>
+```
+
+**Attributes:**
+
+| Attribute | Description |
+|-----------|-------------|
+| `Name` | File name (relative to `PackageBasePath`) |
+| `Outcome` | Validation result (see table below) |
+| `Misc` | Additional details (e.g., timestamp info for signed files) |
+
+**Possible `Outcome` values:**
+
+| Outcome | Meaning |
+|---------|---------|
+| `Signed` | File has a valid signature |
+| `Unsigned` | File should be signed but is not — **this is an error** |
+| `Skipped` | File type is not subject to signing validation |
+| `Excluded` | File matched an entry in the exclusions file |
+| `SkippedAndExcluded` | File was both skipped and excluded |
+
+To quickly extract results from the XML:
+
+```powershell
+# Show all file outcomes
+Get-Content artifacts/log/Debug/signcheck.xml
+
+# List only unsigned files (errors)
+Select-String 'Outcome="Unsigned"' artifacts/log/Debug/signcheck.xml
+
+# Count outcomes
+([xml](Get-Content artifacts/log/Debug/signcheck.xml)).SignCheckResults.File | Group-Object Outcome
+```
+
+### Reading Results from `signcheck.log`
+
+The log file contains the summary line with aggregate counts:
+
+```
+Total Files: 3, Signed: 1, Unsigned: 0, Skipped: 2, Excluded: 0, Skipped & Excluded: 0, Not Unpacked: 1
+```
+
+| Counter | Meaning |
+|---------|---------|
+| Signed | Files with valid signatures |
+| Unsigned | Files that should be signed but are not (errors) |
+| Skipped | Files whose type is not subject to signing |
+| Excluded | Files matching exclusion entries |
+| Not Unpacked | Archives excluded from recursive unpacking via `DO-NOT-UNPACK` |
+
+## Troubleshooting
+
+### SignCheck fails: "no packages directory found"
+
+**Symptom**: Script exits with error about missing `artifacts/packages/<config>/NonShipping`.
+
+**Cause**: The test repo build didn't produce packages.
+
+**Fix**: Either build with `--pack` or specify a directory explicitly:
+```powershell
+pwsh ./scripts/Test-Arcade.ps1 -SignCheck -SignCheckDir /path/to/files
+```
+
+### SignCheck reports unsigned files
+
+**Symptom**: SignCheck logs errors about unsigned or incorrectly signed files.
+
+**Diagnosis**:
+1. Check `artifacts/log/Debug/signcheck.errors.log` for specific file names
+2. Check `artifacts/log/Debug/signcheck.log` for the full scan report
+3. Open `SigningValidation.binlog` with the `mcp-binlog-tool` MCP server for detailed task execution analysis
+
+**Common causes**:
+- Files not listed in `eng/Signing.props`
+- Certificate names don't match configured signing certificates
+- Third-party binaries not added to exclusions file
+
+### SignCheck task not found
+
+**Symptom**: `sdk-task.sh` fails to locate `SigningValidation.proj`.
+
+**Cause**: The Arcade SDK package doesn't contain the task, or `global.json` isn't pinned to the local build.
+
+**Fix**:
+1. Verify the Arcade build produced the SDK package: `ls arcade/artifacts/packages/Release/NonShipping/Microsoft.DotNet.Arcade.Sdk.*.nupkg`
+2. Verify `global.json` was updated: `grep Arcade <test-repo>/global.json`
+3. Clear NuGet caches and retry: `dotnet nuget locals all --clear`
+
+### SignCheck passes but shouldn't
+
+**Symptom**: Files you expect to fail validation pass without errors.
+
+**Cause**: Files may not be in the scanned directory, or they match an exclusion pattern.
+
+**Fix**: Check `signcheck.log` to see which files were actually scanned. Verify `PackageBasePath` points to the correct directory.
+
+## Arcade SignCheck Packages
+
+The Arcade build produces two signing-related packages:
+
+| Package | Purpose |
+|---------|---------|
+| `Microsoft.DotNet.SignCheckTask` | MSBuild task used by `SigningValidation.proj` (preferred) |
+| `Microsoft.DotNet.SignCheck` | Legacy CLI tool (framework-only, maintained for backward compatibility) |
+
+Both are published to the local feed and their versions match the Arcade SDK version.

--- a/.github/skills/test-arcade/references/troubleshooting.md
+++ b/.github/skills/test-arcade/references/troubleshooting.md
@@ -1,0 +1,139 @@
+# Troubleshooting
+
+Common issues when building and testing Arcade locally, with diagnosis steps and fixes.
+
+## Build Failures
+
+### Arcade build fails: "Unable to load service index"
+
+**Symptom**: NuGet restore fails with feed connectivity errors.
+
+**Cause**: Network access to Azure DevOps package feeds is blocked.
+
+**Fix**:
+- Verify VPN/network connectivity to `dev.azure.com/dnceng`
+- Check that `NuGet.config` in the arcade repo has the correct feed URLs
+- Try restoring with `--verbosity diagnostic` to see which feed is failing:
+  ```bash
+  cd /path/to/arcade && ./build.sh --restore --verbosity diagnostic 2>&1 | grep -i "unable to load"
+  ```
+
+### Arcade build fails: wrong .NET SDK
+
+**Symptom**: Build errors related to SDK version mismatch.
+
+**Cause**: The global .NET SDK doesn't match what Arcade expects.
+
+**Fix**:
+- Arcade's `build.sh` should auto-install the correct SDK via `eng/common/dotnet.sh`
+- **NEVER** manually install an SDK — the build installs its own
+- If the auto-install fails, check `global.json` in the Arcade repo for the expected version
+
+### Arcade build: no packages produced
+
+**Symptom**: Build succeeds but `artifacts/packages/` is empty or missing.
+
+**Cause**: Build ran without the `--pack` flag.
+
+**Fix**: Ensure the build command includes `--pack`:
+```powershell
+$OfficialBuildId = "{0}.1" -f (Get-Date).AddYears(5).ToString('yyyyMMdd')
+./build.sh --configuration Release --pack /p:OfficialBuildId=$OfficialBuildId
+```
+
+## Feed Configuration Failures
+
+### "Failed to add local NuGet feed source"
+
+**Symptom**: `dotnet nuget add source` command fails.
+
+**Cause**: Usually a duplicate source name or invalid NuGet.config.
+
+**Fix**:
+- Remove existing source first: `dotnet nuget remove source ArcadeLocalFeed --configfile /path/to/NuGet.config`
+- Verify NuGet.config is valid XML
+- Check file permissions on NuGet.config
+
+### Test repo restore: "Unable to find package Microsoft.DotNet.Arcade.Sdk"
+
+**Symptom**: Test repo can't find the Arcade SDK package during restore.
+
+**Cause**: Feed path doesn't contain the expected package, or NuGet cache is stale.
+
+**Fix**:
+1. Verify the package exists in the feed: `Get-ChildItem (Join-Path ([System.IO.Path]::GetTempPath()) 'arcade-local-feed') -Filter 'Microsoft.DotNet.Arcade.Sdk.*.nupkg'`
+2. Clear NuGet caches: `dotnet nuget locals all --clear`
+3. Verify the source is registered: `dotnet nuget list source --configfile /path/to/NuGet.config`
+4. Check that `global.json` version matches the package version exactly
+
+### SignCheck restore: "Unable to find package Microsoft.DotNet.SignCheckTask"
+
+**Symptom**: SignCheck fails with `NU1102: Unable to find package Microsoft.DotNet.SignCheckTask with version (>= ...)`. The error lists remote feeds but not the local feed.
+
+**Cause**: The `SigningValidation.proj` file runs from inside the NuGet packages cache (not the test repo directory), so it doesn't inherit the test repo's `NuGet.config`. The local feed must be passed explicitly via `/p:RestoreAdditionalProjectSources`.
+
+**Fix**:
+1. Verify the SignCheckTask package exists in the local feed: `Get-ChildItem (Join-Path ([System.IO.Path]::GetTempPath()) 'arcade-local-feed') -Filter 'Microsoft.DotNet.SignCheckTask.*.nupkg'`
+2. Ensure the script passes `/p:RestoreAdditionalProjectSources=$FeedPath` to the SDK task invocation
+3. Clear NuGet caches and retry: `dotnet nuget locals all --clear`
+
+### Version mismatch between global.json and packages
+
+**Symptom**: Restore fails even though packages exist in the feed.
+
+**Cause**: The version in `global.json` doesn't exactly match the `.nupkg` filename.
+
+**Fix**:
+- Check the exact version: `Get-ChildItem (Join-Path ([System.IO.Path]::GetTempPath()) 'arcade-local-feed') -Filter 'Microsoft.DotNet.Arcade.Sdk.*.nupkg'`
+- Compare with `global.json`: `Get-Content /path/to/test-repo/global.json | Select-String 'Arcade'`
+- The script handles this automatically, but manual runs may have mismatches
+
+## Test Repo Build Failures
+
+### Test repo build fails with Arcade-specific errors
+
+**Symptom**: Build errors in MSBuild targets or tasks from Arcade packages.
+
+**Diagnosis**:
+1. Check if the same error occurs with the official Arcade SDK (revert `global.json` and `NuGet.config` changes)
+2. Compare the `.binlog` files between local and official Arcade builds
+3. Look for breaking API changes in your Arcade modifications
+
+### Test repo build fails with unrelated errors
+
+**Symptom**: Errors that don't reference Arcade packages (e.g., source code compilation errors).
+
+**Cause**: The test repo itself has issues independent of Arcade.
+
+**Fix**:
+- Build the test repo without Arcade changes first to establish a baseline
+- Check the test repo's issue tracker for known build issues
+- Ensure the test repo branch is compatible with the Arcade version being tested
+
+## Performance Issues
+
+### Disk space issues
+
+**Symptom**: Build fails with "No space left on device".
+
+**Fix**:
+- Clean previous artifacts: `Remove-Item -Recurse -Force /path/to/arcade/artifacts, /path/to/test-repo/artifacts`
+- Clean NuGet caches: `dotnet nuget locals all --clear`
+- Remove old feed directories
+
+
+## Investigating Build Logs
+
+For detailed build diagnostics, use the MSBuild binary log (`.binlog`). The `mcp-binlog-tool` MCP server can parse these files directly:
+
+```powershell
+# Find binlog files
+Get-ChildItem /path/to/repo/artifacts/log -Recurse -Filter '*.binlog'
+
+# The mcp-binlog-tool (baronfel.binlog.mcp) can open and query these files
+# See the Prerequisites section in SKILL.md for setup
+```
+
+Key locations:
+- Arcade build log: `arcade/artifacts/log/{Configuration}/Build.binlog`
+- Test repo build log: `test-repo/artifacts/log/{Configuration}/Build.binlog`

--- a/.github/skills/test-arcade/scripts/Test-Arcade.ps1
+++ b/.github/skills/test-arcade/scripts/Test-Arcade.ps1
@@ -1,0 +1,260 @@
+<#
+.SYNOPSIS
+    Builds the Arcade SDK from a local checkout, configures a local NuGet feed
+    with the build artifacts, and builds a test repository against them.
+    Optionally runs Signing Validation (SignCheck) on the test repo output.
+
+.DESCRIPTION
+    Prerequisites:
+      - PowerShell 7+ (pwsh)
+      - dotnet CLI (for building and configuring the local NuGet feed)
+      - Network access to Azure DevOps package feeds
+
+.EXAMPLE
+    pwsh ./Test-Arcade.ps1 -Arcade /path/to/arcade -TestRepo /path/to/test-repo
+    pwsh ./Test-Arcade.ps1 -Arcade /path/to/arcade -TestRepo /path/to/test-repo -CleanFeed
+    pwsh ./Test-Arcade.ps1 -Arcade /path/to/arcade -TestRepo /path/to/test-repo -SignCheck
+    pwsh ./Test-Arcade.ps1 -Arcade /path/to/arcade -TestRepo /path/to/test-repo -SignCheck -SignCheckDir path/to/files
+    pwsh ./Test-Arcade.ps1 -Arcade /path/to/arcade -TestRepo /path/to/test-repo -SkipArcadeBuild -SignCheck
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, HelpMessage = "Path to the local dotnet/arcade checkout")]
+    [string]$Arcade,
+
+    [Parameter(Mandatory = $true, HelpMessage = "Path to the Arcade-consuming repo to test against")]
+    [string]$TestRepo,
+
+    [switch]$CleanFeed,
+
+    [switch]$SignCheck,
+
+    [ValidateScript({ Test-Path $_ -PathType Container })]
+    [string]$SignCheckDir,
+
+    [switch]$SkipArcadeBuild
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if ($SignCheckDir) {
+    $SignCheck = $true
+}
+
+# ─── Resolve paths ───────────────────────────────────────────────────────────
+$ScriptDir = Split-Path -Parent $PSCommandPath
+$SkillDir = Split-Path -Parent $ScriptDir
+$FeedPath = Join-Path ([System.IO.Path]::GetTempPath()) 'arcade-local-feed'
+
+$ArcadePath = Resolve-Path -Path $Arcade -ErrorAction SilentlyContinue
+$TestPath = Resolve-Path -Path $TestRepo -ErrorAction SilentlyContinue
+
+if (-not $ArcadePath -or -not (Test-Path $ArcadePath -PathType Container)) {
+    Write-Error "Arcade directory not found at: $Arcade"
+}
+if (-not $TestPath -or -not (Test-Path $TestPath -PathType Container)) {
+    Write-Error "Test repo directory not found at: $TestRepo"
+}
+
+$ArcadePath = $ArcadePath.Path
+$TestPath = $TestPath.Path
+
+Write-Host "Building and testing Arcade with the following parameters:"
+Write-Host "Arcade Repo Path:       $ArcadePath"
+Write-Host "Test Repo Path:         $TestPath"
+Write-Host "Package Feed Path:      $FeedPath"
+if ($SignCheck) {
+    $signMsg = "enabled"
+    if ($SignCheckDir) { $signMsg += " (dir: $SignCheckDir)" }
+    Write-Host "Signing Validation:     $signMsg"
+}
+
+# ─── Platform helpers ────────────────────────────────────────────────────────
+function Get-BuildScript([string]$RepoPath) {
+    if ($IsWindows) {
+        $cmd = Join-Path $RepoPath 'Build.cmd'
+        if (Test-Path $cmd) { return $cmd }
+    }
+    $sh = Join-Path $RepoPath 'build.sh'
+    if (Test-Path $sh) { return $sh }
+    Write-Error "No build script found in $RepoPath"
+}
+
+function Get-SdkTaskScript([string]$RepoPath) {
+    if ($IsWindows) {
+        $ps1 = Join-Path $RepoPath 'eng/common/sdk-task.ps1'
+        if (Test-Path $ps1) { return $ps1 }
+    }
+    $sh = Join-Path $RepoPath 'eng/common/sdk-task.sh'
+    if (Test-Path $sh) { return $sh }
+    Write-Error "No sdk-task script found in $RepoPath"
+}
+
+function Invoke-BuildScript([string]$Script, [string[]]$Arguments) {
+    if ($Script.EndsWith('.cmd')) {
+        & cmd /c "$Script $($Arguments -join ' ')"
+    } elseif ($Script.EndsWith('.ps1')) {
+        & pwsh -NoProfile -File $Script @Arguments
+    } else {
+        & bash $Script @Arguments
+    }
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Build script failed with exit code $LASTEXITCODE"
+    }
+}
+
+# ─── Reset repos ─────────────────────────────────────────────────────────────
+function Reset-Repo([string]$RepoPath) {
+    foreach ($dir in '.packages', 'artifacts') {
+        $target = Join-Path $RepoPath $dir
+        if (Test-Path $target) {
+            Remove-Item -Recurse -Force $target
+        }
+    }
+}
+
+if ($SkipArcadeBuild) {
+    Write-Host "Skipping Arcade build (-SkipArcadeBuild)..."
+    Reset-Repo $TestPath
+} else {
+    Reset-Repo $ArcadePath
+    Reset-Repo $TestPath
+
+    # ─── Reset feed (only if -CleanFeed) ─────────────────────────────────────
+    if ($CleanFeed) {
+        Write-Host "Cleaning feed directory..."
+        if (Test-Path $FeedPath) {
+            Remove-Item -Recurse -Force $FeedPath
+        }
+    }
+    if (-not (Test-Path $FeedPath)) {
+        New-Item -ItemType Directory -Path $FeedPath -Force | Out-Null
+    }
+
+    # ─── Build Arcade ────────────────────────────────────────────────────────
+    $futureDate = (Get-Date).AddYears(5).ToString('yyyyMMdd')
+    $OfficialBuildId = "$futureDate.1"
+    Write-Host "Building Arcade (OfficialBuildId=$OfficialBuildId)..."
+
+    $buildScript = Get-BuildScript $ArcadePath
+    $configFlag = if ($buildScript.EndsWith('.cmd')) { '-configuration' } else { '--configuration' }
+    $packFlag = if ($buildScript.EndsWith('.cmd')) { '-pack' } else { '--pack' }
+    Invoke-BuildScript $buildScript @($configFlag, 'Release', $packFlag, "/p:OfficialBuildId=$OfficialBuildId")
+
+    # ─── Configure local NuGet feed ──────────────────────────────────────────
+    Write-Host "Configuring local NuGet feed..."
+    $ArcadePackagesPath = Join-Path $ArcadePath 'artifacts/packages/Release/NonShipping'
+
+    $nupkgs = Get-ChildItem -Path $ArcadePackagesPath -Filter '*.nupkg' -ErrorAction SilentlyContinue
+    if (-not $nupkgs -or $nupkgs.Count -eq 0) {
+        Write-Error "No .nupkg packages found in $ArcadePackagesPath. The Arcade pack step may have failed."
+    }
+
+    # Validate the Arcade SDK package specifically
+    $arcadeSdkPkg = $nupkgs | Where-Object { $_.Name -like 'Microsoft.DotNet.Arcade.Sdk.*.nupkg' } | Select-Object -First 1
+    if (-not $arcadeSdkPkg) {
+        Write-Error "Microsoft.DotNet.Arcade.Sdk package not found in $ArcadePackagesPath"
+    }
+
+    foreach ($nupkg in $nupkgs) {
+        & dotnet nuget push $nupkg.FullName --source $FeedPath --skip-duplicate
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to push $($nupkg.Name) to local feed"
+        }
+    }
+
+    & dotnet nuget locals all --clear
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Failed to clear NuGet caches — continuing."
+    }
+
+    # Add the local feed to the test repo's NuGet.config using --configfile
+    $nugetConfig = Join-Path $TestPath 'NuGet.config'
+    $feedName = 'ArcadeLocalFeed'
+
+    if (Test-Path $nugetConfig) {
+        $existingSources = & dotnet nuget list source --configfile $nugetConfig 2>&1
+        if ($existingSources -match $feedName) {
+            & dotnet nuget remove source $feedName --configfile $nugetConfig 2>$null
+        }
+    }
+
+    & dotnet nuget add source $FeedPath --name $feedName --configfile $nugetConfig
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to add local feed source to $nugetConfig"
+    }
+
+    # ─── Update global.json ──────────────────────────────────────────────────
+    Write-Host "Updating global.json..."
+
+    # Extract version from the Arcade SDK package filename
+    $arcadeVersion = $arcadeSdkPkg.Name -replace '^Microsoft\.DotNet\.Arcade\.Sdk\.', '' -replace '\.nupkg$', ''
+
+    if (-not $arcadeVersion) {
+        Write-Error "Could not extract Arcade version from $($arcadeSdkPkg.Name)"
+    }
+
+    $globalJsonPath = Join-Path $TestPath 'global.json'
+    $globalJson = Get-Content $globalJsonPath -Raw | ConvertFrom-Json
+
+    $sdks = $globalJson.'msbuild-sdks'
+    if ($null -eq $sdks) {
+        Write-Error "global.json does not contain an 'msbuild-sdks' section"
+    }
+
+    # Only update keys that already exist in the file
+    foreach ($key in @('Microsoft.DotNet.Arcade.Sdk', 'Microsoft.DotNet.Helix.Sdk')) {
+        if ($null -ne $sdks.$key) {
+            $sdks.$key = $arcadeVersion
+        }
+    }
+
+    $globalJson | ConvertTo-Json -Depth 10 | Set-Content $globalJsonPath -Encoding utf8NoBOM
+    Write-Host "Pinned Arcade SDK version: $arcadeVersion"
+}
+
+# ─── Build Test Repo ─────────────────────────────────────────────────────────
+Write-Host "Building test repo..."
+$testBuildScript = Get-BuildScript $TestPath
+Invoke-BuildScript $testBuildScript @()
+
+# ─── Run Signing Validation ──────────────────────────────────────────────────
+if ($SignCheck) {
+    if (-not $SignCheckDir) {
+        foreach ($cfg in 'Debug', 'Release') {
+            $candidate = Join-Path $TestPath "artifacts/packages/$cfg/NonShipping"
+            if (Test-Path $candidate -PathType Container) {
+                $SignCheckDir = $candidate
+                break
+            }
+        }
+        if (-not $SignCheckDir) {
+            Write-Error "No artifacts/packages/<config>/NonShipping directory found. Build the test repo with --pack or specify -SignCheckDir."
+        }
+    }
+
+    if (-not (Test-Path $SignCheckDir -PathType Container)) {
+        Write-Error "SignCheck directory does not exist: $SignCheckDir"
+    }
+
+    Write-Host "Running Signing Validation on: $SignCheckDir"
+    $signCheckExclusions = Join-Path $TestPath 'eng/SignCheckExclusionsFile.txt'
+    $extraArgs = @()
+    if (Test-Path $signCheckExclusions) {
+        Write-Host "Using exclusions file:    $signCheckExclusions"
+        $extraArgs += "/p:SignCheckExclusionsFile=$signCheckExclusions"
+    }
+    $extraArgs += "/p:RestoreAdditionalProjectSources=$FeedPath"
+
+    $sdkTaskScript = Get-SdkTaskScript $TestPath
+    $taskFlag = if ($sdkTaskScript.EndsWith('.ps1')) { '-task' } else { '--task' }
+    $restoreFlag = if ($sdkTaskScript.EndsWith('.ps1')) { '-restore' } else { '--restore' }
+    Push-Location $TestPath
+    try {
+        Invoke-BuildScript $sdkTaskScript (@($taskFlag, 'SigningValidation', $restoreFlag, "/p:PackageBasePath=$SignCheckDir") + $extraArgs)
+    } finally {
+        Pop-Location
+    }
+}


### PR DESCRIPTION
## Summary

Add skills and agent from the [dotnet/arcade-skills](https://github.com/dotnet/arcade-skills/tree/main/plugins/dotnet-dnceng) dotnet-dnceng plugin to `.github/skills/` and `.github/agents/`.

## Skills Added

| Skill | Description |
|-------|-------------|
| ci-analysis | CI build and test status analysis for Azure DevOps and Helix |
| ci-crash-dump | Download and debug crash dumps from CI test failures |
| flow-analysis | Analyze VMR codeflow health using maestro MCP tools |
| flow-tracing | Trace dependency flow across .NET repos through the VMR |
| helix-investigation | Deep-dive Helix test failure investigation |
| known-issue-history | Analyze failure history for Known Build Error issues |
| maestro-cli | Query Maestro/BAR data via the mstro CLI tool |
| pipeline-investigation | Investigate AzDO pipeline failures beyond Helix |
| test-arcade | Build and test Arcade SDK locally against consuming repos |

## Agents Added

| Agent | Description |
|-------|-------------|
| CiInvestigator | Orchestrates CI failure investigations by routing to specialized skills |

## Source

Copied from [dotnet/arcade-skills/plugins/dotnet-dnceng](https://github.com/dotnet/arcade-skills/tree/main/plugins/dotnet-dnceng) (main branch, latest commit).

## Note

There is currently no mechanism for skills/agents aquisition on repo level - so this stays manual. Can be easily automated if there is an interest for that

cc: @danmoseley 