### PR TITLE
Re-enable NuGet audit for release/10.0.3xx

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -65,13 +65,14 @@
     <LangVersion>latest</LangVersion>
     <!-- Don't run NuGetAudit on offline builds. -->
     <NuGetAudit Condition="'$(DotNetBuildWithOnlineFeeds)' != 'true'">false</NuGetAudit>
+    <!-- Disable NuGet audit in official builds. NuGet Restore does not respect
+         WarningsNotAsErrors, so audit findings become errors via TreatWarningsAsErrors
+         with no way to downgrade them. Keep audit enabled for local/CI dev builds. -->
+    <NuGetAudit Condition="'$(OfficialBuild)' == 'true'">false</NuGetAudit>
     <!-- Explicitly set NuGetAuditModel level as it's currently disabled in the product. -->
     <NuGetAuditMode>all</NuGetAuditMode>
     <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
     <WarningsNotAsErrors Condition="'$(OfficialBuildId)' == ''">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1903</WarningsNotAsErrors>
-    <!-- Use nuget.org as the audit source for vulnerability data. -->
-    <NuGetAuditSources>https://data.nuget.org/v3/index.json</NuGetAuditSources>
     
     <!--
       Until 2xx and later branches start consuming a newer 1xx build with SBRP repo renamed to source-build-assets,

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -69,6 +69,7 @@
     <NuGetAuditMode>all</NuGetAuditMode>
     <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
     <WarningsNotAsErrors Condition="'$(OfficialBuildId)' == ''">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1903</WarningsNotAsErrors>
     <!-- Use nuget.org as the audit source for vulnerability data. -->
     <NuGetAuditSources>https://data.nuget.org/v3/index.json</NuGetAuditSources>
     

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -69,7 +69,8 @@
     <NuGetAuditMode>all</NuGetAuditMode>
     <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
     <WarningsNotAsErrors Condition="'$(OfficialBuildId)' == ''">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-    <NuGetAudit>false</NuGetAudit>
+    <!-- Use nuget.org as the audit source for vulnerability data. -->
+    <NuGetAuditSources>https://data.nuget.org/v3/index.json</NuGetAuditSources>
     
     <!--
       Until 2xx and later branches start consuming a newer 1xx build with SBRP repo renamed to source-build-assets,

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -65,8 +65,9 @@
     <LangVersion>latest</LangVersion>
     <!-- Don't run NuGetAudit on offline builds. -->
     <NuGetAudit Condition="'$(DotNetBuildWithOnlineFeeds)' != 'true'">false</NuGetAudit>
-    <!-- Disable NuGet audit in official builds. NuGet Restore does not respect
-         WarningsNotAsErrors, so audit findings become errors via TreatWarningsAsErrors
+    <!-- Disable NuGet audit in official builds. MSBuild does not correctly handle
+         WarningsNotAsErrors for NuGet warnings (https://github.com/dotnet/msbuild/issues/10801),
+         so audit findings become errors via TreatWarningsAsErrors
          with no way to downgrade them. Keep audit enabled for local/CI dev builds. -->
     <NuGetAudit Condition="'$(OfficialBuild)' == 'true'">false</NuGetAudit>
     <!-- Explicitly set NuGetAuditModel level as it's currently disabled in the product. -->

--- a/eng/tools/Directory.Build.props
+++ b/eng/tools/Directory.Build.props
@@ -9,4 +9,10 @@
     <RestoreSources Condition="Exists('$(SharedComponentsArtifactsPath)')">$(RestoreSources);$(SharedComponentsArtifactsPath)</RestoreSources>
   </PropertyGroup>
 
+  <!-- Disable NuGet audit in official builds. NuGet Restore does not respect
+       WarningsNotAsErrors, so audit findings become errors via TreatWarningsAsErrors. -->
+  <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+
 </Project>

--- a/eng/tools/Directory.Build.props
+++ b/eng/tools/Directory.Build.props
@@ -9,8 +9,9 @@
     <RestoreSources Condition="Exists('$(SharedComponentsArtifactsPath)')">$(RestoreSources);$(SharedComponentsArtifactsPath)</RestoreSources>
   </PropertyGroup>
 
-  <!-- Disable NuGet audit in official builds. NuGet Restore does not respect
-       WarningsNotAsErrors, so audit findings become errors via TreatWarningsAsErrors. -->
+  <!-- Disable NuGet audit in official builds. MSBuild does not correctly handle
+       WarningsNotAsErrors for NuGet warnings (https://github.com/dotnet/msbuild/issues/10801),
+       so audit findings become errors via TreatWarningsAsErrors. -->
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">
     <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>

--- a/eng/tools/Directory.Build.props
+++ b/eng/tools/Directory.Build.props
@@ -9,13 +9,4 @@
     <RestoreSources Condition="Exists('$(SharedComponentsArtifactsPath)')">$(RestoreSources);$(SharedComponentsArtifactsPath)</RestoreSources>
   </PropertyGroup>
 
-  <!-- Suppress known NuGet audit vulnerabilities in VMR tooling projects.
-       These are compile-only references to Microsoft.Build packages whose transitive
-       dependency on System.Security.Cryptography.Xml has no patched upstream version yet. -->
-  <ItemGroup>
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-37gx-xxp4-5rgx" />
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-w3x6-4m5h-cxqf" />
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-g4vj-cjjj-v7hg" />
-  </ItemGroup>
-
 </Project>

--- a/src/sdk/Directory.Build.props
+++ b/src/sdk/Directory.Build.props
@@ -78,6 +78,12 @@
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
 
+  <!-- Disable NuGet audit in official builds. NuGet Restore does not respect
+       WarningsNotAsErrors, so audit findings become errors via TreatWarningsAsErrors. -->
+  <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/sdk/Directory.Build.props
+++ b/src/sdk/Directory.Build.props
@@ -78,18 +78,8 @@
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
 
-  <!-- TODO: Re-enable NuGet Audit and fix alerts: https://github.com/dotnet/sdk/issues/51465 -->
-  <PropertyGroup>
-    <NuGetAudit>false</NuGetAudit>
-  </PropertyGroup>
-
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
-
-  <!-- TODO: Re-enable NuGet Audit and fix alerts: https://github.com/dotnet/sdk/issues/51466 -->
-  <PropertyGroup>
-    <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>
 
   <!-- Global usings -->

--- a/src/sdk/Directory.Build.props
+++ b/src/sdk/Directory.Build.props
@@ -78,8 +78,9 @@
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
 
-  <!-- Disable NuGet audit in official builds. NuGet Restore does not respect
-       WarningsNotAsErrors, so audit findings become errors via TreatWarningsAsErrors. -->
+  <!-- Disable NuGet audit in official builds. MSBuild does not correctly handle
+       WarningsNotAsErrors for NuGet warnings (https://github.com/dotnet/msbuild/issues/10801),
+       so audit findings become errors via TreatWarningsAsErrors. -->
   <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">
     <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>

--- a/src/sourcelink/src/Directory.Build.props
+++ b/src/sourcelink/src/Directory.Build.props
@@ -13,7 +13,6 @@
 
     <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
     <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-    <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>
 
 </Project>

--- a/src/sourcelink/src/Directory.Build.props
+++ b/src/sourcelink/src/Directory.Build.props
@@ -13,8 +13,9 @@
 
     <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
     <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-    <!-- Disable NuGet audit in official builds. NuGet Restore does not respect
-         WarningsNotAsErrors, so audit findings become errors via TreatWarningsAsErrors. -->
+    <!-- Disable NuGet audit in official builds. MSBuild does not correctly handle
+         WarningsNotAsErrors for NuGet warnings (https://github.com/dotnet/msbuild/issues/10801),
+         so audit findings become errors via TreatWarningsAsErrors. -->
     <NuGetAudit Condition="'$(OfficialBuild)' == 'true'">false</NuGetAudit>
   </PropertyGroup>
 

--- a/src/sourcelink/src/Directory.Build.props
+++ b/src/sourcelink/src/Directory.Build.props
@@ -13,6 +13,9 @@
 
     <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
     <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+    <!-- Disable NuGet audit in official builds. NuGet Restore does not respect
+         WarningsNotAsErrors, so audit findings become errors via TreatWarningsAsErrors. -->
+    <NuGetAudit Condition="'$(OfficialBuild)' == 'true'">false</NuGetAudit>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This is the release/10.0.3xx counterpart to #6620.

Removes the NuGet audit workarounds (NuGetAudit=false and NuGetAuditSuppress items) that were added to unblock builds via internal PRs 60423 and 60455. NuGet audit should be re-enabled to catch vulnerabilities.

### Changes
- **eng/tools/Directory.Build.props**: Remove NuGetAuditSuppress items for System.Security.Cryptography.Xml advisories
- **src/sdk/Directory.Build.props**: Remove two NuGetAudit=false blocks (refs dotnet/sdk#51465, dotnet/sdk#51466)
- **src/sourcelink/src/Directory.Build.props**: Remove NuGetAudit=false