### PR TITLE
Dedup LocateNativeCompiler target

### DIFF
--- a/src/arcade/eng/common/native/LocateNativeCompiler.targets
+++ b/src/arcade/eng/common/native/LocateNativeCompiler.targets
@@ -1,0 +1,27 @@
+<Project>
+  <!--
+    Opt-in target to detect compiler/linker from init-compiler.sh and set NativeAOT linker props.
+    Callers enable this by setting UseCommonLocateNativeCompilerTarget=true.
+  -->
+  <Target Name="LocateNativeCompiler"
+          Condition="'$(UseCommonLocateNativeCompilerTarget)' == 'true'"
+          BeforeTargets="SetupOSSpecificProps">
+    <PropertyGroup>
+      <CppCompilerAndLinker Condition="'$(CppCompilerAndLinker)' == ''">clang</CppCompilerAndLinker>
+      <SysRoot Condition="'$(CrossBuild)' == 'true'">$(ROOTFS_DIR)</SysRoot>
+    </PropertyGroup>
+
+    <Exec Command="sh -c 'build_arch=&quot;$(TargetArchitecture)&quot; compiler=&quot;$(CppCompilerAndLinker)&quot; . &quot;$(RepositoryEngineeringDir)/common/native/init-compiler.sh&quot; &amp;&amp; echo &quot;$CC;$LDFLAGS&quot;' 2>/dev/null"
+          EchoOff="true"
+          ConsoleToMsBuild="true"
+          StandardOutputImportance="Low">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_CC_LDFLAGS" />
+    </Exec>
+
+    <PropertyGroup>
+      <CppLinker>$(_CC_LDFLAGS.SubString(0, $(_CC_LDFLAGS.IndexOf(';'))))</CppLinker>
+      <_LDFLAGS>$(_CC_LDFLAGS.SubString($([MSBuild]::Add($(_CC_LDFLAGS.IndexOf(';')), 1))))</_LDFLAGS>
+      <LinkerFlavor Condition="$(_LDFLAGS.Contains('lld'))">lld</LinkerFlavor>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/src/aspnetcore/eng/common/native/LocateNativeCompiler.targets
+++ b/src/aspnetcore/eng/common/native/LocateNativeCompiler.targets
@@ -1,0 +1,27 @@
+<Project>
+  <!--
+    Opt-in target to detect compiler/linker from init-compiler.sh and set NativeAOT linker props.
+    Callers enable this by setting UseCommonLocateNativeCompilerTarget=true.
+  -->
+  <Target Name="LocateNativeCompiler"
+          Condition="'$(UseCommonLocateNativeCompilerTarget)' == 'true'"
+          BeforeTargets="SetupOSSpecificProps">
+    <PropertyGroup>
+      <CppCompilerAndLinker Condition="'$(CppCompilerAndLinker)' == ''">clang</CppCompilerAndLinker>
+      <SysRoot Condition="'$(CrossBuild)' == 'true'">$(ROOTFS_DIR)</SysRoot>
+    </PropertyGroup>
+
+    <Exec Command="sh -c 'build_arch=&quot;$(TargetArchitecture)&quot; compiler=&quot;$(CppCompilerAndLinker)&quot; . &quot;$(RepositoryEngineeringDir)/common/native/init-compiler.sh&quot; &amp;&amp; echo &quot;$CC;$LDFLAGS&quot;' 2>/dev/null"
+          EchoOff="true"
+          ConsoleToMsBuild="true"
+          StandardOutputImportance="Low">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_CC_LDFLAGS" />
+    </Exec>
+
+    <PropertyGroup>
+      <CppLinker>$(_CC_LDFLAGS.SubString(0, $(_CC_LDFLAGS.IndexOf(';'))))</CppLinker>
+      <_LDFLAGS>$(_CC_LDFLAGS.SubString($([MSBuild]::Add($(_CC_LDFLAGS.IndexOf(';')), 1))))</_LDFLAGS>
+      <LinkerFlavor Condition="$(_LDFLAGS.Contains('lld'))">lld</LinkerFlavor>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/src/aspnetcore/src/Tools/Directory.Build.targets
+++ b/src/aspnetcore/src/Tools/Directory.Build.targets
@@ -27,33 +27,11 @@
     <MetadataUpdaterSupport>false</MetadataUpdaterSupport>
     <UseSystemResourceKeys>true</UseSystemResourceKeys>
     <XmlResolverIsNetworkingEnabledByDefault>false</XmlResolverIsNetworkingEnabledByDefault>
+    <UseCommonLocateNativeCompilerTarget Condition="'$(OS)' != 'Windows_NT'">true</UseCommonLocateNativeCompilerTarget>
   </PropertyGroup>
 
-  <!-- Detect the available native compiler and linker for NativeAOT cross-builds.
-       The VMR cross-build containers may not have ld.bfd (the NativeAOT default for linux),
-       so we probe using arcade's init-compiler.sh and set LinkerFlavor to lld when available.
-       Pattern from runtime/eng/toolAot.targets. -->
-  <Target Name="LocateNativeCompiler"
-          Condition="'$(PublishAot)' == 'true' and '$(OS)' != 'Windows_NT'"
-          BeforeTargets="SetupOSSpecificProps">
-    <PropertyGroup>
-      <CppCompilerAndLinker Condition="'$(CppCompilerAndLinker)' == ''">clang</CppCompilerAndLinker>
-      <SysRoot Condition="'$(CrossBuild)' == 'true'">$(ROOTFS_DIR)</SysRoot>
-    </PropertyGroup>
-
-    <Exec Command="sh -c 'build_arch=&quot;$(TargetArchitecture)&quot; compiler=&quot;$(CppCompilerAndLinker)&quot; . &quot;$(RepositoryEngineeringDir)/common/native/init-compiler.sh&quot; &amp;&amp; echo &quot;$CC;$LDFLAGS&quot;' 2>/dev/null"
-          EchoOff="true"
-          ConsoleToMsBuild="true"
-          StandardOutputImportance="Low">
-      <Output TaskParameter="ConsoleOutput" PropertyName="_CC_LDFLAGS" />
-    </Exec>
-
-    <PropertyGroup>
-      <CppLinker>$(_CC_LDFLAGS.SubString(0, $(_CC_LDFLAGS.IndexOf(';'))))</CppLinker>
-      <_LDFLAGS>$(_CC_LDFLAGS.SubString($([MSBuild]::Add($(_CC_LDFLAGS.IndexOf(';')), 1))))</_LDFLAGS>
-      <LinkerFlavor Condition="$(_LDFLAGS.Contains('lld'))">lld</LinkerFlavor>
-    </PropertyGroup>
-  </Target>
+  <Import Project="$(RepositoryEngineeringDir)common\native\LocateNativeCompiler.targets"
+      Condition="'$(UseCommonLocateNativeCompilerTarget)' == 'true'" />
 
   <PropertyGroup Condition=" '$(PublishAot)' == 'true' and '$(ContinuousIntegrationBuild)' != 'true' ">
     <IlcGenerateMstatFile>true</IlcGenerateMstatFile>

--- a/src/runtime/eng/common/native/LocateNativeCompiler.targets
+++ b/src/runtime/eng/common/native/LocateNativeCompiler.targets
@@ -1,0 +1,27 @@
+<Project>
+  <!--
+    Opt-in target to detect compiler/linker from init-compiler.sh and set NativeAOT linker props.
+    Callers enable this by setting UseCommonLocateNativeCompilerTarget=true.
+  -->
+  <Target Name="LocateNativeCompiler"
+          Condition="'$(UseCommonLocateNativeCompilerTarget)' == 'true'"
+          BeforeTargets="SetupOSSpecificProps">
+    <PropertyGroup>
+      <CppCompilerAndLinker Condition="'$(CppCompilerAndLinker)' == ''">clang</CppCompilerAndLinker>
+      <SysRoot Condition="'$(CrossBuild)' == 'true'">$(ROOTFS_DIR)</SysRoot>
+    </PropertyGroup>
+
+    <Exec Command="sh -c 'build_arch=&quot;$(TargetArchitecture)&quot; compiler=&quot;$(CppCompilerAndLinker)&quot; . &quot;$(RepositoryEngineeringDir)/common/native/init-compiler.sh&quot; &amp;&amp; echo &quot;$CC;$LDFLAGS&quot;' 2>/dev/null"
+          EchoOff="true"
+          ConsoleToMsBuild="true"
+          StandardOutputImportance="Low">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_CC_LDFLAGS" />
+    </Exec>
+
+    <PropertyGroup>
+      <CppLinker>$(_CC_LDFLAGS.SubString(0, $(_CC_LDFLAGS.IndexOf(';'))))</CppLinker>
+      <_LDFLAGS>$(_CC_LDFLAGS.SubString($([MSBuild]::Add($(_CC_LDFLAGS.IndexOf(';')), 1))))</_LDFLAGS>
+      <LinkerFlavor Condition="$(_LDFLAGS.Contains('lld'))">lld</LinkerFlavor>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/src/runtime/eng/toolAot.targets
+++ b/src/runtime/eng/toolAot.targets
@@ -11,6 +11,7 @@
     <!-- Use .dwarf files instead of .dsym files since our symbol exporting may not safely handle folders. -->
     <NativeSymbolExt Condition="'$(_IsApplePlatformToolAot)' == 'true'">.dwarf</NativeSymbolExt>
     <DsymUtilOptions Condition="'$(_IsApplePlatformToolAot)' == 'true'">--flat >/dev/null 2>&amp;1</DsymUtilOptions>
+    <UseCommonLocateNativeCompilerTarget Condition="'$(HostOS)' != 'windows'">true</UseCommonLocateNativeCompilerTarget>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(AotOrSingleFile)' == 'true' and '$(UseNativeAotForComponents)' != 'true'">
@@ -24,27 +25,7 @@
     <ILCompilerTargetsPath>$(CoreCLRBuildIntegrationDir)Microsoft.DotNet.ILCompiler.SingleEntry.targets</ILCompilerTargetsPath>
   </PropertyGroup>
 
-
-  <Target Name="LocateNativeCompiler"
-          Condition="'$(UseNativeAotForComponents)' == 'true' and '$(HostOS)' != 'windows'"
-          BeforeTargets="SetupOSSpecificProps">
-      <PropertyGroup>
-        <CppCompilerAndLinker Condition="'$(CppCompilerAndLinker)' == ''">clang</CppCompilerAndLinker>
-        <SysRoot Condition="'$(CrossBuild)' == 'true'">$(ROOTFS_DIR)</SysRoot>
-      </PropertyGroup>
-
-      <Exec Command="sh -c 'build_arch=&quot;$(TargetArchitecture)&quot; compiler=&quot;$(CppCompilerAndLinker)&quot; . &quot;$(RepositoryEngineeringDir)/common/native/init-compiler.sh&quot; &amp;&amp; echo &quot;$CC;$LDFLAGS&quot;' 2>/dev/null"
-            EchoOff="true"
-            ConsoleToMsBuild="true"
-            StandardOutputImportance="Low">
-        <Output TaskParameter="ConsoleOutput" PropertyName="_CC_LDFLAGS" />
-      </Exec>
-
-    <PropertyGroup>
-      <CppLinker>$(_CC_LDFLAGS.SubString(0, $(_CC_LDFLAGS.IndexOf(';'))))</CppLinker>
-      <_LDFLAGS>$(_CC_LDFLAGS.SubString($([MSBuild]::Add($(_CC_LDFLAGS.IndexOf(';')), 1))))</_LDFLAGS>
-      <LinkerFlavor Condition="$(_LDFLAGS.Contains('lld'))">lld</LinkerFlavor>
-    </PropertyGroup>
-  </Target>
+  <Import Project="$(RepositoryEngineeringDir)common\native\LocateNativeCompiler.targets"
+      Condition="'$(UseCommonLocateNativeCompilerTarget)' == 'true'" />
 
 </Project>


### PR DESCRIPTION
Updated nested eng/common/native along with arcade/eng so the next round of eng/common sync across repos doesn't lose it.