### PR TITLE
Fix gating of TestResults copy/publish steps

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -663,7 +663,6 @@ jobs:
           -excludeCIBinarylog
           /bl:artifacts/log/Release/Test.binlog
         displayName: Run Tests
-        name: RunTests
         workingDirectory: ${{ variables.sourcesPath }}
         timeoutInMinutes: ${{ variables.runTestsTimeout }}
 
@@ -944,7 +943,6 @@ jobs:
           $customPreBuildArgs ./build.sh $buildArgs
 
         displayName: Run Tests
-        name: RunTests
         timeoutInMinutes: ${{ variables.runTestsTimeout }}
 
   - ${{ if eq(parameters.sign, 'True') }}:
@@ -1008,7 +1006,7 @@ jobs:
         TargetFolder: '$(Build.ArtifactStagingDirectory)/BuildLogs/artifacts/TestResults'
         CleanTargetFolder: true
       continueOnError: true
-      condition: and(succeededOrFailed(), ne(variables['RunTests.result'], 'Skipped'))
+      condition: and(eq(variables['hasTestResults'], 'true'), succeededOrFailed())
 
   - task: CopyFiles@2
     displayName: Copy unmerged artifacts to staging directory
@@ -1034,7 +1032,7 @@ jobs:
   - ${{ if eq(parameters.runTests, 'True') }}:
     - task: PublishTestResults@2
       displayName: Publish Test Results
-      condition: and(succeededOrFailed(), ne(variables['RunTests.result'], 'Skipped'))
+      condition: and(eq(variables['hasTestResults'], 'true'), succeededOrFailed())
       continueOnError: true
       inputs:
         testRunner: VSTest

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -962,12 +962,6 @@
           DependsOnTargets="RepoTest;CleanupRepo" />
   <Target Name="VSTest" DependsOnTargets="Test" />
 
-  <Target Name="SetAzureDevOpsVariableForTestResults"
-          Condition="'$(ContinuousIntegrationBuild)' == 'true'"
-          BeforeTargets="RepoTest">
-    <Message Importance="High" Text="##vso[task.setvariable variable=hasTestResults]true" />
-  </Target>
-
   <!-- Outputs a dependency graph of the repos, in YAML form, to the console. -->
   <Target Name="ShowDependencyGraph">
     <MSBuild Projects="$(MSBuildProjectFullPath)"

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -962,6 +962,12 @@
           DependsOnTargets="RepoTest;CleanupRepo" />
   <Target Name="VSTest" DependsOnTargets="Test" />
 
+  <Target Name="SetAzureDevOpsVariableForTestResults"
+          Condition="'$(ContinuousIntegrationBuild)' == 'true'"
+          BeforeTargets="RepoTest">
+    <Message Importance="High" Text="##vso[task.setvariable variable=hasTestResults]true" />
+  </Target>
+
   <!-- Outputs a dependency graph of the repos, in YAML form, to the console. -->
   <Target Name="ShowDependencyGraph">
     <MSBuild Projects="$(MSBuildProjectFullPath)"

--- a/test/tests.proj
+++ b/test/tests.proj
@@ -50,4 +50,10 @@
           Condition="@(DownloadedNupkg->Count()) > 0" />
   </Target>
 
+  <Target Name="SetAzureDevOpsVariableForTestResults"
+          Condition="'$(ContinuousIntegrationBuild)' == 'true'"
+          BeforeTargets="Test">
+    <Message Importance="High" Text="##vso[task.setvariable variable=hasTestResults]true" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
Follow-up to #6866.

That PR used `variables['RunTests.result']` to gate the `Copy TestResults to BuildLogs staging` and `Publish Test Results` steps, but step `.result` outputs aren't a thing in AzDO YAML (only available for job dependencies). The gate was always empty, so the steps still ran (and errored) when Run Tests was skipped after a Build failure.

This PR mirrors the existing `hasScenarioTestResults` pattern: a `BeforeTargets="Test"` target in `test/tests.proj` emits `##vso[task.setvariable variable=hasTestResults]true`, and the copy/publish steps gate on `eq(variables['hasTestResults'], 'true')`.