### PR TITLE
Add OfficialBuild to SkipArcadeSdkImport fallback block

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,6 +37,10 @@
     <IntermediateOutputPath Condition="'$(PlatformName)' == 'AnyCPU'">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
     <IntermediateOutputPath Condition="'$(PlatformName)' != 'AnyCPU'">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
 
+    <!-- DefaultVersions.props -->
+    <OfficialBuild>false</OfficialBuild>
+    <OfficialBuild Condition="'$(OfficialBuildId)' != ''">true</OfficialBuild>
+
     <!-- TargetFrameworkDefaults.props -->
     <NetCurrent>net10.0</NetCurrent>
   </PropertyGroup>


### PR DESCRIPTION
Projects like BinaryToolKit and MSBuildSdkResolver set \SkipArcadeSdkImport=true\, which prevents Arcade SDK from being imported. Since \OfficialBuild\ is derived from \OfficialBuildId\ by Arcade's \DefaultVersions.props\, it was never set for these projects.

This caused the NuGetAudit disable condition added in #6637 (which checks \OfficialBuild\) to not fire, leaving NuGet audit enabled in official builds where \TreatWarningsAsErrors\ promotes NU1903 audit warnings to errors.

**Fix:** Add the \OfficialBuild\ derivation to the \SkipArcadeSdkImport\ fallback block (which is documented as 'keep in sync with Arcade SDK') so all properties that depend on \OfficialBuild\ work correctly for non-Arcade projects.

Fixes the NU1903 errors for \System.Security.Cryptography.Xml\ in \BinaryToolKit.csproj\ and \Microsoft.DotNet.UnifiedBuild.MSBuildSdkResolver.csproj\ during official builds.