### PR TITLE
Add macOS signing for libdotnet-aot.dylib and use ExecutableType meta…

### DIFF
--- a/src/sdk/eng/Signing.props
+++ b/src/sdk/eng/Signing.props
@@ -101,9 +101,11 @@
   <ItemGroup>
     <FileSignInfo Include="StreamJsonRpc.dll" CertificateName="MicrosoftSHA2" />
     <!-- Roslyn apphosts -->
-    <FileSignInfo Condition="'$(TargetOS)' == 'osx'" Include="csc;vbc;VBCSCompiler" CertificateName="MacDeveloperHarden" />
+    <FileSignInfo Include="csc;vbc;VBCSCompiler" ExecutableType="MachO" CertificateName="MacDeveloperHarden" />
     <!-- MSBuild apphost -->
-    <FileSignInfo Condition="'$(TargetOS)' == 'osx'" Include="MSBuild" CertificateName="MacDeveloperHarden" />
+    <FileSignInfo Include="MSBuild" ExecutableType="MachO" CertificateName="MacDeveloperHarden" />
+    <!-- NativeAOT shared library for dotnet-aot -->
+    <FileSignInfo Include="libdotnet-aot.dylib" ExecutableType="MachO" CertificateName="MacDeveloper" />
   </ItemGroup>
 
   <!-- Filter out any test packages from ItemsToSign -->


### PR DESCRIPTION
…data

The new NativeAOT dotnet-aot shared library (libdotnet-aot.dylib) was missing from the signing configuration, causing notarization failures on macOS.

Also switch existing Mach-O FileSignInfo entries from using Condition="'$(TargetOS)' == 'osx'" to ExecutableType="MachO" metadata, which lets the signing tool match by binary type directly.