### PR TITLE
Upgrade System.CommandLine to 2.0.8 in VMR orchestrator

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <!-- workload manifest version for 1xx SDK feature band, used by 2xx+ branches to include 1xx workloads -->
     <DotNet1xxWorkloadManifestVersion>$([System.Text.RegularExpressions.Regex]::Match($(MicrosoftNETSdkVersion), '^(\d+\.\d+\.\d+)').Value)</DotNet1xxWorkloadManifestVersion>
     <!-- command-line-api dependencies -->
-    <SystemCommandLineVersion>2.0.0-beta5.25208.1</SystemCommandLineVersion>
+    <SystemCommandLineVersion>2.0.8</SystemCommandLineVersion>
     <!-- msbuild dependencies -->
     <MicrosoftBuildVersion>17.12.50</MicrosoftBuildVersion>
     <!-- nuget dependencies -->


### PR DESCRIPTION
Bumps `SystemCommandLineVersion` in `eng/Versions.props` from `2.0.0-beta5.25208.1` to `2.0.8` (latest stable on nuget.org).

## Breaking change analysis

Reviewed the [official migration guide](https://learn.microsoft.com/dotnet/standard/commandline/migration-guide-2.0.0-beta5) and System.CommandLine release notes for all changes between beta5 and 2.0.8 (beta6 → beta7 → rc.1 → rc.2 → 2.0.0 → 2.0.1 → 2.0.2 → ... → 2.0.8).

The only notable API change after beta5 was in beta7 ([#2606](https://github.com/dotnet/command-line-api/pull/2606)): `CommandLineConfiguration` was split into `ParserConfiguration` and `InvocationConfiguration`. Neither of the in-repo consumers uses `CommandLineConfiguration`, so this does not affect them.

## Consumers (outside `src/`)

- `eng/tools/CreateBaselineUpdatePR/Program.cs`
- `eng/tools/BuildComparer/Program.cs`

Every API used (`Option<T>(name, params string[] aliases)`, `Recursive`, `Required`, `DefaultValueFactory`, `CustomParser`, `AllowMultipleArgumentsPerToken`, `Arity`, `SetAction`, `ParseResult.InvokeAsync`, `result.GetValue(option)`, `ArgumentResult.Tokens`) was cross-checked against the v2.0.2 source and is unchanged.

No source changes required.