### PR TITLE
Add workflow to auto-apply milestones to codeflow PRs

### DIFF
--- a/.github/milestone-config.json
+++ b/.github/milestone-config.json
@@ -1,9 +1,15 @@
 {
   "optedOutRepos": [
+    "dotnet/cecil",
+    "dotnet/command-line-api",
+    "dotnet/deployment-tools",
+    "dotnet/diagnostics",
     "dotnet/fsharp",
     "dotnet/msbuild",
     "dotnet/razor",
     "dotnet/roslyn",
+    "dotnet/symreader",
+    "dotnet/xdt",
     "microsoft/vstest",
     "nuget/nuget.client"
   ]

--- a/.github/milestone-config.json
+++ b/.github/milestone-config.json
@@ -1,5 +1,10 @@
 {
   "optedOutRepos": [
+    "dotnet/fsharp",
+    "dotnet/msbuild",
+    "dotnet/razor",
+    "dotnet/roslyn",
+    "microsoft/vstest",
     "nuget/nuget.client"
   ]
 }

--- a/.github/milestone-config.json
+++ b/.github/milestone-config.json
@@ -1,0 +1,5 @@
+{
+  "optedOutRepos": [
+    "nuget/nuget.client"
+  ]
+}

--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -101,7 +101,7 @@ jobs:
 
             // --- Step 1: Resolve milestone name ---
 
-            async function resolveMilestone(branch) {
+            async function resolveMilestone(branch, mergeCommitSha) {
 
               // --- Preview/RC release branches ---
               // release/11.0.1xx-preview4 → 11.0-preview4
@@ -210,7 +210,28 @@ jobs:
                 return `${ver}-${fullLabel}`;
               }
 
-              // Branch exists → branding is stale. Deterministically increment.
+              // Branch exists → branding may be stale, OR the PR was merged just before the snap.
+              // Check if this PR's merge commit is in the release branch.
+              // If it is, the PR shipped in this preview — use current branding.
+              if (mergeCommitSha) {
+                try {
+                  const { data: comparison } = await github.rest.repos.compareCommits({
+                    owner: 'dotnet', repo: 'dotnet',
+                    base: mergeCommitSha,
+                    head: candidateBranch,
+                  });
+                  // If merge commit is behind or equal to the branch, it's included
+                  if (comparison.status === 'ahead' || comparison.status === 'identical') {
+                    core.info(`Merge commit ${mergeCommitSha.substring(0, 8)} is in ${candidateBranch} — using current branding`);
+                    return `${ver}-${fullLabel}`;
+                  }
+                } catch (e) {
+                  core.warning(`Could not check branch reachability: ${e.message}`);
+                }
+              }
+
+              // Merge commit is NOT in the release branch — branding is stale.
+              // Deterministically increment.
               // RC snap means main is now vNext
               if (label === 'rc') {
                 return `${major + 1}.0-preview1`;
@@ -462,13 +483,16 @@ jobs:
 
             // For workflow_dispatch, fetch the PR to get its base branch and checkout its merge commit
             let baseBranch;
+            let mergeCommitSha;
             if (context.payload.pull_request) {
               baseBranch = context.payload.pull_request.base.ref;
+              mergeCommitSha = context.payload.pull_request.merge_commit_sha;
             } else {
               const { data: pr } = await github.rest.pulls.get({
                 owner: 'dotnet', repo: 'dotnet', pull_number: prNumber,
               });
               baseBranch = pr.base.ref;
+              mergeCommitSha = pr.merge_commit_sha;
               if (!pr.merged) {
                 core.setFailed(`PR #${prNumber} has not been merged`);
                 return;
@@ -480,7 +504,7 @@ jobs:
 
             core.info(`Processing PR #${prNumber} against ${baseBranch}`);
 
-            const milestoneName = await resolveMilestone(baseBranch);
+            const milestoneName = await resolveMilestone(baseBranch, mergeCommitSha);
 
             if (!milestoneName) {
               core.info('Could not resolve milestone, skipping');

--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -98,6 +98,11 @@ jobs:
               return null;
             }
 
+            // "alpha" always maps to preview1
+            if (label === 'alpha') {
+              return { name: `${major}.${minor}-preview1`, deferred: false };
+            }
+
             // Combine label + iteration: "preview" + "5" → "preview5"
             const fullLabel = `${label}${iteration}`;
 

--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 2  # Need parent commit for diff
 
       - name: Generate dotnet org token
@@ -86,7 +87,7 @@ jobs:
               // Read patch version from eng/Versions.props on this branch
               const fs = require('fs');
               const versionsProps = fs.readFileSync('eng/Versions.props', 'utf8');
-              const patchMatch = versionsProps.match(/<VersionPatch>(\d+)<\/VersionPatch>/);
+              const patchMatch = versionsProps.match(/<VersionSDKMinorPatch>(\d+)<\/VersionSDKMinorPatch>/);
               const patch = patchMatch ? parseInt(patchMatch[1]) : -1;
 
               if (patch !== 0) {
@@ -270,23 +271,35 @@ jobs:
           // --- Step 3: Find PRs in commit range using GraphQL ---
 
           async function findPRsInRange(owner, repo, oldSha, newSha, octokit) {
-            // Get commits in range — handle large ranges by paginating
-            const { data: comparison } = await octokit.rest.repos.compareCommits({
-              owner, repo,
-              base: oldSha,
-              head: newSha,
-            });
+            // Collect all commits in range, paginating if > 250
+            const allCommits = [];
+            let currentBase = oldSha;
 
-            if (comparison.commits.length === 0) {
-              return [];
+            while (true) {
+              const { data: comparison } = await octokit.rest.repos.compareCommits({
+                owner, repo,
+                base: currentBase,
+                head: newSha,
+                per_page: 250,
+              });
+
+              if (comparison.commits.length === 0) break;
+
+              allCommits.push(...comparison.commits);
+
+              // If we got all commits, we're done
+              if (allCommits.length >= comparison.total_commits) break;
+
+              // Move the base forward to the last commit we got
+              currentBase = comparison.commits[comparison.commits.length - 1].sha;
             }
 
-            if (comparison.total_commits > 250) {
-              core.warning(`${owner}/${repo} has ${comparison.total_commits} commits in range — only first 250 will be processed`);
-            }
+            if (allCommits.length === 0) return [];
+
+            core.info(`${owner}/${repo}: ${allCommits.length} commits in range`);
 
             // Batch query associatedPullRequests via GraphQL
-            const commitAliases = comparison.commits.map((c, i) =>
+            const commitAliases = allCommits.map((c, i) =>
               `c${i}: object(oid: "${c.sha}") { ... on Commit { associatedPullRequests(first: 5) { nodes { number } } } }`
             );
 
@@ -465,5 +478,8 @@ jobs:
           // Process the current PR
           await processOnePR(context.payload.pull_request.number, milestone.name);
 
-          // Process any deferred PRs
-          await processDeferredPRs(milestone.name);
+          // Process any deferred PRs (only on main — deferral only happens on main)
+          const branch = context.payload.pull_request.base.ref;
+          if (branch === 'main') {
+            await processDeferredPRs(milestone.name);
+          }

--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -33,13 +33,13 @@ jobs:
       github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 2  # Need parent commit for diff
 
       - name: Generate dotnet org token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         id: dotnet-token
         with:
           app-id: ${{ secrets.MILESTONE_APP_ID }}
@@ -49,7 +49,7 @@ jobs:
       # Uncomment the step below to enable milestoning for microsoft org repos.
       # Requires the GitHub App to be installed on the microsoft org.
       # - name: Generate microsoft org token
-      #   uses: actions/create-github-app-token@v1
+      #   uses: actions/create-github-app-token@v3
       #   id: microsoft-token
       #   with:
       #     app-id: ${{ secrets.MILESTONE_APP_ID }}
@@ -57,7 +57,7 @@ jobs:
       #     owner: microsoft
 
       - name: Apply milestones
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           DOTNET_TOKEN: ${{ steps.dotnet-token.outputs.token }}
           # MICROSOFT_TOKEN: ${{ steps.microsoft-token.outputs.token }}  # Uncomment when microsoft org app is installed

--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -59,27 +59,29 @@ jobs:
         with:
           github-token: ${{ steps.dotnet-token.outputs.token }}
         env:
+          DOTNET_TOKEN: ${{ steps.dotnet-token.outputs.token }}
           MICROSOFT_TOKEN: ${{ steps.microsoft-token.outputs.token }}
           DRY_RUN: ${{ github.event.inputs.dry-run || 'false' }}
         script: |
           const { Octokit } = require("@octokit/rest");
-          const microsoftOctokit = new Octokit({ auth: process.env.MICROSOFT_TOKEN });
           const DRY_RUN = process.env.DRY_RUN === 'true';
 
-          if (DRY_RUN) core.info('🏃 DRY RUN — no milestones will be created or applied');
+          if (DRY_RUN) core.info('DRY RUN -- no milestones will be created or applied');
 
-          // Supported orgs for milestoning. Repos outside these orgs are skipped.
-          const SUPPORTED_ORGS = new Set(['dotnet', 'microsoft']);
+          // Map of org -> authenticated Octokit client
+          const orgClients = {
+            dotnet: github,
+            microsoft: new Octokit({ auth: process.env.MICROSOFT_TOKEN }),
+          };
 
-          // Repos that have opted out of auto-milestoning — loaded from .github/milestone-config.json
+          function getOctokit(owner) {
+            return orgClients[owner.toLowerCase()] || null;
+          }
+
+          // Repos that have opted out of auto-milestoning
           const fs = require('fs');
           const config = JSON.parse(fs.readFileSync('.github/milestone-config.json', 'utf8'));
           const OPTED_OUT_REPOS = new Set(config.optedOutRepos.map(r => r.toLowerCase()));
-
-          function getOctokit(owner) {
-            if (owner === 'microsoft') return microsoftOctokit;
-            return github;
-          }
 
           // --- Constants: 7 previews, 2 RCs per release ---
           const MAX_PREVIEWS = 7;
@@ -410,17 +412,16 @@ jobs:
                 const [, owner, repoRaw] = urlMatch;
                 const repo = repoRaw.replace(/\.git$/, '');
 
-                if (!SUPPORTED_ORGS.has(owner.toLowerCase())) {
-                  core.info(`Skipping ${owner}/${repo} — org not configured for milestoning`);
-                  continue;
-                }
-
                 if (OPTED_OUT_REPOS.has(`${owner}/${repo}`.toLowerCase())) {
                   core.info(`Skipping ${owner}/${repo} — opted out of auto-milestoning`);
                   continue;
                 }
 
                 const octokit = getOctokit(owner);
+                if (!octokit) {
+                  core.info(`Skipping ${owner}/${repo} — org not configured for milestoning`);
+                  continue;
+                }
 
                 core.info(`Processing ${owner}/${repo}: ${change.oldSha.substring(0, 8)}..${change.newSha.substring(0, 8)}`);
 

--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -105,7 +105,8 @@ jobs:
             }
 
             // --- Bare release branches (e.g. release/11.0.1xx) ---
-            // Used during RC→RTM phase.
+            // Only active during the narrow window where this branch is staging rc2:
+            // branding is "rc2", release/X.Y.1xx-rc1 exists, but release/X.Y.1xx-rc2 does not.
             const bareMatch = branch.match(/^release\/(\d+\.\d+)\.(\d+)xx$/);
             if (bareMatch) {
               const ver = bareMatch[1];
@@ -113,46 +114,47 @@ jobs:
 
               const fs = require('fs');
               const versionsProps = fs.readFileSync('eng/Versions.props', 'utf8');
+
+              // Skip if servicing (patch > 0)
               const patchMatch = versionsProps.match(/<VersionSDKMinorPatch>(\d+)<\/VersionSDKMinorPatch>/);
               const patch = patchMatch ? parseInt(patchMatch[1]) : -1;
-
               if (patch !== 0) {
                 core.info(`Bare release branch ${branch} has patch version ${patch} (servicing), skipping`);
                 return null;
               }
 
-              // Check if sibling rc branches exist
-              let hasRcSibling = false;
+              // Only proceed if branding is rc2
+              const labelMatch = versionsProps.match(/<PreReleaseVersionLabel>([^<]+)<\/PreReleaseVersionLabel>/);
+              const iterationMatch = versionsProps.match(/<PreReleaseVersionIteration>(\d*)<\/PreReleaseVersionIteration>/);
+              const label = labelMatch ? labelMatch[1] : '';
+              const iteration = parseInt(iterationMatch?.[1] || '0');
+
+              if (label !== 'rc' || iteration !== 2) {
+                core.info(`Bare release branch ${branch} branded as "${label}${iteration}", not rc2 — skipping`);
+                return null;
+              }
+
+              // Check that rc1 exists but rc2 does NOT
+              let rc1Exists = false, rc2Exists = false;
               for (const rcN of ['rc1', 'rc2']) {
                 try {
                   await github.rest.repos.getBranch({
                     owner: 'dotnet', repo: 'dotnet',
                     branch: `release/${ver}.${featureBand}xx-${rcN}`,
                   });
-                  hasRcSibling = true;
-                  break;
+                  if (rcN === 'rc1') rc1Exists = true;
+                  if (rcN === 'rc2') rc2Exists = true;
                 } catch (e) {
                   if (e.status !== 404) throw e;
                 }
               }
 
-              if (!hasRcSibling) {
-                core.info(`Bare release branch ${branch} has no sibling rc branches, skipping`);
+              if (!rc1Exists || rc2Exists) {
+                core.info(`Bare release branch ${branch}: rc1=${rc1Exists}, rc2=${rc2Exists} — skipping`);
                 return null;
               }
 
-              // Read branding from this branch
-              const labelMatch = versionsProps.match(/<PreReleaseVersionLabel>([^<]+)<\/PreReleaseVersionLabel>/);
-              const iterationMatch = versionsProps.match(/<PreReleaseVersionIteration>(\d*)<\/PreReleaseVersionIteration>/);
-              const label = labelMatch ? labelMatch[1] : '';
-              const iteration = parseInt(iterationMatch?.[1] || '0');
-
-              if (label === 'servicing' || label === '') {
-                core.info(`Bare release branch ${branch} is branded as "${label || 'empty'}", skipping`);
-                return null;
-              }
-
-              return `${ver}-${label}${iteration}`;
+              return `${ver}-rc2`;
             }
 
             // --- Any other release branch format: skip ---

--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -5,8 +5,7 @@ on:
     types: [closed]
     branches:
       - 'main'
-      - 'release/*.1xx-preview*'
-      - 'release/*.1xx-rc*'
+      - 'release/**'
     paths: ['src/source-manifest.json']
 
 permissions:
@@ -66,14 +65,74 @@ jobs:
           async function resolveMilestone() {
             const branch = context.payload.pull_request.base.ref;
 
-            // Release branches: parse directly from branch name
+            // --- Preview/RC release branches ---
             // release/11.0.1xx-preview4 → 11.0-preview4
             const releaseMatch = branch.match(/^release\/(\d+\.\d+)\.1xx-((?:preview|rc)\d+)$/);
             if (releaseMatch) {
               return { name: `${releaseMatch[1]}-${releaseMatch[2]}`, deferred: false };
             }
 
-            // Main branch: read branding from eng/Versions.props
+            // --- Bare release branches (e.g. release/11.0.1xx) ---
+            // These are used during the RC→RTM phase.
+            const bareMatch = branch.match(/^release\/(\d+\.\d+)\.(\d+)xx$/);
+            if (bareMatch) {
+              const ver = bareMatch[1];        // "11.0"
+              const featureBand = bareMatch[2]; // "1"
+
+              // Read patch version from eng/Versions.props on this branch
+              const fs = require('fs');
+              const versionsProps = fs.readFileSync('eng/Versions.props', 'utf8');
+              const patchMatch = versionsProps.match(/<VersionPatch>(\d+)<\/VersionPatch>/);
+              const patch = patchMatch ? parseInt(patchMatch[1]) : -1;
+
+              if (patch !== 0) {
+                core.info(`Bare release branch ${branch} has patch version ${patch} (servicing), skipping`);
+                return null;
+              }
+
+              // Check if rc1 or rc2 sibling branches exist
+              let rc1Exists = false, rc2Exists = false;
+              for (const rcN of ['rc1', 'rc2']) {
+                try {
+                  await github.rest.repos.getBranch({
+                    owner: 'dotnet', repo: 'dotnet',
+                    branch: `release/${ver}.${featureBand}xx-${rcN}`,
+                  });
+                  if (rcN === 'rc1') rc1Exists = true;
+                  if (rcN === 'rc2') rc2Exists = true;
+                } catch (e) {
+                  if (e.status !== 404) throw e;
+                }
+              }
+
+              if (!rc1Exists && !rc2Exists) {
+                core.info(`Bare release branch ${branch} has no sibling rc branches, skipping`);
+                return null;
+              }
+
+              // Resolve milestone from branding on this branch
+              const labelMatch = versionsProps.match(/<PreReleaseVersionLabel>([^<]+)<\/PreReleaseVersionLabel>/);
+              const iterationMatch = versionsProps.match(/<PreReleaseVersionIteration>(\d*)<\/PreReleaseVersionIteration>/);
+              const label = labelMatch ? labelMatch[1] : '';
+              const iteration = iterationMatch ? iterationMatch[1] : '';
+
+              if (label === 'servicing' || label === '') {
+                // Already RTM-branded, skip
+                core.info(`Bare release branch ${branch} is branded as "${label || 'empty'}", skipping`);
+                return null;
+              }
+
+              const fullLabel = `${label}${iteration}`;
+              return { name: `${ver}-${fullLabel}`, deferred: false };
+            }
+
+            // --- Any other release branch format: skip ---
+            if (branch.startsWith('release/')) {
+              core.info(`Release branch ${branch} does not match expected patterns, skipping`);
+              return null;
+            }
+
+            // --- Main branch: read branding from eng/Versions.props ---
             const fs = require('fs');
             const versionsProps = fs.readFileSync('eng/Versions.props', 'utf8');
 

--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -81,6 +81,27 @@ jobs:
             return github;
           }
 
+          // --- Constants: 7 previews, 2 RCs per release ---
+          const MAX_PREVIEWS = 7;
+
+          // Compute the next milestone given a current label+iteration.
+          // preview1→preview2, preview7→rc1, rc1→rc2, rc2→{ver}.0 (RTM)
+          function nextMilestone(ver, label, iteration) {
+            if (label === 'preview' && iteration < MAX_PREVIEWS) {
+              return `${ver}-preview${iteration + 1}`;
+            }
+            if (label === 'preview' && iteration >= MAX_PREVIEWS) {
+              return `${ver}-rc1`;
+            }
+            if (label === 'rc' && iteration === 1) {
+              return `${ver}-rc2`;
+            }
+            if (label === 'rc' && iteration === 2) {
+              return `${ver}.0`;
+            }
+            return null; // shouldn't happen
+          }
+
           // --- Step 1: Resolve milestone name ---
 
           async function resolveMilestone(branch) {
@@ -89,17 +110,16 @@ jobs:
             // release/11.0.1xx-preview4 → 11.0-preview4
             const releaseMatch = branch.match(/^release\/(\d+\.\d+)\.1xx-((?:preview|rc)\d+)$/);
             if (releaseMatch) {
-              return { name: `${releaseMatch[1]}-${releaseMatch[2]}`, deferred: false };
+              return `${releaseMatch[1]}-${releaseMatch[2]}`;
             }
 
             // --- Bare release branches (e.g. release/11.0.1xx) ---
-            // These are used during the RC→RTM phase.
+            // Used during RC→RTM phase.
             const bareMatch = branch.match(/^release\/(\d+\.\d+)\.(\d+)xx$/);
             if (bareMatch) {
-              const ver = bareMatch[1];        // "11.0"
-              const featureBand = bareMatch[2]; // "1"
+              const ver = bareMatch[1];
+              const featureBand = bareMatch[2];
 
-              // Read patch version from eng/Versions.props on this branch
               const fs = require('fs');
               const versionsProps = fs.readFileSync('eng/Versions.props', 'utf8');
               const patchMatch = versionsProps.match(/<VersionSDKMinorPatch>(\d+)<\/VersionSDKMinorPatch>/);
@@ -110,40 +130,38 @@ jobs:
                 return null;
               }
 
-              // Check if rc1 or rc2 sibling branches exist
-              let rc1Exists = false, rc2Exists = false;
+              // Check if sibling rc branches exist
+              let hasRcSibling = false;
               for (const rcN of ['rc1', 'rc2']) {
                 try {
                   await github.rest.repos.getBranch({
                     owner: 'dotnet', repo: 'dotnet',
                     branch: `release/${ver}.${featureBand}xx-${rcN}`,
                   });
-                  if (rcN === 'rc1') rc1Exists = true;
-                  if (rcN === 'rc2') rc2Exists = true;
+                  hasRcSibling = true;
+                  break;
                 } catch (e) {
                   if (e.status !== 404) throw e;
                 }
               }
 
-              if (!rc1Exists && !rc2Exists) {
+              if (!hasRcSibling) {
                 core.info(`Bare release branch ${branch} has no sibling rc branches, skipping`);
                 return null;
               }
 
-              // Resolve milestone from branding on this branch
+              // Read branding from this branch
               const labelMatch = versionsProps.match(/<PreReleaseVersionLabel>([^<]+)<\/PreReleaseVersionLabel>/);
               const iterationMatch = versionsProps.match(/<PreReleaseVersionIteration>(\d*)<\/PreReleaseVersionIteration>/);
               const label = labelMatch ? labelMatch[1] : '';
-              const iteration = iterationMatch ? iterationMatch[1] : '';
+              const iteration = parseInt(iterationMatch?.[1] || '0');
 
               if (label === 'servicing' || label === '') {
-                // Already RTM-branded, skip
                 core.info(`Bare release branch ${branch} is branded as "${label || 'empty'}", skipping`);
                 return null;
               }
 
-              const fullLabel = `${label}${iteration}`;
-              return { name: `${ver}-${fullLabel}`, deferred: false };
+              return `${ver}-${label}${iteration}`;
             }
 
             // --- Any other release branch format: skip ---
@@ -152,7 +170,7 @@ jobs:
               return null;
             }
 
-            // --- Main branch: read branding from eng/Versions.props ---
+            // --- Main branch ---
             const fs = require('fs');
             const versionsProps = fs.readFileSync('eng/Versions.props', 'utf8');
 
@@ -166,32 +184,29 @@ jobs:
               return null;
             }
 
-            const major = majorMatch[1];
+            const major = parseInt(majorMatch[1]);
             const minor = minorMatch ? minorMatch[1] : '0';
             const label = labelMatch[1];
-            const iteration = iterationMatch ? iterationMatch[1] : '';
+            const iteration = parseInt(iterationMatch?.[1] || '0');
+            const ver = `${major}.${minor}`;
 
-            // For servicing branches on main (shouldn't normally happen), skip
             if (label === 'servicing') {
               core.info('Main branch is branded as servicing, skipping');
               return null;
             }
 
-            // "alpha" always maps to preview1
+            // Alpha always maps to preview1
             if (label === 'alpha') {
-              return { name: `${major}.${minor}-preview1`, deferred: false };
+              return `${ver}-preview1`;
             }
 
-            // Combine label + iteration: "preview" + "5" → "preview5"
-            const fullLabel = `${label}${iteration}`;
-
             // Check if a release branch matching current branding exists
-            const candidateBranch = `release/${major}.${minor}.1xx-${fullLabel}`;
+            const fullLabel = `${label}${iteration}`;
+            const candidateBranch = `release/${ver}.1xx-${fullLabel}`;
             let branchExists = false;
             try {
               await github.rest.repos.getBranch({
-                owner: 'dotnet',
-                repo: 'dotnet',
+                owner: 'dotnet', repo: 'dotnet',
                 branch: candidateBranch,
               });
               branchExists = true;
@@ -200,24 +215,18 @@ jobs:
             }
 
             if (!branchExists) {
-              // Normal case: branding matches, use it
-              return { name: `${major}.${minor}-${fullLabel}`, deferred: false };
+              // Normal case: branding matches
+              return `${ver}-${fullLabel}`;
             }
 
-            // Branch exists → branding is stale (just snapped)
-
-            // vNext snap: main still has rc branding, but the rc branch was
-            // snapped, meaning main is now the next major version.
-            // e.g. main says rc1/11.0, release/11.0.1xx-rc1 exists → main is really 12.0-preview1
+            // Branch exists → branding is stale. Deterministically increment.
+            // RC snap means main is now vNext
             if (label === 'rc') {
-              const nextMajor = parseInt(major) + 1;
-              return { name: `${nextMajor}.0-preview1`, deferred: false };
+              return `${major + 1}.0-preview1`;
             }
 
-            // Can't determine next milestone (preview→rc transition ambiguity)
-            // Defer by labeling the PR
-            core.info(`Branch ${candidateBranch} exists but branding not yet bumped. Deferring milestone.`);
-            return { name: null, deferred: true };
+            // Preview snap: preview7→rc1, previewN→preview(N+1)
+            return nextMilestone(ver, label, iteration);
           }
 
           // --- Step 2: Extract child-repo PRs from source-manifest.json diff ---
@@ -400,37 +409,6 @@ jobs:
             core.info(`Applied milestone to ${owner}/${repo}#${prNumber}`);
           }
 
-          // --- Step 5: Process deferred PRs ---
-
-          async function processDeferredPRs(milestoneName) {
-            const deferredItems = await github.paginate(github.rest.issues.listForRepo, {
-              owner: 'dotnet', repo: 'dotnet',
-              labels: 'needs-milestone',
-              state: 'closed',
-              per_page: 100,
-            });
-
-            // Filter to PRs only (issues also have the listForRepo result)
-            const deferredPRs = deferredItems.filter(i => i.pull_request);
-
-            for (const issue of deferredPRs) {
-              core.info(`Processing deferred PR #${issue.number}`);
-              try {
-                await processOnePR(issue.number, milestoneName);
-
-                // Only remove label if processing fully succeeded
-                await github.rest.issues.removeLabel({
-                  owner: 'dotnet', repo: 'dotnet',
-                  issue_number: issue.number,
-                  name: 'needs-milestone',
-                });
-              } catch (e) {
-                // Keep the label so it gets retried on next run
-                core.warning(`Failed to process deferred PR #${issue.number}: ${e.message}`);
-              }
-            }
-          }
-
           // --- Core logic: process a single dotnet/dotnet PR ---
 
           async function processOnePR(prNumber, milestoneName) {
@@ -509,35 +487,14 @@ jobs:
 
           core.info(`Processing PR #${prNumber} against ${baseBranch}`);
 
-          const milestone = await resolveMilestone(baseBranch);
+          const milestoneName = await resolveMilestone(baseBranch);
 
-          if (!milestone) {
+          if (!milestoneName) {
             core.info('Could not resolve milestone, skipping');
             return;
           }
 
-          if (milestone.deferred) {
-            if (DRY_RUN) {
-              core.info(`[DRY RUN] Would label PR #${prNumber} with needs-milestone`);
-            } else {
-              await github.rest.issues.addLabels({
-                owner: 'dotnet', repo: 'dotnet',
-                issue_number: prNumber,
-                labels: ['needs-milestone'],
-              });
-            }
-            core.info('Milestone deferred — labeled PR with needs-milestone');
-            return;
-          }
-
-          core.info(`Resolved milestone: ${milestone.name}`);
+          core.info(`Resolved milestone: ${milestoneName}`);
 
           // Process the current PR
-          await processOnePR(prNumber, milestone.name);
-
-          // Process any deferred PRs (only on main — deferral only happens on main)
-          if (baseBranch === 'main' && !DRY_RUN) {
-            await processDeferredPRs(milestone.name);
-          } else if (baseBranch === 'main' && DRY_RUN) {
-            core.info('[DRY RUN] Would process deferred PRs with milestone: ' + milestone.name);
-          }
+          await processOnePR(prNumber, milestoneName);

--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -186,17 +186,12 @@ jobs:
 
             // Branch exists → branding is stale (just snapped)
 
-            // Check if this is a vNext snap: main still has rc branding, but
-            // the rc branch was snapped, meaning main is now the next major version.
+            // vNext snap: main still has rc branding, but the rc branch was
+            // snapped, meaning main is now the next major version.
             // e.g. main says rc1/11.0, release/11.0.1xx-rc1 exists → main is really 12.0-preview1
             if (label === 'rc') {
               const nextMajor = parseInt(major) + 1;
               return { name: `${nextMajor}.0-preview1`, deferred: false };
-            }
-
-            if (fullLabel === 'rc2') {
-              // Post-final-RC → RTM
-              return { name: `${major}.${minor}.0`, deferred: false };
             }
 
             // Can't determine next milestone (preview→rc transition ambiguity)

--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -12,6 +12,10 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: milestone-${{ github.event.pull_request.base.ref }}
+  cancel-in-progress: false
+
 jobs:
   apply-milestones:
     if: github.event.pull_request.merged == true
@@ -393,41 +397,45 @@ jobs:
             const changes = await extractChildPRs(prNumber);
 
             for (const change of changes) {
-              const urlMatch = change.remoteUri.match(/github\.com\/([^/]+)\/([^/]+)/);
-              if (!urlMatch) {
-                core.warning(`Could not parse remote URI: ${change.remoteUri}`);
-                continue;
-              }
-
-              const [, owner, repo] = urlMatch;
-
-              if (!SUPPORTED_ORGS.has(owner.toLowerCase())) {
-                core.info(`Skipping ${owner}/${repo} — org not configured for milestoning`);
-                continue;
-              }
-
-              if (OPTED_OUT_REPOS.has(`${owner}/${repo}`.toLowerCase())) {
-                core.info(`Skipping ${owner}/${repo} — opted out of auto-milestoning`);
-                continue;
-              }
-
-              const octokit = getOctokit(owner);
-
-              core.info(`Processing ${owner}/${repo}: ${change.oldSha.substring(0, 8)}..${change.newSha.substring(0, 8)}`);
-
-              const prNumbers = await findPRsInRange(owner, repo, change.oldSha, change.newSha, octokit);
-              core.info(`Found ${prNumbers.length} PRs: ${prNumbers.join(', ')}`);
-
-              if (prNumbers.length === 0) continue;
-
-              const milestoneNumber = await ensureMilestone(owner, repo, milestoneName, octokit);
-
-              for (const childPR of prNumbers) {
-                try {
-                  await applyMilestone(owner, repo, childPR, milestoneNumber, octokit);
-                } catch (e) {
-                  core.warning(`Failed to milestone ${owner}/${repo}#${childPR}: ${e.message}`);
+              try {
+                const urlMatch = change.remoteUri.match(/github\.com\/([^/]+)\/([^/]+)/);
+                if (!urlMatch) {
+                  core.warning(`Could not parse remote URI: ${change.remoteUri}`);
+                  continue;
                 }
+
+                const [, owner, repo] = urlMatch;
+
+                if (!SUPPORTED_ORGS.has(owner.toLowerCase())) {
+                  core.info(`Skipping ${owner}/${repo} — org not configured for milestoning`);
+                  continue;
+                }
+
+                if (OPTED_OUT_REPOS.has(`${owner}/${repo}`.toLowerCase())) {
+                  core.info(`Skipping ${owner}/${repo} — opted out of auto-milestoning`);
+                  continue;
+                }
+
+                const octokit = getOctokit(owner);
+
+                core.info(`Processing ${owner}/${repo}: ${change.oldSha.substring(0, 8)}..${change.newSha.substring(0, 8)}`);
+
+                const prNumbers = await findPRsInRange(owner, repo, change.oldSha, change.newSha, octokit);
+                core.info(`Found ${prNumbers.length} PRs: ${prNumbers.join(', ')}`);
+
+                if (prNumbers.length === 0) continue;
+
+                const milestoneNumber = await ensureMilestone(owner, repo, milestoneName, octokit);
+
+                for (const childPR of prNumbers) {
+                  try {
+                    await applyMilestone(owner, repo, childPR, milestoneNumber, octokit);
+                  } catch (e) {
+                    core.warning(`Failed to milestone ${owner}/${repo}#${childPR}: ${e.message}`);
+                  }
+                }
+              } catch (e) {
+                core.warning(`Failed to process repo ${change.remoteUri}: ${e.message}`);
               }
             }
           }

--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -46,19 +46,21 @@ jobs:
           private-key: ${{ secrets.MILESTONE_APP_PRIVATE_KEY }}
           owner: dotnet
 
-      - name: Generate microsoft org token
-        uses: actions/create-github-app-token@v1
-        id: microsoft-token
-        with:
-          app-id: ${{ secrets.MILESTONE_APP_ID }}
-          private-key: ${{ secrets.MILESTONE_APP_PRIVATE_KEY }}
-          owner: microsoft
+      # Uncomment the step below to enable milestoning for microsoft org repos.
+      # Requires the GitHub App to be installed on the microsoft org.
+      # - name: Generate microsoft org token
+      #   uses: actions/create-github-app-token@v1
+      #   id: microsoft-token
+      #   with:
+      #     app-id: ${{ secrets.MILESTONE_APP_ID }}
+      #     private-key: ${{ secrets.MILESTONE_APP_PRIVATE_KEY }}
+      #     owner: microsoft
 
       - name: Apply milestones
         uses: actions/github-script@v7
         env:
           DOTNET_TOKEN: ${{ steps.dotnet-token.outputs.token }}
-          MICROSOFT_TOKEN: ${{ steps.microsoft-token.outputs.token }}
+          # MICROSOFT_TOKEN: ${{ steps.microsoft-token.outputs.token }}  # Uncomment when microsoft org app is installed
           DRY_RUN: ${{ github.event.inputs.dry-run || 'false' }}
         with:
           github-token: ${{ steps.dotnet-token.outputs.token }}
@@ -69,9 +71,11 @@ jobs:
             if (DRY_RUN) core.info('DRY RUN -- no milestones will be created or applied');
 
             // Map of org -> authenticated Octokit client
+            // To enable microsoft org, uncomment the microsoft-token step above,
+            // the MICROSOFT_TOKEN env var, and the microsoft entry below.
             const orgClients = {
               dotnet: github,
-              microsoft: new Octokit({ auth: process.env.MICROSOFT_TOKEN }),
+              // microsoft: new Octokit({ auth: process.env.MICROSOFT_TOKEN }),
             };
 
             function getOctokit(owner) {

--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -315,7 +315,7 @@ jobs:
 
             // Batch query associatedPullRequests via GraphQL
             const commitAliases = allCommits.map((c, i) =>
-              `c${i}: object(oid: "${c.sha}") { ... on Commit { associatedPullRequests(first: 5) { nodes { number } } } }`
+              `c${i}: object(oid: "${c.sha}") { ... on Commit { associatedPullRequests(first: 10) { nodes { number } } } }`
             );
 
             const prNumbers = new Set();
@@ -367,7 +367,7 @@ jobs:
               } catch (e) {
                 // Handle race condition — another run may have created it
                 if (e.status === 422) {
-                  const { data: retryMilestones } = await octokit.rest.issues.listMilestones({
+                  const retryMilestones = await octokit.paginate(octokit.rest.issues.listMilestones, {
                     owner, repo, state: 'open', per_page: 100,
                   });
                   milestone = retryMilestones.find(m => m.title === milestoneName);
@@ -403,12 +403,15 @@ jobs:
           // --- Step 5: Process deferred PRs ---
 
           async function processDeferredPRs(milestoneName) {
-            const deferredPRs = await github.paginate(github.rest.issues.listForRepo, {
+            const deferredItems = await github.paginate(github.rest.issues.listForRepo, {
               owner: 'dotnet', repo: 'dotnet',
               labels: 'needs-milestone',
               state: 'closed',
               per_page: 100,
             });
+
+            // Filter to PRs only (issues also have the listForRepo result)
+            const deferredPRs = deferredItems.filter(i => i.pull_request);
 
             for (const issue of deferredPRs) {
               core.info(`Processing deferred PR #${issue.number}`);
@@ -441,7 +444,8 @@ jobs:
                   continue;
                 }
 
-                const [, owner, repo] = urlMatch;
+                const [, owner, repoRaw] = urlMatch;
+                const repo = repoRaw.replace(/\.git$/, '');
 
                 if (!SUPPORTED_ORGS.has(owner.toLowerCase())) {
                   core.info(`Skipping ${owner}/${repo} — org not configured for milestoning`);

--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           github-token: ${{ steps.dotnet-token.outputs.token }}
           script: |
-            const { Octokit } = require("@octokit/rest");
+            // const { Octokit } = require("@octokit/rest");  // Uncomment when microsoft org app is installed
             const DRY_RUN = process.env.DRY_RUN === 'true';
 
             if (DRY_RUN) core.info('DRY RUN -- no milestones will be created or applied');

--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -185,6 +185,15 @@ jobs:
             }
 
             // Branch exists → branding is stale (just snapped)
+
+            // Check if this is a vNext snap: main still has rc branding, but
+            // the rc branch was snapped, meaning main is now the next major version.
+            // e.g. main says rc1/11.0, release/11.0.1xx-rc1 exists → main is really 12.0-preview1
+            if (label === 'rc') {
+              const nextMajor = parseInt(major) + 1;
+              return { name: `${nextMajor}.0-preview1`, deferred: false };
+            }
+
             if (fullLabel === 'rc2') {
               // Post-final-RC → RTM
               return { name: `${major}.${minor}.0`, deferred: false };

--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -1,0 +1,393 @@
+name: Apply milestones to codeflow PRs
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - 'main'
+      - 'release/*.1xx-preview*'
+      - 'release/*.1xx-rc*'
+    paths: ['src/source-manifest.json']
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  apply-milestones:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Need parent commit for diff
+
+      - name: Generate dotnet org token
+        uses: actions/create-github-app-token@v1
+        id: dotnet-token
+        with:
+          app-id: ${{ secrets.MILESTONE_APP_ID }}
+          private-key: ${{ secrets.MILESTONE_APP_PRIVATE_KEY }}
+          owner: dotnet
+
+      - name: Generate microsoft org token
+        uses: actions/create-github-app-token@v1
+        id: microsoft-token
+        with:
+          app-id: ${{ secrets.MILESTONE_APP_ID }}
+          private-key: ${{ secrets.MILESTONE_APP_PRIVATE_KEY }}
+          owner: microsoft
+
+      - name: Apply milestones
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.dotnet-token.outputs.token }}
+        env:
+          MICROSOFT_TOKEN: ${{ steps.microsoft-token.outputs.token }}
+        script: |
+          const { Octokit } = require("@octokit/rest");
+          const microsoftOctokit = new Octokit({ auth: process.env.MICROSOFT_TOKEN });
+
+          // Supported orgs for milestoning. Repos outside these orgs are skipped.
+          const SUPPORTED_ORGS = new Set(['dotnet', 'microsoft']);
+
+          // Repos that have opted out of auto-milestoning — loaded from .github/milestone-config.json
+          const fs = require('fs');
+          const config = JSON.parse(fs.readFileSync('.github/milestone-config.json', 'utf8'));
+          const OPTED_OUT_REPOS = new Set(config.optedOutRepos.map(r => r.toLowerCase()));
+
+          function getOctokit(owner) {
+            if (owner === 'microsoft') return microsoftOctokit;
+            return github;
+          }
+
+          // --- Step 1: Resolve milestone name ---
+
+          async function resolveMilestone() {
+            const branch = context.payload.pull_request.base.ref;
+
+            // Release branches: parse directly from branch name
+            // release/11.0.1xx-preview4 → 11.0-preview4
+            const releaseMatch = branch.match(/^release\/(\d+\.\d+)\.1xx-((?:preview|rc)\d+)$/);
+            if (releaseMatch) {
+              return { name: `${releaseMatch[1]}-${releaseMatch[2]}`, deferred: false };
+            }
+
+            // Main branch: read branding from eng/Versions.props
+            const fs = require('fs');
+            const versionsProps = fs.readFileSync('eng/Versions.props', 'utf8');
+
+            const majorMatch = versionsProps.match(/<VersionMajor>(\d+)<\/VersionMajor>/);
+            const minorMatch = versionsProps.match(/<VersionMinor>(\d+)<\/VersionMinor>/);
+            const labelMatch = versionsProps.match(/<PreReleaseVersionLabel>([^<]+)<\/PreReleaseVersionLabel>/);
+            const iterationMatch = versionsProps.match(/<PreReleaseVersionIteration>(\d*)<\/PreReleaseVersionIteration>/);
+
+            if (!majorMatch || !labelMatch) {
+              core.warning('Could not parse version from eng/Versions.props');
+              return null;
+            }
+
+            const major = majorMatch[1];
+            const minor = minorMatch ? minorMatch[1] : '0';
+            const label = labelMatch[1];
+            const iteration = iterationMatch ? iterationMatch[1] : '';
+
+            // For servicing branches on main (shouldn't normally happen), skip
+            if (label === 'servicing') {
+              core.info('Main branch is branded as servicing, skipping');
+              return null;
+            }
+
+            // Combine label + iteration: "preview" + "5" → "preview5"
+            const fullLabel = `${label}${iteration}`;
+
+            // Check if a release branch matching current branding exists
+            const candidateBranch = `release/${major}.${minor}.1xx-${fullLabel}`;
+            let branchExists = false;
+            try {
+              await github.rest.repos.getBranch({
+                owner: 'dotnet',
+                repo: 'dotnet',
+                branch: candidateBranch,
+              });
+              branchExists = true;
+            } catch (e) {
+              if (e.status !== 404) throw e;
+            }
+
+            if (!branchExists) {
+              // Normal case: branding matches, use it
+              return { name: `${major}.${minor}-${fullLabel}`, deferred: false };
+            }
+
+            // Branch exists → branding is stale (just snapped)
+            if (fullLabel === 'rc2') {
+              // Post-final-RC → RTM
+              return { name: `${major}.${minor}.0`, deferred: false };
+            }
+
+            // Can't determine next milestone (preview→rc transition ambiguity)
+            // Defer by labeling the PR
+            core.info(`Branch ${candidateBranch} exists but branding not yet bumped. Deferring milestone.`);
+            return { name: null, deferred: true };
+          }
+
+          // --- Step 2: Extract child-repo PRs from source-manifest.json diff ---
+
+          async function extractChildPRs(prNumber) {
+            // Get the files changed in the PR (paginated)
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: 'dotnet', repo: 'dotnet', pull_number: prNumber,
+            });
+
+            const manifestFile = files.find(f => f.filename === 'src/source-manifest.json');
+            if (!manifestFile) {
+              core.info('No source-manifest.json change found');
+              return [];
+            }
+
+            // Fetch the merge commit SHA from the PR itself (works for both
+            // current event and deferred PRs)
+            const { data: pr } = await github.rest.pulls.get({
+              owner: 'dotnet', repo: 'dotnet', pull_number: prNumber,
+            });
+            const mergeCommitSha = pr.merge_commit_sha;
+            if (!mergeCommitSha) {
+              core.warning(`PR #${prNumber} has no merge commit`);
+              return [];
+            }
+
+            const { data: mergeCommit } = await github.rest.repos.getCommit({
+              owner: 'dotnet', repo: 'dotnet', ref: mergeCommitSha,
+            });
+            const parentSha = mergeCommit.parents[0].sha;
+
+            const [oldManifest, newManifest] = await Promise.all([
+              github.rest.repos.getContent({
+                owner: 'dotnet', repo: 'dotnet',
+                path: 'src/source-manifest.json',
+                ref: parentSha,
+              }),
+              github.rest.repos.getContent({
+                owner: 'dotnet', repo: 'dotnet',
+                path: 'src/source-manifest.json',
+                ref: mergeCommitSha,
+              }),
+            ]);
+
+            const oldRepos = JSON.parse(Buffer.from(oldManifest.data.content, 'base64').toString()).repositories;
+            const newRepos = JSON.parse(Buffer.from(newManifest.data.content, 'base64').toString()).repositories;
+
+            // Find repos whose commitSha changed
+            const changes = [];
+            for (const newRepo of newRepos) {
+              const oldRepo = oldRepos.find(r => r.path === newRepo.path);
+              if (oldRepo && oldRepo.commitSha !== newRepo.commitSha) {
+                changes.push({
+                  path: newRepo.path,
+                  remoteUri: newRepo.remoteUri,
+                  oldSha: oldRepo.commitSha,
+                  newSha: newRepo.commitSha,
+                });
+              }
+            }
+
+            return changes;
+          }
+
+          // --- Step 3: Find PRs in commit range using GraphQL ---
+
+          async function findPRsInRange(owner, repo, oldSha, newSha, octokit) {
+            // Get commits in range — handle large ranges by paginating
+            const { data: comparison } = await octokit.rest.repos.compareCommits({
+              owner, repo,
+              base: oldSha,
+              head: newSha,
+            });
+
+            if (comparison.commits.length === 0) {
+              return [];
+            }
+
+            if (comparison.total_commits > 250) {
+              core.warning(`${owner}/${repo} has ${comparison.total_commits} commits in range — only first 250 will be processed`);
+            }
+
+            // Batch query associatedPullRequests via GraphQL
+            const commitAliases = comparison.commits.map((c, i) =>
+              `c${i}: object(oid: "${c.sha}") { ... on Commit { associatedPullRequests(first: 5) { nodes { number } } } }`
+            );
+
+            const prNumbers = new Set();
+            for (let i = 0; i < commitAliases.length; i += 50) {
+              const batch = commitAliases.slice(i, i + 50);
+              const query = `query { repository(owner: "${owner}", name: "${repo}") { ${batch.join('\n')} } }`;
+
+              const result = await octokit.graphql(query);
+
+              for (const [key, value] of Object.entries(result.repository)) {
+                if (value?.associatedPullRequests?.nodes) {
+                  for (const pr of value.associatedPullRequests.nodes) {
+                    prNumbers.add(pr.number);
+                  }
+                }
+              }
+            }
+
+            return [...prNumbers];
+          }
+
+          // --- Step 4: Ensure milestone exists and apply ---
+
+          async function ensureMilestone(owner, repo, milestoneName, octokit) {
+            // Check if milestone already exists (open then closed)
+            const openMilestones = await octokit.paginate(octokit.rest.issues.listMilestones, {
+              owner, repo, state: 'open', per_page: 100,
+            });
+            let milestone = openMilestones.find(m => m.title === milestoneName);
+
+            if (!milestone) {
+              const closedMilestones = await octokit.paginate(octokit.rest.issues.listMilestones, {
+                owner, repo, state: 'closed', per_page: 100,
+              });
+              milestone = closedMilestones.find(m => m.title === milestoneName);
+            }
+
+            if (!milestone) {
+              core.info(`Creating milestone "${milestoneName}" in ${owner}/${repo}`);
+              try {
+                const { data: created } = await octokit.rest.issues.createMilestone({
+                  owner, repo, title: milestoneName,
+                });
+                return created.number;
+              } catch (e) {
+                // Handle race condition — another run may have created it
+                if (e.status === 422) {
+                  const { data: retryMilestones } = await octokit.rest.issues.listMilestones({
+                    owner, repo, state: 'open', per_page: 100,
+                  });
+                  milestone = retryMilestones.find(m => m.title === milestoneName);
+                  if (milestone) return milestone.number;
+                }
+                throw e;
+              }
+            }
+
+            return milestone.number;
+          }
+
+          async function applyMilestone(owner, repo, prNumber, milestoneNumber, octokit) {
+            // Check if already milestoned
+            const { data: pr } = await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            if (pr.milestone?.number === milestoneNumber) {
+              core.info(`PR ${owner}/${repo}#${prNumber} already has correct milestone`);
+              return;
+            }
+
+            await octokit.rest.issues.update({
+              owner, repo, issue_number: prNumber,
+              milestone: milestoneNumber,
+            });
+            core.info(`Applied milestone to ${owner}/${repo}#${prNumber}`);
+          }
+
+          // --- Step 5: Process deferred PRs ---
+
+          async function processDeferredPRs(milestoneName) {
+            const deferredPRs = await github.paginate(github.rest.issues.listForRepo, {
+              owner: 'dotnet', repo: 'dotnet',
+              labels: 'needs-milestone',
+              state: 'closed',
+              per_page: 100,
+            });
+
+            for (const issue of deferredPRs) {
+              core.info(`Processing deferred PR #${issue.number}`);
+              try {
+                await processOnePR(issue.number, milestoneName);
+
+                // Only remove label if processing fully succeeded
+                await github.rest.issues.removeLabel({
+                  owner: 'dotnet', repo: 'dotnet',
+                  issue_number: issue.number,
+                  name: 'needs-milestone',
+                });
+              } catch (e) {
+                // Keep the label so it gets retried on next run
+                core.warning(`Failed to process deferred PR #${issue.number}: ${e.message}`);
+              }
+            }
+          }
+
+          // --- Core logic: process a single dotnet/dotnet PR ---
+
+          async function processOnePR(prNumber, milestoneName) {
+            const changes = await extractChildPRs(prNumber);
+
+            for (const change of changes) {
+              const urlMatch = change.remoteUri.match(/github\.com\/([^/]+)\/([^/]+)/);
+              if (!urlMatch) {
+                core.warning(`Could not parse remote URI: ${change.remoteUri}`);
+                continue;
+              }
+
+              const [, owner, repo] = urlMatch;
+
+              if (!SUPPORTED_ORGS.has(owner.toLowerCase())) {
+                core.info(`Skipping ${owner}/${repo} — org not configured for milestoning`);
+                continue;
+              }
+
+              if (OPTED_OUT_REPOS.has(`${owner}/${repo}`.toLowerCase())) {
+                core.info(`Skipping ${owner}/${repo} — opted out of auto-milestoning`);
+                continue;
+              }
+
+              const octokit = getOctokit(owner);
+
+              core.info(`Processing ${owner}/${repo}: ${change.oldSha.substring(0, 8)}..${change.newSha.substring(0, 8)}`);
+
+              const prNumbers = await findPRsInRange(owner, repo, change.oldSha, change.newSha, octokit);
+              core.info(`Found ${prNumbers.length} PRs: ${prNumbers.join(', ')}`);
+
+              if (prNumbers.length === 0) continue;
+
+              const milestoneNumber = await ensureMilestone(owner, repo, milestoneName, octokit);
+
+              for (const childPR of prNumbers) {
+                try {
+                  await applyMilestone(owner, repo, childPR, milestoneNumber, octokit);
+                } catch (e) {
+                  core.warning(`Failed to milestone ${owner}/${repo}#${childPR}: ${e.message}`);
+                }
+              }
+            }
+          }
+
+          // --- Main ---
+
+          const milestone = await resolveMilestone();
+
+          if (!milestone) {
+            core.info('Could not resolve milestone, skipping');
+            return;
+          }
+
+          if (milestone.deferred) {
+            // Label the PR for later processing
+            await github.rest.issues.addLabels({
+              owner: 'dotnet', repo: 'dotnet',
+              issue_number: context.payload.pull_request.number,
+              labels: ['needs-milestone'],
+            });
+            core.info('Milestone deferred — labeled PR with needs-milestone');
+            return;
+          }
+
+          core.info(`Resolved milestone: ${milestone.name}`);
+
+          // Process the current PR
+          await processOnePR(context.payload.pull_request.number, milestone.name);
+
+          // Process any deferred PRs
+          await processDeferredPRs(milestone.name);

--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -84,22 +84,13 @@ jobs:
           // --- Constants: 7 previews, 2 RCs per release ---
           const MAX_PREVIEWS = 7;
 
-          // Compute the next milestone given a current label+iteration.
-          // preview1→preview2, preview7→rc1, rc1→rc2, rc2→{ver}.0 (RTM)
-          function nextMilestone(ver, label, iteration) {
-            if (label === 'preview' && iteration < MAX_PREVIEWS) {
+          // Compute the next milestone when a preview branch snap is detected.
+          // preview1→preview2, ..., preview7→rc1
+          function nextPreviewMilestone(ver, iteration) {
+            if (iteration < MAX_PREVIEWS) {
               return `${ver}-preview${iteration + 1}`;
             }
-            if (label === 'preview' && iteration >= MAX_PREVIEWS) {
-              return `${ver}-rc1`;
-            }
-            if (label === 'rc' && iteration === 1) {
-              return `${ver}-rc2`;
-            }
-            if (label === 'rc' && iteration === 2) {
-              return `${ver}.0`;
-            }
-            return null; // shouldn't happen
+            return `${ver}-rc1`;
           }
 
           // --- Step 1: Resolve milestone name ---
@@ -226,7 +217,7 @@ jobs:
             }
 
             // Preview snap: preview7→rc1, previewN→preview(N+1)
-            return nextMilestone(ver, label, iteration);
+            return nextPreviewMilestone(ver, iteration);
           }
 
           // --- Step 2: Extract child-repo PRs from source-manifest.json diff ---
@@ -470,7 +461,7 @@ jobs:
             return;
           }
 
-          // For workflow_dispatch, fetch the PR to get its base branch
+          // For workflow_dispatch, fetch the PR to get its base branch and checkout its merge commit
           let baseBranch;
           if (context.payload.pull_request) {
             baseBranch = context.payload.pull_request.base.ref;
@@ -483,6 +474,9 @@ jobs:
               core.setFailed(`PR #${prNumber} has not been merged`);
               return;
             }
+            // Checkout the merge commit so eng/Versions.props matches the PR's state
+            const { execSync } = require('child_process');
+            execSync(`git fetch origin ${pr.merge_commit_sha} --depth=2 && git checkout ${pr.merge_commit_sha}`, { stdio: 'inherit' });
           }
 
           core.info(`Processing PR #${prNumber} against ${baseBranch}`);

--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -7,18 +7,30 @@ on:
       - 'main'
       - 'release/**'
     paths: ['src/source-manifest.json']
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Log actions without making changes'
+        type: boolean
+        default: true
+      pr-number:
+        description: 'PR number to process (required for manual runs)'
+        type: number
+        required: true
 
 permissions:
   contents: read
   pull-requests: read
 
 concurrency:
-  group: milestone-${{ github.event.pull_request.base.ref }}
+  group: milestone-${{ github.event.pull_request.base.ref || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
   apply-milestones:
-    if: github.event.pull_request.merged == true
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -48,9 +60,13 @@ jobs:
           github-token: ${{ steps.dotnet-token.outputs.token }}
         env:
           MICROSOFT_TOKEN: ${{ steps.microsoft-token.outputs.token }}
+          DRY_RUN: ${{ github.event.inputs.dry-run || 'false' }}
         script: |
           const { Octokit } = require("@octokit/rest");
           const microsoftOctokit = new Octokit({ auth: process.env.MICROSOFT_TOKEN });
+          const DRY_RUN = process.env.DRY_RUN === 'true';
+
+          if (DRY_RUN) core.info('🏃 DRY RUN — no milestones will be created or applied');
 
           // Supported orgs for milestoning. Repos outside these orgs are skipped.
           const SUPPORTED_ORGS = new Set(['dotnet', 'microsoft']);
@@ -67,8 +83,7 @@ jobs:
 
           // --- Step 1: Resolve milestone name ---
 
-          async function resolveMilestone() {
-            const branch = context.payload.pull_request.base.ref;
+          async function resolveMilestone(branch) {
 
             // --- Preview/RC release branches ---
             // release/11.0.1xx-preview4 → 11.0-preview4
@@ -339,6 +354,10 @@ jobs:
             }
 
             if (!milestone) {
+              if (DRY_RUN) {
+                core.info(`[DRY RUN] Would create milestone "${milestoneName}" in ${owner}/${repo}`);
+                return -1;  // Sentinel value for dry run
+              }
               core.info(`Creating milestone "${milestoneName}" in ${owner}/${repo}`);
               try {
                 const { data: created } = await octokit.rest.issues.createMilestone({
@@ -362,6 +381,11 @@ jobs:
           }
 
           async function applyMilestone(owner, repo, prNumber, milestoneNumber, octokit) {
+            if (DRY_RUN) {
+              core.info(`[DRY RUN] Would apply milestone to ${owner}/${repo}#${prNumber}`);
+              return;
+            }
+
             // Check if already milestoned
             const { data: pr } = await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber });
             if (pr.milestone?.number === milestoneNumber) {
@@ -455,7 +479,33 @@ jobs:
 
           // --- Main ---
 
-          const milestone = await resolveMilestone();
+          // Resolve the PR number — from event payload or workflow_dispatch input
+          const prNumber = context.payload.pull_request?.number
+            || parseInt(context.payload.inputs?.['pr-number']);
+
+          if (!prNumber) {
+            core.setFailed('No PR number available. For workflow_dispatch, provide pr-number input.');
+            return;
+          }
+
+          // For workflow_dispatch, fetch the PR to get its base branch
+          let baseBranch;
+          if (context.payload.pull_request) {
+            baseBranch = context.payload.pull_request.base.ref;
+          } else {
+            const { data: pr } = await github.rest.pulls.get({
+              owner: 'dotnet', repo: 'dotnet', pull_number: prNumber,
+            });
+            baseBranch = pr.base.ref;
+            if (!pr.merged) {
+              core.setFailed(`PR #${prNumber} has not been merged`);
+              return;
+            }
+          }
+
+          core.info(`Processing PR #${prNumber} against ${baseBranch}`);
+
+          const milestone = await resolveMilestone(baseBranch);
 
           if (!milestone) {
             core.info('Could not resolve milestone, skipping');
@@ -463,12 +513,15 @@ jobs:
           }
 
           if (milestone.deferred) {
-            // Label the PR for later processing
-            await github.rest.issues.addLabels({
-              owner: 'dotnet', repo: 'dotnet',
-              issue_number: context.payload.pull_request.number,
-              labels: ['needs-milestone'],
-            });
+            if (DRY_RUN) {
+              core.info(`[DRY RUN] Would label PR #${prNumber} with needs-milestone`);
+            } else {
+              await github.rest.issues.addLabels({
+                owner: 'dotnet', repo: 'dotnet',
+                issue_number: prNumber,
+                labels: ['needs-milestone'],
+              });
+            }
             core.info('Milestone deferred — labeled PR with needs-milestone');
             return;
           }
@@ -476,10 +529,11 @@ jobs:
           core.info(`Resolved milestone: ${milestone.name}`);
 
           // Process the current PR
-          await processOnePR(context.payload.pull_request.number, milestone.name);
+          await processOnePR(prNumber, milestone.name);
 
           // Process any deferred PRs (only on main — deferral only happens on main)
-          const branch = context.payload.pull_request.base.ref;
-          if (branch === 'main') {
+          if (baseBranch === 'main' && !DRY_RUN) {
             await processDeferredPRs(milestone.name);
+          } else if (baseBranch === 'main' && DRY_RUN) {
+            core.info('[DRY RUN] Would process deferred PRs with milestone: ' + milestone.name);
           }

--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -56,434 +56,434 @@ jobs:
 
       - name: Apply milestones
         uses: actions/github-script@v7
-        with:
-          github-token: ${{ steps.dotnet-token.outputs.token }}
         env:
           DOTNET_TOKEN: ${{ steps.dotnet-token.outputs.token }}
           MICROSOFT_TOKEN: ${{ steps.microsoft-token.outputs.token }}
           DRY_RUN: ${{ github.event.inputs.dry-run || 'false' }}
-        script: |
-          const { Octokit } = require("@octokit/rest");
-          const DRY_RUN = process.env.DRY_RUN === 'true';
+        with:
+          github-token: ${{ steps.dotnet-token.outputs.token }}
+          script: |
+            const { Octokit } = require("@octokit/rest");
+            const DRY_RUN = process.env.DRY_RUN === 'true';
 
-          if (DRY_RUN) core.info('DRY RUN -- no milestones will be created or applied');
+            if (DRY_RUN) core.info('DRY RUN -- no milestones will be created or applied');
 
-          // Map of org -> authenticated Octokit client
-          const orgClients = {
-            dotnet: github,
-            microsoft: new Octokit({ auth: process.env.MICROSOFT_TOKEN }),
-          };
+            // Map of org -> authenticated Octokit client
+            const orgClients = {
+              dotnet: github,
+              microsoft: new Octokit({ auth: process.env.MICROSOFT_TOKEN }),
+            };
 
-          function getOctokit(owner) {
-            return orgClients[owner.toLowerCase()] || null;
-          }
-
-          // Repos that have opted out of auto-milestoning
-          const fs = require('fs');
-          const config = JSON.parse(fs.readFileSync('.github/milestone-config.json', 'utf8'));
-          const OPTED_OUT_REPOS = new Set(config.optedOutRepos.map(r => r.toLowerCase()));
-
-          // --- Constants: 7 previews, 2 RCs per release ---
-          const MAX_PREVIEWS = 7;
-
-          // Compute the next milestone when a preview branch snap is detected.
-          // preview1→preview2, ..., preview7→rc1
-          function nextPreviewMilestone(ver, iteration) {
-            if (iteration < MAX_PREVIEWS) {
-              return `${ver}-preview${iteration + 1}`;
-            }
-            return `${ver}-rc1`;
-          }
-
-          // --- Step 1: Resolve milestone name ---
-
-          async function resolveMilestone(branch) {
-
-            // --- Preview/RC release branches ---
-            // release/11.0.1xx-preview4 → 11.0-preview4
-            const releaseMatch = branch.match(/^release\/(\d+\.\d+)\.1xx-((?:preview|rc)\d+)$/);
-            if (releaseMatch) {
-              return `${releaseMatch[1]}-${releaseMatch[2]}`;
+            function getOctokit(owner) {
+              return orgClients[owner.toLowerCase()] || null;
             }
 
-            // --- Bare release branches (e.g. release/11.0.1xx) ---
-            // Only active during the narrow window where this branch is staging rc2:
-            // branding is "rc2", release/X.Y.1xx-rc1 exists, but release/X.Y.1xx-rc2 does not.
-            const bareMatch = branch.match(/^release\/(\d+\.\d+)\.(\d+)xx$/);
-            if (bareMatch) {
-              const ver = bareMatch[1];
-              const featureBand = bareMatch[2];
+            // Repos that have opted out of auto-milestoning
+            const fs = require('fs');
+            const config = JSON.parse(fs.readFileSync('.github/milestone-config.json', 'utf8'));
+            const OPTED_OUT_REPOS = new Set(config.optedOutRepos.map(r => r.toLowerCase()));
 
+            // --- Constants: 7 previews, 2 RCs per release ---
+            const MAX_PREVIEWS = 7;
+
+            // Compute the next milestone when a preview branch snap is detected.
+            // preview1→preview2, ..., preview7→rc1
+            function nextPreviewMilestone(ver, iteration) {
+              if (iteration < MAX_PREVIEWS) {
+                return `${ver}-preview${iteration + 1}`;
+              }
+              return `${ver}-rc1`;
+            }
+
+            // --- Step 1: Resolve milestone name ---
+
+            async function resolveMilestone(branch) {
+
+              // --- Preview/RC release branches ---
+              // release/11.0.1xx-preview4 → 11.0-preview4
+              const releaseMatch = branch.match(/^release\/(\d+\.\d+)\.1xx-((?:preview|rc)\d+)$/);
+              if (releaseMatch) {
+                return `${releaseMatch[1]}-${releaseMatch[2]}`;
+              }
+
+              // --- Bare release branches (e.g. release/11.0.1xx) ---
+              // Only active during the narrow window where this branch is staging rc2:
+              // branding is "rc2", release/X.Y.1xx-rc1 exists, but release/X.Y.1xx-rc2 does not.
+              const bareMatch = branch.match(/^release\/(\d+\.\d+)\.(\d+)xx$/);
+              if (bareMatch) {
+                const ver = bareMatch[1];
+                const featureBand = bareMatch[2];
+
+                const fs = require('fs');
+                const versionsProps = fs.readFileSync('eng/Versions.props', 'utf8');
+
+                // Skip if servicing (patch > 0)
+                const patchMatch = versionsProps.match(/<VersionSDKMinorPatch>(\d+)<\/VersionSDKMinorPatch>/);
+                const patch = patchMatch ? parseInt(patchMatch[1]) : -1;
+                if (patch !== 0) {
+                  core.info(`Bare release branch ${branch} has patch version ${patch} (servicing), skipping`);
+                  return null;
+                }
+
+                // Only proceed if branding is rc2
+                const labelMatch = versionsProps.match(/<PreReleaseVersionLabel>([^<]+)<\/PreReleaseVersionLabel>/);
+                const iterationMatch = versionsProps.match(/<PreReleaseVersionIteration>(\d*)<\/PreReleaseVersionIteration>/);
+                const label = labelMatch ? labelMatch[1] : '';
+                const iteration = parseInt(iterationMatch?.[1] || '0');
+
+                if (label !== 'rc' || iteration !== 2) {
+                  core.info(`Bare release branch ${branch} branded as "${label}${iteration}", not rc2 — skipping`);
+                  return null;
+                }
+
+                // Only active if rc2 branch hasn't been snapped yet
+                try {
+                  await github.rest.repos.getBranch({
+                    owner: 'dotnet', repo: 'dotnet',
+                    branch: `release/${ver}.${featureBand}xx-rc2`,
+                  });
+                  core.info(`Bare release branch ${branch}: rc2 branch already snapped, skipping`);
+                  return null;
+                } catch (e) {
+                  if (e.status !== 404) throw e;
+                }
+
+                return `${ver}-rc2`;
+              }
+
+              // --- Any other release branch format: skip ---
+              if (branch.startsWith('release/')) {
+                core.info(`Release branch ${branch} does not match expected patterns, skipping`);
+                return null;
+              }
+
+              // --- Main branch ---
               const fs = require('fs');
               const versionsProps = fs.readFileSync('eng/Versions.props', 'utf8');
 
-              // Skip if servicing (patch > 0)
-              const patchMatch = versionsProps.match(/<VersionSDKMinorPatch>(\d+)<\/VersionSDKMinorPatch>/);
-              const patch = patchMatch ? parseInt(patchMatch[1]) : -1;
-              if (patch !== 0) {
-                core.info(`Bare release branch ${branch} has patch version ${patch} (servicing), skipping`);
-                return null;
-              }
-
-              // Only proceed if branding is rc2
+              const majorMatch = versionsProps.match(/<VersionMajor>(\d+)<\/VersionMajor>/);
+              const minorMatch = versionsProps.match(/<VersionMinor>(\d+)<\/VersionMinor>/);
               const labelMatch = versionsProps.match(/<PreReleaseVersionLabel>([^<]+)<\/PreReleaseVersionLabel>/);
               const iterationMatch = versionsProps.match(/<PreReleaseVersionIteration>(\d*)<\/PreReleaseVersionIteration>/);
-              const label = labelMatch ? labelMatch[1] : '';
-              const iteration = parseInt(iterationMatch?.[1] || '0');
 
-              if (label !== 'rc' || iteration !== 2) {
-                core.info(`Bare release branch ${branch} branded as "${label}${iteration}", not rc2 — skipping`);
+              if (!majorMatch || !labelMatch) {
+                core.warning('Could not parse version from eng/Versions.props');
                 return null;
               }
 
-              // Only active if rc2 branch hasn't been snapped yet
+              const major = parseInt(majorMatch[1]);
+              const minor = minorMatch ? minorMatch[1] : '0';
+              const label = labelMatch[1];
+              const iteration = parseInt(iterationMatch?.[1] || '0');
+              const ver = `${major}.${minor}`;
+
+              if (label === 'servicing') {
+                core.info('Main branch is branded as servicing, skipping');
+                return null;
+              }
+
+              // Alpha always maps to preview1
+              if (label === 'alpha') {
+                return `${ver}-preview1`;
+              }
+
+              // Check if a release branch matching current branding exists
+              const fullLabel = `${label}${iteration}`;
+              const candidateBranch = `release/${ver}.1xx-${fullLabel}`;
+              let branchExists = false;
               try {
                 await github.rest.repos.getBranch({
                   owner: 'dotnet', repo: 'dotnet',
-                  branch: `release/${ver}.${featureBand}xx-rc2`,
+                  branch: candidateBranch,
                 });
-                core.info(`Bare release branch ${branch}: rc2 branch already snapped, skipping`);
-                return null;
+                branchExists = true;
               } catch (e) {
                 if (e.status !== 404) throw e;
               }
 
-              return `${ver}-rc2`;
-            }
-
-            // --- Any other release branch format: skip ---
-            if (branch.startsWith('release/')) {
-              core.info(`Release branch ${branch} does not match expected patterns, skipping`);
-              return null;
-            }
-
-            // --- Main branch ---
-            const fs = require('fs');
-            const versionsProps = fs.readFileSync('eng/Versions.props', 'utf8');
-
-            const majorMatch = versionsProps.match(/<VersionMajor>(\d+)<\/VersionMajor>/);
-            const minorMatch = versionsProps.match(/<VersionMinor>(\d+)<\/VersionMinor>/);
-            const labelMatch = versionsProps.match(/<PreReleaseVersionLabel>([^<]+)<\/PreReleaseVersionLabel>/);
-            const iterationMatch = versionsProps.match(/<PreReleaseVersionIteration>(\d*)<\/PreReleaseVersionIteration>/);
-
-            if (!majorMatch || !labelMatch) {
-              core.warning('Could not parse version from eng/Versions.props');
-              return null;
-            }
-
-            const major = parseInt(majorMatch[1]);
-            const minor = minorMatch ? minorMatch[1] : '0';
-            const label = labelMatch[1];
-            const iteration = parseInt(iterationMatch?.[1] || '0');
-            const ver = `${major}.${minor}`;
-
-            if (label === 'servicing') {
-              core.info('Main branch is branded as servicing, skipping');
-              return null;
-            }
-
-            // Alpha always maps to preview1
-            if (label === 'alpha') {
-              return `${ver}-preview1`;
-            }
-
-            // Check if a release branch matching current branding exists
-            const fullLabel = `${label}${iteration}`;
-            const candidateBranch = `release/${ver}.1xx-${fullLabel}`;
-            let branchExists = false;
-            try {
-              await github.rest.repos.getBranch({
-                owner: 'dotnet', repo: 'dotnet',
-                branch: candidateBranch,
-              });
-              branchExists = true;
-            } catch (e) {
-              if (e.status !== 404) throw e;
-            }
-
-            if (!branchExists) {
-              // Normal case: branding matches
-              return `${ver}-${fullLabel}`;
-            }
-
-            // Branch exists → branding is stale. Deterministically increment.
-            // RC snap means main is now vNext
-            if (label === 'rc') {
-              return `${major + 1}.0-preview1`;
-            }
-
-            // Preview snap: preview7→rc1, previewN→preview(N+1)
-            return nextPreviewMilestone(ver, iteration);
-          }
-
-          // --- Step 2: Extract child-repo PRs from source-manifest.json diff ---
-
-          async function extractChildPRs(prNumber) {
-            // Get the files changed in the PR (paginated)
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner: 'dotnet', repo: 'dotnet', pull_number: prNumber,
-            });
-
-            const manifestFile = files.find(f => f.filename === 'src/source-manifest.json');
-            if (!manifestFile) {
-              core.info('No source-manifest.json change found');
-              return [];
-            }
-
-            // Fetch the merge commit SHA from the PR itself (works for both
-            // current event and deferred PRs)
-            const { data: pr } = await github.rest.pulls.get({
-              owner: 'dotnet', repo: 'dotnet', pull_number: prNumber,
-            });
-            const mergeCommitSha = pr.merge_commit_sha;
-            if (!mergeCommitSha) {
-              core.warning(`PR #${prNumber} has no merge commit`);
-              return [];
-            }
-
-            const { data: mergeCommit } = await github.rest.repos.getCommit({
-              owner: 'dotnet', repo: 'dotnet', ref: mergeCommitSha,
-            });
-            const parentSha = mergeCommit.parents[0].sha;
-
-            const [oldManifest, newManifest] = await Promise.all([
-              github.rest.repos.getContent({
-                owner: 'dotnet', repo: 'dotnet',
-                path: 'src/source-manifest.json',
-                ref: parentSha,
-              }),
-              github.rest.repos.getContent({
-                owner: 'dotnet', repo: 'dotnet',
-                path: 'src/source-manifest.json',
-                ref: mergeCommitSha,
-              }),
-            ]);
-
-            const oldRepos = JSON.parse(Buffer.from(oldManifest.data.content, 'base64').toString()).repositories;
-            const newRepos = JSON.parse(Buffer.from(newManifest.data.content, 'base64').toString()).repositories;
-
-            // Find repos whose commitSha changed
-            const changes = [];
-            for (const newRepo of newRepos) {
-              const oldRepo = oldRepos.find(r => r.path === newRepo.path);
-              if (oldRepo && oldRepo.commitSha !== newRepo.commitSha) {
-                changes.push({
-                  path: newRepo.path,
-                  remoteUri: newRepo.remoteUri,
-                  oldSha: oldRepo.commitSha,
-                  newSha: newRepo.commitSha,
-                });
+              if (!branchExists) {
+                // Normal case: branding matches
+                return `${ver}-${fullLabel}`;
               }
+
+              // Branch exists → branding is stale. Deterministically increment.
+              // RC snap means main is now vNext
+              if (label === 'rc') {
+                return `${major + 1}.0-preview1`;
+              }
+
+              // Preview snap: preview7→rc1, previewN→preview(N+1)
+              return nextPreviewMilestone(ver, iteration);
             }
 
-            return changes;
-          }
+            // --- Step 2: Extract child-repo PRs from source-manifest.json diff ---
 
-          // --- Step 3: Find PRs in commit range using GraphQL ---
-
-          async function findPRsInRange(owner, repo, oldSha, newSha, octokit) {
-            // Collect all commits in range, paginating if > 250
-            const allCommits = [];
-            let currentBase = oldSha;
-
-            while (true) {
-              const { data: comparison } = await octokit.rest.repos.compareCommits({
-                owner, repo,
-                base: currentBase,
-                head: newSha,
-                per_page: 250,
+            async function extractChildPRs(prNumber) {
+              // Get the files changed in the PR (paginated)
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner: 'dotnet', repo: 'dotnet', pull_number: prNumber,
               });
 
-              if (comparison.commits.length === 0) break;
-
-              allCommits.push(...comparison.commits);
-
-              // If we got all commits, we're done
-              if (allCommits.length >= comparison.total_commits) break;
-
-              // Move the base forward to the last commit we got
-              currentBase = comparison.commits[comparison.commits.length - 1].sha;
-            }
-
-            if (allCommits.length === 0) return [];
-
-            core.info(`${owner}/${repo}: ${allCommits.length} commits in range`);
-
-            // Batch query associatedPullRequests via GraphQL
-            const commitAliases = allCommits.map((c, i) =>
-              `c${i}: object(oid: "${c.sha}") { ... on Commit { associatedPullRequests(first: 10) { nodes { number } } } }`
-            );
-
-            const prNumbers = new Set();
-            for (let i = 0; i < commitAliases.length; i += 50) {
-              const batch = commitAliases.slice(i, i + 50);
-              const query = `query { repository(owner: "${owner}", name: "${repo}") { ${batch.join('\n')} } }`;
-
-              const result = await octokit.graphql(query);
-
-              for (const [key, value] of Object.entries(result.repository)) {
-                if (value?.associatedPullRequests?.nodes) {
-                  for (const pr of value.associatedPullRequests.nodes) {
-                    prNumbers.add(pr.number);
-                  }
-                }
+              const manifestFile = files.find(f => f.filename === 'src/source-manifest.json');
+              if (!manifestFile) {
+                core.info('No source-manifest.json change found');
+                return [];
               }
-            }
 
-            return [...prNumbers];
-          }
-
-          // --- Step 4: Ensure milestone exists and apply ---
-
-          async function ensureMilestone(owner, repo, milestoneName, octokit) {
-            // Check if milestone already exists (open then closed)
-            const openMilestones = await octokit.paginate(octokit.rest.issues.listMilestones, {
-              owner, repo, state: 'open', per_page: 100,
-            });
-            let milestone = openMilestones.find(m => m.title === milestoneName);
-
-            if (!milestone) {
-              const closedMilestones = await octokit.paginate(octokit.rest.issues.listMilestones, {
-                owner, repo, state: 'closed', per_page: 100,
+              // Fetch the merge commit SHA from the PR itself (works for both
+              // current event and deferred PRs)
+              const { data: pr } = await github.rest.pulls.get({
+                owner: 'dotnet', repo: 'dotnet', pull_number: prNumber,
               });
-              milestone = closedMilestones.find(m => m.title === milestoneName);
-            }
-
-            if (!milestone) {
-              if (DRY_RUN) {
-                core.info(`[DRY RUN] Would create milestone "${milestoneName}" in ${owner}/${repo}`);
-                return -1;  // Sentinel value for dry run
+              const mergeCommitSha = pr.merge_commit_sha;
+              if (!mergeCommitSha) {
+                core.warning(`PR #${prNumber} has no merge commit`);
+                return [];
               }
-              core.info(`Creating milestone "${milestoneName}" in ${owner}/${repo}`);
-              try {
-                const { data: created } = await octokit.rest.issues.createMilestone({
-                  owner, repo, title: milestoneName,
-                });
-                return created.number;
-              } catch (e) {
-                // Handle race condition — another run may have created it
-                if (e.status === 422) {
-                  const retryMilestones = await octokit.paginate(octokit.rest.issues.listMilestones, {
-                    owner, repo, state: 'open', per_page: 100,
+
+              const { data: mergeCommit } = await github.rest.repos.getCommit({
+                owner: 'dotnet', repo: 'dotnet', ref: mergeCommitSha,
+              });
+              const parentSha = mergeCommit.parents[0].sha;
+
+              const [oldManifest, newManifest] = await Promise.all([
+                github.rest.repos.getContent({
+                  owner: 'dotnet', repo: 'dotnet',
+                  path: 'src/source-manifest.json',
+                  ref: parentSha,
+                }),
+                github.rest.repos.getContent({
+                  owner: 'dotnet', repo: 'dotnet',
+                  path: 'src/source-manifest.json',
+                  ref: mergeCommitSha,
+                }),
+              ]);
+
+              const oldRepos = JSON.parse(Buffer.from(oldManifest.data.content, 'base64').toString()).repositories;
+              const newRepos = JSON.parse(Buffer.from(newManifest.data.content, 'base64').toString()).repositories;
+
+              // Find repos whose commitSha changed
+              const changes = [];
+              for (const newRepo of newRepos) {
+                const oldRepo = oldRepos.find(r => r.path === newRepo.path);
+                if (oldRepo && oldRepo.commitSha !== newRepo.commitSha) {
+                  changes.push({
+                    path: newRepo.path,
+                    remoteUri: newRepo.remoteUri,
+                    oldSha: oldRepo.commitSha,
+                    newSha: newRepo.commitSha,
                   });
-                  milestone = retryMilestones.find(m => m.title === milestoneName);
-                  if (milestone) return milestone.number;
                 }
-                throw e;
               }
+
+              return changes;
             }
 
-            return milestone.number;
-          }
+            // --- Step 3: Find PRs in commit range using GraphQL ---
 
-          async function applyMilestone(owner, repo, prNumber, milestoneNumber, octokit) {
-            if (DRY_RUN) {
-              core.info(`[DRY RUN] Would apply milestone to ${owner}/${repo}#${prNumber}`);
-              return;
-            }
+            async function findPRsInRange(owner, repo, oldSha, newSha, octokit) {
+              // Collect all commits in range, paginating if > 250
+              const allCommits = [];
+              let currentBase = oldSha;
 
-            // Check if already milestoned
-            const { data: pr } = await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber });
-            if (pr.milestone?.number === milestoneNumber) {
-              core.info(`PR ${owner}/${repo}#${prNumber} already has correct milestone`);
-              return;
-            }
+              while (true) {
+                const { data: comparison } = await octokit.rest.repos.compareCommits({
+                  owner, repo,
+                  base: currentBase,
+                  head: newSha,
+                  per_page: 250,
+                });
 
-            await octokit.rest.issues.update({
-              owner, repo, issue_number: prNumber,
-              milestone: milestoneNumber,
-            });
-            core.info(`Applied milestone to ${owner}/${repo}#${prNumber}`);
-          }
+                if (comparison.commits.length === 0) break;
 
-          // --- Core logic: process a single dotnet/dotnet PR ---
+                allCommits.push(...comparison.commits);
 
-          async function processOnePR(prNumber, milestoneName) {
-            const changes = await extractChildPRs(prNumber);
+                // If we got all commits, we're done
+                if (allCommits.length >= comparison.total_commits) break;
 
-            for (const change of changes) {
-              try {
-                const urlMatch = change.remoteUri.match(/github\.com\/([^/]+)\/([^/]+)/);
-                if (!urlMatch) {
-                  core.warning(`Could not parse remote URI: ${change.remoteUri}`);
-                  continue;
-                }
+                // Move the base forward to the last commit we got
+                currentBase = comparison.commits[comparison.commits.length - 1].sha;
+              }
 
-                const [, owner, repoRaw] = urlMatch;
-                const repo = repoRaw.replace(/\.git$/, '');
+              if (allCommits.length === 0) return [];
 
-                if (OPTED_OUT_REPOS.has(`${owner}/${repo}`.toLowerCase())) {
-                  core.info(`Skipping ${owner}/${repo} — opted out of auto-milestoning`);
-                  continue;
-                }
+              core.info(`${owner}/${repo}: ${allCommits.length} commits in range`);
 
-                const octokit = getOctokit(owner);
-                if (!octokit) {
-                  core.info(`Skipping ${owner}/${repo} — org not configured for milestoning`);
-                  continue;
-                }
+              // Batch query associatedPullRequests via GraphQL
+              const commitAliases = allCommits.map((c, i) =>
+                `c${i}: object(oid: "${c.sha}") { ... on Commit { associatedPullRequests(first: 10) { nodes { number } } } }`
+              );
 
-                core.info(`Processing ${owner}/${repo}: ${change.oldSha.substring(0, 8)}..${change.newSha.substring(0, 8)}`);
+              const prNumbers = new Set();
+              for (let i = 0; i < commitAliases.length; i += 50) {
+                const batch = commitAliases.slice(i, i + 50);
+                const query = `query { repository(owner: "${owner}", name: "${repo}") { ${batch.join('\n')} } }`;
 
-                const prNumbers = await findPRsInRange(owner, repo, change.oldSha, change.newSha, octokit);
-                core.info(`Found ${prNumbers.length} PRs: ${prNumbers.join(', ')}`);
+                const result = await octokit.graphql(query);
 
-                if (prNumbers.length === 0) continue;
-
-                const milestoneNumber = await ensureMilestone(owner, repo, milestoneName, octokit);
-
-                for (const childPR of prNumbers) {
-                  try {
-                    await applyMilestone(owner, repo, childPR, milestoneNumber, octokit);
-                  } catch (e) {
-                    core.warning(`Failed to milestone ${owner}/${repo}#${childPR}: ${e.message}`);
+                for (const [key, value] of Object.entries(result.repository)) {
+                  if (value?.associatedPullRequests?.nodes) {
+                    for (const pr of value.associatedPullRequests.nodes) {
+                      prNumbers.add(pr.number);
+                    }
                   }
                 }
-              } catch (e) {
-                core.warning(`Failed to process repo ${change.remoteUri}: ${e.message}`);
+              }
+
+              return [...prNumbers];
+            }
+
+            // --- Step 4: Ensure milestone exists and apply ---
+
+            async function ensureMilestone(owner, repo, milestoneName, octokit) {
+              // Check if milestone already exists (open then closed)
+              const openMilestones = await octokit.paginate(octokit.rest.issues.listMilestones, {
+                owner, repo, state: 'open', per_page: 100,
+              });
+              let milestone = openMilestones.find(m => m.title === milestoneName);
+
+              if (!milestone) {
+                const closedMilestones = await octokit.paginate(octokit.rest.issues.listMilestones, {
+                  owner, repo, state: 'closed', per_page: 100,
+                });
+                milestone = closedMilestones.find(m => m.title === milestoneName);
+              }
+
+              if (!milestone) {
+                if (DRY_RUN) {
+                  core.info(`[DRY RUN] Would create milestone "${milestoneName}" in ${owner}/${repo}`);
+                  return -1;  // Sentinel value for dry run
+                }
+                core.info(`Creating milestone "${milestoneName}" in ${owner}/${repo}`);
+                try {
+                  const { data: created } = await octokit.rest.issues.createMilestone({
+                    owner, repo, title: milestoneName,
+                  });
+                  return created.number;
+                } catch (e) {
+                  // Handle race condition — another run may have created it
+                  if (e.status === 422) {
+                    const retryMilestones = await octokit.paginate(octokit.rest.issues.listMilestones, {
+                      owner, repo, state: 'open', per_page: 100,
+                    });
+                    milestone = retryMilestones.find(m => m.title === milestoneName);
+                    if (milestone) return milestone.number;
+                  }
+                  throw e;
+                }
+              }
+
+              return milestone.number;
+            }
+
+            async function applyMilestone(owner, repo, prNumber, milestoneNumber, octokit) {
+              if (DRY_RUN) {
+                core.info(`[DRY RUN] Would apply milestone to ${owner}/${repo}#${prNumber}`);
+                return;
+              }
+
+              // Check if already milestoned
+              const { data: pr } = await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber });
+              if (pr.milestone?.number === milestoneNumber) {
+                core.info(`PR ${owner}/${repo}#${prNumber} already has correct milestone`);
+                return;
+              }
+
+              await octokit.rest.issues.update({
+                owner, repo, issue_number: prNumber,
+                milestone: milestoneNumber,
+              });
+              core.info(`Applied milestone to ${owner}/${repo}#${prNumber}`);
+            }
+
+            // --- Core logic: process a single dotnet/dotnet PR ---
+
+            async function processOnePR(prNumber, milestoneName) {
+              const changes = await extractChildPRs(prNumber);
+
+              for (const change of changes) {
+                try {
+                  const urlMatch = change.remoteUri.match(/github\.com\/([^/]+)\/([^/]+)/);
+                  if (!urlMatch) {
+                    core.warning(`Could not parse remote URI: ${change.remoteUri}`);
+                    continue;
+                  }
+
+                  const [, owner, repoRaw] = urlMatch;
+                  const repo = repoRaw.replace(/\.git$/, '');
+
+                  if (OPTED_OUT_REPOS.has(`${owner}/${repo}`.toLowerCase())) {
+                    core.info(`Skipping ${owner}/${repo} — opted out of auto-milestoning`);
+                    continue;
+                  }
+
+                  const octokit = getOctokit(owner);
+                  if (!octokit) {
+                    core.info(`Skipping ${owner}/${repo} — org not configured for milestoning`);
+                    continue;
+                  }
+
+                  core.info(`Processing ${owner}/${repo}: ${change.oldSha.substring(0, 8)}..${change.newSha.substring(0, 8)}`);
+
+                  const prNumbers = await findPRsInRange(owner, repo, change.oldSha, change.newSha, octokit);
+                  core.info(`Found ${prNumbers.length} PRs: ${prNumbers.join(', ')}`);
+
+                  if (prNumbers.length === 0) continue;
+
+                  const milestoneNumber = await ensureMilestone(owner, repo, milestoneName, octokit);
+
+                  for (const childPR of prNumbers) {
+                    try {
+                      await applyMilestone(owner, repo, childPR, milestoneNumber, octokit);
+                    } catch (e) {
+                      core.warning(`Failed to milestone ${owner}/${repo}#${childPR}: ${e.message}`);
+                    }
+                  }
+                } catch (e) {
+                  core.warning(`Failed to process repo ${change.remoteUri}: ${e.message}`);
+                }
               }
             }
-          }
 
-          // --- Main ---
+            // --- Main ---
 
-          // Resolve the PR number — from event payload or workflow_dispatch input
-          const prNumber = context.payload.pull_request?.number
-            || parseInt(context.payload.inputs?.['pr-number']);
+            // Resolve the PR number — from event payload or workflow_dispatch input
+            const prNumber = context.payload.pull_request?.number
+              || parseInt(context.payload.inputs?.['pr-number']);
 
-          if (!prNumber) {
-            core.setFailed('No PR number available. For workflow_dispatch, provide pr-number input.');
-            return;
-          }
-
-          // For workflow_dispatch, fetch the PR to get its base branch and checkout its merge commit
-          let baseBranch;
-          if (context.payload.pull_request) {
-            baseBranch = context.payload.pull_request.base.ref;
-          } else {
-            const { data: pr } = await github.rest.pulls.get({
-              owner: 'dotnet', repo: 'dotnet', pull_number: prNumber,
-            });
-            baseBranch = pr.base.ref;
-            if (!pr.merged) {
-              core.setFailed(`PR #${prNumber} has not been merged`);
+            if (!prNumber) {
+              core.setFailed('No PR number available. For workflow_dispatch, provide pr-number input.');
               return;
             }
-            // Checkout the merge commit so eng/Versions.props matches the PR's state
-            const { execSync } = require('child_process');
-            execSync(`git fetch origin ${pr.merge_commit_sha} --depth=2 && git checkout ${pr.merge_commit_sha}`, { stdio: 'inherit' });
-          }
 
-          core.info(`Processing PR #${prNumber} against ${baseBranch}`);
+            // For workflow_dispatch, fetch the PR to get its base branch and checkout its merge commit
+            let baseBranch;
+            if (context.payload.pull_request) {
+              baseBranch = context.payload.pull_request.base.ref;
+            } else {
+              const { data: pr } = await github.rest.pulls.get({
+                owner: 'dotnet', repo: 'dotnet', pull_number: prNumber,
+              });
+              baseBranch = pr.base.ref;
+              if (!pr.merged) {
+                core.setFailed(`PR #${prNumber} has not been merged`);
+                return;
+              }
+              // Checkout the merge commit so eng/Versions.props matches the PR's state
+              const { execSync } = require('child_process');
+              execSync(`git fetch origin ${pr.merge_commit_sha} --depth=2 && git checkout ${pr.merge_commit_sha}`, { stdio: 'inherit' });
+            }
 
-          const milestoneName = await resolveMilestone(baseBranch);
+            core.info(`Processing PR #${prNumber} against ${baseBranch}`);
 
-          if (!milestoneName) {
-            core.info('Could not resolve milestone, skipping');
-            return;
-          }
+            const milestoneName = await resolveMilestone(baseBranch);
 
-          core.info(`Resolved milestone: ${milestoneName}`);
+            if (!milestoneName) {
+              core.info('Could not resolve milestone, skipping');
+              return;
+            }
 
-          // Process the current PR
-          await processOnePR(prNumber, milestoneName);
+            core.info(`Resolved milestone: ${milestoneName}`);
+
+            // Process the current PR
+            await processOnePR(prNumber, milestoneName);

--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -134,24 +134,16 @@ jobs:
                 return null;
               }
 
-              // Check that rc1 exists but rc2 does NOT
-              let rc1Exists = false, rc2Exists = false;
-              for (const rcN of ['rc1', 'rc2']) {
-                try {
-                  await github.rest.repos.getBranch({
-                    owner: 'dotnet', repo: 'dotnet',
-                    branch: `release/${ver}.${featureBand}xx-${rcN}`,
-                  });
-                  if (rcN === 'rc1') rc1Exists = true;
-                  if (rcN === 'rc2') rc2Exists = true;
-                } catch (e) {
-                  if (e.status !== 404) throw e;
-                }
-              }
-
-              if (!rc1Exists || rc2Exists) {
-                core.info(`Bare release branch ${branch}: rc1=${rc1Exists}, rc2=${rc2Exists} — skipping`);
+              // Only active if rc2 branch hasn't been snapped yet
+              try {
+                await github.rest.repos.getBranch({
+                  owner: 'dotnet', repo: 'dotnet',
+                  branch: `release/${ver}.${featureBand}xx-rc2`,
+                });
+                core.info(`Bare release branch ${branch}: rc2 branch already snapped, skipping`);
                 return null;
+              } catch (e) {
+                if (e.status !== 404) throw e;
               }
 
               return `${ver}-rc2`;

--- a/src/aspnetcore/.github/policies/resourceManagement.yml
+++ b/src/aspnetcore/.github/policies/resourceManagement.yml
@@ -433,27 +433,6 @@ configuration:
           reply: Thanks for your PR, ${issueAuthor}. Someone from the team will get assigned to your PR shortly and we'll get it reviewed.
       description: Label community PRs with `community contribution` label
     - if:
-      - payloadType: Pull_Request
-      - isAction:
-          action: Closed
-      - targetsBranch:
-          branch: main
-      then:
-      - addMilestone:
-          milestone: 11.0-preview5
-      description: '[Milestone Assignments] Assign Milestone to PRs merged to the `main` branch'
-    - if:
-      - payloadType: Pull_Request
-      - isAction:
-          action: Closed
-      - targetsBranch:
-          branch: release/11.0-preview4
-      then:
-      - removeMilestone
-      - addMilestone:
-          milestone: 11.0-preview4
-      description: '[Milestone Assignments] Assign Milestone to PRs merged to release/11.0-preview4 branch'
-    - if:
       - payloadType: Issues
       - isAction:
           action: Labeled

--- a/src/winforms/.github/policies/resourceManagement.yml
+++ b/src/winforms/.github/policies/resourceManagement.yml
@@ -182,23 +182,6 @@ configuration:
       description: In-PR label
     - if:
       - payloadType: Pull_Request
-      - targetsBranch:
-          branch: main
-      - and:
-        - isAction:
-            action: Closed
-        - isMerged
-        - not:
-            titleContains:
-              pattern: '[main] Update dependencies'
-              isRegex: False
-      then:
-      - addMilestone:
-          milestone: 10.0 Preview7
-      description: Apply milestone to PRs on the main branch
-      triggerOnOwnActions: true
-    - if:
-      - payloadType: Pull_Request
       - isActivitySender:
           user: dotnet-maestro[bot]
           issueAuthor: False

--- a/src/wpf/.github/policies/resourceManagement.yml
+++ b/src/wpf/.github/policies/resourceManagement.yml
@@ -217,23 +217,6 @@ configuration:
       description: In-PR label
     - if:
       - payloadType: Pull_Request
-      - targetsBranch:
-          branch: main
-      - and:
-        - isAction:
-            action: Closed
-        - isMerged
-        - not:
-            titleContains:
-              pattern: '[main] Update dependencies'
-              isRegex: False
-      then:
-      - addMilestone:
-          milestone: 7.0 Preview4
-      description: Apply milestone '7.0' to PRs on the main branch
-      triggerOnOwnActions: true
-    - if:
-      - payloadType: Pull_Request
       - isActivitySender:
           user: dotnet-maestro[bot]
           issueAuthor: False


### PR DESCRIPTION
## Summary

Adds a GitHub Action that automatically applies milestones to child-repo PRs when codeflow PRs merge into dotnet/dotnet. Triggered whenever `src/source-manifest.json` is modified on `main` or any `release/**` branch.

## How it works

1. **Diffs `source-manifest.json`** (merge commit vs parent) to find which repo changed and its old→new commit range
2. **Discovers child PRs** via GitHub GraphQL `associatedPullRequests` on each commit in the range (paginated for large ranges)
3. **Resolves the milestone name** based on the target branch (see corner cases below)
4. **Creates the milestone** in the child repo if it doesn't exist, then applies it to each discovered PR

## Milestone resolution by branch type

### Release branches with suffix (e.g. `release/11.0.1xx-preview5`)
Milestone is extracted directly from the branch name: `11.0-preview5`.

### Main branch
Reads `PreReleaseVersionLabel` and `PreReleaseVersionIteration` from `eng/Versions.props` at the merge commit. The label determines behavior:

- **`alpha`**: Always maps to `preview1` (alpha builds ship as part of the first preview).
- **`preview`/`rc` with no matching release branch**: Normal case. Milestone is `{major}.{minor}-{label}{iteration}` (e.g. `11.0-preview5`, `11.0-rc1`).
- **`preview` with matching release branch exists**: Branch was just snapped but branding hasn't been bumped yet. We can't tell if the next milestone is another preview or rc1, so we **defer** by labeling the dotnet/dotnet PR with `needs-milestone`. The next run after branding is updated will process deferred PRs.
- **`rc` with matching release branch exists**: This is the **vNext snap** — main has become the next major version (e.g. main says `rc1`/`11.0` but `release/11.0.1xx-rc1` exists -> main is really `12.0`). Milestone is `{major+1}.0-preview1`.
- **`servicing`**: Skip (shouldn't happen on main).

### Bare release branches (e.g. `release/11.0.1xx`)
These are used during the RC->RTM phase. After snapping `release/11.0.1xx-rc1`, the `release/11.0.1xx` branch becomes the staging branch for rc2 and eventually RTM.

- **`VersionSDKMinorPatch` == 0 AND a sibling `rc1` or `rc2` branch exists**: Active pre-RTM branch. Milestone is read from the branch's own `eng/Versions.props` branding (e.g. `11.0-rc2`).
- **`VersionSDKMinorPatch` != 0**: Servicing branch, skip.
- **No sibling rc branches**: Not in the RC->RTM phase, skip.
- **Branded as `servicing` or empty**: Already shipped RTM, skip.

### Other release branch formats
Skipped (no-op).

## Deferred milestone processing

When the workflow can't determine the correct milestone (preview->rc ambiguity during branch snaps), it labels the dotnet/dotnet PR with `needs-milestone` instead. On subsequent runs against `main` where the milestone resolves successfully, the workflow processes all `needs-milestone`-labeled PRs. The label is only removed after successful processing; failures preserve it for retry.

## Cross-organization support

Repos can be in the `dotnet` or `microsoft` GitHub orgs. A GitHub App installed on both orgs provides separate tokens via `actions/create-github-app-token`. Repos in other orgs are skipped.

## Opt-out

Repos listed in `.github/milestone-config.json` are skipped. Currently opted out:
- Repos with independent versioning schemes (roslyn, msbuild, fsharp, razor, vstest, etc.)
- Repos with non-standard major versions (cecil, diagnostics, command-line-api, etc.)
- NuGet repos (ship on their own cadence)

## Dry-run mode

The workflow supports `workflow_dispatch` with a `dry-run` input (default: true) and a `pr-number` input for testing against any merged PR. In dry-run mode, all read/resolution logic runs normally but no milestones are created, applied, or labels changed.

## Error handling

- **Per-repo isolation**: A failure processing one child repo doesn't block others.
- **Per-PR isolation**: A failure milestoning one PR doesn't block others.
- **Milestone creation race**: Handles 422 "already exists" from concurrent runs.
- **Concurrency**: Workflow runs are serialized per target branch to prevent race conditions in deferred processing.
- **Pagination**: Both commit comparison (250/page) and milestone listing are fully paginated.

## Prerequisites

Before enabling, a GitHub App needs to be created and installed on the `dotnet` and `microsoft` orgs with the following permissions:
- **Issues**: Read & Write (create milestones, apply milestones to PRs, manage `needs-milestone` label)
- **Pull Requests**: Read (list files, get PR details)
- **Contents**: Read (read `source-manifest.json` and `eng/Versions.props` at specific commits)
- **Metadata**: Read (required by all GitHub Apps)

The app ID and private key go into repository secrets `MILESTONE_APP_ID` and `MILESTONE_APP_PRIVATE_KEY`.

## Files

- `.github/workflows/apply-milestones.yml` — the workflow
- `.github/milestone-config.json` — opt-out configuration

## Removed pre-existing automation

This PR also removes preview/rc milestone automation from child repo `resourceManagement.yml` policies that are now superseded by the centralized workflow:

- **aspnetcore**: Removed rules milestoning PRs merged to `main` (11.0-preview5) and `release/11.0-preview4` (11.0-preview4)
- **winforms**: Removed rule milestoning PRs merged to `main` (10.0 Preview7)
- **wpf**: Removed rule milestoning PRs merged to `main` (7.0 Preview4 — very stale)

Servicing milestone policies (e.g. aspnetcore's release/10.0 -> 10.0.9) are left intact since the new workflow only handles preview/rc/RTM milestones, not servicing.