### PR TITLE
Add source index stage 1 upload to official VMR build

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -932,7 +932,7 @@ jobs:
       parameters:
         sourceIndexName: ${{ parameters.sourceIndexName }}
         sourcesPath: $(sourcesPath)
-        logsPath: $(sourcesPath)/artifacts/log
+        logsPath: $(sourcesPath)/artifacts/log/Release
         excludeRepos: ${{ parameters.sourceIndexExcludeRepos }}
         includeRepos: ${{ parameters.sourceIndexIncludeRepos }}
 

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -163,6 +163,20 @@ parameters:
   type: boolean
   default: false
 
+# Source Index: name for the uploaded source index bundle (e.g., 'dotnet-dotnet').
+# When set, processes per-repo Build.binlog files and uploads SLN data.
+- name: sourceIndexName
+  type: string
+  default: ''
+
+- name: sourceIndexExcludeRepos
+  type: string
+  default: ''
+
+- name: sourceIndexIncludeRepos
+  type: string
+  default: ''
+
 jobs:
 - job: ${{ parameters.buildName }}_${{ parameters.targetArchitecture }}${{ replace(format('_BuildPass{0}', coalesce(parameters.buildPass, '1')), '_BuildPass1', '') }}
   pool: ${{ parameters.pool }}
@@ -912,6 +926,15 @@ jobs:
         parameters:
           enableMicrobuild: true
           enableMicrobuildForMacAndLinux: true
+
+  - ${{ if and(ne(parameters.sourceIndexName, ''), eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'PullRequest'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['SourceIndexForce'], 'true'))) }}:
+    - template: ../steps/source-index-stage1.yml
+      parameters:
+        sourceIndexName: ${{ parameters.sourceIndexName }}
+        sourcesPath: $(sourcesPath)
+        logsPath: $(sourcesPath)/artifacts/log
+        excludeRepos: ${{ parameters.sourceIndexExcludeRepos }}
+        includeRepos: ${{ parameters.sourceIndexIncludeRepos }}
 
   # Keep the following two CopyFiles tasks separate to avoid scanning the entire artifacts folder
   - task: CopyFiles@2

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -927,7 +927,7 @@ jobs:
           enableMicrobuild: true
           enableMicrobuildForMacAndLinux: true
 
-  - ${{ if and(ne(parameters.sourceIndexName, ''), eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'PullRequest'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['SourceIndexForce'], 'true'))) }}:
+  - ${{ if and(ne(parameters.sourceIndexName, ''), eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - template: ../steps/source-index-stage1.yml
       parameters:
         sourceIndexName: ${{ parameters.sourceIndexName }}

--- a/eng/pipelines/templates/stages/source-build-and-validate.yml
+++ b/eng/pipelines/templates/stages/source-build-and-validate.yml
@@ -144,6 +144,9 @@ stages:
         brandingType: ${{ variables.brandingType }}
         ${{ if leg.disableBinaryAnalysisCaching }}:
           disableBinaryAnalysisCaching: true
+        ${{ if leg.sourceIndexName }}:
+          sourceIndexName: ${{ leg.sourceIndexName }}
+          sourceIndexExcludeRepos: ${{ leg.sourceIndexExcludeRepos }}
         
         # We only want to publish SB artifacts for each distinct distro/version/arch combination.
         # Stage 2 legs (those with reuseBuildArtifactsFrom) also get extraPropertiesStage2.

--- a/eng/pipelines/templates/stages/source-build-stages.yml
+++ b/eng/pipelines/templates/stages/source-build-stages.yml
@@ -127,6 +127,8 @@ stages:
             withPreviousSDK: false             # 🚫
             disableSigning: true               # ✅
             createSourceArtifact: false        # 🚫
+            sourceIndexName: dotnet-dotnet
+            sourceIndexExcludeRepos: 'winforms wpf windowsdesktop'
             ${{ if in(parameters.scope, 'lite') }}:
               extraProperties: /p:DotNetSkipTestsRequiringMicrosoftArtifacts=true
 

--- a/eng/pipelines/templates/stages/source-build-stages.yml
+++ b/eng/pipelines/templates/stages/source-build-stages.yml
@@ -128,7 +128,7 @@ stages:
             disableSigning: true               # ✅
             createSourceArtifact: false        # 🚫
             sourceIndexName: dotnet-dotnet
-            sourceIndexExcludeRepos: 'winforms wpf windowsdesktop'
+            sourceIndexExcludeRepos: 'winforms wpf windowsdesktop source-build-assets'
             ${{ if in(parameters.scope, 'lite') }}:
               extraProperties: /p:DotNetSkipTestsRequiringMicrosoftArtifacts=true
 

--- a/eng/pipelines/templates/stages/vmr-verticals.yml
+++ b/eng/pipelines/templates/stages/vmr-verticals.yml
@@ -158,6 +158,8 @@ stages:
           targetArchitecture: x64
           enableIBCOptimization: ${{ variables.ibcEnabled }}
           brandingType: ${{ variables.brandingType }}
+          sourceIndexName: dotnet-dotnet-windows
+          sourceIndexIncludeRepos: 'winforms wpf windowsdesktop'
 
     - ${{ if containsValue(parameters.verifications, 'unified-build-windows-x86') }}:
       - template: ../jobs/vmr-build.yml

--- a/eng/pipelines/templates/steps/source-index-stage1.yml
+++ b/eng/pipelines/templates/steps/source-index-stage1.yml
@@ -1,0 +1,102 @@
+### Steps to process multiple per-repo Build.binlog files into SLN format and upload
+### as source index stage 1 data for https://github.com/dotnet/source-indexer.
+###
+### Unlike eng/common/core-templates/steps/source-index-stage1-publish.yml which
+### handles a single binlog, this template processes all per-repo Build.binlog files
+### produced by a VMR build.
+
+parameters:
+  # The name to use when uploading the source index data (e.g., 'dotnet-dotnet')
+  sourceIndexName: ''
+
+  # The root directory of the VMR sources
+  sourcesPath: ''
+
+  # The directory containing per-repo build logs (artifacts/log/<RepoName>/Build.binlog)
+  logsPath: ''
+
+  # Repos to exclude from source indexing (space-separated list of repo directory names)
+  excludeRepos: ''
+
+  # Repos to include (if set, ONLY these repos will be indexed; space-separated)
+  includeRepos: ''
+
+  sourceIndexUploadPackageVersion: 2.0.0-20260505.1
+  sourceIndexProcessBinlogPackageVersion: 1.0.1-20260505.1
+  sourceIndexPackageSource: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
+
+steps:
+- pwsh: |
+    $toolPath = Join-Path '$(Agent.TempDirectory)' '.source-index' 'tools'
+    dotnet tool install BinLogToSln --version ${{ parameters.sourceIndexProcessBinlogPackageVersion }} --source ${{ parameters.sourceIndexPackageSource }} --tool-path $toolPath
+    dotnet tool install UploadIndexStage1 --version ${{ parameters.sourceIndexUploadPackageVersion }} --source ${{ parameters.sourceIndexPackageSource }} --tool-path $toolPath
+  displayName: "Source Index: Install Tools"
+
+- pwsh: |
+    $ErrorActionPreference = 'Continue'
+
+    $sourcesPath = "${{ parameters.sourcesPath }}"
+    $logsPath = "${{ parameters.logsPath }}"
+    $outputDir = Join-Path '$(Agent.TempDirectory)' '.source-index' 'stage1output'
+    $toolPath = Join-Path '$(Agent.TempDirectory)' '.source-index' 'tools'
+    $excludeRepos = "${{ parameters.excludeRepos }}" -split '\s+' | Where-Object { $_ }
+    $includeRepos = "${{ parameters.includeRepos }}" -split '\s+' | Where-Object { $_ }
+
+    New-Item -ItemType Directory -Force -Path $outputDir | Out-Null
+
+    $binLogToSln = Join-Path $toolPath 'BinLogToSln'
+    if ($IsWindows) { $binLogToSln += '.exe' }
+
+    $binlogs = Get-ChildItem -Path $logsPath -Filter "Build.binlog" -Recurse -ErrorAction SilentlyContinue
+    foreach ($binlog in $binlogs) {
+      $repoName = $binlog.Directory.Name
+
+      if ($includeRepos.Count -gt 0 -and $repoName -notin $includeRepos) {
+        Write-Host "Skipping repo not in include list: $repoName"
+        continue
+      }
+
+      if ($excludeRepos -contains $repoName) {
+        Write-Host "Skipping excluded repo: $repoName"
+        continue
+      }
+
+      Write-Host "Processing binlog for repo: $repoName"
+      & $binLogToSln -i $binlog.FullName -r $sourcesPath -n $repoName -o $outputDir
+
+      if ($LASTEXITCODE -ne 0) {
+        Write-Host "##vso[task.logissue type=warning]BinLogToSln failed for $repoName, continuing..."
+        $global:LASTEXITCODE = 0
+      }
+    }
+
+    # Verify output
+    if (Test-Path $outputDir) {
+      $files = Get-ChildItem -Path $outputDir -Recurse -File
+      if ($files.Count -gt 0) {
+        Write-Host "Source index stage 1 output produced successfully. $($files.Count) files."
+        $files | Select-Object -First 20 | ForEach-Object { Write-Host $_.FullName }
+      } else {
+        Write-Host "##vso[task.logissue type=warning]No source index stage 1 output was produced."
+      }
+    }
+  displayName: "Source Index: Process Binlogs into indexable SLN files"
+
+- task: AzureCLI@2
+  displayName: "Source Index: Upload to Azure (${{ parameters.sourceIndexName }})"
+  inputs:
+    azureSubscription: 'SourceDotNet Stage1 Publish'
+    addSpnToEnvironment: true
+    scriptType: 'pscore'
+    scriptLocation: 'inlineScript'
+    inlineScript: |
+      $outputDir = Join-Path '$(Agent.TempDirectory)' '.source-index' 'stage1output'
+      $toolPath = Join-Path '$(Agent.TempDirectory)' '.source-index' 'tools'
+      $uploadTool = Join-Path $toolPath 'UploadIndexStage1'
+      if ($IsWindows) { $uploadTool += '.exe' }
+
+      if ((Test-Path $outputDir) -and (Get-ChildItem -Path $outputDir -Recurse -File).Count -gt 0) {
+        & $uploadTool -i $outputDir -n "${{ parameters.sourceIndexName }}" -s netsourceindexstage1 -b stage1
+      } else {
+        Write-Host "No source index output to upload."
+      }

--- a/eng/pipelines/templates/steps/source-index-stage1.yml
+++ b/eng/pipelines/templates/steps/source-index-stage1.yml
@@ -21,8 +21,8 @@ parameters:
   # Repos to include (if set, ONLY these repos will be indexed; space-separated)
   includeRepos: ''
 
-  sourceIndexUploadPackageVersion: 2.0.0-20260515.1
-  sourceIndexProcessBinlogPackageVersion: 1.0.1-20260515.1
+  sourceIndexUploadPackageVersion: 2.0.0-20260515.3
+  sourceIndexProcessBinlogPackageVersion: 1.0.1-20260515.3
   sourceIndexPackageSource: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
   sourceIndexBaseDir: $(Agent.TempDirectory)/.source-index
 

--- a/eng/pipelines/templates/steps/source-index-stage1.yml
+++ b/eng/pipelines/templates/steps/source-index-stage1.yml
@@ -21,8 +21,8 @@ parameters:
   # Repos to include (if set, ONLY these repos will be indexed; space-separated)
   includeRepos: ''
 
-  sourceIndexUploadPackageVersion: 2.0.0-20260505.1
-  sourceIndexProcessBinlogPackageVersion: 1.0.1-20260505.1
+  sourceIndexUploadPackageVersion: 2.0.0-20260511.3
+  sourceIndexProcessBinlogPackageVersion: 1.0.1-20260511.3
   sourceIndexPackageSource: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
   sourceIndexBaseDir: $(Agent.TempDirectory)/.source-index
 

--- a/eng/pipelines/templates/steps/source-index-stage1.yml
+++ b/eng/pipelines/templates/steps/source-index-stage1.yml
@@ -29,6 +29,7 @@ parameters:
 steps:
 - task: UseDotNet@2
   displayName: "Source Index: Install .NET SDK"
+  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['SourceIndexForce'], 'true')))
   inputs:
     packageType: sdk
     version: 10.0.x
@@ -43,6 +44,7 @@ steps:
     & $dotnet tool install BinLogToSln --version ${{ parameters.sourceIndexProcessBinlogPackageVersion }} --source ${{ parameters.sourceIndexPackageSource }} --tool-path $toolPath
     & $dotnet tool install UploadIndexStage1 --version ${{ parameters.sourceIndexUploadPackageVersion }} --source ${{ parameters.sourceIndexPackageSource }} --tool-path $toolPath
   displayName: "Source Index: Install Tools"
+  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['SourceIndexForce'], 'true')))
   workingDirectory: $(Agent.TempDirectory)
 
 - pwsh: |
@@ -103,9 +105,11 @@ steps:
       }
     }
   displayName: "Source Index: Process Binlogs into indexable SLN files"
+  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['SourceIndexForce'], 'true')))
 
 - task: AzureCLI@2
   displayName: "Source Index: Upload to Azure (${{ parameters.sourceIndexName }})"
+  condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['SourceIndexForce'], 'true')))
   inputs:
     azureSubscription: 'SourceDotNet Stage1 Publish'
     addSpnToEnvironment: true

--- a/eng/pipelines/templates/steps/source-index-stage1.yml
+++ b/eng/pipelines/templates/steps/source-index-stage1.yml
@@ -21,8 +21,8 @@ parameters:
   # Repos to include (if set, ONLY these repos will be indexed; space-separated)
   includeRepos: ''
 
-  sourceIndexUploadPackageVersion: 2.0.0-20260514.2
-  sourceIndexProcessBinlogPackageVersion: 1.0.1-20260514.2
+  sourceIndexUploadPackageVersion: 2.0.0-20260514.4
+  sourceIndexProcessBinlogPackageVersion: 1.0.1-20260514.4
   sourceIndexPackageSource: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
   sourceIndexBaseDir: $(Agent.TempDirectory)/.source-index
 

--- a/eng/pipelines/templates/steps/source-index-stage1.yml
+++ b/eng/pipelines/templates/steps/source-index-stage1.yml
@@ -21,8 +21,8 @@ parameters:
   # Repos to include (if set, ONLY these repos will be indexed; space-separated)
   includeRepos: ''
 
-  sourceIndexUploadPackageVersion: 2.0.0-20260514.4
-  sourceIndexProcessBinlogPackageVersion: 1.0.1-20260514.4
+  sourceIndexUploadPackageVersion: 2.0.0-20260515.1
+  sourceIndexProcessBinlogPackageVersion: 1.0.1-20260515.1
   sourceIndexPackageSource: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
   sourceIndexBaseDir: $(Agent.TempDirectory)/.source-index
 

--- a/eng/pipelines/templates/steps/source-index-stage1.yml
+++ b/eng/pipelines/templates/steps/source-index-stage1.yml
@@ -21,8 +21,8 @@ parameters:
   # Repos to include (if set, ONLY these repos will be indexed; space-separated)
   includeRepos: ''
 
-  sourceIndexUploadPackageVersion: 2.0.0-20260511.3
-  sourceIndexProcessBinlogPackageVersion: 1.0.1-20260511.3
+  sourceIndexUploadPackageVersion: 2.0.0-20260514.2
+  sourceIndexProcessBinlogPackageVersion: 1.0.1-20260514.2
   sourceIndexPackageSource: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
   sourceIndexBaseDir: $(Agent.TempDirectory)/.source-index
 

--- a/eng/pipelines/templates/steps/source-index-stage1.yml
+++ b/eng/pipelines/templates/steps/source-index-stage1.yml
@@ -90,7 +90,7 @@ steps:
           $global:LASTEXITCODE = 0
         }
       } catch {
-        Write-Host "##vso[task.logissue type=warning]BinLogToSln threw an exception for $repoName: $_"
+        Write-Host "##vso[task.logissue type=warning]BinLogToSln threw an exception for ${repoName}: $_"
       }
     }
 

--- a/eng/pipelines/templates/steps/source-index-stage1.yml
+++ b/eng/pipelines/templates/steps/source-index-stage1.yml
@@ -24,21 +24,35 @@ parameters:
   sourceIndexUploadPackageVersion: 2.0.0-20260505.1
   sourceIndexProcessBinlogPackageVersion: 1.0.1-20260505.1
   sourceIndexPackageSource: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
+  sourceIndexBaseDir: $(Agent.TempDirectory)/.source-index
 
 steps:
+- task: UseDotNet@2
+  displayName: "Source Index: Install .NET SDK"
+  inputs:
+    packageType: sdk
+    version: 10.0.x
+    installationPath: ${{ parameters.sourceIndexBaseDir }}/dotnet
+    workingDirectory: $(Agent.TempDirectory)
+
 - pwsh: |
-    $toolPath = Join-Path '$(Agent.TempDirectory)' '.source-index' 'tools'
-    dotnet tool install BinLogToSln --version ${{ parameters.sourceIndexProcessBinlogPackageVersion }} --source ${{ parameters.sourceIndexPackageSource }} --tool-path $toolPath
-    dotnet tool install UploadIndexStage1 --version ${{ parameters.sourceIndexUploadPackageVersion }} --source ${{ parameters.sourceIndexPackageSource }} --tool-path $toolPath
+    $baseDir = "${{ parameters.sourceIndexBaseDir }}"
+    $dotnet = Join-Path $baseDir 'dotnet' 'dotnet'
+    if ($IsWindows) { $dotnet += '.exe' }
+    $toolPath = Join-Path $baseDir 'tools'
+    & $dotnet tool install BinLogToSln --version ${{ parameters.sourceIndexProcessBinlogPackageVersion }} --source ${{ parameters.sourceIndexPackageSource }} --tool-path $toolPath
+    & $dotnet tool install UploadIndexStage1 --version ${{ parameters.sourceIndexUploadPackageVersion }} --source ${{ parameters.sourceIndexPackageSource }} --tool-path $toolPath
   displayName: "Source Index: Install Tools"
+  workingDirectory: $(Agent.TempDirectory)
 
 - pwsh: |
-    $ErrorActionPreference = 'Continue'
+    $ErrorActionPreference = 'Stop'
 
+    $baseDir = "${{ parameters.sourceIndexBaseDir }}"
     $sourcesPath = "${{ parameters.sourcesPath }}"
     $logsPath = "${{ parameters.logsPath }}"
-    $outputDir = Join-Path '$(Agent.TempDirectory)' '.source-index' 'stage1output'
-    $toolPath = Join-Path '$(Agent.TempDirectory)' '.source-index' 'tools'
+    $outputDir = Join-Path $baseDir 'stage1output'
+    $toolPath = Join-Path $baseDir 'tools'
     $excludeRepos = "${{ parameters.excludeRepos }}" -split '\s+' | Where-Object { $_ }
     $includeRepos = "${{ parameters.includeRepos }}" -split '\s+' | Where-Object { $_ }
 
@@ -47,7 +61,12 @@ steps:
     $binLogToSln = Join-Path $toolPath 'BinLogToSln'
     if ($IsWindows) { $binLogToSln += '.exe' }
 
-    $binlogs = Get-ChildItem -Path $logsPath -Filter "Build.binlog" -Recurse -ErrorAction SilentlyContinue
+    # Only look for Build.binlog in immediate subdirectories (per-repo logs).
+    # This avoids picking up the VMR orchestrator log at artifacts/log/Release/Build.binlog.
+    $binlogs = Get-ChildItem -Path $logsPath -Directory |
+      ForEach-Object { Get-ChildItem -Path $_.FullName -Filter "Build.binlog" -File -ErrorAction SilentlyContinue } |
+      Where-Object { $_ }
+
     foreach ($binlog in $binlogs) {
       $repoName = $binlog.Directory.Name
 
@@ -62,11 +81,14 @@ steps:
       }
 
       Write-Host "Processing binlog for repo: $repoName"
-      & $binLogToSln -i $binlog.FullName -r $sourcesPath -n $repoName -o $outputDir
-
-      if ($LASTEXITCODE -ne 0) {
-        Write-Host "##vso[task.logissue type=warning]BinLogToSln failed for $repoName, continuing..."
-        $global:LASTEXITCODE = 0
+      try {
+        & $binLogToSln -i $binlog.FullName -r $sourcesPath -n $repoName -o $outputDir
+        if ($LASTEXITCODE -ne 0) {
+          Write-Host "##vso[task.logissue type=warning]BinLogToSln failed for $repoName (exit code $LASTEXITCODE), continuing..."
+          $global:LASTEXITCODE = 0
+        }
+      } catch {
+        Write-Host "##vso[task.logissue type=warning]BinLogToSln threw an exception for $repoName: $_"
       }
     }
 
@@ -90,8 +112,9 @@ steps:
     scriptType: 'pscore'
     scriptLocation: 'inlineScript'
     inlineScript: |
-      $outputDir = Join-Path '$(Agent.TempDirectory)' '.source-index' 'stage1output'
-      $toolPath = Join-Path '$(Agent.TempDirectory)' '.source-index' 'tools'
+      $baseDir = "${{ parameters.sourceIndexBaseDir }}"
+      $outputDir = Join-Path $baseDir 'stage1output'
+      $toolPath = Join-Path $baseDir 'tools'
       $uploadTool = Join-Path $toolPath 'UploadIndexStage1'
       if ($IsWindows) { $uploadTool += '.exe' }
 

--- a/src/arcade/azure-pipelines-pr.yml
+++ b/src/arcade/azure-pipelines-pr.yml
@@ -56,7 +56,6 @@ stages:
           logs: true
           manifests: true
       enableMicrobuild: true
-      enableSourceIndex: true
       enableSourceBuild: true
       workspace:
         clean: all

--- a/src/arcade/eng/build.yml
+++ b/src/arcade/eng/build.yml
@@ -25,7 +25,6 @@ stages:
       enableMicrobuild: false
       microbuildUseESRP: ${{ parameters.microbuildUseESRP }}
       enablePublishBuildAssets: true
-      enableSourceIndex: true
       enableSourceBuild: true
       publishingVersion: 4
       workspace:

--- a/src/aspnetcore/.azure/pipelines/ci.yml
+++ b/src/aspnetcore/.azure/pipelines/ci.yml
@@ -49,9 +49,6 @@ variables:
     value: --publish
 - name: _UseHelixOpenQueues
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
-- ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
-  - name: enableSourceIndex
-    value: true
 - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
   - name: _BuildArgs
     value: /p:TeamName=$(_TeamName)
@@ -702,21 +699,7 @@ extends:
                 # Log environment variables in binary logs to ease debugging
                 MSBUILDLOGALLENVIRONMENTVARIABLES: true
 
-      - ${{ if eq(variables.enableSourceIndex, 'true') }}:
-        - template: /eng/common/templates-official/job/source-index-stage1.yml@self
-          parameters:
-            sourceIndexBuildCommand: ./eng/build.cmd -Configuration Release -ci -prepareMachine -noBuildJava -binaryLog /p:OnlyPackPlatformSpecificPackages=true
-            binlogPath: artifacts/log/Release/Build.binlog
-            presteps:
-            - task: UseNode@1
-              displayName: Install Node 24.14.1
-              inputs:
-                version: 24.14.1
-            pool:
-              name: $(DncEngInternalBuildPool)
-              demands: ImageOverride -equals windows.vs2026preview.scout.amd64
-
-      # Publish to the BAR and perform source indexing. Wait until everything else is done.
+      # Publish to the BAR. Wait until everything else is done.
       - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
         - template: /eng/common/templates-official/job/publish-build-assets.yml@self
           parameters:

--- a/src/roslyn/azure-pipelines-official.yml
+++ b/src/roslyn/azure-pipelines-official.yml
@@ -111,9 +111,6 @@ variables:
   - name: Insertion.TitleSuffix
     value: ''
 
-  - ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
-    - name: enableSourceIndex
-      value: true
   - name: VSCodeOptimizationDataRoot
     value: $(Pipeline.Workspace)/profilingInputs/merged mibc
 
@@ -383,15 +380,6 @@ extends:
           pool:
             name: $(DncEngInternalBuildPool)
             demands: ImageOverride -equals windows.vs2022.amd64
-
-      - ${{ if eq(variables.enableSourceIndex, 'true') }}:
-        - template: /eng/common/templates-official/job/source-index-stage1.yml@self
-          parameters:
-            sourceIndexBuildCommand: powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "eng\build.ps1 -configuration Release -prepareMachine -ci -restore -build -binaryLogName Build.binlog -skipDocumentation -msbuildEngine dotnet /p:UsingToolVSSDK=false /p:GenerateSatelliteAssemblies=false /p:PublishReadyToRun=false"
-            binlogPath: artifacts/log/$(BuildConfiguration)/Build.binlog
-            pool:
-              name: $(DncEngInternalBuildPool)
-              demands: ImageOverride -equals 1es-windows-2022
 
     - stage: insert
       dependsOn:

--- a/src/runtime/eng/pipelines/runtime-official.yml
+++ b/src/runtime/eng/pipelines/runtime-official.yml
@@ -17,13 +17,6 @@ trigger:
     - PATENTS.TXT
     - THIRD-PARTY-NOTICES.TXT
 
-schedules:
-- cron: "0 9 * * *"
-  displayName: Daily SourceIndex
-  branches:
-    include:
-    - main
-
 # This is an official pipeline that should not be triggerable from a PR,
 # there is no public pipeline associated with it.
 pr: none

--- a/src/runtime/eng/pipelines/runtime-official.yml
+++ b/src/runtime/eng/pipelines/runtime-official.yml
@@ -55,18 +55,6 @@ extends:
             LclSource: lclFilesfromPackage
             LclPackageId: 'LCL-JUNO-PROD-RUNTIME'
 
-      - ${{ if or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual')) }}:
-        - stage: Source_Index
-          dependsOn: []
-          displayName: Source Index
-          jobs:
-          #
-          # Source Index Build
-          #
-            - template: /eng/common/templates-official/job/source-index-stage1.yml
-              parameters:
-                sourceIndexBuildCommand: build.cmd -subset libs.sfx+libs.oob -binarylog -os linux -ci /p:SkipLibrariesNativeRuntimePackages=true
-
     - stage: Publish
       dependsOn: []
       jobs:

--- a/src/winforms/azure-pipelines.yml
+++ b/src/winforms/azure-pipelines.yml
@@ -12,8 +12,6 @@ variables:
     value: false
   - name: EnableLoc
     value: ${{ contains(variables['Build.SourceBranch'], 'main') }}
-  - name: enableSourceIndex
-    value: ${{ contains(variables['Build.SourceBranch'], 'main') }}
   - template: /eng/common/templates-official/variables/pool-providers.yml@self
 
 resources:
@@ -43,15 +41,6 @@ extends:
           publishAssetsImmediately: true
           isAssetlessBuild: true
           enableTelemetry: true
-
-      - ${{ if eq(variables.enableSourceIndex, 'true') }}:
-        - template: /eng/common/templates-official/job/source-index-stage1.yml@self
-          parameters:
-            sourceIndexBuildCommand: eng\CIBuild.cmd -restore -build -configuration Release /p:Platform=x64 /p:TargetArchitecture=x64 /bl:msbuild.binlog
-            binlogPath: msbuild.binlog
-            pool:
-              name: $(DncEngInternalBuildPool)
-              demands: ImageOverride -equals windows.vs2026preview.scout.amd64
 
       - ${{ if eq(variables['EnableLoc'], 'true') }}:
         - template: /eng/common/templates-official/job/onelocbuild.yml@self

--- a/src/wpf/azure-pipelines.yml
+++ b/src/wpf/azure-pipelines.yml
@@ -44,10 +44,3 @@ extends:
           publishAssetsImmediately: true
           isAssetlessBuild: true
           enableTelemetry: true
-          enableSourceIndex: true
-          sourceIndexParams:
-            condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
-            binlogPath: artifacts/log/Debug/x86/Build.binlog
-            pool:
-              name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals windows.vs2026preview.scout.amd64

--- a/src/wpf/eng/wpfautomatedtests.yml
+++ b/src/wpf/eng/wpfautomatedtests.yml
@@ -18,17 +18,6 @@ jobs:
     enablePublishBuildAssets: true
     enablePublishUsingPipelines: true
     enableTelemetry: true
-    enableSourceIndex: true
-    sourceIndexParams:
-      condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
-      binlogPath: artifacts/log/Debug/x86/Build.binlog
-      pool:
-        ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCore-Public
-          demands: ImageOverride -equals windows.vs2022preview.amd64.Open
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals windows.vs2022preview.amd64
     helixRepo: $(repoName)
 
     jobs:


### PR DESCRIPTION
Process per-repo Build.binlog files into indexable SLN format using BinLogToSln and upload via UploadIndexStage1 for consumption by https://github.com/dotnet/source-indexer.

Two bundles are uploaded from different build legs:
- dotnet-dotnet: from the SB_CentOSStream10_Online_MsftSdk source-build leg (all repos except winforms/wpf/windowsdesktop)
- dotnet-dotnet-windows: from the Windows_x64 vertical build leg (winforms/wpf/windowsdesktop only)

This replaces the need for individual repos to upload their own source index data, since the VMR build produces binlogs for all repos in a single build.

Test build https://dev.azure.com/dnceng/internal/_build/results?buildId=2967769&view=results

Source-indexer change https://github.com/dotnet/source-indexer/pull/254