### PR TITLE
Log value of SOURCE_DATE_EPOCH during repo build

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -446,6 +446,7 @@ jobs:
 
   - ${{ if eq(parameters.setSourceDateEpoch, true) }}:
     - pwsh: |
+        # extract the date and revision from the build number (YYYYMMDD.Revision) and use it to calculate the SOURCE_DATE_EPOCH
         $parts = '$(Build.BuildNumber)'.Split('.')
         $epoch = ([DateTimeOffset]::ParseExact($parts[0], 'yyyyMMdd', $null, 'AssumeUniversal')).ToUnixTimeSeconds() + [int]$parts[1]
         Write-Host "Calculated SOURCE_DATE_EPOCH: $epoch from Build.BuildNumber: $(Build.BuildNumber)"

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -615,6 +615,7 @@
     <Message Importance="High" Text="  With Environment Variables:"/>
     <Message Importance="High" Text="    %(EnvironmentVariables.Identity)" />
     <Message Importance="High" Text="    %(BuildEnvironmentVariable.Identity)" Condition="'@(BuildEnvironmentVariable)' != ''" />
+    <Message Importance="High" Text="    SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH)" Condition="'$(SOURCE_DATE_EPOCH)' != ''" />
 
     <Message Text="DirSize Before Building $(RepositoryName)" Importance="High" Condition=" '$(CleanWhileBuilding)' == 'true'" />
     <Exec Command="$(DiskUsageCommand)" Condition="'$(CleanWhileBuilding)' == 'true'" />


### PR DESCRIPTION
This makes it easier to confirm the value that is passed to the build