### PR TITLE
Turn off runtime-async for mono builds in aspnetcore

### DIFF
--- a/src/aspnetcore/Directory.Build.targets
+++ b/src/aspnetcore/Directory.Build.targets
@@ -143,6 +143,7 @@
       '$(IsPackable)' != 'true' AND
       $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0')) AND
       '$(UseRuntimeAsync)' != 'false' AND
+      '$(DotNetBuildUseMonoRuntime)' != 'true' AND
       '$(TargetOS)' != 'browser' AND
       !$(RuntimeIdentifier.StartsWith('browser-'))">
     <Features>$(Features);runtime-async=on</Features>
@@ -152,6 +153,7 @@
   <PropertyGroup Condition="'$(IsTestProject)' == 'true' AND
       $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0')) AND
       '$(UseRuntimeAsync)' != 'false' AND
+      '$(DotNetBuildUseMonoRuntime)' != 'true' AND
       '$(TargetOS)' != 'browser' AND
       !$(RuntimeIdentifier.StartsWith('browser-'))">
     <Features>$(Features);runtime-async=on</Features>


### PR DESCRIPTION
Mono doesn't support runtime-async.
Fixes https://github.com/dotnet/source-build/issues/5557