### PR TITLE
Remove GDN_EXTRACT variables from official.yml

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -54,12 +54,6 @@ variables:
 - name: isScheduleTrigger
   value: ${{ eq(variables['Build.Reason'], 'Schedule') }}
 
-- name: GDN_EXTRACT_TOOLS
-  value: 'binskim,bandit,roslynanalyzers'
- 
-- name: GDN_EXTRACT_FILTER
-  value: 'f|**/*.zip;f|**/*.nupkg;f|**/*.vsix;f|**/*.cspkg;f|**/*.sfpkg;f|**/*.package'
-
 - name: Codeql.DoNotStartTimes
   value: 'Mon;Tue;Wed;Thu;Fri;Sat' # run only on the scheduled build on Sunday
 


### PR DESCRIPTION
Removed GDN_EXTRACT_TOOLS and GDN_EXTRACT_FILTER variables from the official pipeline configuration.

1EPT now has this natively.