### PR TITLE
Revert "Pin Node to 24.14.1 to work around npm ci 0xDEAD bug"

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -615,12 +615,10 @@ jobs:
   - ${{ if eq(parameters.targetOS, 'windows') }}:
     # Node is a toolset dependency to build aspnetcore
     # Keep in sync with aspnetcore: https://github.com/dotnet/aspnetcore/blob/7d5309210d8f7bae8fa074da495e9d009d67f1b4/.azure/pipelines/ci.yml#L719-L722
-    # Pinned to 24.14.1 to work around npm ci exit code 57005 bug in Node 24.15.
-    # Tracking issue to revert: https://github.com/dotnet/aspnetcore/issues/66501
     - task: UseNode@1
-      displayName: Install Node 24.14.1
+      displayName: Install Node 24.x
       inputs:
-        version: 24.14.1
+        version: 24.x
 
     - ${{ if eq(parameters.signDac, 'true') }}:
       # TODO: Once we turn off the dotnet/runtime official build, move these templates into the VMR's eng folder.

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -614,7 +614,7 @@ jobs:
 
   - ${{ if eq(parameters.targetOS, 'windows') }}:
     # Node is a toolset dependency to build aspnetcore
-    # Keep in sync with aspnetcore: https://github.com/dotnet/aspnetcore/blob/7d5309210d8f7bae8fa074da495e9d009d67f1b4/.azure/pipelines/ci.yml#L719-L722
+    # Keep in sync with aspnetcore: https://github.com/dotnet/aspnetcore/blob/main/.azure/pipelines/jobs/default-build.yml (UseNode@1 "Install Node" step)
     - task: UseNode@1
       displayName: Install Node 24.x
       inputs:


### PR DESCRIPTION
https://github.com/nodejs/node/issues/62991 appears to be resolved in v24.16.0 - see https://github.com/dotnet/aspnetcore/pull/66979