### PR TITLE
Detect stale assembly version diff exclusions and remove confirmed no-ops

### DIFF
--- a/test/Microsoft.DotNet.SourceBuild.Tests/SdkContentTests.cs
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/SdkContentTests.cs
@@ -292,7 +292,8 @@ public partial class SdkContentTests : SdkTests
     {
         // Remove any excluded files as long as SB SDK's file has the same or greater assembly version compared to the corresponding
         // file in the MSFT SDK. If the version is less, the file will show up in the results as this is not a scenario
-        // that is valid for shipping.
+        // that is valid for shipping. Only mark an exclusion as "used" when it actually suppresses a version difference;
+        // exclusions matching files with identical versions are stale and should be cleaned up.
         ExclusionsHelper exclusionsHelper = new ExclusionsHelper("SdkAssemblyVersionDiffExclusions.txt", Config.LogsDirectory, BaselineSubDir);
         string[] sbSdkFileArray = sbSdkAssemblyVersions.Keys.ToArray();
         for (int i = sbSdkFileArray.Length - 1; i >= 0; i--)
@@ -308,6 +309,7 @@ public partial class SdkContentTests : SdkTests
             if (sbVersionInfo.AssemblyVersion is not null &&
                 msftVersionInfo.AssemblyVersion is not null &&
                 sbVersionInfo.AssemblyVersion >= msftVersionInfo.AssemblyVersion &&
+                sbVersionInfo != msftVersionInfo &&
                 exclusionsHelper.IsFileExcluded(assemblyPath))
             {
                 sbSdkAssemblyVersions.Remove(assemblyPath);

--- a/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/SdkAssemblyVersionDiffExclusions.txt
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests/SdkAssemblyVersionDiffExclusions.txt
@@ -13,15 +13,5 @@
 # 'folder/*' matches all files and directories in 'folder/'. It will not match 'folder/abc/def'
 # 'folder/' is equivalent to 'folder/**. It matches 'folder/', 'folder/abc', and 'folder/abc/def/'
 
-# SBRP/VMR commit hash diff: https://github.com/dotnet/source-build/issues/5506
-./sdk/x.y.z/Containers/tasks/netx.y/Valleysoft.DockerCredsProvider.dll
-./sdk/x.y.z/Spectre.Console.dll
-
-# File version missing revision: https://github.com/dotnet/source-build/issues/5511
-./sdk/**/Newtonsoft.Json.dll
-
 # Product version diff: https://github.com/dotnet/source-build/issues/5512
 ./sdk/x.y.z/Microsoft.VisualStudio.SolutionPersistence.dll
-
-# Product version diff: https://github.com/dotnet/source-build/issues/5507
-./sdk/x.y.z/Sdks/**/Microsoft.Css.Parser.dll


### PR DESCRIPTION
The `ExclusionsHelper` marks an exclusion as 'used' whenever its glob matches a file, even when all version fields are identical between MSFT and SB SDKs. This prevents the automated PR mechanism from cleaning up stale exclusions whose underlying version diffs have been fixed.

Add a version equality check (`sbVersionInfo != msftVersionInfo`) before calling `IsFileExcluded()`, so exclusions are only marked as 'used' when they actually suppress a real version difference. Files with identical versions produce no diff output regardless of exclusion status.

Also remove 4 confirmed stale exclusions.