### PR TITLE
Rename ReportSbrpUsage build option to ReportSbaUsage

### DIFF
--- a/eng/finish-source-only.proj
+++ b/eng/finish-source-only.proj
@@ -146,21 +146,21 @@
     </Touch>
   </Target>
 
-  <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.WriteSBRPUsageReport" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
-  <Target Name="ReportSbrpUsage"
+  <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.WriteSbaUsageReport" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
+  <Target Name="ReportSbaUsage"
           AfterTargets="Build"
           DependsOnTargets="ResolveProjectReferences"
-          Condition="'$(ReportSbrpUsage)' == 'true'">
+          Condition="'$(ReportSbaUsage)' == 'true'">
     <ItemGroup>
       <ProjectAssetsJsonFile Include="$(ArtifactsDir)**/project.assets.json" />
       <ProjectAssetsJsonFile Include="$(SrcDir)**/artifacts/**/project.assets.json" />
     </ItemGroup>
 
-    <WriteSbrpUsageReport ContinueOnError="WarnAndContinue"
-                          SbaRepoSrcPath="$(SourceBuildAssetsRepoSrcDir)"
-                          SbaPackagesPath="$(ArtifactsShippingPackagesDir)/source-build-assets"
-                          ProjectAssetsJsons="@(ProjectAssetsJsonFile)"
-                          OutputPath="$(ArtifactsLogDir)" />
+    <WriteSbaUsageReport ContinueOnError="WarnAndContinue"
+                         SbaRepoSrcPath="$(SourceBuildAssetsRepoSrcDir)"
+                         SbaPackagesPath="$(ArtifactsShippingPackagesDir)/source-build-assets"
+                         ProjectAssetsJsons="@(ProjectAssetsJsonFile)"
+                         OutputPath="$(ArtifactsLogDir)" />
   </Target>
 
   <Target Name="DetermineSourceBuiltSdkNonStableVersion"

--- a/eng/finish-source-only.proj
+++ b/eng/finish-source-only.proj
@@ -13,7 +13,7 @@
     <ResultingPrebuiltPackagesDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsLogDir)', 'prebuilt-packages'))</ResultingPrebuiltPackagesDir>
 
     <!-- SBRP usage report is diagnostic-only and should not fail the build -->
-    <MSBuildWarningsNotAsErrors>$(MSBuildWarningsNotAsErrors);SBRP001</MSBuildWarningsNotAsErrors>
+    <MSBuildWarningsNotAsErrors>$(MSBuildWarningsNotAsErrors);SBA001</MSBuildWarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -772,7 +772,7 @@ jobs:
             extraBuildProperties="$extraBuildProperties $(signProperties)"
           else
             customBuildArgs="$customBuildArgs --source-only"
-            extraBuildProperties="$extraBuildProperties /p:ReportSbrpUsage=true"
+            extraBuildProperties="$extraBuildProperties /p:ReportSbaUsage=true"
             if [[ '${{ parameters.sign }}' == 'True' ]]; then
               # Set up for signing source-built artifacts post-build.
               extraBuildProperties="$extraBuildProperties /p:DotNetSourceOnlyPostBuildSign=true"

--- a/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/WriteSbaUsageReport.cs
+++ b/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/WriteSbaUsageReport.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.UnifiedBuild.Tasks;
 public partial class WriteSbaUsageReport : Task
 {
     private const string SbaRepoName = "source-build-assets";
-    private const string ErrorCode = "SBRP001";
+    private const string ErrorCode = "SBA001";
 
     private readonly Dictionary<string, PackageInfo> _sbaPackages = [];
 

--- a/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/WriteSbaUsageReport.cs
+++ b/eng/tools/tasks/Microsoft.DotNet.UnifiedBuild.Tasks/WriteSbaUsageReport.cs
@@ -17,11 +17,11 @@ using NuGet.ProjectModel;
 namespace Microsoft.DotNet.UnifiedBuild.Tasks;
 
 /// <summary>
-/// Reports the usage of the source-build-reference-packages:
+/// Reports the usage of the source-build-assets packages:
 /// 1. SBA references
 /// 2. Unreferenced packages
 /// </summary>
-public partial class WriteSbrpUsageReport : Task
+public partial class WriteSbaUsageReport : Task
 {
     private const string SbaRepoName = "source-build-assets";
     private const string ErrorCode = "SBRP001";

--- a/src/source-build-assets/README.md
+++ b/src/source-build-assets/README.md
@@ -300,15 +300,15 @@ Other source build related issues should be opened in [dotnet/source-build](http
 Periodically, packages that are unreferenced by the product source build should be deleted. The number of
 unreferenced packages build up over time as the product repositories upgrade their dependencies to newer
 versions. Ideally this cleanup would be performed around RC1 timeframe as the product locks down in preparation
-for the GA release. To find which packages are unreferenced, you can run a VMR build with the `ReportSbrpUsage`
-option to generate an SBRP package usage report. The resulting report will be written to
-`artifacts/log/<configuration>/sbrpPackageUsage.json`.
+for the GA release. To find which packages are unreferenced, you can run a VMR build with the `ReportSbaUsage`
+option to generate an SBA package usage report. The resulting report will be written to
+`artifacts/log/<configuration>/sbaPackageUsage.json`.
 
 ``` bash
-./build.sh -sb /p:ReportSbrpUsage=true
+./build.sh -sb /p:ReportSbaUsage=true
 ```
 
-The VMR CI runs with the `ReportSbrpUsage` option set therefore you can grab the usage report from any build's
+The VMR CI runs with the `ReportSbaUsage` option set therefore you can grab the usage report from any build's
 artifacts.
 
 > **Note:** [The package usage report does not currently support external packages](https://github.com/dotnet/source-build/issues/3405).

--- a/src/source-build-assets/README.md
+++ b/src/source-build-assets/README.md
@@ -301,7 +301,7 @@ Periodically, packages that are unreferenced by the product source build should 
 unreferenced packages build up over time as the product repositories upgrade their dependencies to newer
 versions. Ideally this cleanup would be performed around RC1 timeframe as the product locks down in preparation
 for the GA release. To find which packages are unreferenced, you can run a VMR build with the `ReportSbaUsage`
-option to generate an SBA package usage report. The resulting report will be written to
+option to generate a package usage report. The resulting report will be written to
 `artifacts/log/<configuration>/sbaPackageUsage.json`.
 
 ``` bash

--- a/src/source-build-assets/azure-pipelines/builds/cleanup-unreferenced-packages.yml
+++ b/src/source-build-assets/azure-pipelines/builds/cleanup-unreferenced-packages.yml
@@ -4,7 +4,7 @@ parameters:
 - name: artifactName
   type: string
   default: SB_CentOSStream10_Online_MsftSdk_x64_BuildLogs_Attempt1
-  displayName: (Optional) Source Build Artrifact Name to retrieve sbrpPackageUsage.json from
+  displayName: (Optional) Source Build Artrifact Name to retrieve sbaPackageUsage.json from
 
 - name: skipPackages
   type: string
@@ -14,7 +14,7 @@ parameters:
 - name: knownFalsePositives
   type: string
   default: 'microsoft.build.notargets/3.7.0 microsoft.build.traversal/3.4.0'
-  displayName: List of known false positives (<name>[/<version>]) in the sbrpPackageUsage.json to skip from deletion (space separated)
+  displayName: List of known false positives (<name>[/<version>]) in the sbaPackageUsage.json to skip from deletion (space separated)
 
 pool:
   name: NetCore1ESPool-Svc-Internal
@@ -63,19 +63,19 @@ stages:
         definition: $(resources.pipeline.dotnet-unified-build.pipelineName)
         pipelineId: $(resources.pipeline.dotnet-unified-build.runID)
         artifactName: ${{ parameters.artifactName }}
-        itemPattern: '**/sbrpPackageUsage.json'
+        itemPattern: '**/sbaPackageUsage.json'
         targetPath: $(Pipeline.Workspace)
         allowPartiallySucceededBuilds: true
         allowFailedBuilds: true
 
     - script: |
-        if [ -f "$(Pipeline.Workspace)/artifacts/log/Release/sbrpPackageUsage.json" ]; then
-          echo "sbrpPackageUsage.json file found."
-          cat "$(Pipeline.Workspace)/artifacts/log/Release/sbrpPackageUsage.json"
+        if [ -f "$(Pipeline.Workspace)/artifacts/log/Release/sbaPackageUsage.json" ]; then
+          echo "sbaPackageUsage.json file found."
+          cat "$(Pipeline.Workspace)/artifacts/log/Release/sbaPackageUsage.json"
         else
-          echo "sbrpPackageUsage.json file not found."
+          echo "sbaPackageUsage.json file not found."
         fi
-      displayName: Check and display sbrpPackageUsage.json
+      displayName: Check and display sbaPackageUsage.json
 
     - script: |
         time="$(date +%s)"
@@ -100,8 +100,8 @@ stages:
         GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)
 
     - script: |
-        json_file="$(Pipeline.Workspace)/artifacts/log/Release/sbrpPackageUsage.json"
-        unreferenced_paths=$(jq -r '.UnreferencedSbrps[]' "$json_file")
+        json_file="$(Pipeline.Workspace)/artifacts/log/Release/sbaPackageUsage.json"
+        unreferenced_paths=$(jq -r '.UnreferencedSbaPackages[]' "$json_file")
         skip_packages_array=(${{ lower(parameters.skipPackages) }} ${{ lower(parameters.knownFalsePositives) }})
 
         for path in $unreferenced_paths; do

--- a/src/source-build-assets/azure-pipelines/builds/cleanup-unreferenced-packages.yml
+++ b/src/source-build-assets/azure-pipelines/builds/cleanup-unreferenced-packages.yml
@@ -4,7 +4,7 @@ parameters:
 - name: artifactName
   type: string
   default: SB_CentOSStream10_Online_MsftSdk_x64_BuildLogs_Attempt1
-  displayName: (Optional) Source Build Artrifact Name to retrieve sbaPackageUsage.json from
+  displayName: (Optional) Source Build Artifact Name to retrieve sbaPackageUsage.json from
 
 - name: skipPackages
   type: string


### PR DESCRIPTION
The `source-build-reference-packages` repo was renamed to `source-build-assets` but the `ReportSbrpUsage` build property, MSBuild target, task class, and error code were not updated to match. This renames them for consistency.

## Changes

- **Build property:** `ReportSbrpUsage` -> `ReportSbaUsage`
- **MSBuild target:** `ReportSbrpUsage` -> `ReportSbaUsage`
- **Task class + file:** `WriteSbrpUsageReport` -> `WriteSbaUsageReport`
- **Error code:** `SBRP001` -> `SBA001`
- **Pipeline reference:** Updated `vmr-build.yml` to pass `/p:ReportSbaUsage=true`
- **source-build-assets README:** Updated the Cleanup section to reference the new property name and output file (`sbaPackageUsage.json`)
- **Cleanup pipeline:** Updated `cleanup-unreferenced-packages.yml` to use `sbaPackageUsage.json` and the correct JSON field name (`.UnreferencedSbaPackages[]` which already matches what the task emits)

Related to: https://github.com/dotnet/source-build-assets/issues/1311
