### PR TITLE
Pin Node to 24.14.1 to work around npm ci 0xDEAD bug

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -554,10 +554,12 @@ jobs:
   - ${{ if eq(parameters.targetOS, 'windows') }}:
     # Node is a toolset dependency to build aspnetcore
     # Keep in sync with aspnetcore: https://github.com/dotnet/aspnetcore/blob/7d5309210d8f7bae8fa074da495e9d009d67f1b4/.azure/pipelines/ci.yml#L719-L722
+    # Pinned to 24.14.1 to work around npm ci exit code 57005 bug in Node 24.15.
+    # Tracking issue to revert: https://github.com/dotnet/aspnetcore/issues/66501
     - task: UseNode@1
-      displayName: Install Node 24.x
+      displayName: Install Node 24.14.1
       inputs:
-        version: 24.x
+        version: 24.14.1
 
     - ${{ if eq(parameters.signDac, 'true') }}:
       # TODO: Once we turn off the dotnet/runtime official build, move these templates into the VMR's eng folder.


### PR DESCRIPTION
## Summary

Pins Node.js to **24.14.1** in the VMR build pipeline to work around a bug in Node 24.15 where `npm ci` exits with code 57005 (0xDEAD).

## Problem

Since ~April 20, all main branch rolling builds (public + internal) fail in the aspnetcore build step on Windows legs:

```
src\aspnetcore\eng\Npm.Workspace.nodeproj(140,5): error MSB3073: The command "npm ci" exited with code 57005.
```

This is caused by a bug in npm shipped with Node 24.15.

## Fix

Changed `eng/pipelines/templates/jobs/vmr-build.yml` from `version: 24.x` to `version: 24.14.1`.

## Tracking

- Tracking issue to revert when a fixed Node is available: https://github.com/dotnet/aspnetcore/issues/66501
- Related aspnetcore workaround: https://github.com/dotnet/aspnetcore/pull/66465