### PR TITLE
[release/10.0.1xx] Rebrand to patch 10

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,7 +4,7 @@
     <VersionMajor>10</VersionMajor>
     <VersionMinor>0</VersionMinor>
     <VersionSDKMinor>1</VersionSDKMinor>
-    <VersionSDKMinorPatch>9</VersionSDKMinorPatch>
+    <VersionSDKMinorPatch>10</VersionSDKMinorPatch>
     <VersionFeature>$([System.String]::Copy('$(VersionSDKMinorPatch)').PadLeft(2, '0'))</VersionFeature>
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionSDKMinor)$(VersionFeature)</VersionPrefix>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>


### PR DESCRIPTION
Increment patch version 9 -> 10 on release/10.0.1xx

Sets prerelease label to 'servicing' and iteration to empty string.