### PR TITLE
Revert "[main] Source code updates from dotnet/sdk"

### DIFF
--- a/src/sdk/.github/policies/resourceManagement.yml
+++ b/src/sdk/.github/policies/resourceManagement.yml
@@ -68,7 +68,7 @@ configuration:
       then:
       - addReply:
           reply: >-
-            Thanks for your PR, ${issueAuthor}.
+            Thanks for your PR, @${issueAuthor}.
 
             To learn about the PR process and branching schedule of this repo, please take a look at the [SDK PR Guide](https://github.com/dotnet/sdk/blob/main/documentation/project-docs/SDK-PR-guide.md).
       description: Remind ASP.NET Core PR authors the process to follow

--- a/src/sdk/eng/Version.Details.props
+++ b/src/sdk/eng/Version.Details.props
@@ -135,8 +135,8 @@ This file should be imported by eng/Versions.props
     <SystemTextJsonPackageVersion>11.0.0-preview.4.26208.110</SystemTextJsonPackageVersion>
     <SystemWindowsExtensionsPackageVersion>11.0.0-preview.4.26208.110</SystemWindowsExtensionsPackageVersion>
     <!-- microsoft-testfx dependencies -->
-    <MicrosoftTestingPlatformPackageVersion>2.3.0-preview.26252.2</MicrosoftTestingPlatformPackageVersion>
-    <MSTestPackageVersion>4.3.0-preview.26252.2</MSTestPackageVersion>
+    <MicrosoftTestingPlatformPackageVersion>2.3.0-preview.26219.1</MicrosoftTestingPlatformPackageVersion>
+    <MSTestPackageVersion>4.3.0-preview.26219.1</MSTestPackageVersion>
   </PropertyGroup>
   <!--Property group for alternate package version names-->
   <PropertyGroup>

--- a/src/sdk/eng/Version.Details.xml
+++ b/src/sdk/eng/Version.Details.xml
@@ -516,13 +516,13 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>0cf6b19ed68d2d52e097e6af6d6046b4eeefefe2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Testing.Platform" Version="2.3.0-preview.26252.2">
+    <Dependency Name="Microsoft.Testing.Platform" Version="2.3.0-preview.26219.1">
       <Uri>https://github.com/microsoft/testfx</Uri>
-      <Sha>65a70b6c827eccb94609be7511e97b0a002dd136</Sha>
+      <Sha>2f487896471027b0c37c24b2d5b58cd20a195427</Sha>
     </Dependency>
-    <Dependency Name="MSTest" Version="4.3.0-preview.26252.2">
+    <Dependency Name="MSTest" Version="4.3.0-preview.26219.1">
       <Uri>https://github.com/microsoft/testfx</Uri>
-      <Sha>65a70b6c827eccb94609be7511e97b0a002dd136</Sha>
+      <Sha>2f487896471027b0c37c24b2d5b58cd20a195427</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Ini" Version="11.0.0-preview.4.26208.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>

--- a/src/sdk/src/Cli/dotnet-aot/dotnet-aot.csproj
+++ b/src/sdk/src/Cli/dotnet-aot/dotnet-aot.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
@@ -29,14 +29,6 @@
       https://github.com/dotnet/docs/blob/main/docs/core/deploying/native-aot/security.md#control-flow-guard
     -->
     <ControlFlowGuard>Guard</ControlFlowGuard>
-
-    <!--
-      Declare RuntimeIdentifier so that centralized NuGet restore (via sdk.slnx) generates
-      the RID-specific target (e.g. net11.0/win-x64) in project.assets.json. Without this,
-      the assets file only has the TFM target and Publish fails with NETSDK1047.
-      Conditioned to platforms where NativeAOT publish is supported.
-    -->
-    <RuntimeIdentifier Condition="$(TargetRid.StartsWith('win')) or $(TargetRid.StartsWith('linux')) or $(TargetRid.StartsWith('osx'))">$(TargetRid)</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/sdk/src/Dotnet.Watch/HotReloadAgent.Host/.editorconfig
+++ b/src/sdk/src/Dotnet.Watch/HotReloadAgent.Host/.editorconfig
@@ -4,7 +4,3 @@
 # The directive needs to be included since all sources in a source package are considered generated code
 # when referenced from a project via package reference.
 dotnet_diagnostic.IDE0240.severity = none
-
-# CA2007: This assembly runs inside the user's app process where a SynchronizationContext may be present.
-# Missing ConfigureAwait(false) can cause deadlocks (e.g. iOS UIKitSynchronizationContext).
-dotnet_diagnostic.CA2007.severity = error

--- a/src/sdk/src/Dotnet.Watch/HotReloadAgent.Host/NamedPipeTransport.cs
+++ b/src/sdk/src/Dotnet.Watch/HotReloadAgent.Host/NamedPipeTransport.cs
@@ -34,8 +34,8 @@ internal sealed class NamedPipeTransport(string pipeName, Action<string> log, in
             }
         }
 
-        await _pipeClient.WriteAsync((byte)response.Type, cancellationToken).ConfigureAwait(false);
-        await response.WriteAsync(_pipeClient, cancellationToken).ConfigureAwait(false);
+        await _pipeClient.WriteAsync((byte)response.Type, cancellationToken);
+        await response.WriteAsync(_pipeClient, cancellationToken);
     }
 
     public override ValueTask<RequestStream> ReceiveAsync(CancellationToken cancellationToken)

--- a/src/sdk/src/Dotnet.Watch/HotReloadAgent.Host/StartupHook.cs
+++ b/src/sdk/src/Dotnet.Watch/HotReloadAgent.Host/StartupHook.cs
@@ -84,7 +84,7 @@ internal sealed class StartupHook
                 {
                     try
                     {
-                        await listener.SendResponseAsync(new HotReloadExceptionCreatedNotification(code, message), CancellationToken.None).ConfigureAwait(false);
+                        await listener.SendResponseAsync(new HotReloadExceptionCreatedNotification(code, message), CancellationToken.None);
                     }
                     catch
                     {

--- a/src/sdk/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/sdk/src/Layout/redist/targets/GenerateLayout.targets
@@ -537,16 +537,20 @@
     </PropertyGroup>
 
     <!--
-      Publish via Exec in a separate process to avoid BuildManager caching/scheduling
-      interference in CI's multi-node parallel build context.
-      
-      The dotnet-aot project declares RuntimeIdentifier=$(TargetRid) so that centralized
-      NuGet restore (via sdk.slnx) generates the RID-specific target in project.assets.json.
-      Restore is NOT skipped here because runtime packs (e.g. Microsoft.NETCore.App.Runtime)
-      are only downloaded during a RID-aware restore, which the centralized restore may not cover.
+      In CI, Arcade's centralized NuGet restore runs via NuGet.targets and does not include
+      RuntimeIdentifier, so the assets file lacks the RID-specific target (NETSDK1047).
+      Restore here with RuntimeIdentifiers (plural) to add the RID target to the assets file.
     -->
-    <Exec Command="&quot;$(DotNetTool)&quot; publish &quot;$(RepoRoot)src/Cli/dotnet-aot/dotnet-aot.csproj&quot; -c $(Configuration) -r $(TargetRid) -o &quot;$(_DotnetAotPublishDir)&quot;"
-          IgnoreStandardErrorWarningFormat="true" />
+    <MSBuild
+      Targets="Restore"
+      Projects="$(RepoRoot)/src/Cli/dotnet-aot/dotnet-aot.csproj"
+      Properties="Configuration=$(Configuration);RuntimeIdentifiers=$(TargetRid)" />
+
+    <!-- Publish the dotnet-aot project as a NativeAOT shared library -->
+    <MSBuild
+      Targets="Publish"
+      Projects="$(RepoRoot)/src/Cli/dotnet-aot/dotnet-aot.csproj"
+      Properties="Configuration=$(Configuration);RuntimeIdentifier=$(TargetRid);PublishDir=$(_DotnetAotPublishDir)" />
 
     <!-- Verify the native library was produced -->
     <Error Condition="!Exists('$(_DotnetAotPublishDir)$(_DotnetAotNativeLibName)')"

--- a/src/sdk/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.Tasks/Microsoft.TemplateEngine.Authoring.Tasks.csproj
+++ b/src/sdk/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.Tasks/Microsoft.TemplateEngine.Authoring.Tasks.csproj
@@ -44,24 +44,6 @@
     </ItemGroup>
   </Target>
 
-  <!-- Copy the nupkg to TestPackagesDir so integration tests can consume it.
-       This replaces the BuildTestPackages.targets entry that re-packed this project
-       with different global properties, which caused a parallel-build race condition.
-       Guard with IsCrossTargetingBuild so this runs only once in the outer build of a
-       multi-targeting project, avoiding concurrent copies per inner TFM build.
-       Skip in VMR/source-build where integration tests don't run and versioning
-       properties may not be available in the outer cross-targeting evaluation. -->
-  <Target Name="CopyPackageToTestPackagesDir" AfterTargets="Pack"
-          Condition="'$(TestLayoutDir)' != '' and '$(DotNetBuild)' != 'true' and ('$(IsCrossTargetingBuild)' == 'true' or '$(TargetFrameworks)' == '')">
-    <PropertyGroup>
-      <_TestPackagesDir>$(TestLayoutDir)testpackages/</_TestPackagesDir>
-    </PropertyGroup>
-    <MakeDir Directories="$(_TestPackagesDir)" Condition="!Exists('$(_TestPackagesDir)')" />
-    <Copy SourceFiles="$(PackageOutputPath)$(PackageId).$(PackageVersion).nupkg"
-          DestinationFolder="$(_TestPackagesDir)"
-          SkipUnchangedFiles="true" />
-  </Target>
-
   <Target Name="AddBuildOutputToPackageNetFramework" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <ItemGroup>
       <TfmSpecificPackageFile Include="$(OutputPath)**" PackagePath="$(BuildOutputTargetFolder)/netframework/%(RecursiveDir)%(FileName)%(Extension)"/>

--- a/src/sdk/test/Microsoft.NET.TestFramework/BuildTestPackages.targets
+++ b/src/sdk/test/Microsoft.NET.TestFramework/BuildTestPackages.targets
@@ -159,10 +159,11 @@
         <ProjectName>Microsoft.Net.Sdk.Compilers.Toolset.csproj</ProjectName>
         <Version>$(Version)</Version>
       </BaseTestPackageProject>
-      <!-- Microsoft.TemplateEngine.Authoring.Tasks is excluded here because it has
-           GeneratePackageOnBuild=true and is in the solution. Packing it again with
-           different global properties causes a parallel-build race condition on the
-           obj/ output DLL. The project copies its nupkg to TestPackagesDir itself. -->
+      <BaseTestPackageProject Include="src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.Tasks">
+        <Name>Microsoft.TemplateEngine.Authoring.Tasks</Name>
+        <ProjectName>Microsoft.TemplateEngine.Authoring.Tasks.csproj</ProjectName>
+        <Version>$(Version)</Version>
+      </BaseTestPackageProject>
       <BaseTestPackageProject Include="src/TemplateEngine/Tools/Microsoft.TemplateSearch.TemplateDiscovery">
         <Name>Microsoft.TemplateSearch.TemplateDiscovery</Name>
         <ProjectName>Microsoft.TemplateSearch.TemplateDiscovery.csproj</ProjectName>

--- a/src/sdk/test/dotnet-watch.Tests/Watch/FileUpdateTests.cs
+++ b/src/sdk/test/dotnet-watch.Tests/Watch/FileUpdateTests.cs
@@ -52,7 +52,7 @@ public class FileUpdateTests(ITestOutputHelper logger) : DotNetWatchTestBase(log
     /// <summary>
     /// Validates `dotnet watch test` scenario: https://github.com/dotnet/sdk/issues/52528
     /// </summary>
-    [Fact(Skip = "https://github.com/dotnet/sdk/issues/54176")]
+    [Fact] 
     public async Task TestCommand()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchXUnit")

--- a/src/source-manifest.json
+++ b/src/source-manifest.json
@@ -91,10 +91,10 @@
       "commitSha": "69ea163b4d04fec951117d883ba353e058b95c24"
     },
     {
-      "barId": 313644,
+      "barId": 313350,
       "path": "sdk",
       "remoteUri": "https://github.com/dotnet/sdk",
-      "commitSha": "9a363f2d88a8e7226f77cb6b8e0ff1fa4a8f2513"
+      "commitSha": "6dc6b337ba082226f836da7585a07f58d781e7f1"
     },
     {
       "barId": 313491,


### PR DESCRIPTION
Reverts dotnet/dotnet#6524

Official build is failing with:
```
##[error].dotnet\sdk\11.0.100-preview.5.26227.104\NuGet.Build.Tasks.Pack.targets(222,5): error NU5026: (NETCORE_ENGINEERING_TELEMETRY=Build) The file 'D:\a\_work\1\s\src\sdk\artifacts\bin\Microsoft.DotNet.Cli.Utils\Release\net11.0\Microsoft.DotNet.Cli.Utils.pdb' to be packed was not found on disk.
  D:\a\_work\1\s\.dotnet\sdk\11.0.100-preview.5.26227.104\NuGet.Build.Tasks.Pack.targets(222,5): error NU5026: The file 'D:\a\_work\1\s\src\sdk\artifacts\bin\Microsoft.DotNet.Cli.Utils\Release\net11.0\Microsoft.DotNet.Cli.Utils.pdb' to be packed was not found on disk. [D:\a\_work\1\s\src\sdk\src\Cli\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj]
```

https://dev.azure.com/dnceng/internal/_build/results?buildId=2972942&view=logs&j=9050e078-31bf-5111-d8ec-8b6fa95caf9c&t=71ed8226-4101-5eec-23b4-99befb5c82cb