### PR TITLE
Normalize project paths in Arcade Build.proj restore exclude

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/toolset/Build.proj
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/toolset/Build.proj
@@ -225,8 +225,15 @@
         <RestoreInParallel>true</RestoreInParallel>
       </_ProjectToRestore>
 
-      <!-- Invoke the 'Restore' target on solutions and projects which do not support NuGet. -->
-      <_ProjectToRestore Include="@(ProjectToBuild)" Exclude="@(_ProjectToRestoreWithNuGet)" />
+      <!--
+        Invoke the 'Restore' target on solutions and projects which do not support NuGet.
+        Project paths are normalized via %(FullPath) on both sides so that user-supplied
+        paths with redundant separators (e.g. '/repo//src/foo.csproj') still match the
+        NuGet-normalized paths returned by _IsProjectRestoreSupported. Without this
+        normalization the Exclude can miss, causing the same project to be restored
+        twice in parallel and racing on project.assets.json.
+      -->
+      <_ProjectToRestore Include="@(ProjectToBuild->'%(FullPath)')" Exclude="@(_ProjectToRestoreWithNuGet->'%(FullPath)')" />
     </ItemGroup>
 
     <!-- Enable binlog generation during static graph restore evaluation -->


### PR DESCRIPTION
## Problem

The `Exclude="@(_ProjectToRestoreWithNuGet)"` in `Microsoft.DotNet.Arcade.Sdk/toolset/Build.proj` does a literal item-spec comparison. When a caller passes a project path with redundant separators (e.g. a build script that does `$repo_root/foo` while `$repo_root` already ends in `/`, producing `/repo//foo`), the path differs from the NuGet-normalized form returned by `_IsProjectRestoreSupported`. The Exclude misses, the project ends up in `_ProjectToRestore` **twice**, and MSBuild kicks off two parallel `Restore` invocations against the same graph.

Both restores then race to commit the same `project.assets.json` via `File.Move(overwrite: true)`, which is non-atomic on Linux, producing the flaky:

```
error : The file '.../obj/<project>/project.assets.json' already exists.
   at System.IO.FileSystem.LinkOrCopyFile(...)
   at NuGet.Commands.RestoreResult.CommitAssetsFileAsync(...)
```

This was observed in a VMR build of `src/fsharp` where `eng/build.sh` passes `$repo_root/src/Microsoft.FSharp.Compiler/Microsoft.FSharp.Compiler.fsproj` (with `$repo_root` already trailing-slashed by `eng/common/tools.sh`), producing a double slash. Two `RestoreTask` invocations both started within ~28 ms of each other and raced on `FSharp.DependencyManager.Nuget`'s assets file.

## Fix

Project both sides of the Exclude through `%(FullPath)`, which applies MSBuild's path normalization (collapses `//`, resolves `.`/`..`, normalizes separators). The comparison then no longer depends on the caller passing a canonical path, protecting every Arcade-using repo from this class of flaky parallel-restore failure.

```xml
<_ProjectToRestore Include="@(ProjectToBuild->'%(FullPath)')" Exclude="@(_ProjectToRestoreWithNuGet->'%(FullPath)')" />
```

No behavior change for callers that already pass canonical paths.