### PR TITLE
[release/11.0.1xx-preview5] Revert sharedfx.targets property differentiation from #6697

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
+++ b/src/arcade/src/Microsoft.DotNet.SharedFramework.Sdk/targets/sharedfx.targets
@@ -537,12 +537,8 @@
 
   <Target Name="_AddFilesToNuGetPackage" BeforeTargets="_GetPackageFiles">
 
-    <!-- Set _GettingFilesForPackage=true to differentiate global properties for this nested MSBuild call
-         and avoid an intermittent circular dependency (MSB4006) when the scheduler builds the same project
-         concurrently with identical global properties. See https://github.com/dotnet/msbuild/issues/13599 -->
     <MSBuild Projects="$(MSBuildProjectFullPath)"
           Targets="_GetAllSharedFrameworkFiles"
-          Properties="_GettingFilesForPackage=true"
           RemoveProperties="NoBuild">
       <Output TaskParameter="TargetOutputs" ItemName="_FilesToPackage" />
     </MSBuild>
@@ -574,11 +570,8 @@
 
   <Target Name="GetFilesToPublish">
 
-    <!-- Set _GettingFilesForPublish=true to differentiate global properties for this nested MSBuild call
-         and avoid an intermittent circular dependency (MSB4006). -->
     <MSBuild Projects="$(MSBuildProjectFullPath)"
           Targets="_GetAllSharedFrameworkFiles"
-          Properties="_GettingFilesForPublish=true"
           RemoveProperties="OutputPath;SymbolsOutputPath">
       <Output TaskParameter="TargetOutputs" ItemName="_FilesToPackage" />
     </MSBuild>

--- a/src/aspnetcore/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
+++ b/src/aspnetcore/src/Framework/App.Runtime/src/Microsoft.AspNetCore.App.Runtime.sfxproj
@@ -136,9 +136,10 @@
   </Target>
 
   <Target Name="PublishToSharedLayoutRoot" BeforeTargets="Build">
+    <!-- Set _PublishingToLayout=true to differentiate global properties for this nested MSBuild call and avoid an intermittent circular dependency involving GetFilesToPublish. -->
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="PublishToDisk"
-             Properties="OutputPath=$(SharedFrameworkLayoutRoot)" />
+             Properties="OutputPath=$(SharedFrameworkLayoutRoot);_PublishingToLayout=true" />
   </Target>
 
   <Target Name="ReturnProductVersion" Returns="$(Version)" />


### PR DESCRIPTION
Port of #6752 to `release/11.0.1xx-preview5`.

Same fix — reverts the `_GettingFilesForPackage`/`_GettingFilesForPublish` property additions in `sharedfx.targets` and restores `_PublishingToLayout=true` in aspnetcore sfxproj to fix deterministic file-lock build failures caused by concurrent `deps.json` writes.

Keeps the `PlatformManifestFileEntry` bug fix for `Microsoft.NETCore.App.Runtime.CoreCLR.r2r.dylib`.

See #6752 for full analysis.

cc @wtgodbe @dotnet/dnceng