### PR TITLE
Port SuppressValidation fix for WiX ICE failures to preview5

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
+++ b/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix/wix.targets
@@ -376,6 +376,7 @@
       NoLogo="true"
       Cultures="en-us"
       InstallerFile="$(_OutInstallerFile)"
+      SuppressValidation="true"
       WixExtensions="@(WixExtensions)"
       WixSrcFiles="@(WixSrcFile -> '$(WixObjDir)%(Filename).wixobj');@(DirectoryToHarvest -> '%(WixObjFile)')">
       <Output TaskParameter="OutputFile" PropertyName="_LightCommandPackageNameOutput" />

--- a/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLightCommandPackageDrop.cs
+++ b/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/src/CreateLightCommandPackageDrop.cs
@@ -22,6 +22,7 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
         public string OutputsFile { get; set; }
         public string BuiltOutputsFile { get; set; }
         public ITaskItem [] Sice { get; set; }
+        public bool SuppressValidation { get;set; }
 
         // The light command that was originally used to generate the MSI.  This is purely used for informational purposes
         // and to validate that the light command being created by this task is correct (assist with debugging).
@@ -73,6 +74,10 @@ namespace Microsoft.DotNet.Build.Tasks.Installers
                 {
                     commandString.Append($" -sice:{siceItem.ItemSpec}");
                 }
+            }
+            if (SuppressValidation)
+            {
+                commandString.Append(" -sval");
             }
         }
     }

--- a/src/arcade/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Wix/LinkerToolTask.cs
+++ b/src/arcade/src/Microsoft.DotNet.Build.Tasks.Workloads/src/Wix/LinkerToolTask.cs
@@ -76,7 +76,7 @@ namespace Microsoft.DotNet.Build.Tasks.Workloads.Wix
             CommandLineBuilder.AppendSwitchIfNotNull("-o ", OutputFile);
             CommandLineBuilder.AppendSwitchIfTrue("-fv", AddFileVersion);
             CommandLineBuilder.AppendArrayIfNotNull("-ext ", Extensions.ToArray());
-            CommandLineBuilder.AppendSwitchIfNotNull("-sice:", SuppressIces);
+            CommandLineBuilder.AppendSwitch("-sval");
             CommandLineBuilder.AppendFileNamesIfNotNull(SourceFiles.ToArray(), " ");
 
             return CommandLineBuilder.ToString();

--- a/src/sdk/src/Workloads/VSInsertion/workloads.csproj
+++ b/src/sdk/src/Workloads/VSInsertion/workloads.csproj
@@ -565,6 +565,7 @@
       NoLogo="true"
       Cultures="en-us"
       InstallerFile="$(_Msi)"
+      SuppressValidation="true"
       WixExtensions="WixUIExtension;WixDependencyExtension;WixUtilExtension"
       WixSrcFiles="@(_WixObj)">
       <Output TaskParameter="OutputFile" PropertyName="_LightCommandPackageNameOutput" />


### PR DESCRIPTION
Cherry-pick of #6398 from preview4.

Ports the fix that adds `-sval` (suppress all ICE validation) to WiX `light.exe` invocations. Without this, MSI repackaging after signing fails with `LGHT0217` errors when the Windows Installer service is unavailable on the build agent.

**Changes:**
- `LinkerToolTask.cs`: Replace `-sice:` with `-sval`
- `CreateLightCommandPackageDrop.cs`: Add `SuppressValidation` property and `-sval` flag support
- `wix.targets`: Set `SuppressValidation=true`
- `workloads.csproj`: Set `SuppressValidation=true`

Fixes the build failure in build [#2984751](https://dev.azure.com/dnceng/internal/_build/results?buildId=2984751).