### PR TITLE
Set _IsPublishing=true and add ProjectReference for PublishDotnetAot

### DIFF
--- a/src/sdk/src/Layout/redist/redist.csproj
+++ b/src/sdk/src/Layout/redist/redist.csproj
@@ -75,8 +75,15 @@
          Without an explicit reference, the outer Build (writing to bin\dotnet-aot\...) and the
          Publish call's internal Build (writing to the same paths) can run concurrently and
          race over shared bin\ and obj\ directories. This ProjectReference sequences the outer
-         Build to complete before redist's GenerateSdkLayout target runs. -->
-    <ProjectReference Include="$(RepoRoot)src\Cli\dotnet-aot\dotnet-aot.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Private="false" />
+         Build to complete before redist's GenerateSdkLayout target runs.
+
+         Conditioned on the same TargetRid prefix check as the PublishDotnetAot target itself;
+         when NativeAOT publish doesn't run (e.g. source-build with TargetRid like centos.10-x64),
+         pulling dotnet-aot.csproj into the restore graph would demand the ILCompiler RID-specific
+         runtime pack, which isn't available from source-built feeds (NU1100). -->
+    <ProjectReference Include="$(RepoRoot)src\Cli\dotnet-aot\dotnet-aot.csproj"
+                      Condition="'$(TargetRid)' == '$(HostRid)' and ($(TargetRid.StartsWith('win')) or $(TargetRid.StartsWith('linux')) or $(TargetRid.StartsWith('osx')))"
+                      ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Private="false" />
 
     <ProjectReference Include="$(RepoRoot)template_feed\*\*.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Private="false" />
 

--- a/src/sdk/src/Layout/redist/redist.csproj
+++ b/src/sdk/src/Layout/redist/redist.csproj
@@ -69,6 +69,15 @@
     <ProjectReference Include="$(RepoRoot)src\Dotnet.Watch\dotnet-watch\dotnet-watch.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Private="false" />
     <ProjectReference Include="$(RepoRoot)src\Dotnet.Format\dotnet-format\dotnet-format.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Private="false" />
 
+    <!-- The PublishDotnetAot target in GenerateLayout.targets calls <MSBuild Targets="Publish"> on
+         dotnet-aot.csproj. That call passes _IsPublishing=true, which makes it a different
+         BuildManager project instance than the outer build's evaluation of dotnet-aot.csproj.
+         Without an explicit reference, the outer Build (writing to bin\dotnet-aot\...) and the
+         Publish call's internal Build (writing to the same paths) can run concurrently and
+         race over shared bin\ and obj\ directories. This ProjectReference sequences the outer
+         Build to complete before redist's GenerateSdkLayout target runs. -->
+    <ProjectReference Include="$(RepoRoot)src\Cli\dotnet-aot\dotnet-aot.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Private="false" />
+
     <ProjectReference Include="$(RepoRoot)template_feed\*\*.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Private="false" />
 
     <ProjectReference Include="$(RepoRoot)src\Microsoft.CodeAnalysis.NetAnalyzers\src\Microsoft.CodeAnalysis.NetAnalyzers.Package.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" Private="false" />

--- a/src/sdk/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/sdk/src/Layout/redist/targets/GenerateLayout.targets
@@ -536,16 +536,19 @@
 
     <!--
       Publish the dotnet-aot project.  The project is configured with a RuntimeIdentifier
-      and with PublishAot=true, so this creates the NativeAOT library.  We avoid passing
-      any global properties to avoid issues with a different builds overwriting existing
-      outputs.
+      and with PublishAot=true, so this creates the NativeAOT library.  We pass
+      _IsPublishing=true as a global property because that's the property the SDK uses
+      to gate Publish-time behaviors (for example, suppressing apphost generation when
+      PublishAot is true); without it, running the Publish target directly is known to
+      produce subtly wrong behaviors.
 
       Also call PublishItemsOutputGroup to retrieve the published file list, so we
       don't have to hard-code or predict the publish output directory.
     -->
     <MSBuild
       Targets="Publish;PublishItemsOutputGroup"
-      Projects="$(RepoRoot)src/Cli/dotnet-aot/dotnet-aot.csproj">
+      Projects="$(RepoRoot)src/Cli/dotnet-aot/dotnet-aot.csproj"
+      Properties="_IsPublishing=true">
       <Output TaskParameter="TargetOutputs" ItemName="_DotnetAotPublishedItems" />
     </MSBuild>
 


### PR DESCRIPTION
## Summary

Follow-up to #6576. Two related changes to `PublishDotnetAot` in `src/sdk/src/Layout/redist/`:

1. **Pass `_IsPublishing=true` as a global property** to the `<MSBuild Targets="Publish">` call on `dotnet-aot.csproj`. Per @MichalStrehovsky's feedback on #6576, running the Publish target without `_IsPublishing=true` has been a source of subtle issues — it's the property the SDK uses to gate Publish-aware behaviors (suppressing apphost generation when `PublishAot=true`, several `NETSdkError` conditions, `_RuntimeIdentifierUsesAppHost` adjustments, etc.).

2. **Add a `ProjectReference` from `redist.csproj` to `dotnet-aot.csproj`** (`ReferenceOutputAssembly=false`, `SkipGetTargetFrameworkProperties=true`, `Private=false`). This sequences the outer solution build's evaluation of `dotnet-aot.csproj` to complete before redist's `GenerateSdkLayout` target runs, eliminating the race surface re-introduced by change (1).

cc @ericstj @MichalStrehovsky @NikolaMilosavljevic
