### PR TITLE
[release/11.0.1xx-preview5] Hardcode defaultPoolName for internal builds to fix disk space issues

### DIFF
--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -288,7 +288,7 @@ variables:
       value: windows.vs2026.amd64.open
 - ${{ else }}:
   - name: defaultPoolName
-    value: $(DncEngInternalBuildPool)
+    value: NetCore1ESPool-Internal
   - name: shortStackPoolName
     value: $(DncEngInternalBuildPool)
   - name: poolImage_Linux


### PR DESCRIPTION
Ports the fix from release/11.0.1xx-preview4: hardcode `defaultPoolName` to `NetCore1ESPool-Internal` instead of using the `$(DncEngInternalBuildPool)` variable, which resolves to a pool with insufficient disk space for full VMR builds.

**Change:** `eng/pipelines/templates/variables/vmr-build.yml` — `defaultPoolName` changed from `$(DncEngInternalBuildPool)` to `NetCore1ESPool-Internal` for internal builds. `shortStackPoolName` remains using the variable since short-stack builds do not need extra disk.