### PR TITLE
Fix intermittent circular dependency in sharedfx.targets (MSB4006)

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/arcade/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -537,8 +537,12 @@
 
   <Target Name="_AddFilesToNuGetPackage" BeforeTargets="_GetPackageFiles">
 
+    <!-- Set _GettingFilesForPackage=true to differentiate global properties for this nested MSBuild call
+         and avoid an intermittent circular dependency (MSB4006) when the scheduler builds the same project
+         concurrently with identical global properties. See https://github.com/dotnet/msbuild/issues/13599 -->
     <MSBuild Projects="$(MSBuildProjectFullPath)"
           Targets="_GetAllSharedFrameworkFiles"
+          Properties="_GettingFilesForPackage=true"
           RemoveProperties="NoBuild">
       <Output TaskParameter="TargetOutputs" ItemName="_FilesToPackage" />
     </MSBuild>
@@ -570,8 +574,11 @@
 
   <Target Name="GetFilesToPublish">
 
+    <!-- Set _GettingFilesForPublish=true to differentiate global properties for this nested MSBuild call
+         and avoid an intermittent circular dependency (MSB4006). -->
     <MSBuild Projects="$(MSBuildProjectFullPath)"
           Targets="_GetAllSharedFrameworkFiles"
+          Properties="_GettingFilesForPublish=true"
           RemoveProperties="OutputPath;SymbolsOutputPath">
       <Output TaskParameter="TargetOutputs" ItemName="_FilesToPackage" />
     </MSBuild>

--- a/src/aspnetcore/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
+++ b/src/aspnetcore/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
@@ -136,10 +136,9 @@
   </Target>
 
   <Target Name="PublishToSharedLayoutRoot" BeforeTargets="Build">
-    <!-- Set _PublishingToLayout=true to differentiate global properties for this nested MSBuild call and avoid an intermittent circular dependency involving GetFilesToPublish. -->
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishToDisk"
-             Properties="OutputPath=$(SharedFrameworkLayoutRoot);_PublishingToLayout=true" />
+             Properties="OutputPath=$(SharedFrameworkLayoutRoot)" />
   </Target>
 
   <Target Name="ReturnProductVersion" Returns="$(Version)" />

--- a/src/runtime/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/runtime/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -75,6 +75,7 @@
     <PlatformManifestFileEntry Include="System.Private.Xml.Linq.dll" />
     <!-- Platform-Native Composite R2R images -->
     <PlatformManifestFileEntry Include="Microsoft.NETCore.App.r2r.dylib" />
+    <PlatformManifestFileEntry Include="Microsoft.NETCore.App.Runtime.CoreCLR.r2r.dylib" />
     <!-- Native libraries -->
     <PlatformManifestFileEntry Include="libSystem.Globalization.Native.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libSystem.Globalization.Native.dylib" IsNative="true" />


### PR DESCRIPTION
## Summary

Fixes an intermittent `MSB4006: There is a circular dependency in the target dependency graph` build failure in shared framework projects, and fixes a latent platform manifest bug exposed by the fix.

## Problem 1: Circular dependency (MSB4006)

`sharedfx.targets` contains self-referencing `<MSBuild Projects="$(MSBuildProjectFullPath)">` calls in `_AddFilesToNuGetPackage` and `GetFilesToPublish`. When these nested calls produce **identical global properties** to the parent build, the MSBuild scheduler treats them as the same build and detects a false circular dependency.

`_AddFilesToNuGetPackage` (line 540) uses `RemoveProperties="NoBuild"`, but when `NoBuild` isn't set in the outer build, removing it is a no-op — the nested call has identical global properties to the parent.

### Fix

Add differentiating dummy properties (`_GettingFilesForPackage=true`, `_GettingFilesForPublish=true`) to the nested MSBuild calls so they always have distinct global property sets from the parent build.

This is the same pattern used in the workaround at dotnet/aspnetcore#65667 (which added `_PublishingToLayout=true` to the caller side for `GetFilesToPublish`). This PR fixes both targets at the source in arcade and removes the aspnetcore workaround.

### Evidence

- **Failing build**: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1426800 (aspnetcore CI, Linux x64)
- **Error**: `sharedfx.targets(540,5): error MSB4006: There is a circular dependency in the target dependency graph involving target "_AddFilesToNuGetPackage"`
- **MSBuild issue**: https://github.com/dotnet/msbuild/issues/13599

## Problem 2: Missing platform manifest entry (exposed by fix)

With the circular dependency fix, the nested MSBuild call in `_AddFilesToNuGetPackage` now correctly runs as a **distinct build** instead of reusing cached results from the parent. This causes `_ValidateAllFilesInTemplatedPlatformManifest` to evaluate freshly and catch a pre-existing bug: `Microsoft.NETCore.App.Runtime.CoreCLR.r2r.dylib` (the composite R2R Mach-O image produced by `Microsoft.NETCore.App.Runtime.CoreCLR.sfxproj` on Apple mobile platforms) was missing from the `PlatformManifestFileEntry` list.

The manifest already had `Microsoft.NETCore.App.r2r.dylib` (from the Mono sfxproj), but not the CoreCLR variant. This bug was latent — previously hidden because MSBuild reused the parent build's already-evaluated targets, skipping fresh validation.

### Fix

Add `Microsoft.NETCore.App.Runtime.CoreCLR.r2r.dylib` to the `PlatformManifestFileEntry` list in `src/runtime/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props`.

## Changes

| Commit | Component | Change |
|--------|-----------|--------|
| 1 | src/arcade | Add `_GettingFilesForPackage` and `_GettingFilesForPublish` differentiating properties to nested MSBuild calls in sharedfx.targets |
| 2 | src/aspnetcore | Remove `_PublishingToLayout` workaround from sfxproj (no longer needed) |
| 3 | src/runtime | Add missing `Microsoft.NETCore.App.Runtime.CoreCLR.r2r.dylib` platform manifest entry |