### PR TITLE
Fix ReleaseConfigs item pattern in v3 promotion publish flow

### DIFF
--- a/src/arcade/eng/publishing/v3/publish.yml
+++ b/src/arcade/eng/publishing/v3/publish.yml
@@ -90,7 +90,7 @@ stages:
         downloadType: 'specific'
         artifact: ReleaseConfigs
         itemPattern: |
-          ReleaseConfigs/SymbolPublishingExclusionsFile.txt
+          **/SymbolPublishingExclusionsFile.txt
         downloadPath: '$(Build.ArtifactStagingDirectory)/ReleaseConfigs'
 
     - task: NuGetToolInstaller@1


### PR DESCRIPTION
Mirror of [dotnet/arcade#16781](https://github.com/dotnet/arcade/pull/16781) to unblock the `dotnet-unified-build` internal publish path while the arcade → VMR codeflow PR clears.

## Symptom

The dotnet/dotnet (VMR) internal `dotnet-unified-build` definition has been failing in `Publish Using Darc` since [#6342](https://github.com/dotnet/dotnet/pull/6342) "Re-Bootstrap to .NET 11.0.100-preview.5.26227.104" merged on 2026-05-06. The channel-promotion sub-build errors out in `Publish packages, blobs and symbols`:

```
PublishArtifactsInManifest.proj(128,5): error :
  [AddPackagesToRequest/<guid>/Microsoft.NETCore.App.Runtime.win-arm64.<ver>.symbols.nupkg]
  Multiple files '$mscordaccore.dll' found for runtime '...runtimes\win-arm64\native\coreclr.dll':
    ...tools\x64_arm64\mscordaccore.dll,
    ...runtimes\win-arm64\native\mscordaccore.dll
  Multiple files with same name to be indexed under same runtime - aborting manifest creation
  Failed to generate symbol manifest
```

Verified failures: [internal builds 2968891, 2969080, 2969239](https://dev.azure.com/dnceng/internal/_build?definitionId=1330) (first failing run is on commit `8bf09af` which IS PR #6342). The previous run [2968708](https://dev.azure.com/dnceng/internal/_build/results?buildId=2968708) on commit `d64191f` (one before the bootstrap) successfully promoted to the same `.NET 11.0.1xx SDK` channel.

## Root cause

PR #6342 picked up an `eng/common` template change that switched the `ReleaseConfigs` artifact (which carries `SymbolPublishingExclusionsFile.txt` to the promotion sub-build) from `PublishBuildArtifacts` (legacy build artifacts, with the artifact name preserved as a path segment) to `PublishPipelineArtifact`:

```diff
-    - template: /eng/common/core-templates/steps/publish-build-artifacts.yml
-        pathToPublish: '$(Build.StagingDirectory)/ReleaseConfigs'
-        publishLocation: Container
+    - template: /eng/common/core-templates/steps/publish-pipeline-artifacts.yml
+        targetPath: '$(Build.StagingDirectory)/ReleaseConfigs'
         artifactName: ReleaseConfigs
```

The two artifact systems flatten paths differently. With pipeline artifacts the artifact name is metadata, not a path segment, so the contents land at the artifact root (`SymbolPublishingExclusionsFile.txt`), not under `ReleaseConfigs/...`.

`DownloadPipelineArtifact@2` in `src/arcade/eng/publishing/v3/publish.yml` still asks for the old prefixed pattern. The pattern matches nothing in the new layout, the step is `continueOnError: true` so the failure is silent, the staging dir comes out empty, `LoadExclusions` sees a missing file, and `SymbolPublishingExclusionsFile.txt` never reaches the manifest generator. That tripped a long-tolerated dual-`mscordaccore.dll` layout in `Microsoft.NETCore.App.Runtime.win-arm64.symbols.nupkg` (cross-targeting host `tools/x64_arm64/mscordaccore.dll` vs native `runtimes/win-arm64/native/mscordaccore.dll`), which the runtime exclusion list has covered since 2019.

## Fix

Use the same `**/<filename>` pattern that the **Download V4 Merged Manifest** step a few lines above uses (`**/MergedManifest.xml`), so the download matches regardless of how the upstream publish step lays the artifact out. The `downloadPath` is unchanged, so the consumer's expected location (`$(Build.ArtifactStagingDirectory)/ReleaseConfigs/SymbolPublishingExclusionsFile.txt` at line 158) stays correct.

```diff
         itemPattern: |
-          ReleaseConfigs/SymbolPublishingExclusionsFile.txt
+          **/SymbolPublishingExclusionsFile.txt
         downloadPath: '$(Build.ArtifactStagingDirectory)/ReleaseConfigs'
```
