### PR TITLE
Configure nuget audit to not block CI builds but still fail PR builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -65,6 +65,10 @@
     <LangVersion>latest</LangVersion>
     <!-- Don't run NuGetAudit on offline builds. -->
     <NuGetAudit Condition="'$(DotNetBuildWithOnlineFeeds)' != 'true'">false</NuGetAudit>
+    <!-- Disable NuGet audit in official builds. NuGet Restore does not respect
+         WarningsNotAsErrors, so audit findings become errors via TreatWarningsAsErrors
+         with no way to downgrade them. Keep audit enabled for local/CI dev builds. -->
+    <NuGetAudit Condition="'$(OfficialBuild)' == 'true'">false</NuGetAudit>
     <!-- Explicitly set NuGetAuditModel level as it's currently disabled in the product. -->
     <NuGetAuditMode>all</NuGetAuditMode>
     <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -65,8 +65,9 @@
     <LangVersion>latest</LangVersion>
     <!-- Don't run NuGetAudit on offline builds. -->
     <NuGetAudit Condition="'$(DotNetBuildWithOnlineFeeds)' != 'true'">false</NuGetAudit>
-    <!-- Disable NuGet audit in official builds. NuGet Restore does not respect
-         WarningsNotAsErrors, so audit findings become errors via TreatWarningsAsErrors
+    <!-- Disable NuGet audit in official builds. MSBuild does not correctly handle
+         WarningsNotAsErrors for NuGet warnings (https://github.com/dotnet/msbuild/issues/10801),
+         so audit findings become errors via TreatWarningsAsErrors
          with no way to downgrade them. Keep audit enabled for local/CI dev builds. -->
     <NuGetAudit Condition="'$(OfficialBuild)' == 'true'">false</NuGetAudit>
     <!-- Explicitly set NuGetAuditModel level as it's currently disabled in the product. -->

--- a/eng/tools/Directory.Build.props
+++ b/eng/tools/Directory.Build.props
@@ -9,4 +9,10 @@
     <RestoreSources Condition="Exists('$(SharedComponentsArtifactsPath)')">$(RestoreSources);$(SharedComponentsArtifactsPath)</RestoreSources>
   </PropertyGroup>
 
+  <!-- Disable NuGet audit in official builds. NuGet Restore does not respect
+       WarningsNotAsErrors, so audit findings become errors via TreatWarningsAsErrors. -->
+  <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+
 </Project>

--- a/eng/tools/Directory.Build.props
+++ b/eng/tools/Directory.Build.props
@@ -9,8 +9,9 @@
     <RestoreSources Condition="Exists('$(SharedComponentsArtifactsPath)')">$(RestoreSources);$(SharedComponentsArtifactsPath)</RestoreSources>
   </PropertyGroup>
 
-  <!-- Disable NuGet audit in official builds. NuGet Restore does not respect
-       WarningsNotAsErrors, so audit findings become errors via TreatWarningsAsErrors. -->
+  <!-- Disable NuGet audit in official builds. MSBuild does not correctly handle
+       WarningsNotAsErrors for NuGet warnings (https://github.com/dotnet/msbuild/issues/10801),
+       so audit findings become errors via TreatWarningsAsErrors. -->
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">
     <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>

--- a/eng/tools/Directory.Build.props
+++ b/eng/tools/Directory.Build.props
@@ -9,13 +9,4 @@
     <RestoreSources Condition="Exists('$(SharedComponentsArtifactsPath)')">$(RestoreSources);$(SharedComponentsArtifactsPath)</RestoreSources>
   </PropertyGroup>
 
-  <!-- Suppress known NuGet audit vulnerabilities in VMR tooling projects.
-       These are compile-only references to Microsoft.Build packages whose transitive
-       dependency on System.Security.Cryptography.Xml has no patched upstream version yet. -->
-  <ItemGroup>
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-37gx-xxp4-5rgx" />
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-w3x6-4m5h-cxqf" />
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-g4vj-cjjj-v7hg" />
-  </ItemGroup>
-
 </Project>

--- a/src/sdk/Directory.Build.props
+++ b/src/sdk/Directory.Build.props
@@ -79,8 +79,9 @@
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
 
-  <!-- Disable NuGet audit in official builds. NuGet Restore does not respect
-       WarningsNotAsErrors, so audit findings become errors via TreatWarningsAsErrors. -->
+  <!-- Disable NuGet audit in official builds. MSBuild does not correctly handle
+       WarningsNotAsErrors for NuGet warnings (https://github.com/dotnet/msbuild/issues/10801),
+       so audit findings become errors via TreatWarningsAsErrors. -->
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">
     <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>

--- a/src/sdk/Directory.Build.props
+++ b/src/sdk/Directory.Build.props
@@ -79,18 +79,8 @@
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
 
-  <!-- TODO: Re-enable NuGet Audit and fix alerts: https://github.com/dotnet/sdk/issues/51465 -->
-  <PropertyGroup>
-    <NuGetAudit>false</NuGetAudit>
-  </PropertyGroup>
-
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
-
-  <!-- TODO: Re-enable NuGet Audit and fix alerts: https://github.com/dotnet/sdk/issues/51466 -->
-  <PropertyGroup>
-    <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>
 
   <!-- Global usings -->

--- a/src/sdk/Directory.Build.props
+++ b/src/sdk/Directory.Build.props
@@ -79,6 +79,12 @@
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
 
+  <!-- Disable NuGet audit in official builds. NuGet Restore does not respect
+       WarningsNotAsErrors, so audit findings become errors via TreatWarningsAsErrors. -->
+  <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/sourcelink/src/Directory.Build.props
+++ b/src/sourcelink/src/Directory.Build.props
@@ -13,7 +13,6 @@
 
     <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
     <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-    <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>
 
 </Project>

--- a/src/sourcelink/src/Directory.Build.props
+++ b/src/sourcelink/src/Directory.Build.props
@@ -13,8 +13,9 @@
 
     <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
     <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-    <!-- Disable NuGet audit in official builds. NuGet Restore does not respect
-         WarningsNotAsErrors, so audit findings become errors via TreatWarningsAsErrors. -->
+    <!-- Disable NuGet audit in official builds. MSBuild does not correctly handle
+         WarningsNotAsErrors for NuGet warnings (https://github.com/dotnet/msbuild/issues/10801),
+         so audit findings become errors via TreatWarningsAsErrors. -->
     <NuGetAudit Condition="'$(OfficialBuild)' == 'true'">false</NuGetAudit>
   </PropertyGroup>
 

--- a/src/sourcelink/src/Directory.Build.props
+++ b/src/sourcelink/src/Directory.Build.props
@@ -13,6 +13,9 @@
 
     <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
     <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+    <!-- Disable NuGet audit in official builds. NuGet Restore does not respect
+         WarningsNotAsErrors, so audit findings become errors via TreatWarningsAsErrors. -->
+    <NuGetAudit Condition="'$(OfficialBuild)' == 'true'">false</NuGetAudit>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
- Remove nuget audit disablement that was put in place for servicing
- Check what fails in the PR and CI builds
- See if we can configure WarnNotAsError for these warnings in the official build