### PR TITLE
Fix ChangeValidation running against internal AzDO PRs

### DIFF
--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -113,4 +113,3 @@ stages:
           env:
             SYSTEM_PULLREQUEST_TARGETBRANCH: $(System.PullRequest.TargetBranch)
             SYSTEM_PULLREQUEST_SOURCEBRANCH: $(System.PullRequest.SourceBranch)
-            SYSTEM_PULLREQUEST_PULLREQUESTNUMBER: $(System.PullRequest.PullRequestNumber)

--- a/eng/tools/ChangeValidation/ExclusionFileValidation.cs
+++ b/eng/tools/ChangeValidation/ExclusionFileValidation.cs
@@ -40,13 +40,22 @@ internal class ExclusionFileValidation : IValidationStep
 
     public async Task<bool> Validate(PrInfo prInfo)
     {
+        LogInfo($"Starting exclusion file validation against target branch: {prInfo.TargetBranch}");
+        LogInfo($"VMR path: {_vmrInfo.VmrPath}");
+
         ILocalGitRepo vmr = _localGitRepoFactory.Create(_vmrInfo.VmrPath);
 
         var newExclusionRules = await GetExclusionPatterns(); // We are already checked to the PR Head commit, just parse exclusions from file
+        LogInfo($"Found {newExclusionRules.Count} exclusion rules from PR head.");
+
         var originalExclusionRules = await GetExclusionPatternsFromBranch(vmr, prInfo.TargetBranch);
+        LogInfo($"Found {originalExclusionRules.Count} exclusion rules from target branch.");
 
         var newExcludedFiles = FindMatchingFiles(newExclusionRules);
+        LogInfo($"Files matching new exclusion rules: {newExcludedFiles.Count}");
+
         var originalExcludedFiles = FindMatchingFiles(originalExclusionRules);
+        LogInfo($"Files matching original exclusion rules: {originalExcludedFiles.Count}");
 
         var excludedFilesInPr = prInfo.ChangedFiles
             .Where(file => newExcludedFiles.Contains(NormalizePath(file)))
@@ -89,14 +98,17 @@ internal class ExclusionFileValidation : IValidationStep
     private async Task<List<string>> GetExclusionPatternsFromBranch(ILocalGitRepo vmr, string branchName)
     {
         string originalRef = await vmr.GetCheckedOutBranchAsync();
+        LogInfo($"Current checked out ref: {originalRef}");
         try
         {
             LogInfo($"Checking out branch {branchName} to get exclusion patterns.");
             await vmr.CheckoutAsync(branchName);
+            LogInfo($"Successfully checked out {branchName}.");
             return await GetExclusionPatterns();
         }
         finally
         {
+            LogInfo($"Restoring checkout to {originalRef}.");
             await vmr.CheckoutAsync(originalRef);
         }
     }

--- a/eng/tools/ChangeValidation/Validation.cs
+++ b/eng/tools/ChangeValidation/Validation.cs
@@ -52,7 +52,7 @@ internal static class Validation
             catch (Exception ex)
             {
                 LogError($"{validationStep.DisplayName} was interrupted with an unexpected error.");
-                LogError($"Exception: {ex}");
+                Console.WriteLine(ex);
             }
             if (validationSuccess)
             {
@@ -93,13 +93,13 @@ internal static class Validation
         }
 
         // AzDO may provide the branch as "refs/heads/..." or just the branch name — normalize to "origin/<branch>"
-        string? targetBranch = rawTargetBranch?.StartsWith("refs/heads/") == true
+        string targetBranch = rawTargetBranch.StartsWith("refs/heads/")
             ? $"origin/{rawTargetBranch["refs/heads/".Length..]}"
             : $"origin/{rawTargetBranch}";
 
         LogInfo($"Resolved target branch ref: {targetBranch}");
 
-        // HEAD is already the PR source branch (checked out by the pipeline).
+        // HEAD is the PR ref checked out by the pipeline (source or merge commit).
         // Compute the merge-base between HEAD and the target branch to get only PR changes.
         string mergeBaseCommit = (await pm.ExecuteGit(repoPath, ["merge-base", "HEAD", targetBranch])).StandardOutput.Trim();
         LogInfo($"Merge base commit: {mergeBaseCommit}");

--- a/eng/tools/ChangeValidation/Validation.cs
+++ b/eng/tools/ChangeValidation/Validation.cs
@@ -22,6 +22,7 @@ internal static class Validation
         var pm = new ProcessManager(NullLogger<ProcessManager>.Instance, "git");
 
         var repoRoot = pm.FindGitRoot(AppContext.BaseDirectory);
+        LogInfo($"Repository root: {repoRoot}");
 
         var serviceProvider = RegisterServices(repoRoot);
 
@@ -48,9 +49,10 @@ internal static class Validation
             {
                 validationSuccess = await validationStep.Validate(prInfo);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 LogError($"{validationStep.DisplayName} was interrupted with an unexpected error.");
+                LogError($"Exception: {ex}");
             }
             if (validationSuccess)
             {
@@ -78,17 +80,29 @@ internal static class Validation
 
     private static async Task<PrInfo> SetupPrInfo(IProcessManager pm, string repoPath)
     {
-        string? targetBranch = $"origin/{Environment.GetEnvironmentVariable("SYSTEM_PULLREQUEST_TARGETBRANCH")}";
+        string? rawTargetBranch = Environment.GetEnvironmentVariable("SYSTEM_PULLREQUEST_TARGETBRANCH");
+        string? rawSourceBranch = Environment.GetEnvironmentVariable("SYSTEM_PULLREQUEST_SOURCEBRANCH");
         string? prNumber = Environment.GetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER");
 
-        if (string.IsNullOrEmpty(targetBranch))
+        LogInfo($"Raw environment variables:");
+        LogInfo($"  SYSTEM_PULLREQUEST_TARGETBRANCH: {rawTargetBranch}");
+        LogInfo($"  SYSTEM_PULLREQUEST_SOURCEBRANCH: {rawSourceBranch}");
+        LogInfo($"  SYSTEM_PULLREQUEST_PULLREQUESTNUMBER: {prNumber}");
+
+        string? targetBranch = $"origin/{rawTargetBranch}";
+
+        if (string.IsNullOrEmpty(rawTargetBranch))
         {
             throw new ArgumentException("Cannot determine PR target branch.");
         }
 
+        LogInfo($"Resolved target branch ref: {targetBranch}");
+
         // Create a git reference to the original branching-off point of the PR branch from the target branch
+        LogInfo($"Fetching PR merge ref: refs/pull/{prNumber}/merge");
         await pm.ExecuteGit(repoPath, "fetch", "origin", $"refs/pull/{prNumber}/merge:pr-merge");
 
+        LogInfo($"Computing diff between {targetBranch} and pr-merge...");
         var diffOutput = (await pm.ExecuteGit(repoPath, ["diff", "--name-only", targetBranch, "pr-merge"])).StandardOutput.Trim();
 
         var changedFiles = diffOutput
@@ -96,7 +110,7 @@ internal static class Validation
             .Select(f => f.Replace('\\', '/').Trim())
             .ToImmutableList();
 
-        Console.WriteLine($"Found modifications to {changedFiles.Count} file(s) in PR head branch");
+        LogInfo($"Found modifications to {changedFiles.Count} file(s) in PR head branch");
 
         return new PrInfo(targetBranch, changedFiles);
     }

--- a/eng/tools/ChangeValidation/Validation.cs
+++ b/eng/tools/ChangeValidation/Validation.cs
@@ -89,12 +89,15 @@ internal static class Validation
         LogInfo($"  SYSTEM_PULLREQUEST_SOURCEBRANCH: {rawSourceBranch}");
         LogInfo($"  SYSTEM_PULLREQUEST_PULLREQUESTNUMBER: {prNumber}");
 
-        string? targetBranch = $"origin/{rawTargetBranch}";
-
         if (string.IsNullOrEmpty(rawTargetBranch))
         {
             throw new ArgumentException("Cannot determine PR target branch.");
         }
+
+        // AzDO may provide the branch as "refs/heads/..." or just the branch name — normalize to "origin/<branch>"
+        string? targetBranch = rawTargetBranch?.StartsWith("refs/heads/") == true
+            ? $"origin/{rawTargetBranch["refs/heads/".Length..]}"
+            : $"origin/{rawTargetBranch}";
 
         LogInfo($"Resolved target branch ref: {targetBranch}");
 

--- a/eng/tools/ChangeValidation/Validation.cs
+++ b/eng/tools/ChangeValidation/Validation.cs
@@ -82,12 +82,10 @@ internal static class Validation
     {
         string? rawTargetBranch = Environment.GetEnvironmentVariable("SYSTEM_PULLREQUEST_TARGETBRANCH");
         string? rawSourceBranch = Environment.GetEnvironmentVariable("SYSTEM_PULLREQUEST_SOURCEBRANCH");
-        string? prNumber = Environment.GetEnvironmentVariable("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER");
 
         LogInfo($"Raw environment variables:");
         LogInfo($"  SYSTEM_PULLREQUEST_TARGETBRANCH: {rawTargetBranch}");
         LogInfo($"  SYSTEM_PULLREQUEST_SOURCEBRANCH: {rawSourceBranch}");
-        LogInfo($"  SYSTEM_PULLREQUEST_PULLREQUESTNUMBER: {prNumber}");
 
         if (string.IsNullOrEmpty(rawTargetBranch))
         {
@@ -101,12 +99,13 @@ internal static class Validation
 
         LogInfo($"Resolved target branch ref: {targetBranch}");
 
-        // Create a git reference to the original branching-off point of the PR branch from the target branch
-        LogInfo($"Fetching PR merge ref: refs/pull/{prNumber}/merge");
-        await pm.ExecuteGit(repoPath, "fetch", "origin", $"refs/pull/{prNumber}/merge:pr-merge");
+        // HEAD is already the PR source branch (checked out by the pipeline).
+        // Compute the merge-base between HEAD and the target branch to get only PR changes.
+        string mergeBaseCommit = (await pm.ExecuteGit(repoPath, ["merge-base", "HEAD", targetBranch])).StandardOutput.Trim();
+        LogInfo($"Merge base commit: {mergeBaseCommit}");
 
-        LogInfo($"Computing diff between {targetBranch} and pr-merge...");
-        var diffOutput = (await pm.ExecuteGit(repoPath, ["diff", "--name-only", targetBranch, "pr-merge"])).StandardOutput.Trim();
+        LogInfo($"Computing diff between {mergeBaseCommit} and HEAD...");
+        var diffOutput = (await pm.ExecuteGit(repoPath, ["diff", "--name-only", mergeBaseCommit, "HEAD"])).StandardOutput.Trim();
 
         var changedFiles = diffOutput
             .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)


### PR DESCRIPTION
The main issue was that we use `System.PullRequest.TargetBranch` which contains the `refs/heads/` prefix and we need to strip that.

Also fix calculating the changed files since `System.PullRequest.PullRequestNumber` only works for GitHub PRs, not AzDO PRs. We don't actually need it to calculate the changes, we can use `merge-base` instead.

Added logging to make it easier to see what's going on.

I tested this in an internal validation PR.