### PR TITLE
Move nuget and msbuild forward to latest 18.0 versions and pin Cryptography.Xml dependency

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,6 +26,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsHostingVersion)" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
   </ItemGroup>
 
   <!-- External dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,15 +48,16 @@
     <!-- command-line-api dependencies -->
     <SystemCommandLineVersion>2.0.0-beta5.25208.1</SystemCommandLineVersion>
     <!-- msbuild dependencies -->
-    <MicrosoftBuildVersion>17.12.50</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion>18.0.2</MicrosoftBuildVersion>
     <!-- nuget dependencies -->
-    <NuGetProtocolVersion>6.13.1</NuGetProtocolVersion>
-    <NuGetProjectModelVersion>6.13.1</NuGetProjectModelVersion>
+    <NuGetProtocolVersion>7.0.3</NuGetProtocolVersion>
+    <NuGetProjectModelVersion>7.0.3</NuGetProjectModelVersion>
     <!-- runtime dependencies -->
     <MicrosoftExtensionsFileSystemGlobbingVersion>10.0.1</MicrosoftExtensionsFileSystemGlobbingVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>10.0.1</MicrosoftExtensionsLoggingConsoleVersion>
     <MicrosoftExtensionsLoggingVersion>10.0.1</MicrosoftExtensionsLoggingVersion>
     <MicrosoftExtensionsHostingVersion>10.0.1</MicrosoftExtensionsHostingVersion>
+    <SystemSecurityCryptographyXmlVersion>10.0.8</SystemSecurityCryptographyXmlVersion>
     <!-- external dependencies -->
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <OctokitVersion>14.0.0</OctokitVersion>


### PR DESCRIPTION
Port of https://github.com/dotnet/dotnet/pull/6718 and https://github.com/dotnet/dotnet/pull/6732 to release/10.0.3xx.

Changes:
- Update Microsoft.Build from 17.12.50 to 18.0.2
- Update NuGet.Protocol and NuGet.ProjectModel from 6.13.1 to 7.0.3
- Pin System.Security.Cryptography.Xml transitive dependency to 10.0.8