### PR TITLE
Fix EF Core template versions in source-build and add test

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,7 @@
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
     <!-- NuGet dependencies -->
+    <PackageVersion Include="NuGet.Packaging" Version="$(NuGetProtocolVersion)" />
     <PackageVersion Include="NuGet.ProjectModel" Version="$(NuGetProjectModelVersion)" />
     <PackageVersion Include="NuGet.Protocol" Version="$(NuGetProtocolVersion)" />
     <!-- Roslyn dependencies -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
     <!-- NuGet dependencies -->
-    <PackageVersion Include="NuGet.Packaging" Version="$(NuGetProtocolVersion)" />
+    <PackageVersion Include="NuGet.Packaging" Version="$(NuGetPackagingVersion)" />
     <PackageVersion Include="NuGet.ProjectModel" Version="$(NuGetProjectModelVersion)" />
     <PackageVersion Include="NuGet.Protocol" Version="$(NuGetProtocolVersion)" />
     <!-- Roslyn dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -52,8 +52,9 @@
     <!-- msbuild dependencies -->
     <MicrosoftBuildVersion>17.12.50</MicrosoftBuildVersion>
     <!-- nuget dependencies -->
-    <NuGetProtocolVersion>6.13.1</NuGetProtocolVersion>
-    <NuGetProjectModelVersion>6.13.1</NuGetProjectModelVersion>
+    <NuGetPackagingVersion>6.14.0</NuGetPackagingVersion>
+    <NuGetProtocolVersion>6.14.0</NuGetProtocolVersion>
+    <NuGetProjectModelVersion>6.14.0</NuGetProjectModelVersion>
     <!-- roslyn dependencies -->
     <MicrosoftCodeAnalysisVersion>4.4.0</MicrosoftCodeAnalysisVersion>
     <!-- runtime dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -52,9 +52,9 @@
     <!-- msbuild dependencies -->
     <MicrosoftBuildVersion>17.12.50</MicrosoftBuildVersion>
     <!-- nuget dependencies -->
-    <NuGetPackagingVersion>6.14.0</NuGetPackagingVersion>
-    <NuGetProtocolVersion>6.14.0</NuGetProtocolVersion>
-    <NuGetProjectModelVersion>6.14.0</NuGetProjectModelVersion>
+    <NuGetPackagingVersion>7.0.1</NuGetPackagingVersion>
+    <NuGetProtocolVersion>7.0.1</NuGetProtocolVersion>
+    <NuGetProjectModelVersion>7.0.1</NuGetProjectModelVersion>
     <!-- roslyn dependencies -->
     <MicrosoftCodeAnalysisVersion>4.4.0</MicrosoftCodeAnalysisVersion>
     <!-- runtime dependencies -->

--- a/repo-projects/aspnetcore.proj
+++ b/repo-projects/aspnetcore.proj
@@ -80,6 +80,21 @@
     <ExtraPackageVersionPropsPackageInfo Include="MicrosoftCodeAnalysisSourceGeneratorVersion" Version="%24(MicrosoftCodeAnalysisCSharpPreviousVersion)" />
     <ExtraPackageVersionPropsPackageInfo Include="Analyzer_MicrosoftCodeAnalysisCSharpVersion" Version="%24(MicrosoftCodeAnalysisCSharpPreviousVersion)" />
     <ExtraPackageVersionPropsPackageInfo Include="Analyzer_MicrosoftCodeAnalysisCSharpWorkspacesVersion" Version="%24(MicrosoftCodeAnalysisCSharpWorkspacesPreviousVersion)" />
+
+    <!--
+      In the Microsoft build, efcore is a RepositoryReference of aspnetcore, so efcore's package versions
+      flow automatically via WritePackageVersionsProps. In source-build, efcore can't be built as a dependency
+      because it requires Windows runtime packages. Instead, override the EF Core version properties to use
+      the VMR build version (same as runtime) so that web templates get the correct versions.
+      See https://github.com/dotnet/source-build/issues/5493
+    -->
+    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftEntityFrameworkCoreVersion" Version="%24(MicrosoftNETCoreAppRefPackageVersion)" />
+    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftEntityFrameworkCoreDesignVersion" Version="%24(MicrosoftNETCoreAppRefPackageVersion)" />
+    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftEntityFrameworkCoreInMemoryVersion" Version="%24(MicrosoftNETCoreAppRefPackageVersion)" />
+    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftEntityFrameworkCoreRelationalVersion" Version="%24(MicrosoftNETCoreAppRefPackageVersion)" />
+    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftEntityFrameworkCoreSqliteVersion" Version="%24(MicrosoftNETCoreAppRefPackageVersion)" />
+    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftEntityFrameworkCoreSqlServerVersion" Version="%24(MicrosoftNETCoreAppRefPackageVersion)" />
+    <ExtraPackageVersionPropsPackageInfo Include="MicrosoftEntityFrameworkCoreToolsVersion" Version="%24(MicrosoftNETCoreAppRefPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.DotNet.SourceBuild.Tests/Microsoft.DotNet.SourceBuild.Tests.csproj
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/Microsoft.DotNet.SourceBuild.Tests.csproj
@@ -32,6 +32,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
+    <PackageReference Include="NuGet.Packaging" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.DotNet.SourceBuild.Tests/SdkContentTests.cs
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/SdkContentTests.cs
@@ -223,7 +223,7 @@ public partial class SdkContentTests : SdkTests
         {
             doc = XDocument.Load(stream);
         }
-        catch (XmlException)
+        catch
         {
             return versions;
         }

--- a/test/Microsoft.DotNet.SourceBuild.Tests/SdkContentTests.cs
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/SdkContentTests.cs
@@ -11,8 +11,10 @@ using System.IO.Enumeration;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using System.Xml;
 using System.Xml.Linq;
 using Microsoft.Extensions.FileSystemGlobbing;
+using NuGet.Packaging;
 using TestUtilities;
 using Xunit;
 using Xunit.Abstractions;
@@ -166,7 +168,7 @@ public partial class SdkContentTests : SdkTests
 
     /// <summary>
     /// Scans all template nupkgs in an extracted SDK and returns a flat dictionary of
-    /// "nupkgName|projPath|PackageName" → version string, with versions in the key normalized.
+    /// "nupkgId,projPath,PackageName" → version string, with versions in the key normalized.
     /// </summary>
     private static Dictionary<string, string> GetTemplatePackageVersions(string sdkRootDir, ExclusionsHelper exclusionsHelper, string sdkType)
     {
@@ -180,18 +182,18 @@ public partial class SdkContentTests : SdkTests
 
         foreach (string nupkgPath in nupkgFiles)
         {
-            string normalizedNupkgName = GetPackageIdFromFileName(Path.GetFileNameWithoutExtension(nupkgPath));
+            using PackageArchiveReader packageReader = new(nupkgPath);
+            string normalizedNupkgName = BaselineHelper.RemoveVersions(packageReader.GetIdentity().Id);
 
-            using ZipArchive archive = ZipFile.OpenRead(nupkgPath);
-            IEnumerable<ZipArchiveEntry> projectEntries = archive.Entries
-                .Where(e => projectExtensions.Contains(Path.GetExtension(e.FullName), StringComparer.OrdinalIgnoreCase));
+            IEnumerable<string> projectFiles = packageReader.GetFiles()
+                .Where(f => projectExtensions.Contains(Path.GetExtension(f), StringComparer.OrdinalIgnoreCase));
 
-            foreach (ZipArchiveEntry entry in projectEntries)
+            foreach (string projectFile in projectFiles)
             {
-                Dictionary<string, string> packageVersions = GetPackageReferencesFromProjectFile(entry);
+                Dictionary<string, string> packageVersions = GetPackageReferencesFromProjectFile(packageReader.GetEntry(projectFile));
                 foreach ((string packageName, string version) in packageVersions)
                 {
-                    string sanitizedEntryName = entry.FullName.Replace('/', '-');
+                    string sanitizedEntryName = projectFile.Replace('/', '-');
                     string key = $"{normalizedNupkgName},{sanitizedEntryName},{packageName}";
                     if (!exclusionsHelper.IsFileExcluded(key, sdkType))
                     {
@@ -246,34 +248,6 @@ public partial class SdkContentTests : SdkTests
         }
 
         return versions;
-    }
-
-    /// <summary>
-    /// Extracts the package ID from a nupkg filename (without extension).
-    /// Nupkg filenames follow the pattern "{id}.{version}" where the version starts with a digit.
-    /// </summary>
-    private static string GetPackageIdFromFileName(string fileNameWithoutExtension)
-    {
-        // Walk backwards to find the last segment that starts with a digit — that's where the version begins.
-        // E.g. "Microsoft.DotNet.Web.ProjectTemplates.11.0.11.0.0-preview.5.26226.111"
-        //       ID = "Microsoft.DotNet.Web.ProjectTemplates.11.0", version = "11.0.0-preview.5.26226.111"
-        string[] parts = fileNameWithoutExtension.Split('.');
-        int versionStart = -1;
-        for (int i = parts.Length - 1; i >= 0; i--)
-        {
-            if (parts[i].Length > 0 && char.IsDigit(parts[i][0]))
-            {
-                versionStart = i;
-            }
-            else
-            {
-                break;
-            }
-        }
-
-        return versionStart > 0
-            ? string.Join('.', parts[0..versionStart])
-            : fileNameWithoutExtension;
     }
 
     private string NormalizeApiDiffSuppressionFileContent(string content)

--- a/test/Microsoft.DotNet.SourceBuild.Tests/SdkContentTests.cs
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/SdkContentTests.cs
@@ -223,9 +223,9 @@ public partial class SdkContentTests : SdkTests
         {
             doc = XDocument.Load(stream);
         }
-        catch
+        catch (XmlException ex)
         {
-            return versions;
+            throw new Exception($"Failed to parse project file '{entry.FullName}' from package archive.", ex);
         }
 
         IEnumerable<XElement> packageRefs = doc.Descendants()

--- a/test/Microsoft.DotNet.SourceBuild.Tests/SdkContentTests.cs
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/SdkContentTests.cs
@@ -174,9 +174,13 @@ public partial class SdkContentTests : SdkTests
     {
         Dictionary<string, string> result = [];
 
-        string[] nupkgFiles = Directory.GetFiles(sdkRootDir, "*.nupkg", SearchOption.AllDirectories)
-            .Where(p => Path.GetRelativePath(sdkRootDir, p).StartsWith("templates" + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
-            .ToArray();
+        string templatesDir = Path.Combine(sdkRootDir, "templates");
+        if (!Directory.Exists(templatesDir))
+        {
+            return result;
+        }
+
+        string[] nupkgFiles = Directory.GetFiles(templatesDir, "*.nupkg", SearchOption.AllDirectories);
 
         string[] projectExtensions = [".csproj", ".fsproj"];
 

--- a/test/Microsoft.DotNet.SourceBuild.Tests/SdkContentTests.cs
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/SdkContentTests.cs
@@ -219,7 +219,7 @@ public partial class SdkContentTests : SdkTests
         {
             doc = XDocument.Load(stream);
         }
-        catch
+        catch (XmlException)
         {
             return versions;
         }

--- a/test/Microsoft.DotNet.SourceBuild.Tests/SdkContentTests.cs
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/SdkContentTests.cs
@@ -6,10 +6,12 @@ using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
 using System.IO.Enumeration;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using System.Xml.Linq;
 using Microsoft.Extensions.FileSystemGlobbing;
 using TestUtilities;
 using Xunit;
@@ -118,6 +120,160 @@ public partial class SdkContentTests : SdkTests
         {
             tempDir.Delete(recursive: true);
         }
+    }
+
+    /// <Summary>
+    /// Verifies that PackageReference versions in template nupkgs are consistent between
+    /// the source-built and Microsoft-built SDKs (e.g. https://github.com/dotnet/source-build/issues/5493).
+    /// </Summary>
+    [ConditionalFact(typeof(SdkContentTests), nameof(IncludeSdkContentTests))]
+    public void CompareMsftToSbTemplatePackageVersions()
+    {
+        Assert.NotNull(Config.MsftSdkTarballPath);
+        Assert.NotNull(Config.SdkTarballPath);
+
+        DirectoryInfo tempDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
+        try
+        {
+            DirectoryInfo sbSdkDir = Directory.CreateDirectory(Path.Combine(tempDir.FullName, SourceBuildSdkType));
+            Utilities.ExtractTarball(Config.SdkTarballPath, sbSdkDir.FullName, OutputHelper);
+
+            DirectoryInfo msftSdkDir = Directory.CreateDirectory(Path.Combine(tempDir.FullName, MsftSdkType));
+            Utilities.ExtractTarball(Config.MsftSdkTarballPath, msftSdkDir.FullName, OutputHelper);
+
+            ExclusionsHelper exclusionsHelper = new("SdkTemplateVersionDiffExclusions.txt", Config.LogsDirectory, BaselineSubDir);
+
+            Dictionary<string, string> sbVersions = GetTemplatePackageVersions(sbSdkDir.FullName, exclusionsHelper, SourceBuildSdkType);
+            Dictionary<string, string> msftVersions = GetTemplatePackageVersions(msftSdkDir.FullName, exclusionsHelper, MsftSdkType);
+
+            exclusionsHelper.GenerateNewBaselineFile("TemplateVersions");
+
+            const string MsftVersionsFileName = "msft_templateversions.txt";
+            const string SbVersionsFileName = "sb_templateversions.txt";
+
+            File.WriteAllLines(MsftVersionsFileName, msftVersions.OrderBy(kvp => kvp.Key).Select(kvp => $"{kvp.Key} {kvp.Value}"));
+            File.WriteAllLines(SbVersionsFileName, sbVersions.OrderBy(kvp => kvp.Key).Select(kvp => $"{kvp.Key} {kvp.Value}"));
+
+            string diff = BaselineHelper.DiffFiles(MsftVersionsFileName, SbVersionsFileName, OutputHelper);
+            diff = RemoveDiffMarkers(diff);
+            BaselineHelper.CompareBaselineContents("MsftToSbSdkTemplateVersions.diff", diff, OutputHelper, BaselineSubDir);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Scans all template nupkgs in an extracted SDK and returns a flat dictionary of
+    /// "nupkgName|projPath|PackageName" → version string, with versions in the key normalized.
+    /// </summary>
+    private static Dictionary<string, string> GetTemplatePackageVersions(string sdkRootDir, ExclusionsHelper exclusionsHelper, string sdkType)
+    {
+        Dictionary<string, string> result = [];
+
+        string[] nupkgFiles = Directory.GetFiles(sdkRootDir, "*.nupkg", SearchOption.AllDirectories)
+            .Where(p => Path.GetRelativePath(sdkRootDir, p).StartsWith("templates" + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        string[] projectExtensions = [".csproj", ".fsproj"];
+
+        foreach (string nupkgPath in nupkgFiles)
+        {
+            string normalizedNupkgName = GetPackageIdFromFileName(Path.GetFileNameWithoutExtension(nupkgPath));
+
+            using ZipArchive archive = ZipFile.OpenRead(nupkgPath);
+            IEnumerable<ZipArchiveEntry> projectEntries = archive.Entries
+                .Where(e => projectExtensions.Contains(Path.GetExtension(e.FullName), StringComparer.OrdinalIgnoreCase));
+
+            foreach (ZipArchiveEntry entry in projectEntries)
+            {
+                Dictionary<string, string> packageVersions = GetPackageReferencesFromProjectFile(entry);
+                foreach ((string packageName, string version) in packageVersions)
+                {
+                    string sanitizedEntryName = entry.FullName.Replace('/', '-');
+                    string key = $"{normalizedNupkgName},{sanitizedEntryName},{packageName}";
+                    if (!exclusionsHelper.IsFileExcluded(key, sdkType))
+                    {
+                        result[key] = version;
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Parses PackageReference elements from a project file (.csproj/.fsproj) zip entry and returns package name to version mappings.
+    /// </summary>
+    private static Dictionary<string, string> GetPackageReferencesFromProjectFile(ZipArchiveEntry entry)
+    {
+        Dictionary<string, string> versions = [];
+
+        using Stream stream = entry.Open();
+        XDocument doc;
+        try
+        {
+            doc = XDocument.Load(stream);
+        }
+        catch
+        {
+            return versions;
+        }
+
+        IEnumerable<XElement> packageRefs = doc.Descendants()
+            .Where(e => e.Name.LocalName == "PackageReference");
+
+        foreach (XElement packageRef in packageRefs)
+        {
+            string? packageName = packageRef.Attribute("Include")?.Value
+                ?? packageRef.Attribute("Update")?.Value;
+
+            if (string.IsNullOrEmpty(packageName))
+            {
+                continue;
+            }
+
+            // Version can be an attribute or a child element
+            string? version = packageRef.Attribute("Version")?.Value
+                ?? packageRef.Elements().FirstOrDefault(e => e.Name.LocalName == "Version")?.Value;
+
+            if (!string.IsNullOrEmpty(version))
+            {
+                versions[packageName] = version;
+            }
+        }
+
+        return versions;
+    }
+
+    /// <summary>
+    /// Extracts the package ID from a nupkg filename (without extension).
+    /// Nupkg filenames follow the pattern "{id}.{version}" where the version starts with a digit.
+    /// </summary>
+    private static string GetPackageIdFromFileName(string fileNameWithoutExtension)
+    {
+        // Walk backwards to find the last segment that starts with a digit — that's where the version begins.
+        // E.g. "Microsoft.DotNet.Web.ProjectTemplates.11.0.11.0.0-preview.5.26226.111"
+        //       ID = "Microsoft.DotNet.Web.ProjectTemplates.11.0", version = "11.0.0-preview.5.26226.111"
+        string[] parts = fileNameWithoutExtension.Split('.');
+        int versionStart = -1;
+        for (int i = parts.Length - 1; i >= 0; i--)
+        {
+            if (parts[i].Length > 0 && char.IsDigit(parts[i][0]))
+            {
+                versionStart = i;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        return versionStart > 0
+            ? string.Join('.', parts[0..versionStart])
+            : fileNameWithoutExtension;
     }
 
     private string NormalizeApiDiffSuppressionFileContent(string content)

--- a/test/Microsoft.DotNet.SourceBuild.Tests/assets/LicenseScanTests/LicenseExclusions.txt
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/assets/LicenseScanTests/LicenseExclusions.txt
@@ -1,6 +1,6 @@
 # Contains the list of files to be excluded from license scanning.
 #
-# This list is processed using FileSystemName.MatchesSimpleExpression
+# This list is processed using Microsoft.Extensions.FileSystemGlobbing.Matcher
 #
 # Format:
 #   Exclude the file entirely from license scanning:

--- a/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/SdkAssemblyVersionDiffExclusions.txt
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/SdkAssemblyVersionDiffExclusions.txt
@@ -3,7 +3,7 @@
 # the version in the MSFT SDK. If the version is less, the file will show up in the results as this is not a scenario
 # that is valid for shipping.
 #
-# This list is processed using FileSystemName.MatchesSimpleExpression
+# This list is processed using Microsoft.Extensions.FileSystemGlobbing.Matcher
 #
 # '*' in exclusions match zero or more characters.
 # '*' will match files and directory names but it will not match separator characters.

--- a/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/SdkFileDiffExclusions.txt
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/SdkFileDiffExclusions.txt
@@ -1,4 +1,4 @@
-# This list is processed using FileSystemName.MatchesSimpleExpression
+# This list is processed using Microsoft.Extensions.FileSystemGlobbing.Matcher
 #
 # Format
 #   Exclude the path entirely:

--- a/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/SdkTemplateVersionDiffExclusions.txt
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/SdkTemplateVersionDiffExclusions.txt
@@ -1,0 +1,9 @@
+# Contains the list of template PackageReference entries to exclude from version comparison
+# between the MSFT & SB SDK.
+#
+# Format: nupkgName,projPath,PackageName
+# Suffix (msft or sb) can be appended after a pipe character to limit to one SDK type.
+#
+# This list is processed using FileSystemName.MatchesSimpleExpression
+#
+# '*' in exclusions match zero or more characters.

--- a/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/SdkTemplateVersionDiffExclusions.txt
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/SdkTemplateVersionDiffExclusions.txt
@@ -1,9 +1,9 @@
 # Contains the list of template PackageReference entries to exclude from version comparison
 # between the MSFT & SB SDK.
 #
-# Format: nupkgName,projPath,PackageName
+# Format: nupkgId,projPath,PackageName
 # Suffix (msft or sb) can be appended after a pipe character to limit to one SDK type.
 #
-# This list is processed using FileSystemName.MatchesSimpleExpression
+# This list is processed using Microsoft.Extensions.FileSystemGlobbing.Matcher
 #
 # '*' in exclusions match zero or more characters.


### PR DESCRIPTION
In source-build mode, EF Core package versions weren't flowing to aspnetcore, causing template project files in the SDK to have stale versions compared to the Microsoft-built SDK.

Fix by adding `ExtraPackageVersionPropsPackageInfo `entries to aspnetcore.proj that override `*Version properties` for EF Core packages, referencing the runtime's `MicrosoftNETCoreAppRefPackageVersion` (which shares the same version).

Add `CompareMsftToSbTemplatePackageVersions` test in `SdkContentTests` that extracts template nupkgs from both SDK tarballs, parses `PackageReference` versions from project files, and diffs them. This catches any future version flow issues in templates. The test follows existing patterns with baseline diff and exclusion file support.

Fix https://github.com/dotnet/source-build/issues/5493