### PR TITLE
Add SkipUnchanged param to GenerateFileFromTemplate & ingest in aspnetcore

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.Build.Tasks.Templating/src/GenerateFileFromTemplate.cs
+++ b/src/arcade/src/Microsoft.DotNet.Build.Tasks.Templating/src/GenerateFileFromTemplate.cs
@@ -49,6 +49,16 @@ namespace Microsoft.DotNet.Build.Tasks.Templating
         public string[] Properties { get; set; }
 
         /// <summary>
+        /// When <see langword="true"/>, the output file is only written if it does not already exist
+        /// or if its current contents differ from what the task would write. Defaults to <see langword="false"/>.
+        /// <para>
+        /// Enabling this preserves the output file's timestamp when its contents are unchanged, which can
+        /// significantly speed up incremental builds by avoiding unnecessary invalidation of downstream targets.
+        /// </para>
+        /// </summary>
+        public bool SkipUnchanged { get; set; }
+
+        /// <summary>
         /// The destination for the generated file resolved by this task.
         /// </summary>
         [Output]
@@ -68,10 +78,49 @@ namespace Microsoft.DotNet.Build.Tasks.Templating
             string template = File.ReadAllText(TemplateFile);
 
             string result = Replace(template, values);
+
+            // File.WriteAllText writes UTF-8 without a byte-order mark, so compare against the same encoding
+            // to determine whether the on-disk bytes would actually change.
+            byte[] resultBytes = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false).GetBytes(result);
+
+            if (SkipUnchanged && FileContentsMatch(ResolvedOutputPath, resultBytes))
+            {
+                Log.LogMessage(MessageImportance.Low, $"Skipping unchanged file {ResolvedOutputPath}");
+                return !Log.HasLoggedErrors;
+            }
+
             Directory.CreateDirectory(Path.GetDirectoryName(ResolvedOutputPath));
-            File.WriteAllText(ResolvedOutputPath, result);
+            File.WriteAllBytes(ResolvedOutputPath, resultBytes);
 
             return !Log.HasLoggedErrors;
+        }
+
+        private static bool FileContentsMatch(string path, byte[] expectedBytes)
+        {
+            var fileInfo = new FileInfo(path);
+            if (!fileInfo.Exists || fileInfo.Length != expectedBytes.Length)
+            {
+                return false;
+            }
+
+            using FileStream stream = fileInfo.OpenRead();
+            byte[] buffer = new byte[4096];
+            int offset = 0;
+            int bytesRead;
+            while ((bytesRead = stream.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                for (int i = 0; i < bytesRead; i++)
+                {
+                    if (buffer[i] != expectedBytes[offset + i])
+                    {
+                        return false;
+                    }
+                }
+
+                offset += bytesRead;
+            }
+
+            return true;
         }
 
         public string Replace(string template, IDictionary<string, string> values)

--- a/src/arcade/src/Microsoft.DotNet.Build.Tasks.Templating/src/GenerateFileFromTemplate.cs
+++ b/src/arcade/src/Microsoft.DotNet.Build.Tasks.Templating/src/GenerateFileFromTemplate.cs
@@ -89,7 +89,12 @@ namespace Microsoft.DotNet.Build.Tasks.Templating
                 return !Log.HasLoggedErrors;
             }
 
-            Directory.CreateDirectory(Path.GetDirectoryName(ResolvedOutputPath));
+            string directory = Path.GetDirectoryName(ResolvedOutputPath);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
             File.WriteAllBytes(ResolvedOutputPath, resultBytes);
 
             return !Log.HasLoggedErrors;
@@ -109,6 +114,12 @@ namespace Microsoft.DotNet.Build.Tasks.Templating
             int bytesRead;
             while ((bytesRead = stream.Read(buffer, 0, buffer.Length)) > 0)
             {
+                // Guard against the file growing after the initial length check.
+                if (offset + bytesRead > expectedBytes.Length)
+                {
+                    return false;
+                }
+
                 for (int i = 0; i < bytesRead; i++)
                 {
                     if (buffer[i] != expectedBytes[offset + i])
@@ -120,7 +131,8 @@ namespace Microsoft.DotNet.Build.Tasks.Templating
                 offset += bytesRead;
             }
 
-            return true;
+            // Ensure every expected byte was compared (guards against the file being truncated).
+            return offset == expectedBytes.Length;
         }
 
         public string Replace(string template, IDictionary<string, string> values)

--- a/src/arcade/src/Microsoft.DotNet.Build.Tasks.Templating/test/GenerateFileFromTemplateTests.cs
+++ b/src/arcade/src/Microsoft.DotNet.Build.Tasks.Templating/test/GenerateFileFromTemplateTests.cs
@@ -85,6 +85,91 @@ namespace Microsoft.DotNet.Build.Tasks.Templating.Tests
             }
         }
 
+        [Fact]
+        public void GenerateFileFromTemplate_SkipUnchanged_DoesNotRewriteUnchangedFile()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            string filePath = Path.Combine(tempDir, "Directory.Build.props");
+
+            try
+            {
+                GenerateFileFromTemplate task = new();
+                task.BuildEngine = new MockBuildEngine();
+                task.TemplateFile = GetFullPath("Directory.Build.props.in");
+                task.OutputPath = filePath;
+                task.Properties = new[] { "DefaultNetCoreTargetFramework=net6.0" };
+                task.SkipUnchanged = true;
+
+                Assert.True(task.Execute());
+
+                // Move the timestamp into the past so a rewrite would be observable.
+                DateTime originalWriteTime = DateTime.UtcNow.AddDays(-1);
+                File.SetLastWriteTimeUtc(filePath, originalWriteTime);
+                long originalLength = new FileInfo(filePath).Length;
+
+                Assert.True(task.Execute());
+
+                Assert.Equal(originalWriteTime, File.GetLastWriteTimeUtc(filePath));
+                Assert.Equal(originalLength, new FileInfo(filePath).Length);
+            }
+            finally
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+
+        [Fact]
+        public void GenerateFileFromTemplate_SkipUnchanged_RewritesWhenContentsDiffer()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            string filePath = Path.Combine(tempDir, "Directory.Build.props");
+
+            try
+            {
+                Directory.CreateDirectory(tempDir);
+                File.WriteAllText(filePath, "stale contents");
+
+                GenerateFileFromTemplate task = new();
+                task.BuildEngine = new MockBuildEngine();
+                task.TemplateFile = GetFullPath("Directory.Build.props.in");
+                task.OutputPath = filePath;
+                task.Properties = new[] { "DefaultNetCoreTargetFramework=net6.0" };
+                task.SkipUnchanged = true;
+
+                Assert.True(task.Execute());
+                Assert.Equal(ReadAllText("Directory.Build.props.in").Replace("${DefaultNetCoreTargetFramework}", "net6.0"), File.ReadAllText(filePath));
+            }
+            finally
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+
+        [Fact]
+        public void GenerateFileFromTemplate_SkipUnchanged_WritesWhenFileMissing()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            string filePath = Path.Combine(tempDir, "Directory.Build.props");
+
+            try
+            {
+                GenerateFileFromTemplate task = new();
+                task.BuildEngine = new MockBuildEngine();
+                task.TemplateFile = GetFullPath("Directory.Build.props.in");
+                task.OutputPath = filePath;
+                task.Properties = new[] { "DefaultNetCoreTargetFramework=net6.0" };
+                task.SkipUnchanged = true;
+
+                Assert.True(task.Execute());
+                Assert.True(File.Exists(filePath));
+                Assert.Equal(ReadAllText("Directory.Build.props.in").Replace("${DefaultNetCoreTargetFramework}", "net6.0"), File.ReadAllText(filePath));
+            }
+            finally
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+
         public static string GetFullPath(string relativeTestInputPath)
         {
             return Path.Combine(

--- a/src/arcade/src/Microsoft.DotNet.Build.Tasks.Templating/test/GenerateFileFromTemplateTests.cs
+++ b/src/arcade/src/Microsoft.DotNet.Build.Tasks.Templating/test/GenerateFileFromTemplateTests.cs
@@ -103,8 +103,9 @@ namespace Microsoft.DotNet.Build.Tasks.Templating.Tests
                 Assert.True(task.Execute());
 
                 // Move the timestamp into the past so a rewrite would be observable.
-                DateTime originalWriteTime = DateTime.UtcNow.AddDays(-1);
-                File.SetLastWriteTimeUtc(filePath, originalWriteTime);
+                // Capture the on-disk value after setting it, since the filesystem may round it.
+                File.SetLastWriteTimeUtc(filePath, DateTime.UtcNow.AddDays(-1));
+                DateTime originalWriteTime = File.GetLastWriteTimeUtc(filePath);
                 long originalLength = new FileInfo(filePath).Length;
 
                 Assert.True(task.Execute());

--- a/src/aspnetcore/eng/tools/GenerateFiles/GenerateFiles.csproj
+++ b/src/aspnetcore/eng/tools/GenerateFiles/GenerateFiles.csproj
@@ -35,16 +35,19 @@
     <Message Importance="High" Text="$(MSBuildProjectName) -&gt; $(BaseOutputPath)Directory.Build.props" />
     <GenerateFileFromTemplate TemplateFile="$(MSBuildThisFileDirectory)Directory.Build.props.in"
       Properties="$(_TemplateProperties)"
+      SkipUnchanged="true"
       OutputPath="$(BaseOutputPath)Directory.Build.props" />
 
     <Message Importance="High" Text="$(MSBuildProjectName) -&gt; $(BaseOutputPath)Directory.Build.targets" />
     <GenerateFileFromTemplate TemplateFile="$(MSBuildThisFileDirectory)Directory.Build.targets.in"
       Properties="$(_TemplateProperties)"
+      SkipUnchanged="true"
       OutputPath="$(BaseOutputPath)Directory.Build.targets" />
 
     <Message Importance="High" Text="$(MSBuildProjectName) -&gt; $(ConfigDirectory)dotnet-tools.json" />
     <GenerateFileFromTemplate TemplateFile="$(MSBuildThisFileDirectory)dotnet-tools.json.in"
       Properties="$(_TemplateProperties)"
+      SkipUnchanged="true"
       OutputPath="$(ConfigDirectory)dotnet-tools.json" />
   </Target>
 </Project>

--- a/src/aspnetcore/src/Components/Gateway/src/Microsoft.AspNetCore.Components.Gateway.csproj
+++ b/src/aspnetcore/src/Components/Gateway/src/Microsoft.AspNetCore.Components.Gateway.csproj
@@ -49,6 +49,7 @@
     <GenerateFileFromTemplate
       TemplateFile="blazor-gateway.runtimeconfig.json.in"
       Properties="$(_RuntimeConfigProperties)"
+      SkipUnchanged="true"
       OutputPath="$(_RuntimeConfigPath)" />
   </Target>
 

--- a/src/aspnetcore/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
+++ b/src/aspnetcore/src/Components/WebAssembly/DevServer/src/Microsoft.AspNetCore.Components.WebAssembly.DevServer.csproj
@@ -61,6 +61,7 @@
     <GenerateFileFromTemplate
       TemplateFile="blazor-devserver.runtimeconfig.json.in"
       Properties="$(_RuntimeConfigProperties)"
+      SkipUnchanged="true"
       OutputPath="$(_RuntimeConfigPath)" />
   </Target>
 

--- a/src/aspnetcore/src/ProjectTemplates/GenerateContent.targets
+++ b/src/aspnetcore/src/ProjectTemplates/GenerateContent.targets
@@ -43,6 +43,7 @@
     <GenerateFileFromTemplate
       TemplateFile="%(GeneratedContent.Identity)"
       Properties="$(GeneratedContentProperties);%(GeneratedContent.AdditionalProperties)"
+      SkipUnchanged="true"
       OutputPath="%(GeneratedContent.OutputPath)">
 
       <Output TaskParameter="ResolvedOutputPath" ItemName="FileWrites" />

--- a/src/aspnetcore/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
+++ b/src/aspnetcore/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
@@ -136,7 +136,6 @@
     <GenerateFileFromTemplate
       TemplateFile="$(MSBuildThisFileDirectory)..\TestInfrastructure\Directory.Build.targets.in"
       Properties="Configuration=$(Configuration);
-      Properties="Configuration=$(Configuration);
           RestoreAdditionalProjectSources=$([MSBuild]::Escape('$(RestoreAdditionalProjectSources);$(ArtifactsShippingPackagesDir);$(ArtifactsNonShippingPackagesDir)'));MicrosoftAspNetCoreComponentsWebAssemblyDevServerVersion=$(PackageVersion);MicrosoftAspNetCoreComponentsGatewayVersion=$(PackageVersion)"
       SkipUnchanged="true"
       OutputPath="$(TestTemplateCreationFolder)Directory.Build.targets" />

--- a/src/aspnetcore/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
+++ b/src/aspnetcore/src/ProjectTemplates/TestInfrastructure/PrepareForTest.targets
@@ -136,12 +136,15 @@
     <GenerateFileFromTemplate
       TemplateFile="$(MSBuildThisFileDirectory)..\TestInfrastructure\Directory.Build.targets.in"
       Properties="Configuration=$(Configuration);
+      Properties="Configuration=$(Configuration);
           RestoreAdditionalProjectSources=$([MSBuild]::Escape('$(RestoreAdditionalProjectSources);$(ArtifactsShippingPackagesDir);$(ArtifactsNonShippingPackagesDir)'));MicrosoftAspNetCoreComponentsWebAssemblyDevServerVersion=$(PackageVersion);MicrosoftAspNetCoreComponentsGatewayVersion=$(PackageVersion)"
+      SkipUnchanged="true"
       OutputPath="$(TestTemplateCreationFolder)Directory.Build.targets" />
 
     <GenerateFileFromTemplate
       TemplateFile="$(MSBuildThisFileDirectory)..\TestInfrastructure\Directory.Build.props.in"
       Properties="RepoRoot=$(RepoRoot);ArtifactsBinDir=$(ArtifactsBinDir);TargetingPackLayoutRoot=$(TargetingPackLayoutRoot);SharedFrameworkLayoutRoot=$(SharedFrameworkLayoutRoot);TestDependsOnAspNetPackages=$(TestDependsOnAspNetPackages);MicrosoftAspNetCoreAppRuntimeVersion=$(SharedFxVersion)"
+      SkipUnchanged="true"
       OutputPath="$(TestTemplateCreationFolder)Directory.Build.props" />
 
     <!-- Workaround https://github.com/dotnet/core-setup/issues/6420 - there is no MSBuild setting for rollforward yet -->


### PR DESCRIPTION
Prevents unnecessary re-generation of unchanged template files - re-generating those files updates the timestamp, which can cascade into re-running compilation targets & add extra build time.

Fixes https://github.com/dotnet/aspnetcore/issues/66972