### PR TITLE
Replace `darc vmr scan-cloaked-files` with an in-VMR tool

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,12 +1,5 @@
 {
   "version": 1,
   "isRoot": true,
-  "tools": {
-    "microsoft.dotnet.darc": {
-      "version": "1.1.0-beta.26268.2",
-      "commands": [
-        "darc"
-      ]
-    }
-  }
+  "tools": {}
 }

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -10,10 +10,6 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>bf38c69d5d4087d1098b5f31283ad147feadf787</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Darc" Version="1.1.0-beta.26268.2" SkipProperty="True">
-      <Uri>https://github.com/dotnet/arcade-services</Uri>
-      <Sha>8690d7113c92d2dd112a20bc77b80d314b8f669b</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.DotNet.DarcLib" Version="1.1.0-beta.26268.2">
       <Uri>https://github.com/dotnet/arcade-services</Uri>
       <Sha>8690d7113c92d2dd112a20bc77b80d314b8f669b</Sha>

--- a/eng/pipelines/templates/stages/vmr-scan.yml
+++ b/eng/pipelines/templates/stages/vmr-scan.yml
@@ -13,19 +13,7 @@ stages:
       retryCountOnTaskFailure: 5
 
     - script: |
-        source ./eng/common/tools.sh
-        InitializeDotNetCli true
-        echo "##vso[task.setvariable variable=DotNetPath]$_InitializeDotNetCli"
-      displayName: Install .NET CLI
-  
-    - script: |
-        $(DotNetPath)/dotnet tool restore
-      displayName: Restore tools
-
-    - script: >
-        $(DotNetPath)/dotnet darc vmr scan-cloaked-files
-        --vmr "$(Build.SourcesDirectory)"
-        --tmp "$(Agent.TempDirectory)"
-        || (echo '##[error]Found cloaked files in the VMR' && exit 1)
+        set -ex
+        eng/common/dotnet.sh run --project eng/tools/CloakedFileScan/CloakedFileScan.csproj
       displayName: Scan for cloaked files
       continueOnError: true

--- a/eng/tools/CloakedFileScan/CloakedFileScan.csproj
+++ b/eng/tools/CloakedFileScan/CloakedFileScan.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(BundledNETCoreAppTargetFramework)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>CloakedFileScan</RootNamespace>
+    <!-- Suppress CS8002 because DarcLib assemblies are not signed -->
+    <NoWarn>$(NoWarn);CS8002</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.DotNet.DarcLib" />
+  </ItemGroup>
+
+</Project>

--- a/eng/tools/CloakedFileScan/Program.cs
+++ b/eng/tools/CloakedFileScan/Program.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Maestro.Common;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.DarcLib.VirtualMonoRepo;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CloakedFileScan;
+
+internal static class Program
+{
+    private static void LogInfo(string message) => Console.WriteLine(message);
+    private static void LogError(string message) => Console.WriteLine($"##vso[task.logissue type=error] {message}");
+
+    internal static async Task<int> Main()
+    {
+        var pm = new ProcessManager(NullLogger<ProcessManager>.Instance, "git");
+        var vmrPath = pm.FindGitRoot(AppContext.BaseDirectory);
+
+        LogInfo($"VMR root: {vmrPath}");
+
+        var serviceProvider = RegisterServices(vmrPath);
+        await using var scope = serviceProvider.CreateAsyncScope();
+
+        var scanner = scope.ServiceProvider.GetRequiredService<VmrCloakedFileScanner>();
+
+        LogInfo("Scanning VMR for cloaked files...");
+        var files = await scanner.ScanVmr(baselineFilePath: null, CancellationToken.None);
+
+        foreach (var file in files)
+        {
+            Console.WriteLine(file);
+        }
+
+        if (files.Count > 0)
+        {
+            LogError($"Found {files.Count} cloaked file(s) in the VMR.");
+            return 1;
+        }
+
+        LogInfo("No cloaked files found.");
+        return 0;
+    }
+
+    private static ServiceProvider RegisterServices(string vmrPath)
+    {
+        return new ServiceCollection()
+            .AddCodeflow("tmp", vmrPath: vmrPath)
+            .AddSingleton<IRemoteTokenProvider, NullRemoteTokenProvider>()
+            .AddLogging(b => b.AddConsole())
+            .BuildServiceProvider();
+    }
+
+    private sealed class NullRemoteTokenProvider : IRemoteTokenProvider
+    {
+        public string? GetTokenForRepository(string repoUri) => null;
+        public Task<string?> GetTokenForRepositoryAsync(string repoUri) => Task.FromResult<string?>(null);
+    }
+}

--- a/eng/tools/tools.proj
+++ b/eng/tools/tools.proj
@@ -8,6 +8,7 @@
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <ProjectReference Remove="BuildComparer\BuildComparer.csproj" />
     <ProjectReference Remove="ChangeValidation\ChangeValidation.csproj" />
+    <ProjectReference Remove="CloakedFileScan\CloakedFileScan.csproj" />
     <ProjectReference Remove="CreateBaselineUpdatePR\CreateBaselineUpdatePR.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Replaces the `darc vmr scan-cloaked-files` invocation in the VMR scan pipeline with a dedicated in-VMR tool at `eng/tools/CloakedFileScan/`, modeled after `eng/tools/ChangeValidation/`.

The new tool consumes `Microsoft.DotNet.DarcLib` and instantiates `VmrCloakedFileScanner` directly, producing identical scan results (git-diff against the empty tree with cloaked path filters from `src/source-mappings.json`) and emitting AzDO `##vso[task.logissue type=error]` annotations for any matches.

### Why

This lets us drop the pinned `microsoft.dotnet.darc` global tool. Removed:
- `microsoft.dotnet.darc` entry from `.config/dotnet-tools.json` (now empty)
- `Microsoft.DotNet.Darc` `<Dependency>` from `eng/Version.Details.xml`

`Microsoft.DotNet.DarcLib` is kept — it's already used by `ChangeValidation` and is now also used by the new tool.

### Pipeline change

`eng/pipelines/templates/stages/vmr-scan.yml` no longer needs to bootstrap the .NET CLI separately or run `dotnet tool restore`; it just runs the project via `eng/common/dotnet.sh run`.

### Verification

Built and run locally against this VMR:
- Clean tree → `0 cloaked files`, exit 0.
- Staged a test file matching a cloak rule (`src/roslyn/.../ObfuscatedCloakTest.dll`) → tool reported it with the expected AzDO error annotation, exit 1.
