### PR TITLE
Stop leaking SDK tarballs into binary-report in Source-Only validation

### DIFF
--- a/eng/pipelines/templates/steps/download-artifacts.yml
+++ b/eng/pipelines/templates/steps/download-artifacts.yml
@@ -20,6 +20,11 @@ steps:
   displayName: Copy ${{ parameters.artifactDescription }}
   inputs:
     SourceFolder: $(Pipeline.Workspace)/${{ parameters.artifactName }}
-    Contents: '**'
+    Contents: ${{ parameters.downloadFilePatterns }}
     FlattenFolders: ${{ parameters.flattenDirs }}
     TargetFolder: ${{ parameters.copyDestination }}
+- task: DeleteFiles@1
+  displayName: Clean up ${{ parameters.artifactDescription }} download
+  inputs:
+    SourceFolder: $(Pipeline.Workspace)/${{ parameters.artifactName }}
+    Contents: '**'


### PR DESCRIPTION
Three download-artifacts.yml calls in source-build-and-validate.yml share the same pipeline artifact name, so `$(Pipeline.Workspace)/<artifactName>/` accumulates files across calls.

download-artifacts.yml's CopyFiles used `Contents: '**'`, which dragged SDK tar.gz files left by an earlier download into `artifacts/log/Release/binary-report/ `(via flattenDirs).

Those then got staged under BuildLogs/ and rescanned by 1ES PT's injected Binary Analysis Scan Optimization.

- Filter CopyFiles by downloadFilePatterns so only requested files are copied.
- Delete the staging folder after copy to free disk and prevent similar leaks.