### PR TITLE
Use lld for ASP.NET Core AOT musl tools

### DIFF
--- a/src/aspnetcore/src/Tools/Directory.Build.targets
+++ b/src/aspnetcore/src/Tools/Directory.Build.targets
@@ -16,6 +16,8 @@
   <PropertyGroup Condition=" '$(PublishAot)' == 'true' ">
     <InvariantGlobalization>true</InvariantGlobalization>
     <OptimizationPreference>Size</OptimizationPreference>
+    <!-- NativeAOT defaults Linux to bfd, but the VMR musl cross-build images provide lld instead. -->
+    <LinkerFlavor Condition=" '$(LinkerFlavor)' == '' and $(RuntimeIdentifier.StartsWith('linux-musl-')) ">lld</LinkerFlavor>
     <StackTraceSupport>false</StackTraceSupport>
     <EventSourceSupport>false</EventSourceSupport>
     <MetricsSupport>false</MetricsSupport>

--- a/src/aspnetcore/src/Tools/Directory.Build.targets
+++ b/src/aspnetcore/src/Tools/Directory.Build.targets
@@ -16,8 +16,6 @@
   <PropertyGroup Condition=" '$(PublishAot)' == 'true' ">
     <InvariantGlobalization>true</InvariantGlobalization>
     <OptimizationPreference>Size</OptimizationPreference>
-    <!-- NativeAOT defaults Linux to bfd, but the VMR musl cross-build images provide lld instead. -->
-    <LinkerFlavor Condition=" '$(LinkerFlavor)' == '' and $(RuntimeIdentifier.StartsWith('linux-musl-')) ">lld</LinkerFlavor>
     <StackTraceSupport>false</StackTraceSupport>
     <EventSourceSupport>false</EventSourceSupport>
     <MetricsSupport>false</MetricsSupport>
@@ -30,6 +28,32 @@
     <UseSystemResourceKeys>true</UseSystemResourceKeys>
     <XmlResolverIsNetworkingEnabledByDefault>false</XmlResolverIsNetworkingEnabledByDefault>
   </PropertyGroup>
+
+  <!-- Detect the available native compiler and linker for NativeAOT cross-builds.
+       The VMR cross-build containers may not have ld.bfd (the NativeAOT default for linux),
+       so we probe using arcade's init-compiler.sh and set LinkerFlavor to lld when available.
+       Pattern from runtime/eng/toolAot.targets. -->
+  <Target Name="LocateNativeCompiler"
+          Condition="'$(PublishAot)' == 'true' and '$(OS)' != 'Windows_NT'"
+          BeforeTargets="SetupOSSpecificProps">
+    <PropertyGroup>
+      <CppCompilerAndLinker Condition="'$(CppCompilerAndLinker)' == ''">clang</CppCompilerAndLinker>
+      <SysRoot Condition="'$(CrossBuild)' == 'true'">$(ROOTFS_DIR)</SysRoot>
+    </PropertyGroup>
+
+    <Exec Command="sh -c 'build_arch=&quot;$(TargetArchitecture)&quot; compiler=&quot;$(CppCompilerAndLinker)&quot; . &quot;$(RepositoryEngineeringDir)/common/native/init-compiler.sh&quot; &amp;&amp; echo &quot;$CC;$LDFLAGS&quot;' 2>/dev/null"
+          EchoOff="true"
+          ConsoleToMsBuild="true"
+          StandardOutputImportance="Low">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_CC_LDFLAGS" />
+    </Exec>
+
+    <PropertyGroup>
+      <CppLinker>$(_CC_LDFLAGS.SubString(0, $(_CC_LDFLAGS.IndexOf(';'))))</CppLinker>
+      <_LDFLAGS>$(_CC_LDFLAGS.SubString($([MSBuild]::Add($(_CC_LDFLAGS.IndexOf(';')), 1))))</_LDFLAGS>
+      <LinkerFlavor Condition="$(_LDFLAGS.Contains('lld'))">lld</LinkerFlavor>
+    </PropertyGroup>
+  </Target>
 
   <PropertyGroup Condition=" '$(PublishAot)' == 'true' and '$(ContinuousIntegrationBuild)' != 'true' ">
     <IlcGenerateMstatFile>true</IlcGenerateMstatFile>


### PR DESCRIPTION
Fixes the VMR rolling build failure reported after #6720 where NativeAOT publishing for the ASP.NET Core bundled tools selected the Linux default `bfd` linker for `linux-musl-*` RIDs, but the cross-build containers do not provide `ld.bfd`.

This scopes the workaround to the ASP.NET Core tool NativeAOT publishes by setting `LinkerFlavor=lld` only when `RuntimeIdentifier` starts with `linux-musl-`. Non-musl Linux publishes continue to use the existing NativeAOT default.

Tagging @lewing and @am11 from the #6720 discussion.

> [!NOTE]
> This PR description was generated by GitHub Copilot.

Validation:
- Restored the repo-local ASP.NET Core SDK with `src\aspnetcore\restore.cmd`.
- Evaluated `LinkerFlavor` via MSBuild for `dotnet-user-secrets`, `dotnet-user-jwts`, and `dotnet-dev-certs`: `linux-musl-arm64=lld`; `linux-x64=bfd`.