### PR TITLE
Fix NuGetAuthenticate for devdiv-engineering-feed-r-wif WIF service connection

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -569,7 +569,12 @@ jobs:
     # Authenticate with service connections to be able to pull packages to external nuget feeds.
     - task: NuGetAuthenticate@1
       inputs:
-        nuGetServiceConnections: devdiv-engineering-feed-r-wif, devdiv/dotnet-core-internal-tooling
+        nuGetServiceConnections: devdiv/dotnet-core-internal-tooling
+    - task: NuGetAuthenticate@1
+      displayName: Authenticate devdiv/Engineering feed (WIF)
+      inputs:
+        azureDevOpsServiceConnection: devdiv-engineering-feed-r-wif
+        feedUrl: https://devdiv.pkgs.visualstudio.com/_packaging/Engineering/nuget/v3/index.json
 
   - ${{ if and(eq(parameters.sign, 'True'), ne(parameters.signType, 'DryRun')) }}:
     - template: ${{ variables['Build.SourcesDirectory'] }}/eng/common/core-templates/steps/install-microbuild.yml


### PR DESCRIPTION
## Summary

Fixes the NuGetAuthenticate@1 task configuration for the `devdiv-engineering-feed-r-wif` service connection in the VMR build template.

## Problem

PR #6635 added `devdiv-engineering-feed-r-wif` to the `nuGetServiceConnections` input, but that input only accepts service connections of type `ExternalNuGetFeed`. Our WIF service connection is type `workloadidentityuser`, which causes:

> The pipeline is not valid. Step NuGetAuthenticate input nuGetServiceConnections expects a service connection of type ExternalNuGetFeed but the provided service connection is of type workloadidentityuser.

This is the same issue that was discovered and fixed in dotnet/roslyn#83918.

## Fix

Split into two separate NuGetAuthenticate@1 tasks:
- One using `nuGetServiceConnections` for the ExternalNuGetFeed type (`devdiv/dotnet-core-internal-tooling`)
- One using `azureDevOpsServiceConnection` + `feedUrl` for the WIF type (`devdiv-engineering-feed-r-wif`)

## Related

- Work item: https://dev.azure.com/dnceng/internal/_workitems/edit/10126
- Same fix pattern: dotnet/roslyn#83918, dotnet/razor#13171, dotnet/razor#13172