### PR TITLE
Fix deps.json file race in sharedfx.targets using isolated output directory

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/arcade/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -572,7 +572,8 @@
 
     <MSBuild Projects="$(MSBuildProjectFullPath)"
           Targets="_GetAllSharedFrameworkFiles"
-          RemoveProperties="OutputPath;SymbolsOutputPath">
+          RemoveProperties="OutputPath;SymbolsOutputPath"
+          Properties="IntermediateOutputPath=$(IntermediateOutputPath)publish/">
       <Output TaskParameter="TargetOutputs" ItemName="_FilesToPackage" />
     </MSBuild>
 

--- a/src/arcade/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/arcade/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -185,9 +185,11 @@
           DependsOnTargets="GetFilesToPackage"
           Condition="'$(PlatformPackageType)' == 'RuntimePack'">
     <PropertyGroup>
+      <_DepsFileOutputDir>$([MSBuild]::ValueOrDefault('$(_DepsFileIntermediateDir)', '$(IntermediateOutputPath)'))</_DepsFileOutputDir>
       <_TargetRootForFilesForDepsFile Condition="'$(HostJsonTargetPath)' == '$(_DefaultHostJsonTargetPath)'">runtimes/$(RuntimeIdentifier)</_TargetRootForFilesForDepsFile>
       <_TargetRootForFilesForDepsFile Condition="'$(HostJsonTargetPath)' != '$(_DefaultHostJsonTargetPath)'">$(HostJsonTargetPath)</_TargetRootForFilesForDepsFile>
     </PropertyGroup>
+    <MakeDir Directories="$(_DepsFileOutputDir)" Condition="'$(_DepsFileIntermediateDir)' != ''" />
     <ItemGroup>
       <_FilesForDepsFile Include="@(FilesToPackage)"
                          Condition="'%(FilesToPackage.IsSymbolFile)' != 'true' and
@@ -201,7 +203,7 @@
                                      SharedFrameworkPackName="$(PackageId)"
                                      Version="$(Version)"
                                      Files="@(_FilesForDepsFile)"
-                                     IntermediateOutputPath="$(IntermediateOutputPath)"
+                                     IntermediateOutputPath="$(_DepsFileOutputDir)"
                                      SharedFrameworkDepsNameOverride="$(SharedFrameworkHostFileNameOverride)"
                                      RuntimeIdentifierGraph="$([MSBuild]::ValueOrDefault('$(RuntimeIdentifierGraphPath)', '$(BundledRuntimeIdentifierGraphFile)'))"
                                      IncludeFallbacksInDepsFile="$(IncludeFallbacksInDepsFile)">
@@ -573,7 +575,7 @@
     <MSBuild Projects="$(MSBuildProjectFullPath)"
           Targets="_GetAllSharedFrameworkFiles"
           RemoveProperties="OutputPath;SymbolsOutputPath"
-          Properties="IntermediateOutputPath=$(IntermediateOutputPath)publish/">
+          Properties="_DepsFileIntermediateDir=$(IntermediateOutputPath)publish/">
       <Output TaskParameter="TargetOutputs" ItemName="_FilesToPackage" />
     </MSBuild>
 


### PR DESCRIPTION
## Summary

Fix file race in `sharedfx.targets` between Pack and Publish paths that write `deps.json` to the same `IntermediateOutputPath`.

## Root Cause

Two MSBuild self-calls in `sharedfx.targets` trigger `_GenerateSharedFrameworkDepsFile`:
1. **Pack path** (`_AddFilesToNuGetPackage`): `RemoveProperties="NoBuild"`
2. **Publish path** (`GetFilesToPublish`): `RemoveProperties="OutputPath;SymbolsOutputPath"`

Different `RemoveProperties` = different global property dictionaries = different MSBuild configurations = **no deduplication** = both run in parallel and write `.deps.json` to the same directory.

## Fix

Pass a custom property `_DepsFileIntermediateDir` (not `IntermediateOutputPath`) from the Publish self-call. The `_GenerateSharedFrameworkDepsFile` target uses this property (with fallback to `IntermediateOutputPath`) to write deps.json to a unique subdirectory.

**Why not IntermediateOutputPath directly?** Setting `IntermediateOutputPath` as a global property on the MSBuild task propagates it to ALL P2P references (`ResolveReferences` is in the dependency chain). This caused `ILLink.Tasks.csproj` to build with the wrong intermediate path and fail when copying its output to a location locked by other nodes.

## Impact

- Fixes `deps.json` file race that caused `Microsoft.NETCore.App.Runtime.CoreCLR.sfxproj` to fail
- No propagation to P2P references (fixes `ILLink.Tasks.dll` copy failure on Windows)
- No change to build ordering or parallelism semantics
