### PR TITLE
Include current RID for ASP.NET Core bundled tools

### DIFF
--- a/src/sdk/src/Layout/redist/targets/BundledDotnetTools.targets
+++ b/src/sdk/src/Layout/redist/targets/BundledDotnetTools.targets
@@ -3,9 +3,8 @@
   <UsingTask TaskName="Microsoft.NET.Build.Tasks.SelectRuntimeIdentifierSpecificItems" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
 
   <PropertyGroup>
-    <AspNetCoreRidSpecificToolPackageRids>linux-x64;linux-arm;linux-arm64;linux-musl-x64;linux-musl-arm;linux-musl-arm64;win-x64;win-x86;win-arm64;osx-x64;osx-arm64</AspNetCoreRidSpecificToolPackageRids>
-    <_AspNetCoreRidSpecificToolPackageRidsWithDelimiters>;$(AspNetCoreRidSpecificToolPackageRids);</_AspNetCoreRidSpecificToolPackageRidsWithDelimiters>
-    <AspNetCoreRidSpecificToolPackageRids Condition="'$(ProductMonikerRid)' != '' and !$(_AspNetCoreRidSpecificToolPackageRidsWithDelimiters.Contains(';$(ProductMonikerRid);'))">$(AspNetCoreRidSpecificToolPackageRids);$(ProductMonikerRid)</AspNetCoreRidSpecificToolPackageRids>
+    <AspNetCoreRidSpecificToolPackageRids>;linux-x64;linux-arm;linux-arm64;linux-musl-x64;linux-musl-arm;linux-musl-arm64;win-x64;win-x86;win-arm64;osx-x64;osx-arm64;</AspNetCoreRidSpecificToolPackageRids>
+    <AspNetCoreRidSpecificToolPackageRids Condition="'$(ProductMonikerRid)' != '' and !$(AspNetCoreRidSpecificToolPackageRids.Contains(';$(ProductMonikerRid);'))">$(AspNetCoreRidSpecificToolPackageRids)$(ProductMonikerRid);</AspNetCoreRidSpecificToolPackageRids>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IncludeAspNetCoreRuntime)' != 'false'">

--- a/src/sdk/src/Layout/redist/targets/BundledDotnetTools.targets
+++ b/src/sdk/src/Layout/redist/targets/BundledDotnetTools.targets
@@ -4,6 +4,8 @@
 
   <PropertyGroup>
     <AspNetCoreRidSpecificToolPackageRids>linux-x64;linux-arm;linux-arm64;linux-musl-x64;linux-musl-arm;linux-musl-arm64;win-x64;win-x86;win-arm64;osx-x64;osx-arm64</AspNetCoreRidSpecificToolPackageRids>
+    <_AspNetCoreRidSpecificToolPackageRidsWithDelimiters>;$(AspNetCoreRidSpecificToolPackageRids);</_AspNetCoreRidSpecificToolPackageRidsWithDelimiters>
+    <AspNetCoreRidSpecificToolPackageRids Condition="'$(ProductMonikerRid)' != '' and !$(_AspNetCoreRidSpecificToolPackageRidsWithDelimiters.Contains(';$(ProductMonikerRid);'))">$(AspNetCoreRidSpecificToolPackageRids);$(ProductMonikerRid)</AspNetCoreRidSpecificToolPackageRids>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IncludeAspNetCoreRuntime)' != 'false'">


### PR DESCRIPTION
Addresses feedback from https://github.com/dotnet/dotnet/pull/6720#pullrequestreview-4350211177.

This appends the current product RID (`ProductMonikerRid`, derived from `TargetRid`) to the ASP.NET Core RID-specific bundled tool package list only when it is not already present. This lets community platform builds select their matching native AOT tool packages while preserving the existing official SDK RID list without duplicates.

@am11 @baronfel 