### PR TITLE
Re-enable NuGet audit for release/10.0.4xx

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -66,6 +66,11 @@
     <LangVersion>latest</LangVersion>
     <!-- Don't run NuGetAudit on offline builds. -->
     <NuGetAudit Condition="'$(DotNetBuildWithOnlineFeeds)' != 'true'">false</NuGetAudit>
+    <!-- Disable NuGet audit in official builds. MSBuild does not correctly handle
+         WarningsNotAsErrors for NuGet warnings (https://github.com/dotnet/msbuild/issues/10801),
+         so audit findings become errors via TreatWarningsAsErrors
+         with no way to downgrade them. Keep audit enabled for local/CI dev builds. -->
+    <NuGetAudit Condition="'$(OfficialBuild)' == 'true'">false</NuGetAudit>
     <!-- Explicitly set NuGetAuditModel level as it's currently disabled in the product. -->
     <NuGetAuditMode>all</NuGetAuditMode>
     <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->

--- a/eng/tools/Directory.Build.props
+++ b/eng/tools/Directory.Build.props
@@ -9,13 +9,11 @@
     <RestoreSources Condition="Exists('$(SharedComponentsArtifactsPath)')">$(RestoreSources);$(SharedComponentsArtifactsPath)</RestoreSources>
   </PropertyGroup>
 
-  <!-- Suppress known NuGet audit vulnerabilities in VMR tooling projects.
-       These are compile-only references to Microsoft.Build packages whose transitive
-       dependency on System.Security.Cryptography.Xml has no patched upstream version yet. -->
-  <ItemGroup>
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-37gx-xxp4-5rgx" />
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-w3x6-4m5h-cxqf" />
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-g4vj-cjjj-v7hg" />
-  </ItemGroup>
+  <!-- Disable NuGet audit in official builds. MSBuild does not correctly handle
+       WarningsNotAsErrors for NuGet warnings (https://github.com/dotnet/msbuild/issues/10801),
+       so audit findings become errors via TreatWarningsAsErrors. -->
+  <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
 
 </Project>

--- a/src/sdk/Directory.Build.props
+++ b/src/sdk/Directory.Build.props
@@ -87,8 +87,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
-  <!-- TODO: Re-enable NuGet Audit and fix alerts: https://github.com/dotnet/sdk/issues/51466 -->
-  <PropertyGroup>
+  <!-- Disable NuGet audit in official builds. MSBuild does not correctly handle
+       WarningsNotAsErrors for NuGet warnings (https://github.com/dotnet/msbuild/issues/10801),
+       so audit findings become errors via TreatWarningsAsErrors. -->
+  <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">
     <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>
 


### PR DESCRIPTION
This is the release/10.0.4xx counterpart to #6620 and #6637.

Removes the NuGet audit workarounds (NuGetAuditSuppress items and unconditional NuGetAudit=false) that were added to unblock builds. NuGet audit is now disabled only in official builds due to an MSBuild bug (https://github.com/dotnet/msbuild/issues/10801) where WarningsNotAsErrors is not correctly handled for NuGet warnings.

### Changes
- **Directory.Build.props**: Add NuGetAudit=false conditioned on OfficialBuild
- **eng/tools/Directory.Build.props**: Replace NuGetAuditSuppress items with NuGetAudit=false for OfficialBuild only
- **src/sdk/Directory.Build.props**: Replace unconditional NuGetAudit=false (ref dotnet/sdk#51466) with OfficialBuild-conditioned disable