### PR TITLE
[release/11.0.1xx-preview4] dotnet/roslyn: Fix regression in CreateFallbackEncoding

### DIFF
--- a/src/roslyn/src/Compilers/Core/CodeAnalysisTest/Text/StringTextDecodingTests.cs
+++ b/src/roslyn/src/Compilers/Core/CodeAnalysisTest/Text/StringTextDecodingTests.cs
@@ -341,5 +341,42 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 Assert.Equal('\u2026', sourceText[0]);
             }
         }
+
+        [ConditionalFact(typeof(HasEnglishDefaultEncoding))]
+        public void NonUtf8_MiddleDot()
+        {
+            // Bytes 0xA0 and 0xB7 are invalid UTF-8 but valid in CodePage 1252 (and Latin-1).
+            // 0xA0 = No-Break Space (U+00A0)
+            // 0xB7 = Middle Dot (U+00B7)
+            // Verifies that the fallback encoding correctly decodes these bytes
+            // instead of treating them as invalid UTF-8 replacement characters (U+FFFD).
+            byte[] srcBytes = [0xA0, 0xB7];
+            using var stream = new MemoryStream(srcBytes);
+            var sourceText = EncodedStringText.Create(stream);
+            Assert.Equal(2, sourceText.Length);
+            Assert.Equal('\u00A0', sourceText[0]);
+            Assert.Equal('\u00B7', sourceText[1]);
+        }
+
+        [Fact]
+        public void CreateFallbackEncoding_IsNotUtf8OnWindows()
+        {
+            var fallback = EncodedStringText.CreateFallbackEncoding();
+
+            if (ExecutionConditionUtil.IsWindows)
+            {
+                // On Windows, registering CodePagesEncodingProvider makes GetEncoding(0) return
+                // the real ANSI code page (e.g., 1252) even when the UTF-8 locale setting is enabled.
+                // The fallback is used when a source file without BOM contains bytes that are not
+                // valid UTF-8. If the fallback were UTF-8, those bytes would be decoded as replacement
+                // characters (U+FFFD) instead of the intended code page characters.
+                Assert.NotEqual(Encoding.UTF8.CodePage, fallback.CodePage);
+            }
+            else
+            {
+                // On Linux/macOS there is no ANSI code page, so the fallback is UTF-8.
+                Assert.Equal(Encoding.UTF8.CodePage, fallback.CodePage);
+            }
+        }
     }
 }

--- a/src/roslyn/src/Compilers/Core/Portable/EncodedStringText.cs
+++ b/src/roslyn/src/Compilers/Core/Portable/EncodedStringText.cs
@@ -5,7 +5,6 @@
 using System;
 using System.IO;
 using System.Text;
-using System.Threading;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Text
@@ -33,6 +32,8 @@ namespace Microsoft.CodeAnalysis.Text
         /// </summary>
         internal static Encoding CreateFallbackEncoding()
         {
+            EnsureEncodingProviderRegistered();
+
             // Try to get the default ANSI code page in the operating system's
             // regional and language settings, and fall back to 1252 otherwise
             return TryGetCodePageEncoding(0)
@@ -40,53 +41,26 @@ namespace Microsoft.CodeAnalysis.Text
                 ?? Encoding.GetEncoding(name: "Latin1");
         }
 
+        private static void EnsureEncodingProviderRegistered()
+        {
+            if (!s_encodingProviderRegistered)
+            {
+                if (CodePagesEncodingProvider.Instance is { } provider)
+                {
+                    Encoding.RegisterProvider(provider);
+                }
+
+                s_encodingProviderRegistered = true;
+            }
+        }
+
         internal static Encoding? TryGetCodePageEncoding(int codePage)
         {
-            // Read to local to avoid race condition when multiple threads fail to get the encoding,
-            // only one of them executes the filter to retry, sets the static field and suppresses retry for the other threads.
-            var encodingProviderRegistered = s_encodingProviderRegistered;
+            EnsureEncodingProviderRegistered();
 
             try
             {
                 return Encoding.GetEncoding(codePage);
-            }
-            catch (NotSupportedException) when (!encodingProviderRegistered)
-            {
-                // From documentation:
-                //   - 'GetEncoding' throws NotSupportedException when codepage is not supported by the underlying platform.
-                //   - 'EncodingProvider.Instance' gets an encoding provider for code pages supported
-                //     in the desktop .NET Framework but not by the current underlying platform.
-                //   - 'Encoding.RegisterProvider' makes character encodings available on a platform that does not otherwise support them.
-                //      * Once the encoding provider is registered, the encodings that it supports can be retrieved by calling any
-                //        Encoding.GetEncoding overload.
-                //      * Registering an encoding provider by using the 'RegisterProvider' method also affects the behavior of
-                //        GetEncoding(Int32) when passed an argument of 0.
-                //      * If multiple providers are registered, GetEncoding(Int32) attempts to retrieve the encoding from the most recently
-                //        registered provider first.
-                //      * If the 'RegisterProvider' method is called to register multiple providers that handle the same encoding,
-                //        the last registered provider is the used for all encoding and decoding operations. Any previously registered providers are ignored.
-                //      * If the same encoding provider is used in multiple calls to the 'RegisterProvider' method,
-                //        only the first method call registers the provider. Subsequent calls are ignored.
-                //      
-                //  Given all that:
-                //   - We don't call 'Encoding.RegisterProvider' unconditionally to avoid changing environment
-                //     that is already configured to support the requested codepage. We call it only when we encounter
-                //     a 'NotSupportedException'.
-                //   - We also do not attempt to call 'Encoding.RegisterProvider' more than once.
-                try
-                {
-                    // Ignore any exceptions from an attempt to register the provider.
-                    Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-                }
-                catch
-                {
-                }
-
-                s_encodingProviderRegistered = true;
-
-                // Try to get the encoding again after attempting to register the provider.
-                // Since we set `s_registeredEncodingProvider` to true, we won't get here again.
-                return TryGetCodePageEncoding(codePage);
             }
             catch (Exception)
             {


### PR DESCRIPTION
Cherry-pick of https://github.com/dotnet/roslyn/pull/83320.