### PR TITLE
Fix InitializeNuGetPackageCachePath on non-Windows

### DIFF
--- a/src/arcade/eng/common/tools.ps1
+++ b/src/arcade/eng/common/tools.ps1
@@ -596,9 +596,10 @@ function InitializeNuGetPackageCachePath() {
     # use global cache in dev builds to avoid cost of downloading packages.
     # For directory normalization, see also: https://github.com/NuGet/Home/issues/7968
     if ($useGlobalNuGetCache) {
-      $env:NUGET_PACKAGES = Join-Path $env:UserProfile '.nuget\packages\'
+      $userProfile = if (IsWindowsPlatform) { $env:UserProfile } else { $env:HOME }
+      $env:NUGET_PACKAGES = [IO.Path]::Combine($userProfile, '.nuget', 'packages') + [IO.Path]::DirectorySeparatorChar
     } else {
-      $env:NUGET_PACKAGES = Join-Path $RepoRoot '.packages\'
+      $env:NUGET_PACKAGES = [IO.Path]::Combine($RepoRoot, '.packages') + [IO.Path]::DirectorySeparatorChar
     }
   }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/dotnet/arcade/pull/16934 into the VMR's mirrored `src/arcade/eng/common/tools.ps1` so the "Setup Internal Feeds" CI step stops failing while we wait for the arcade fix to flow back.

Since da58b411 ("[main] Source code updates from dotnet/arcade (#6949)") the new arcade `tools.ps1` invokes `InitializeNuGetPackageCachePath` unconditionally at script load. When `SetupNugetSources.ps1` dot-sources it on Linux, `$env:UserProfile` is null and `Join-Path` throws:

```
SetupNugetSources.ps1: /__w/_temp/...ps1:10
Line |
  10 |    & $setupScript $nugetConfig $env:Token
     |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot bind argument to parameter 'Path' because it is null.
```

This breaks "Setup Internal Feeds" only on the `arcade` iteration (the only mirrored `eng/common` that already has the new `tools.ps1`).

Fix: use the existing `IsWindowsPlatform` helper to pick `$env:HOME` on non-Windows.

Note: `src/arcade/eng/common` is normally overwritten by codeflow from dotnet/arcade. This PR is a temporary patch; the canonical fix is dotnet/arcade#16934.