### PR TITLE
Use MSBuild task instead of Exec for PublishDotnetAot

### DIFF
--- a/src/sdk/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/sdk/src/Layout/redist/targets/GenerateLayout.targets
@@ -537,16 +537,29 @@
     </PropertyGroup>
 
     <!--
-      Publish via Exec in a separate process to avoid BuildManager caching/scheduling
-      interference in CI's multi-node parallel build context.
-      
-      The dotnet-aot project declares RuntimeIdentifier=$(TargetRid) so that centralized
-      NuGet restore (via sdk.slnx) generates the RID-specific target in project.assets.json.
-      Restore is NOT skipped here because runtime packs (e.g. Microsoft.NETCore.App.Runtime)
-      are only downloaded during a RID-aware restore, which the centralized restore may not cover.
+      Publish in-process via the MSBuild task so this participates in the outer build's
+      project graph and BuildManager cache.
+
+      The dotnet-aot project declares RuntimeIdentifier=$(TargetRid), so the centralized
+      restore (via sdk.slnx) already generates the RID-specific target in
+      project.assets.json and adds a PackageDownload for
+      Microsoft.NETCore.App.Runtime.NativeAOT.$(TargetRid) (verified in the SolutionRestore
+      evaluation's ProcessFrameworkReferences output) — no separate Restore call is
+      required here.
+
+      Do NOT Exec a child 'dotnet publish' process: a child process does not inherit the
+      outer build's MSBuild global properties (DotNetBuild, DotNetBuildFromVMR, Arcade /
+      source-build flags, DebugType, signing, version overrides, etc.). It would re-Build
+      this project's ProjectReferences (Microsoft.DotNet.Cli.Utils, Cli.CoreUtils,
+      NativeWrapper) from scratch with different evaluated properties, clobbering the PDBs
+      the outer build had already produced. The outer build then fails at Copy/Pack with
+      MSB3030 / NU5026 (see dnceng/internal dotnet-unified-build 2972531 — the dnceng
+      regression that prompted this fix).
     -->
-    <Exec Command="&quot;$(DotNetTool)&quot; publish &quot;$(RepoRoot)src/Cli/dotnet-aot/dotnet-aot.csproj&quot; -c $(Configuration) -r $(TargetRid) -o &quot;$(_DotnetAotPublishDir)&quot;"
-          IgnoreStandardErrorWarningFormat="true" />
+    <MSBuild
+      Targets="Publish"
+      Projects="$(RepoRoot)src/Cli/dotnet-aot/dotnet-aot.csproj"
+      Properties="Configuration=$(Configuration);RuntimeIdentifier=$(TargetRid);PublishDir=$(_DotnetAotPublishDir)" />
 
     <!-- Verify the native library was produced -->
     <Error Condition="!Exists('$(_DotnetAotPublishDir)$(_DotnetAotNativeLibName)')"

--- a/src/sdk/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/sdk/src/Layout/redist/targets/GenerateLayout.targets
@@ -532,42 +532,37 @@
       <_DotnetAotNativeLibExtension Condition="'$(OSName)' == 'osx'">.dylib</_DotnetAotNativeLibExtension>
       <_DotnetAotNativeLibExtension Condition="'$(_DotnetAotNativeLibExtension)' == ''">.so</_DotnetAotNativeLibExtension>
       <_DotnetAotNativeLibName>$(_DotnetAotNativeLibPrefix)dotnet-aot$(_DotnetAotNativeLibExtension)</_DotnetAotNativeLibName>
-
-      <_DotnetAotPublishDir>$(ArtifactsBinDir)dotnet-aot-redist\$(Configuration)\$(SdkTargetFramework)\$(TargetRid)\publish\</_DotnetAotPublishDir>
     </PropertyGroup>
 
     <!--
-      Publish in-process via the MSBuild task so this participates in the outer build's
-      project graph and BuildManager cache.
+      Publish the dotnet-aot project.  The project is configured with a RuntimeIdentifier
+      and with PublishAot=true, so this creates the NativeAOT library.  We avoid passing
+      any global properties to avoid issues with a different builds overwriting existing
+      outputs.
 
-      The dotnet-aot project declares RuntimeIdentifier=$(TargetRid), so the centralized
-      restore (via sdk.slnx) already generates the RID-specific target in
-      project.assets.json and adds a PackageDownload for
-      Microsoft.NETCore.App.Runtime.NativeAOT.$(TargetRid) (verified in the SolutionRestore
-      evaluation's ProcessFrameworkReferences output) — no separate Restore call is
-      required here.
-
-      Do NOT Exec a child 'dotnet publish' process: a child process does not inherit the
-      outer build's MSBuild global properties (DotNetBuild, DotNetBuildFromVMR, Arcade /
-      source-build flags, DebugType, signing, version overrides, etc.). It would re-Build
-      this project's ProjectReferences (Microsoft.DotNet.Cli.Utils, Cli.CoreUtils,
-      NativeWrapper) from scratch with different evaluated properties, clobbering the PDBs
-      the outer build had already produced. The outer build then fails at Copy/Pack with
-      MSB3030 / NU5026 (see dnceng/internal dotnet-unified-build 2972531 — the dnceng
-      regression that prompted this fix).
+      Also call PublishItemsOutputGroup to retrieve the published file list, so we
+      don't have to hard-code or predict the publish output directory.
     -->
     <MSBuild
-      Targets="Publish"
-      Projects="$(RepoRoot)src/Cli/dotnet-aot/dotnet-aot.csproj"
-      Properties="Configuration=$(Configuration);RuntimeIdentifier=$(TargetRid);PublishDir=$(_DotnetAotPublishDir)" />
+      Targets="Publish;PublishItemsOutputGroup"
+      Projects="$(RepoRoot)src/Cli/dotnet-aot/dotnet-aot.csproj">
+      <Output TaskParameter="TargetOutputs" ItemName="_DotnetAotPublishedItems" />
+    </MSBuild>
 
-    <!-- Verify the native library was produced -->
-    <Error Condition="!Exists('$(_DotnetAotPublishDir)$(_DotnetAotNativeLibName)')"
-           Text="dotnet-aot native library not found at '$(_DotnetAotPublishDir)$(_DotnetAotNativeLibName)'. NativeAOT publish may have failed for RID '$(TargetRid)'." />
+    <!-- Find the NativeAOT shared library among the published items. -->
+    <ItemGroup>
+      <_DotnetAotNativeLib Include="@(_DotnetAotPublishedItems)"
+                           Condition="'%(Filename)%(Extension)' == '$(_DotnetAotNativeLibName)'" />
+    </ItemGroup>
 
-    <!-- Copy the native library to the SDK output directory -->
+    <Error Condition="'@(_DotnetAotNativeLib)' == ''"
+           Text="dotnet-aot native library '$(_DotnetAotNativeLibName)' was not produced by Publish for RID '$(TargetRid)'." />
+
+    <!-- Copy the native library to the SDK output directory.  Use the OutputPath
+         metadata, which is the absolute path of the published file (the item's
+         Identity is the source path, before Publish processed it). -->
     <Copy
-      SourceFiles="$(_DotnetAotPublishDir)$(_DotnetAotNativeLibName)"
+      SourceFiles="@(_DotnetAotNativeLib->'%(OutputPath)')"
       DestinationFolder="$(OutputPath)"
       SkipUnchangedFiles="true" />
   </Target>


### PR DESCRIPTION
## Summary

Replace the `<Exec>` of `dotnet publish` in `PublishDotnetAot` with an in-process `<MSBuild Targets="Publish" ...>` task call. The Exec was the root cause of the dotnet-unified-build internal regression on dnceng/internal (build 2972531) — see error details below.

## Root cause

The Exec-based child `dotnet publish` introduced by `dotnet/sdk#54222` and adjusted by `73010df` (manual VMR fix removing `--no-restore`) spawned a fresh MSBuild process to publish `dotnet-aot.csproj`. The child process:

1. Did not inherit the outer build's MSBuild global properties (`DotNetBuild=True`, `DotNetBuildFromVMR=True`, Arcade / source-build flags, DebugType, signing, version overrides, etc.).
2. Re-Built `dotnet-aot.csproj`'s `ProjectReference`s — `Microsoft.DotNet.Cli.Utils`, `Cli.CoreUtils`, `NativeWrapper` — from scratch with different evaluated properties.
3. **Clobbered the PDBs the outer build had produced**, writing them with different DebugType/symbol settings (or not producing them at all).

The outer build's subsequent Copy and Pack steps then failed:

```
MSB3030: Could not copy the file
  "...\artifacts\bin\Microsoft.DotNet.Cli.CoreUtils\Release\net11.0\Microsoft.DotNet.Cli.CoreUtils.pdb"
because it was not found.

NU5026: The file
  "...\artifacts\bin\Microsoft.DotNet.Cli.Utils\Release\net11.0\Microsoft.DotNet.Cli.Utils.pdb"
to be packed was not found on disk.
```

This regression doesn't surface in dotnet/sdk public CI because public CI doesn't run the source-build Copy/Pack steps that consume those PDBs — the clobber still happens, it's just invisible.

## Why an in-process `<MSBuild>` task fixes it

An in-process `<MSBuild Targets="Publish" ...>` call shares the outer build's BuildManager. When that call needs `dotnet-aot.csproj`'s `ProjectReference`s, the BuildManager sees they were already built earlier in the same session (matching Configuration and global properties) and returns the cached results instead of rebuilding. The PDBs from the outer build stay intact.

## Why this does NOT bring back NETSDK1112 (Marc's stated reason for removing `--no-restore`)

Verified directly from the failing build's sdk binlog (`Windows_x64_BuildLogs_Attempt1/artifacts/log/Release/sdk/Build.binlog` from build 2972531):

* The centralized `sdk.slnx` restore in the VMR **is** RID-aware. The SolutionRestore evaluation of `dotnet-aot.csproj` has `RuntimeIdentifier=win-x64` (flowing from the conditional declaration in dotnet-aot.csproj added in dotnet/sdk#54222).

* `ProcessFrameworkReferences` on `dotnet-aot.csproj` during the SolutionRestore evaluation logs:

  ```
  Adding tool pack ILCompiler for runtime 11.0
  ...
  Added ILCompiler runtime pack 'runtime.win-x64.Microsoft.DotNet.ILCompiler@11.0.0-preview.5.26261.113'
  Checking for cross-targeting compilation packs for win-x64
  Added Microsoft.NETCore.App.Runtime.NativeAOT.win-x64@11.0.0-preview.5.26261.113 for cross-targeting compilation for win-x64
  Added PackageDownload for Microsoft.NETCore.App.Runtime.NativeAOT.win-x64@11.0.0-preview.5.26261.113 for cross-targeting compilation for win-x64
  ```

* The pack lands on disk at `artifacts/.packages/microsoft.netcore.app.runtime.nativeaot.win-x64/11.0.0-preview.5.26261.113`.

So the NativeAOT runtime pack is reliably present after the centralized restore — no separate Restore call is needed. The previous "Restore is NOT skipped here because runtime packs are only downloaded during a RID-aware restore" rationale was based on a misdiagnosis: the actual VMR failure was the PDB clobber, not missing runtime packs.

## Validation

* Locally validated the equivalent fix on dotnet/sdk main with a clean `build.cmd -ci -c Release`: 0 errors, AOT shared library (`dotnet-aot.dll`) produced and placed in the SDK layout as expected.
* Full VMR build not run locally (impractical). A private dotnet-unified-build run from this PR is the right validation; the binlog evidence above makes the fix high-confidence.

cc @marcpopMSFT (who authored the previous VMR manual fix `73010df` — the NU5026/MSB3030 in build 2972531 is what motivated finding the real root cause)
