### PR TITLE
Set 1ESPT-specific component governance disabling variable

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -245,6 +245,8 @@ jobs:
       value: false
 
   - ${{ if eq(parameters.disableComponentGovernance, true) }}:
+    - name: ONEES_ENFORCED_COMPONENTGOVERNANCE_ENABLED
+      value: false
     - name: skipComponentGovernanceDetection
       value: true
 


### PR DESCRIPTION
`skipComponentGovernanceDetection` only prevents injecting the AzDO CG task, but not the one from 1ES PT.

We only disabled this on linux-musl-based Linux builds today because CG doesn't work there (will be fixed by https://github.com/microsoft/component-detection-internal/pull/1479)