### PR TITLE
Align versioning with 10.0

### DIFF
--- a/src/deployment-tools/eng/Publishing.props
+++ b/src/deployment-tools/eng/Publishing.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- This avoids creating VS.*.symbols.nupkg packages that are identical to the original package. -->
     <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages>
-    <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
+    <ProducesDotNetReleaseShippingAssets Condition="'$(DotNetBuildFromVMR)' == 'true'">true</ProducesDotNetReleaseShippingAssets>
   </PropertyGroup>
   
   <!-- Update all Artifacts with Kind=Package to have additional metadata item Category="ToolingPackage".

--- a/src/deployment-tools/eng/Publishing.props
+++ b/src/deployment-tools/eng/Publishing.props
@@ -3,13 +3,14 @@
   <PropertyGroup>
     <!-- This avoids creating VS.*.symbols.nupkg packages that are identical to the original package. -->
     <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages>
+    <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
   </PropertyGroup>
   
   <!-- Update all Artifacts with Kind=Package to have additional metadata item Category="ToolingPackage".
-        This will mean that in VMR builds, deployment tool packages can get published to a different feed depending on
-        the channel configuration. -->
-   <ItemGroup>
-     <Artifact Update="@(Artifact->WithMetadataValue('Kind', 'Package'))" Category="ToolingPackage" />
-   </ItemGroup>
+       This will mean that in VMR builds, deployment tool packages can get published to a different feed depending on
+       the channel configuration. -->
+  <ItemGroup>
+    <Artifact Update="@(Artifact->WithMetadataValue('Kind', 'Package'))" Category="ToolingPackage" />
+  </ItemGroup>
 
 </Project>

--- a/src/deployment-tools/eng/Versions.props
+++ b/src/deployment-tools/eng/Versions.props
@@ -1,13 +1,13 @@
 <Project>
   <Import Project="Version.Details.props" Condition="Exists('Version.Details.props')" />
   <PropertyGroup>
-    <!-- The .NET product branding version -->
-    <ProductVersion>10.0.0</ProductVersion>
     <!-- File version numbers -->
     <MajorVersion>10</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>0</PatchVersion>
-    <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
+    <PatchVersion>9</PatchVersion>
+    <!-- The .NET product branding version -->
+    <ProductVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</ProductVersion>
+    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <!-- Enable to remove prerelease label. -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>

--- a/src/deployment-tools/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
+++ b/src/deployment-tools/src/Microsoft.Deployment.DotNet.Releases/src/Microsoft.Deployment.DotNet.Releases.csproj
@@ -4,14 +4,10 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
 
-    <MajorVersion>2</MajorVersion>
-    <MinorVersion>0</MinorVersion>
-    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
-    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-
     <!-- Always produce this package in the .NET unified product build so that it may flow to downstream consumers. -->
     <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>
+    <IsShippingPackage>true</IsShippingPackage>
     <PackageId>Microsoft.Deployment.DotNet.Releases</PackageId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EnableXlfLocalization>true</EnableXlfLocalization>


### PR DESCRIPTION
Fix the versioning for Microsoft.Deployment.DotNet.Releases. Currently, active release branches are all producing some form of a 2.0.0 prerelease package, none of which ship on NuGet. This is causing problems for the VMR when some 2.0.0 packages land on the wrong feed.

Starting with 10.0 and 11.0, we'll produce versioned packages that will flow to the SDK and into other products like Visual Studio (this happens as part of the template locator from the SDK that's inserted into Visual Studio).