### PR TITLE
Remove CodeQL disabling for macOS

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -238,12 +238,6 @@ jobs:
   - name: failedJobArtifactName
     value: $(successfulJobArtifactName)_Attempt$(System.JobAttempt)
 
-  # manually disable CodeQL until https://dev.azure.com/mseng/1ES/_workitems/edit/2211548 is implemented
-  # CodeQL doesn't work on arm64 macOS, see https://portal.microsofticm.com/imp/v5/incidents/details/532165079/summary
-  - ${{ if eq(parameters.pool.os, 'macOS') }}:
-    - name: ONEES_ENFORCED_CODEQL_ENABLED
-      value: false
-
   - ${{ if eq(parameters.disableComponentGovernance, true) }}:
     - name: skipComponentGovernanceDetection
       value: true


### PR DESCRIPTION
CodeQL is disabled by default on arm64 macOS since last year so we no longer need this workaround.