### PR TITLE
Revert sharedfx.targets property differentiation from #6697

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/arcade/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -537,12 +537,8 @@
 
   <Target Name="_AddFilesToNuGetPackage" BeforeTargets="_GetPackageFiles">
 
-    <!-- Set _GettingFilesForPackage=true to differentiate global properties for this nested MSBuild call
-         and avoid an intermittent circular dependency (MSB4006) when the scheduler builds the same project
-         concurrently with identical global properties. See https://github.com/dotnet/msbuild/issues/13599 -->
     <MSBuild Projects="$(MSBuildProjectFullPath)"
           Targets="_GetAllSharedFrameworkFiles"
-          Properties="_GettingFilesForPackage=true"
           RemoveProperties="NoBuild">
       <Output TaskParameter="TargetOutputs" ItemName="_FilesToPackage" />
     </MSBuild>
@@ -574,11 +570,8 @@
 
   <Target Name="GetFilesToPublish">
 
-    <!-- Set _GettingFilesForPublish=true to differentiate global properties for this nested MSBuild call
-         and avoid an intermittent circular dependency (MSB4006). -->
     <MSBuild Projects="$(MSBuildProjectFullPath)"
           Targets="_GetAllSharedFrameworkFiles"
-          Properties="_GettingFilesForPublish=true"
           RemoveProperties="OutputPath;SymbolsOutputPath">
       <Output TaskParameter="TargetOutputs" ItemName="_FilesToPackage" />
     </MSBuild>

--- a/src/aspnetcore/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
+++ b/src/aspnetcore/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
@@ -136,9 +136,10 @@
   </Target>
 
   <Target Name="PublishToSharedLayoutRoot" BeforeTargets="Build">
+    <!-- Set _PublishingToLayout=true to differentiate global properties for this nested MSBuild call and avoid an intermittent circular dependency involving GetFilesToPublish. -->
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishToDisk"
-             Properties="OutputPath=$(SharedFrameworkLayoutRoot)" />
+             Properties="OutputPath=$(SharedFrameworkLayoutRoot);_PublishingToLayout=true" />
   </Target>
 
   <Target Name="ReturnProductVersion" Returns="$(Version)" />


### PR DESCRIPTION
## Summary

Partial revert of #6697 to fix the **deterministic file-lock build failures on `main`** (6/6 internal rolling builds failed in the last 24h).

## Problem

PR #6697 added `_GettingFilesForPackage=true` / `_GettingFilesForPublish=true` properties to nested `<MSBuild>` calls in `sharedfx.targets` to fix an intermittent MSB4006 circular dependency. However, this caused MSBuild's scheduler to treat the nested calls as **separate project instances** (different global properties = different cache entries), allowing them to run **concurrently on different worker nodes**. Both instances execute `_GenerateSharedFrameworkDepsFile` and write to the same `.deps.json` file with `FileShare.None`, producing deterministic file-lock crashes.

See: https://github.com/dotnet/dotnet/pull/6697#issuecomment-4511165895

## What this PR does

- **Reverts** the `_GettingFilesForPackage` / `_GettingFilesForPublish` property additions in `sharedfx.targets`
- **Restores** `_PublishingToLayout=true` in aspnetcore's `Microsoft.AspNetCore.App.Runtime.sfxproj` (was removed by #6697)
- **Keeps** the `PlatformManifestFileEntry` addition for `Microsoft.NETCore.App.Runtime.CoreCLR.r2r.dylib` (that was a real bug fix)

## Trade-off

The intermittent MSB4006 (false circular dependency) may return, but it's far less damaging than 100% deterministic build failure. The underlying MSBuild scheduling issue is tracked at https://github.com/dotnet/msbuild/issues/13599.

cc @wtgodbe @dotnet/dnceng