### PR TITLE
Add dotnet-runtime-deps package for Azure Linux 4 (#6579)

### DIFF
--- a/src/runtime/src/installer/pkg/sfx/installers.proj
+++ b/src/runtime/src/installer/pkg/sfx/installers.proj
@@ -10,6 +10,7 @@
   <ItemGroup Condition="'$(TargetsLinuxGlibc)' == 'true'">
     <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-debian.proj" />
     <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-azl.3.proj" />
+    <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-azl.4.proj" />
     <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-opensuse.15.proj" />
     <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-sles.15.proj" />
   </ItemGroup>

--- a/src/runtime/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-azl.4.proj
+++ b/src/runtime/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-azl.4.proj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <BuildDebPackage>false</BuildDebPackage>
+    <BuildRpmPackage>true</BuildRpmPackage>
+    <PackageTargetOS>azl.4</PackageTargetOS>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <LinuxPackageDependency Include="openssl-libs;icu;krb5-libs;ca-certificates" />
+  </ItemGroup>
+</Project>

--- a/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
+++ b/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
@@ -552,9 +552,22 @@ public partial class LinuxInstallerTests : IDisposable
 
     private string GetMatchingDepsPackage(string baseImage, PackageType packageType)
     {
-        string matchPattern = packageType == PackageType.Deb
-            ? $"{DotnetRuntimeDepsPrefix}*.deb"
-            : $"{DotnetRuntimeDepsPrefix}*azl*.rpm"; // We currently only support Azure Linux deps image
+        string matchPattern;
+        if (packageType == PackageType.Deb)
+        {
+            matchPattern = $"{DotnetRuntimeDepsPrefix}*.deb";
+        }
+        else
+        {
+            // Select the deps RPM that matches the base image's Azure Linux version
+            string azlVersion = baseImage switch
+            {
+                _ when baseImage.Contains("azurelinux3") => "azl.3",
+                _ when baseImage.Contains("azurelinux4") => "azl.4",
+                _ => "azl"
+            };
+            matchPattern = $"{DotnetRuntimeDepsPrefix}*{azlVersion}*.rpm";
+        }
 
         string[] files = Directory.GetFiles(_contextDir, matchPattern, SearchOption.AllDirectories);
         if (files.Length == 0)
@@ -809,13 +822,13 @@ public partial class LinuxInstallerTests : IDisposable
             }
 
             // Runtime deps distro variants (RPM only)
-            string[] distros = new[] { "azl.3", "opensuse.15", "sles.15" };
+            string[] distros = new[] { "azl.3", "azl.4", "opensuse.15", "sles.15" };
             foreach (string distro in distros)
             {
                 patterns.Add($"dotnet-runtime-deps-*-{distro}-{arch}{extension}");
 
                 // `azl` deps packages do not have a -newkey- variant
-                if (distro != "azl.3")
+                if (!distro.StartsWith("azl", StringComparison.Ordinal))
                 {
                     patterns.Add($"dotnet-runtime-deps-*-{distro}-newkey-{arch}{extension}");
                 }


### PR DESCRIPTION
Backport of https://github.com/dotnet/dotnet/pull/6579

Changes:
- Add `dotnet-runtime-deps-azl.4.proj` with `krb5-libs` replacing `krb5`
- Register the new project in `installers.proj`
- Update `LinuxInstallerTests` to expect AZL4 deps packages and generalize the `newkey` skip condition for all AZL versions

No arcade infrastructure changes are needed - existing conditions in `installer.build.targets` already handle new azl.* `PackageTargetOS` values correctly.