### PR TITLE
Fix PublishDotnetAot picking dSYM over real dylib on macOS

### DIFF
--- a/src/sdk/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/sdk/src/Layout/redist/targets/GenerateLayout.targets
@@ -551,7 +551,7 @@
 
     <!-- Match on %(TargetPath) so the macOS dSYM bundle's inner Mach-O
          (libdotnet-aot.dylib.dSYM/Contents/Resources/DWARF/libdotnet-aot.dylib)
-         is not picked alongside the real dylib. See dotnet/sdk#54296. -->
+         is not picked alongside the real dylib. -->
     <ItemGroup>
       <_DotnetAotNativeLib Include="@(_DotnetAotPublishedItems)"
                            Condition="'%(TargetPath)' == '$(_DotnetAotNativeLibName)'" />

--- a/src/sdk/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/sdk/src/Layout/redist/targets/GenerateLayout.targets
@@ -549,10 +549,12 @@
       <Output TaskParameter="TargetOutputs" ItemName="_DotnetAotPublishedItems" />
     </MSBuild>
 
-    <!-- Find the NativeAOT shared library among the published items. -->
+    <!-- Match on %(TargetPath) so the macOS dSYM bundle's inner Mach-O
+         (libdotnet-aot.dylib.dSYM/Contents/Resources/DWARF/libdotnet-aot.dylib)
+         is not picked alongside the real dylib. See dotnet/sdk#54296. -->
     <ItemGroup>
       <_DotnetAotNativeLib Include="@(_DotnetAotPublishedItems)"
-                           Condition="'%(Filename)%(Extension)' == '$(_DotnetAotNativeLibName)'" />
+                           Condition="'%(TargetPath)' == '$(_DotnetAotNativeLibName)'" />
     </ItemGroup>
 
     <Error Condition="'@(_DotnetAotNativeLib)' == ''"


### PR DESCRIPTION
## Summary

Fixes the macOS regression introduced by #6576 where the SDK ships a dSYM Mach-O at `sdk/<version>/libdotnet-aot.dylib` instead of the actual NativeAOT shared library, breaking the `dotnet` AOT path on osx-arm64 / osx-x64. 

Tracking issue: dotnet/sdk#54296.

## Root cause

#6576 changed `PublishDotnetAot` in `src/sdk/src/Layout/redist/targets/GenerateLayout.targets` to use an in-process `<MSBuild Targets="Publish;PublishItemsOutputGroup">` and pick the native library out of the returned items by file name:

```xml
<_DotnetAotNativeLib Include="@(_DotnetAotPublishedItems)"
                     Condition="'%(Filename)%(Extension)' == '$(_DotnetAotNativeLibName)'" />
```

On macOS, NativeAOT publish runs `dsymutil` and emits a dSYM bundle next to the dylib. The bundle's inner Mach-O reuses the original library name:

```
publish/libdotnet-aot.dylib                                                    # MH_DYLIB (filetype 6)
publish/libdotnet-aot.dylib.dSYM/Contents/Resources/DWARF/libdotnet-aot.dylib  # MH_DSYM  (filetype 10)
```

Both items match the `%(Filename)%(Extension)` filter, both are passed to `<Copy DestinationFolder="$(OutputPath)" />`, and both target `$(OutputPath)libdotnet-aot.dylib`. The dSYM is emitted after the dylib so it wins the Copy, and the SDK ships the dSYM in place of the real dylib.

Builds 26258.110 and 26261.101 (before #6576) shipped the correct dylib.
