### PR TITLE
Generate baseline-update PRs for internal branches

### DIFF
--- a/eng/dependabot/Directory.Packages.props
+++ b/eng/dependabot/Directory.Packages.props
@@ -4,7 +4,6 @@
        because it can't handle global.json due to https://github.com/dependabot/dependabot-core/issues/11479 -->
 
   <ItemGroup>
-    <PackageVersion Include="Octokit" Version="14.0.0" />
   </ItemGroup>
 
 </Project>

--- a/eng/pipelines/templates/jobs/reproducibility-test.yml
+++ b/eng/pipelines/templates/jobs/reproducibility-test.yml
@@ -135,13 +135,12 @@ jobs:
       publishRunAttachments: true
       testRunTitle: Tests_$(Agent.JobName)
 
-  - ${{ if and(eq(parameters.publishTestResultsPr, 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release'))) }}:
+  - ${{ if eq(parameters.publishTestResultsPr, 'true') }}:
       # Publish both Updated*Exclusions.txt and Updated*Baseline.diff. The CreateBaselineUpdatePR
       # tool filters to files prefixed with "Updated", so other build logs in BuildLogs are ignored.
       - template: /eng/pipelines/templates/steps/create-baseline-update-pr.yml@self
         parameters:
           pipeline: reproducibility
-          repo: dotnet/dotnet
           originalFilesDirectory: test/Microsoft.DotNet.Reproducibility.Tests/assets
           updatedFilesDirectory: $(Build.StagingDirectory)/BuildLogs
           pullRequestTitle: ${{ parameters.pullRequestTitle }}

--- a/eng/pipelines/templates/jobs/sdk-diff-tests.yml
+++ b/eng/pipelines/templates/jobs/sdk-diff-tests.yml
@@ -187,12 +187,11 @@ jobs:
       publishRunAttachments: true
       testRunTitle: $(Agent.JobName)
 
-  - ${{ if and(eq(parameters.publishTestResultsPr, 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release'))) }}:
+  - ${{ if eq(parameters.publishTestResultsPr, 'true') }}:
       - template: ../steps/create-baseline-update-pr.yml
         parameters:
           dotnetPath: $(DotNetPath)
           pipeline: sdk
-          repo: dotnet/dotnet
           originalFilesDirectory: test/Microsoft.DotNet.SourceBuild.Tests/assets/SdkContentTests
           updatedFilesDirectory: $(Build.StagingDirectory)/BuildLogs
           pullRequestTitle: Update Source-Build SDK Diff Tests Baselines and Exclusions

--- a/eng/pipelines/templates/stages/vmr-license-scan.yml
+++ b/eng/pipelines/templates/stages/vmr-license-scan.yml
@@ -160,7 +160,7 @@ stages:
 
   - job: Publish_Test_Results_PR
     dependsOn: LicenseScan
-    condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release'))
+    condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'))
     variables:
     - template: /eng/pipelines/templates/variables/pipelines.yml@self
       # GH access token for SB bot - BotAccount-dotnet-sb-bot-pat
@@ -189,7 +189,6 @@ stages:
       parameters:
         dotnetPath: $(DotNetPath)
         pipeline: license
-        repo: dotnet/dotnet
         originalFilesDirectory: test/Microsoft.DotNet.SourceBuild.Tests/assets/LicenseScanTests
         updatedFilesDirectory: $(Pipeline.Workspace)/Artifacts
         pullRequestTitle: Update Source-Build License Scan Baselines and Exclusions

--- a/eng/pipelines/templates/steps/create-baseline-update-pr.yml
+++ b/eng/pipelines/templates/steps/create-baseline-update-pr.yml
@@ -9,13 +9,8 @@ parameters:
 - name: pipeline
   type: string
 
-# The GitHub repository to create the PR in.
-# Should be in the form '<owner>/<repo-name>'
-- name: repo
-  type: string
-
 # Path to the directory containing the original test files
-# Should be relative to the "repo" parameter
+# Should be relative to the targeted repo
 - name: originalFilesDirectory
   type: string
 
@@ -28,25 +23,49 @@ parameters:
   type: string
   default: Update Test Baselines
 
+# Two separate invocations of the underlying runner, gated by mutually-exclusive
+# branch conditions. This is defensive programming to ensure that an internal
+# branch isn't accidentally pushed to a public repository.
 steps:
-  - script: |
-      restoreSources="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"
-      restoreSources+="%3Bhttps://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json"
+- ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
+  - template: run-baseline-update-pr-tool.yml
+    parameters:
+      dotnetPath: ${{ parameters.dotnetPath }}
+      pipeline: ${{ parameters.pipeline }}
+      repoUrl: 'https://github.com/dotnet/dotnet'
+      token: $(BotAccount-dotnet-sb-bot-pat)
+      originalFilesDirectory: ${{ parameters.originalFilesDirectory }}
+      updatedFilesDirectory: ${{ parameters.updatedFilesDirectory }}
+      pullRequestTitle: ${{ parameters.pullRequestTitle }}
 
-      branchName=$(echo "$(Build.SourceBranch)" | sed 's/refs\/heads\///g')
-
-      ${{ parameters.dotnetPath }}/dotnet run \
-        --project eng/tools/CreateBaselineUpdatePR/ \
-        --property:RestoreSources="$restoreSources" \
-        "${{ parameters.pipeline }}" \
-        "${{ parameters.repo }}" \
-        "${{ parameters.originalFilesDirectory }}" \
-        "${{ parameters.updatedFilesDirectory }}" \
-        "$(Build.BuildId)" \
-        --title "${{ parameters.pullRequestTitle }}" \
-        --branch "$branchName"
-    displayName: Publish Test Results PR
-    workingDirectory: $(Build.SourcesDirectory)
+- ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/') }}:
+  - task: AzureCLI@2
+    displayName: Mint AzDO token (WIF)
     condition: succeededOrFailed()
-    env:
-      GH_TOKEN: $(BotAccount-dotnet-sb-bot-pat)
+    inputs:
+      azureSubscription: dnceng-build-rw-code-rw-wif
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript: |
+        # Azure DevOps AAD resource ID
+        $azureDevOpsResourceId = "499b84ac-1321-427f-aa17-267ca6975798"
+        $token = az account get-access-token --resource $azureDevOpsResourceId --query accessToken -o tsv
+        if ($LASTEXITCODE -ne 0) {
+          Write-Error "Failed to acquire Azure DevOps token via 'az account get-access-token'. Exit code: $LASTEXITCODE"
+          exit 1
+        }
+        $token = $token.Trim()
+        if ([string]::IsNullOrWhiteSpace($token)) {
+          Write-Error "Received an empty Azure DevOps token from 'az account get-access-token'."
+          exit 1
+        }
+        Write-Host "##vso[task.setvariable variable=BaselinePrAzdoToken;issecret=true]$token"
+  - template: run-baseline-update-pr-tool.yml
+    parameters:
+      dotnetPath: ${{ parameters.dotnetPath }}
+      pipeline: ${{ parameters.pipeline }}
+      repoUrl: 'https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet'
+      token: $(BaselinePrAzdoToken)
+      originalFilesDirectory: ${{ parameters.originalFilesDirectory }}
+      updatedFilesDirectory: ${{ parameters.updatedFilesDirectory }}
+      pullRequestTitle: ${{ parameters.pullRequestTitle }}

--- a/eng/pipelines/templates/steps/run-baseline-update-pr-tool.yml
+++ b/eng/pipelines/templates/steps/run-baseline-update-pr-tool.yml
@@ -1,0 +1,59 @@
+parameters:
+- name: dotnetPath
+  type: string
+  default: '$(Build.SourcesDirectory)/.dotnet'
+
+# The pipeline that is being run
+# Used to determine the correct baseline update tool to run
+# Currently supports "sdk", "license", and "reproducibility"
+- name: pipeline
+  type: string
+
+# Full URL of the repository to create the PR in.
+# Supported forms:
+#   - https://github.com/<owner>/<repo>
+#   - https://dev.azure.com/<account>/<project>/_git/<repo>
+- name: repoUrl
+  type: string
+
+# The token used to authenticate the PR push and creation.
+- name: token
+  type: string
+
+# Path to the directory containing the original test files
+# Should be relative to the targeted repo
+- name: originalFilesDirectory
+  type: string
+
+# Path to the directory containing the updated test files
+# Should be absolute or relative to the working directory of the tool
+- name: updatedFilesDirectory
+  type: string
+
+- name: pullRequestTitle
+  type: string
+  default: Update Test Baselines
+
+steps:
+  - script: |
+      restoreSources="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"
+      restoreSources+="%3Bhttps://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json"
+      restoreSources+="%3Bhttps://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json"
+
+      branchName=$(echo "$(Build.SourceBranch)" | sed 's/refs\/heads\///g')
+
+      ${{ parameters.dotnetPath }}/dotnet run \
+        --project eng/tools/CreateBaselineUpdatePR/ \
+        --property:RestoreSources="$restoreSources" \
+        "${{ parameters.pipeline }}" \
+        "${{ parameters.repoUrl }}" \
+        "${{ parameters.originalFilesDirectory }}" \
+        "${{ parameters.updatedFilesDirectory }}" \
+        "$(Build.BuildId)" \
+        --title "${{ parameters.pullRequestTitle }}" \
+        --branch "$branchName"
+    displayName: Publish Test Results PR
+    workingDirectory: $(Build.SourcesDirectory)
+    condition: succeededOrFailed()
+    env:
+      GIT_TOKEN: ${{ parameters.token }}

--- a/eng/tools/CreateBaselineUpdatePR/AzureDevOpsGitClient.cs
+++ b/eng/tools/CreateBaselineUpdatePR/AzureDevOpsGitClient.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Maestro.Common.AzureDevOpsTokens;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CreateBaselineUpdatePR;
+
+/// <summary>
+/// <see cref="GitClient"/> implementation targeting Azure DevOps.
+/// </summary>
+public sealed class AzureDevOpsGitClient : GitClient
+{
+    public AzureDevOpsGitClient(string repoUri, string token)
+        : base(CreateUnderlyingClient(repoUri, token), repoUri)
+    {
+    }
+
+    public static bool Matches(string repoUri) =>
+        repoUri.StartsWith("https://dev.azure.com/", StringComparison.OrdinalIgnoreCase)
+        || repoUri.Contains(".visualstudio.com/", StringComparison.OrdinalIgnoreCase);
+
+    public override string BuildPullRequestApiUrl(int pullRequestId)
+    {
+        (string account, string project, string repo) = AzureDevOpsClient.ParseRepoUri(RepoUri);
+        return $"https://dev.azure.com/{account}/{project}/_apis/git/repositories/{repo}/pullRequests/{pullRequestId}";
+    }
+
+    public override string BuildPullRequestHtmlUrl(int pullRequestId)
+    {
+        (string account, string project, string repo) = AzureDevOpsClient.ParseRepoUri(RepoUri);
+        return $"https://dev.azure.com/{account}/{project}/_git/{repo}/pullrequest/{pullRequestId}";
+    }
+
+    private static AzureDevOpsClient CreateUnderlyingClient(string repoUri, string token)
+    {
+        (string account, _, _) = AzureDevOpsClient.ParseRepoUri(repoUri);
+        var tokenOptions = new AzureDevOpsTokenProviderOptions
+        {
+            [account] = new AzureDevOpsCredentialResolverOptions { Token = token }
+        };
+        return new AzureDevOpsClient(
+            AzureDevOpsTokenProvider.FromStaticOptions(tokenOptions),
+            new ProcessManager(NullLogger<IProcessManager>.Instance, "git"),
+            NullLogger<AzureDevOpsClient>.Instance);
+    }
+}

--- a/eng/tools/CreateBaselineUpdatePR/CreateBaselineUpdatePR.csproj
+++ b/eng/tools/CreateBaselineUpdatePR/CreateBaselineUpdatePR.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.DarcLib" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="System.CommandLine" />
-    <PackageReference Include="Octokit" />
   </ItemGroup>
 
 </Project>

--- a/eng/tools/CreateBaselineUpdatePR/GitClient.cs
+++ b/eng/tools/CreateBaselineUpdatePR/GitClient.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.DarcLib;
+
+namespace CreateBaselineUpdatePR;
+
+/// <summary>
+/// Wraps a DarcLib <see cref="IRemoteGitRepo"/> together with helpers for
+/// constructing provider-specific PR URLs that DarcLib's own APIs require.
+/// </summary>
+public abstract class GitClient
+{
+    public IRemoteGitRepo Repo { get; }
+
+    public string RepoUri { get; }
+
+    protected GitClient(IRemoteGitRepo repo, string repoUri)
+    {
+        Repo = repo;
+        RepoUri = repoUri;
+    }
+
+    /// <summary>
+    /// Returns an API-style URL for the given pull request, suitable for use with
+    /// DarcLib's <c>UpdatePullRequestAsync</c> / <c>GetPullRequestAsync</c>.
+    /// </summary>
+    public abstract string BuildPullRequestApiUrl(int pullRequestId);
+
+    /// <summary>
+    /// Returns a human-friendly HTML URL for the given pull request.
+    /// </summary>
+    public abstract string BuildPullRequestHtmlUrl(int pullRequestId);
+
+    /// <summary>
+    /// Creates a <see cref="GitClient"/> appropriate for the given repository URL.
+    /// </summary>
+    public static GitClient Create(string repoUri, string token)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(repoUri);
+        ArgumentException.ThrowIfNullOrEmpty(token);
+
+        if (GitHubGitClient.Matches(repoUri))
+        {
+            return new GitHubGitClient(repoUri, token);
+        }
+
+        if (AzureDevOpsGitClient.Matches(repoUri))
+        {
+            return new AzureDevOpsGitClient(repoUri, token);
+        }
+
+        throw new ArgumentException($"Unsupported repository URL '{repoUri}'.", nameof(repoUri));
+    }
+}

--- a/eng/tools/CreateBaselineUpdatePR/GitHubGitClient.cs
+++ b/eng/tools/CreateBaselineUpdatePR/GitHubGitClient.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Maestro.Common;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CreateBaselineUpdatePR;
+
+/// <summary>
+/// <see cref="GitClient"/> implementation targeting GitHub.
+/// </summary>
+public sealed class GitHubGitClient : GitClient
+{
+    public GitHubGitClient(string repoUri, string token)
+        : base(CreateUnderlyingClient(token), repoUri)
+    {
+    }
+
+    public static bool Matches(string repoUri) =>
+        repoUri.StartsWith("https://github.com/", StringComparison.OrdinalIgnoreCase);
+
+    public override string BuildPullRequestApiUrl(int pullRequestId)
+    {
+        (string owner, string repo) = GitHubClient.ParseRepoUri(RepoUri);
+        return $"https://api.github.com/repos/{owner}/{repo}/pulls/{pullRequestId}";
+    }
+
+    public override string BuildPullRequestHtmlUrl(int pullRequestId)
+    {
+        (string owner, string repo) = GitHubClient.ParseRepoUri(RepoUri);
+        return $"https://github.com/{owner}/{repo}/pull/{pullRequestId}";
+    }
+
+    private static GitHubClient CreateUnderlyingClient(string token) =>
+        new(
+            new ResolvedTokenProvider(token),
+            new ProcessManager(NullLogger<IProcessManager>.Instance, "git"),
+            NullLogger<GitHubClient>.Instance,
+            cache: null);
+}

--- a/eng/tools/CreateBaselineUpdatePR/PRCreator.cs
+++ b/eng/tools/CreateBaselineUpdatePR/PRCreator.cs
@@ -197,7 +197,7 @@ public partial class PRCreator
     private static List<TreeFile> UpdateFile(List<TreeFile> tree, string? content, string searchFileName, string updatedPath)
     {
         var originalTreeItem = tree
-            .Where(item => item.RelativePath.Contains(searchFileName))
+            .Where(item => item.RelativePath.Contains(searchFileName, StringComparison.Ordinal))
             .FirstOrDefault();
 
         if (content == null)

--- a/eng/tools/CreateBaselineUpdatePR/PRCreator.cs
+++ b/eng/tools/CreateBaselineUpdatePR/PRCreator.cs
@@ -3,106 +3,83 @@
 
 namespace CreateBaselineUpdatePR;
 
-using Octokit;
+using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
+using Microsoft.DotNet.DarcLib;
+using Microsoft.DotNet.DarcLib.Helpers;
+using Microsoft.DotNet.DarcLib.Models;
 
-public class PRCreator
+public partial class PRCreator
 {
-    private readonly string _repoOwner;
-    private readonly string _repoName;
-    private readonly GitHubClient _client;
+    private readonly GitClient _gitClient;
+    private readonly Pipelines _pipeline;
     private const string BuildLink = "https://dev.azure.com/dnceng/internal/_build/results?buildId=";
     private const string DefaultLicenseBaselineContent = "{\n  \"files\": []\n}";
-    private const string TreeMode = "040000";
     private const string UpdatedFilePrefix = "updated";
-    private const int MaxRetries = 10;
-    public PRCreator(string repo, string gitHubToken)
+    public PRCreator(GitClient gitClient, Pipelines pipeline)
     {
-        // Create a new GitHub client
-        _client = new GitHubClient(new ProductHeaderValue(System.Reflection.Assembly.GetExecutingAssembly().GetName().Name));
-        var authToken = new Credentials(gitHubToken);
-        _client.Credentials = authToken;
-        _repoOwner = repo.Split('/')[0];
-        _repoName = repo.Split('/')[1];
+        _gitClient = gitClient;
+        _pipeline = pipeline;
     }
+
+    [GeneratedRegex("-+")]
+    private static partial Regex ConsecutiveDashesRegex { get; }
 
     public async Task ExecuteAsync(
         string originalFilesDirectory,
         string updatedFilesDirectory,
         int buildId,
         string title,
-        string targetBranch,
-        Pipelines pipeline)
+        string targetBranch)
     {
         DateTime startTime = DateTime.Now.ToUniversalTime();
 
-        Log.LogInformation($"Starting PR creation at {startTime} UTC for pipeline {pipeline}.");
+        Log.LogInformation($"Starting PR creation at {startTime} UTC for pipeline {_pipeline}.");
 
         var updatedTestsFiles = GetUpdatedFiles(updatedFilesDirectory);
 
         // Fetch the files within the desired path from the original tree
-        TreeResponse originalTreeResponse = await ApiRequestWithRetries(() => _client.Git.Tree.Get(_repoOwner, _repoName, targetBranch));
-        List<NewTreeItem> originalTreeItems = await FetchOriginalTreeItemsAsync(originalTreeResponse, targetBranch, originalFilesDirectory);
+        List<TreeFile> originalTreeItems = await FetchOriginalTreeItemsAsync(targetBranch, originalFilesDirectory);
 
         // Update the test results tree based on the pipeline
-        originalTreeItems = await UpdateAllFilesAsync(updatedTestsFiles, originalTreeItems, pipeline);
-        var testResultsTreeResponse = await CreateTreeFromItemsAsync(originalTreeItems);
-        var parentTreeResponse = await CreateParentTreeAsync(testResultsTreeResponse, originalTreeResponse, originalFilesDirectory);
+        List<TreeFile> modifiedTreeItems = UpdateAllFiles(updatedTestsFiles, [.. originalTreeItems], _pipeline);
 
-        await CreateOrUpdatePullRequestAsync(parentTreeResponse, buildId, title, targetBranch);
+        await CreateOrUpdatePullRequestAsync(originalTreeItems, modifiedTreeItems, originalFilesDirectory, buildId, title, targetBranch);
     }
 
-    private async Task<List<NewTreeItem>> FetchOriginalTreeItemsAsync(
-        TreeResponse? treeResponse,
+    private async Task<List<TreeFile>> FetchOriginalTreeItemsAsync(
         string targetBranch,
         string desiredPath)
     {
-        ConcurrentBag<NewTreeItem> treeItems = [];
-        await FetchOriginalTreeItemsAsync(treeResponse, treeItems, targetBranch, desiredPath);
-        return treeItems.ToList();
-    }
+        string? commitSha = await _gitClient.Repo.GetLastCommitShaAsync(_gitClient.RepoUri, targetBranch)
+            ?? throw new InvalidOperationException(
+                $"Could not resolve target branch '{targetBranch}' in {_gitClient.RepoUri}.");
 
-    private async Task FetchOriginalTreeItemsAsync(
-        TreeResponse? treeResponse,
-        ConcurrentBag<NewTreeItem> treeItems,
-        string targetBranch,
-        string desiredPath,
-        string relativePath = "")
-    {
-        if (treeResponse == null)
+        List<GitFile> files;
+        try
         {
-            return;
+            files = await _gitClient.Repo.GetFilesAtCommitAsync(_gitClient.RepoUri, commitSha, desiredPath);
+        }
+        catch (DependencyFileNotFoundException)
+        {
+            // The desired path may not exist yet (no baseline directory). Treat as empty tree.
+            return [];
         }
 
-        await Parallel.ForEachAsync(treeResponse.Tree, async (item, cancellationToken) =>
+        string prefix = desiredPath.Replace('\\', '/').TrimEnd('/') + "/";
+        return [.. files.Select(f =>
         {
-            string path = Path.Combine(relativePath, item.Path);
-            if (!path.StartsWith(desiredPath) && !desiredPath.StartsWith(path))
-            {
-                return;
-            }
-
-            if (item.Type == TreeType.Tree)
-            {
-                TreeResponse subTree = await ApiRequestWithRetries(() => _client.Git.Tree.Get(_repoOwner, _repoName, item.Sha));
-                await FetchOriginalTreeItemsAsync(subTree, treeItems, targetBranch, desiredPath, path);
-            }
-            else
-            {
-                var newItem = new NewTreeItem
-                {
-                    Path = Path.GetRelativePath(desiredPath, path),
-                    Mode = item.Mode,
-                    Type = item.Type.Value,
-                    Sha = item.Sha
-                };
-
-                treeItems.Add(newItem);
-            }
-        });
+            string relativePath = f.FilePath.StartsWith(prefix) ? f.FilePath[prefix.Length..] : f.FilePath;
+            // Decode base64 blobs (DarcLib's GitHub client returns text files with
+            // ContentEncoding.Base64) so the in-memory tree is uniformly plain UTF-8 text.
+            string content = f.ContentEncoding == ContentEncoding.Base64
+                ? Encoding.UTF8.GetString(Convert.FromBase64String(f.Content))
+                : f.Content;
+            return new TreeFile(relativePath, content);
+        })];
     }
 
     // Return a dictionary using the filename without the 
@@ -117,7 +94,7 @@ public class PRCreator
                 group => new HashSet<string>(group)
             );
 
-    private async Task<List<NewTreeItem>> UpdateAllFilesAsync(Dictionary<string, HashSet<string>> updatedFiles, List<NewTreeItem> tree, Pipelines pipeline)
+    private List<TreeFile> UpdateAllFiles(Dictionary<string, HashSet<string>> updatedFiles, List<TreeFile> tree, Pipelines pipeline)
     {
         bool unionExclusions = pipeline switch
         {
@@ -131,17 +108,17 @@ public class PRCreator
         {
             if (updatedFile.Key.Contains("Exclusions"))
             {
-                tree = await UpdateExclusionFileAsync(updatedFile.Key, updatedFile.Value, tree, union: unionExclusions);
+                tree = UpdateExclusionFile(updatedFile.Key, updatedFile.Value, tree, union: unionExclusions);
             }
             else
             {
-                tree = await UpdateRegularFilesAsync(updatedFile.Value, tree, defaultContent);
+                tree = UpdateRegularFiles(updatedFile.Value, tree, defaultContent);
             }
         }
         return tree;
     }
 
-    private async Task<List<NewTreeItem>> UpdateExclusionFileAsync(string fileNameKey, HashSet<string> updatedFiles, List<NewTreeItem> tree, bool union = false)
+    private static List<TreeFile> UpdateExclusionFile(string fileNameKey, HashSet<string> updatedFiles, List<TreeFile> tree, bool union = false)
     {
         string? content = null;
         IEnumerable<string> parsedFile = Enumerable.Empty<string>();
@@ -168,15 +145,14 @@ public class PRCreator
         {
             // Need to compare to the original file and remove any lines that are not in the parsed updated file
 
-            // Find the key in the tree, download the blob, and convert it to utf8
+            // Find the key in the tree
             var originalTreeItem = tree
-                .Where(item => item.Path.Contains(fileNameKey))
+                .Where(item => item.RelativePath.Contains(fileNameKey))
                 .FirstOrDefault();
 
             if (originalTreeItem != null)
             {
-                var originalBlob = await ApiRequestWithRetries(() => _client.Git.Blob.Get(_repoOwner, _repoName, originalTreeItem.Sha));
-                content = Encoding.UTF8.GetString(Convert.FromBase64String(originalBlob.Content));
+                content = originalTreeItem.Content;
                 var originalContent = content.Split("\n");
 
                 foreach (var line in originalContent)
@@ -200,10 +176,10 @@ public class PRCreator
         }
 
         string updatedFilePath = fileNameKey + ".txt";
-        return await UpdateFileAsync(tree, content, fileNameKey, updatedFilePath);
+        return UpdateFile(tree, content, fileNameKey, updatedFilePath);
     }
 
-    private async Task<List<NewTreeItem>> UpdateRegularFilesAsync(HashSet<string> updatedFiles, List<NewTreeItem> tree, string? compareContent = null)
+    private static List<TreeFile> UpdateRegularFiles(HashSet<string> updatedFiles, List<TreeFile> tree, string? compareContent = null)
     {
         foreach (var filePath in updatedFiles)
         {
@@ -213,15 +189,15 @@ public class PRCreator
                 content = null;
             }
             string originalFileName = Path.GetFileName(ParseUpdatedFileName(filePath));
-            tree = await UpdateFileAsync(tree, content, originalFileName, originalFileName);
+            tree = UpdateFile(tree, content, originalFileName, originalFileName);
         }
         return tree;
     }
 
-    private async Task<List<NewTreeItem>> UpdateFileAsync(List<NewTreeItem> tree, string? content, string searchFileName, string updatedPath)
+    private static List<TreeFile> UpdateFile(List<TreeFile> tree, string? content, string searchFileName, string updatedPath)
     {
         var originalTreeItem = tree
-            .Where(item => item.Path.Contains(searchFileName))
+            .Where(item => item.RelativePath.Contains(searchFileName))
             .FirstOrDefault();
 
         if (content == null)
@@ -235,35 +211,18 @@ public class PRCreator
         else if (originalTreeItem == null)
         {
             // Path not in the tree, add a new tree item
-            var blob = await CreateBlobAsync(content);
-            tree.Add(new NewTreeItem
-            {
-                Type = TreeType.Blob,
-                Mode = FileMode.File,
-                Path = updatedPath,
-                Sha = blob.Sha
-            });
+            tree.Add(new TreeFile(updatedPath, content));
         }
         else
         {
-            // Path in the tree, update the sha and the content
-            var blob = await CreateBlobAsync(content);
-            originalTreeItem.Sha = blob.Sha;
+            // Path in the tree, update the content (TreeFile is immutable so replace the entry)
+            tree.Remove(originalTreeItem);
+            tree.Add(originalTreeItem with { Content = content });
         }
         return tree;
     }
 
-    private async Task<BlobReference> CreateBlobAsync(string content)
-    {
-        var blob = new NewBlob
-        {
-            Content = content,
-            Encoding = EncodingType.Utf8
-        };
-        return await ApiRequestWithRetries(() => _client.Git.Blob.Create(_repoOwner, _repoName, blob));
-    }
-
-    private string ParseUpdatedFileName(string updatedFile)
+    private static string ParseUpdatedFileName(string updatedFile)
     {
         string fileName = Path.GetFileName(updatedFile);
         if (fileName.StartsWith(UpdatedFilePrefix, StringComparison.OrdinalIgnoreCase))
@@ -273,214 +232,240 @@ public class PRCreator
         throw new ArgumentException($"File name '{fileName}' does not start with '{UpdatedFilePrefix}' prefix.", nameof(updatedFile));
     }
 
-    private async Task<TreeResponse> CreateTreeFromItemsAsync(List<NewTreeItem> items, string path = "")
+    private async Task CreateOrUpdatePullRequestAsync(
+        List<TreeFile> originalTreeItems,
+        List<TreeFile> modifiedTreeItems,
+        string originalFilesDirectory,
+        int buildId,
+        string title,
+        string targetBranch)
     {
-        List<NewTreeItem> newTreeItems = [];
+        // Use a deterministic head branch name so re-runs reuse the same PR. DarcLib's
+        // SearchPullRequestsAsync requires a head branch on both GitHub and AzDO, so
+        // looking up the PR by branch is the cleanest cross-provider option.
+        string newBranchName = BuildHeadBranchName(targetBranch);
+        int? existingPullRequestId = await GetExistingPullRequestAsync(newBranchName, targetBranch);
 
-        var groups = items.GroupBy(item => Path.GetDirectoryName(item.Path));
-        foreach (var group in groups)
+        // Choose the "base" tree for the diff:
+        //   - Create path: the target branch's tree. The commit lands on a fresh branch
+        //     reset to target by EnsureHeadBranchAsync, so target-relative diff is correct.
+        //   - Update path: the existing PR head's tree. DarcLib's CommitFilesWithNoCloningAsync
+        //     bases new commits on the current branch HEAD, so the diff MUST be computed
+        //     against PR head — otherwise stale modifications from prior runs (files no
+        //     longer in modifiedTreeItems, or files that should revert to target's content)
+        //     would silently persist on the PR branch.
+        List<TreeFile> baseTreeItems = existingPullRequestId is null
+            ? originalTreeItems
+            : await FetchOriginalTreeItemsAsync(newBranchName, originalFilesDirectory);
+
+        // Compute the actual set of file changes and bail early if nothing differs.
+        // NOTE: We do not merge the target branch into an existing PR branch before pushing
+        // (the original Octokit-based tool did, via Repository.Merging.Create). DarcLib's
+        // IRemoteGitRepo abstraction doesn't expose a server-side merge, and adding per-provider
+        // escapes for it isn't justified for this use case. Consequence: a long-lived baseline
+        // PR may show "behind target" in the PR UI. In practice these PRs merge quickly.
+        List<GitFile> commitFiles = ComputeChangeSet(baseTreeItems, modifiedTreeItems, originalFilesDirectory);
+        if (!ShouldMakeUpdates(commitFiles))
         {
-            if (string.IsNullOrEmpty(group.Key) || group.Key == path)
-            {
-                // These items are in the current directory, so add them to the new tree items
-                foreach (var item in group)
-                {
-                    if (item.Type != TreeType.Tree)
-                    {
-                        newTreeItems.Add(new NewTreeItem
-                        {
-                            Path = path == string.Empty ? item.Path : Path.GetRelativePath(path, item.Path),
-                            Mode = item.Mode,
-                            Type = item.Type,
-                            Sha = item.Sha
-                        });
-                    }
-                }
-            }
-            else
-            {
-                // These items are in a subdirectory, so recursively create a tree for them
-                var subtreeResponse = await CreateTreeFromItemsAsync(group.ToList(), group.Key);
-                newTreeItems.Add(new NewTreeItem
-                {
-                    Path = group.Key,
-                    Mode = TreeMode,
-                    Type = TreeType.Tree,
-                    Sha = subtreeResponse.Sha
-                });
-            }
+            return;
         }
 
-        var newTree = new NewTree();
-        foreach (var item in newTreeItems)
+        string pullRequestBody = $"This PR was created by the `CreateBaselineUpdatePR` tool for build {buildId}. \n\n" +
+                             $"The updated test results can be found at {BuildLink}{buildId} (internal Microsoft link)";
+        string commitMessage = $"Update baselines for build {BuildLink}{buildId} (internal Microsoft link)";
+
+        if (existingPullRequestId != null)
         {
-            newTree.Tree.Add(item);
-        }
-        return await ApiRequestWithRetries(() => _client.Git.Tree.Create(_repoOwner, _repoName, newTree));
-    }
-
-    private async Task<TreeResponse> CreateParentTreeAsync(TreeResponse testResultsTreeResponse, TreeResponse originalTreeResponse, string originalFilesDirectory)
-    {
-        // Create a new tree for the parent directory
-        NewTree parentTree = new NewTree { BaseTree = originalTreeResponse.Sha };
-
-        //  Connect the updated test results tree
-        parentTree.Tree.Add(new NewTreeItem
-        {
-            Path = originalFilesDirectory,
-            Mode = TreeMode,
-            Type = TreeType.Tree,
-            Sha = testResultsTreeResponse.Sha
-        });
-
-        return await ApiRequestWithRetries(() => _client.Git.Tree.Create(_repoOwner, _repoName, parentTree));
-    }
-
-    private async Task CreateOrUpdatePullRequestAsync(TreeResponse parentTreeResponse, int buildId, string title, string targetBranch)
-    {
-        var existingPullRequest = await GetExistingPullRequestAsync(title, targetBranch);
-
-        // Create the branch name and get the head reference
-        string newBranchName = string.Empty;
-        string headSha = await GetHeadShaAsync(targetBranch);
-        if (existingPullRequest == null)
-        {
-            string utcTime = DateTime.UtcNow.ToString("yyyyMMddHHmmss");
-            newBranchName = $"pr-baseline-{utcTime}";
+            await UpdatePullRequestAsync(newBranchName, commitFiles, commitMessage, title, pullRequestBody, existingPullRequestId.Value);
         }
         else
         {
-            newBranchName = existingPullRequest.Head.Ref;
-
-            try
-            {
-                // Merge the target branch into the existing pull request
-                var merge = new NewMerge(newBranchName, headSha);
-                await ApiRequestWithRetries(() => _client.Repository.Merging.Create(_repoOwner, _repoName, merge));
-            }
-            catch (Exception e)
-            {
-                Log.LogWarning($"Failed to merge the target branch into the existing pull request: {e.Message}");
-                Log.LogWarning("Continuing with updating the existing pull request. You may need to resolve conflicts manually in the PR.");
-            }
-
-            headSha = await GetHeadShaAsync(newBranchName);
-        }
-
-        var commitSha = await CreateCommitAsync(parentTreeResponse.Sha, headSha, $"Update baselines for build {BuildLink}{buildId} (internal Microsoft link)");
-        if (await ShouldMakeUpdatesAsync(headSha, commitSha))
-        {
-            string pullRequestBody = $"This PR was created by the `CreateBaselineUpdatePR` tool for build {buildId}. \n\n" +
-                                 $"The updated test results can be found at {BuildLink}{buildId} (internal Microsoft link)";
-            if (existingPullRequest != null)
-            {
-                await UpdatePullRequestAsync(newBranchName, commitSha, pullRequestBody, existingPullRequest);
-            }
-            else
-            {
-                await CreatePullRequestAsync(newBranchName, commitSha, targetBranch, title, pullRequestBody);
-            }
+            await CreatePullRequestAsync(newBranchName, commitFiles, commitMessage, targetBranch, title, pullRequestBody);
         }
     }
 
-    private async Task<PullRequest?> GetExistingPullRequestAsync(string title, string targetBranch)
+    private async Task<int?> GetExistingPullRequestAsync(string headBranch, string targetBranch)
     {
-        var request = new PullRequestRequest
+        // Do NOT catch exceptions here. A lookup failure must propagate, because the caller
+        // would otherwise take the "no PR exists" path, where EnsureHeadBranchAsync would
+        // delete the deterministic head branch that backs the active PR. Failing the
+        // pipeline cleanly on transient errors is recoverable; clobbering an open PR's
+        // branch is not.
+        IEnumerable<int> ids = await _gitClient.Repo.SearchPullRequestsAsync(
+            _gitClient.RepoUri, headBranch, PrStatus.Open);
+
+        // SearchPullRequestsAsync filters by source branch. Verify the target branch also matches.
+        foreach (int id in ids)
         {
-            Base = targetBranch
-        };
-        var existingPullRequest = await ApiRequestWithRetries(() => _client.PullRequest.GetAllForRepository(_repoOwner, _repoName, request));
-        return existingPullRequest.FirstOrDefault(pr => pr.Title == title);
+            PullRequest pr = await _gitClient.Repo.GetPullRequestAsync(_gitClient.BuildPullRequestApiUrl(id));
+            if (string.Equals(pr.BaseBranch, targetBranch, StringComparison.Ordinal))
+            {
+                return id;
+            }
+        }
+        return null;
     }
 
-    private async Task<string> CreateCommitAsync(string newSha, string headSha, string commitMessage)
+    private static bool ShouldMakeUpdates(List<GitFile> changes)
     {
-        var newCommit = new NewCommit(commitMessage, newSha, headSha);
-        var commit = await ApiRequestWithRetries(() => _client.Git.Commit.Create(_repoOwner, _repoName, newCommit));
-        return commit.Sha;
-    }
-
-    private async Task<bool> ShouldMakeUpdatesAsync(string headSha, string commitSha)
-    {
-        var comparison = await ApiRequestWithRetries(() => _client.Repository.Commit.Compare(_repoOwner, _repoName, headSha, commitSha));
-        if (!comparison.Files.Any())
+        if (changes.Count == 0)
         {
             Log.LogInformation("No changes to commit. Skipping PR creation/updates.");
             return false;
         }
+        
         return true;
     }
 
-    private async Task UpdatePullRequestAsync(string branchName, string commitSha, string body, PullRequest pullRequest)
+    private async Task UpdatePullRequestAsync(string branchName, List<GitFile> commitFiles, string commitMessage, string title, string body, int pullRequestId)
     {
-        await UpdateReferenceAsync(branchName, commitSha);
+        await _gitClient.Repo.CommitFilesWithNoCloningAsync(commitFiles, _gitClient.RepoUri, branchName, commitMessage);
 
-        var pullRequestUpdate = new PullRequestUpdate
+        string apiUrl = _gitClient.BuildPullRequestApiUrl(pullRequestId);
+        // Explicitly include Title in the update payload. DarcLib's AzureDevOpsClient
+        // forwards null Title into a GitPullRequest sent through GitHttpClient.UpdatePullRequestAsync,
+        // which serializes nulls and may either clear the PR title or reject the request.
+        var pullRequestUpdate = new PullRequest
         {
-            Body = body
+            Title = title,
+            Description = body
         };
-        await ApiRequestWithRetries(() => _client.PullRequest.Update(_repoOwner, _repoName, pullRequest.Number, pullRequestUpdate));
+        await _gitClient.Repo.UpdatePullRequestAsync(apiUrl, pullRequestUpdate);
 
-        Log.LogInformation($"Updated existing pull request #{pullRequest.Number}. URL: {pullRequest.HtmlUrl}");
+        Log.LogInformation($"Updated existing pull request #{pullRequestId}. URL: {_gitClient.BuildPullRequestHtmlUrl(pullRequestId)}");
     }
 
-    private async Task CreatePullRequestAsync(string newBranchName, string commitSha, string targetBranch, string title, string body)
+    private async Task CreatePullRequestAsync(string newBranchName, List<GitFile> commitFiles, string commitMessage, string targetBranch, string title, string body)
     {
-        await CreateReferenceAsync(newBranchName, commitSha);
+        await EnsureHeadBranchAsync(newBranchName, targetBranch);
+        await _gitClient.Repo.CommitFilesWithNoCloningAsync(commitFiles, _gitClient.RepoUri, newBranchName, commitMessage);
 
-        var newPullRequest = new NewPullRequest(title, newBranchName, targetBranch)
+        var newPullRequest = new PullRequest
         {
-            Body = body
+            Title = title,
+            Description = body,
+            BaseBranch = targetBranch,
+            HeadBranch = newBranchName
         };
-        var pullRequest = await ApiRequestWithRetries(() => _client.PullRequest.Create(_repoOwner, _repoName, newPullRequest));
+        PullRequest pullRequest = await _gitClient.Repo.CreatePullRequestAsync(_gitClient.RepoUri, newPullRequest);
 
-        Log.LogInformation($"Created pull request #{pullRequest.Number}. URL: {pullRequest.HtmlUrl}");
+        // DarcLib returns the provider's API URL (e.g. https://api.github.com/repos/<o>/<r>/pulls/<id>),
+        // which isn't user-friendly. Convert to the human-facing HTML URL via the same helper the
+        // update path uses, so both code paths log a clickable browser link.
+        int pullRequestId = ParsePullRequestIdFromUrl(pullRequest.Url);
+        Log.LogInformation($"Created pull request. URL: {_gitClient.BuildPullRequestHtmlUrl(pullRequestId)}");
     }
 
-    private async Task<string> GetHeadShaAsync(string branchName)
+    // Both GitHub (.../pulls/<id>) and AzDO (.../pullRequests/<id>) API URLs end with the PR id,
+    // and our BuildPullRequestApiUrl overrides produce the same shape. Pull the trailing integer
+    // segment off rather than parsing the full URI per provider.
+    private static int ParsePullRequestIdFromUrl(string url)
     {
-        var reference = await ApiRequestWithRetries(() => _client.Git.Reference.Get(_repoOwner, _repoName, $"heads/{branchName}"));
-        return reference.Object.Sha;
-    }
-
-    private async Task UpdateReferenceAsync(string branchName, string commitSha)
-    {
-        var referenceUpdate = new ReferenceUpdate(commitSha);
-        await ApiRequestWithRetries(() => _client.Git.Reference.Update(_repoOwner, _repoName, $"heads/{branchName}", referenceUpdate));
-    }
-
-    private async Task CreateReferenceAsync(string branchName, string commitSha)
-    {
-        var newReference = new NewReference($"refs/heads/{branchName}", commitSha);
-        await ApiRequestWithRetries(() => _client.Git.Reference.Create(_repoOwner, _repoName, newReference));
-    }
-
-    private async Task<T> ApiRequestWithRetries<T>(Func<Task<T>> action)
-    {
-        int attempt = 0;
-        int delayMilliseconds = 1000;
-        while (true)
+        string trimmed = url.TrimEnd('/');
+        int lastSlash = trimmed.LastIndexOf('/');
+        string idSegment = lastSlash >= 0 ? trimmed[(lastSlash + 1)..] : trimmed;
+        if (!int.TryParse(idSegment, out int id))
         {
-            try
+            throw new InvalidOperationException(
+                $"Could not parse pull request id from URL '{url}'.");
+        }
+        return id;
+    }
+
+    // Diff (originalTreeItems, modifiedTreeItems) → list of DarcLib GitFiles to commit.
+    // Paths in the input lists are relative to `originalFilesDirectory`; output paths are
+    // repo-relative. This is the boundary at which the in-memory TreeFile representation
+    // is converted to DarcLib's commit-side model.
+    private static List<GitFile> ComputeChangeSet(List<TreeFile> originalTreeItems, List<TreeFile> modifiedTreeItems, string originalFilesDirectory)
+    {
+        var originalByPath = originalTreeItems.ToDictionary(f => f.RelativePath, StringComparer.Ordinal);
+        var modifiedByPath = modifiedTreeItems.ToDictionary(f => f.RelativePath, StringComparer.Ordinal);
+        string prefix = originalFilesDirectory.Replace('\\', '/').TrimEnd('/') + "/";
+
+        var changes = new List<GitFile>();
+
+        foreach (var (path, modifiedItem) in modifiedByPath)
+        {
+            if (!originalByPath.TryGetValue(path, out var originalItem) || originalItem.Content != modifiedItem.Content)
             {
-                return await action();
-            }
-            catch (RateLimitExceededException ex)
-            {
-                var resetTime = ex.Reset.UtcDateTime;
-                var delay = resetTime - DateTime.UtcNow;
-                Log.LogWarning($"Rate limit exceeded. Retrying after {delay.TotalSeconds} seconds...");
-                await Task.Delay(delay);
-            }
-            catch (Exception ex) when (
-                attempt < MaxRetries
-                && (ex is ApiException || ex is HttpRequestException)
-                && (ex.InnerException is TaskCanceledException))
-            {
-                attempt++;
-                Log.LogWarning($"Attempt {attempt} failed: {ex.Message}. Retrying in {delayMilliseconds}ms...");
-                await Task.Delay(delayMilliseconds * attempt); // Exponential backoff
+                changes.Add(new GitFile(prefix + path, modifiedItem.Content));
             }
         }
+
+        foreach (var (path, _) in originalByPath)
+        {
+            if (!modifiedByPath.ContainsKey(path))
+            {
+                changes.Add(new GitFile(prefix + path, "", ContentEncoding.Utf8, operation: GitFileOperation.Delete));
+            }
+        }
+
+        return changes;
     }
+
+    private async Task EnsureHeadBranchAsync(string headBranch, string targetBranch)
+    {
+        if (await _gitClient.Repo.DoesBranchExistAsync(_gitClient.RepoUri, headBranch))
+        {
+            // Orphan branch from a previously-closed PR. Delete and recreate so we start fresh.
+            try
+            {
+                await _gitClient.Repo.DeleteBranchAsync(_gitClient.RepoUri, headBranch);
+            }
+            catch (Exception ex)
+            {
+                Log.LogWarning($"Failed to delete orphan head branch '{headBranch}': {ex.Message}");
+            }
+        }
+
+        Log.LogInformation($"Creating branch '{headBranch}' from '{targetBranch}'.");
+        await _gitClient.Repo.CreateBranchAsync(_gitClient.RepoUri, headBranch, targetBranch);
+
+        // Verify creation actually took. DarcLib's AzDO CreateBranchAsync silently
+        // returns success even when GetLastCommitShaAsync failed to resolve the base
+        // branch (it sends a request with a null newObjectId, which the server accepts
+        // as a no-op). If we don't fail here, the subsequent CommitFilesWithNoCloningAsync gives
+        // a confusing "couldn't find remote ref" error.
+        if (!await _gitClient.Repo.DoesBranchExistAsync(_gitClient.RepoUri, headBranch))
+        {
+            throw new InvalidOperationException(
+                $"Branch '{headBranch}' was not created on '{_gitClient.RepoUri}' from base '{targetBranch}'. " +
+                "This usually indicates the base branch could not be resolved on the remote.");
+        }
+        Log.LogInformation($"Branch '{headBranch}' exists on remote.");
+    }
+
+    // Builds a stable, branch-safe head-branch name for the PR. Includes a short hash of the
+    // unsanitized inputs to avoid lossy collisions when the target branch name contains
+    // characters that get folded to '-'.
+    private string BuildHeadBranchName(string targetBranch)
+    {
+        string sanitized = SanitizeForBranchName(targetBranch);
+        string hash = ShortHash($"{_pipeline}|{targetBranch}");
+        return $"pr-baseline-{_pipeline.ToString().ToLowerInvariant()}-{sanitized}-{hash}";
+    }
+
+    private static string SanitizeForBranchName(string s)
+    {
+        var sb = new StringBuilder(s.Length);
+        foreach (char c in s)
+        {
+            sb.Append(char.IsLetterOrDigit(c) ? char.ToLowerInvariant(c) : '-');
+        }
+        return ConsecutiveDashesRegex.Replace(sb.ToString(), "-").Trim('-');
+    }
+
+    private static string ShortHash(string s)
+    {
+        byte[] bytes = SHA256.HashData(Encoding.UTF8.GetBytes(s));
+        return Convert.ToHexString(bytes, 0, 4).ToLowerInvariant();
+    }
+
+    // In-memory representation of a baseline file fetched from / staged for the target tree.
+    // Kept distinct from DarcLib's GitFile because (a) GitFile.Content semantics depend on
+    // ContentEncoding (base64 vs UTF-8), and (b) the GitFile constructor normalizes newlines
+    // and appends trailing '\n', both of which would corrupt content used for in-memory
+    // comparisons. DarcLib GitFiles are only constructed at the commit boundary
+    // (ComputeChangeSet → CommitFilesWithNoCloningAsync).
+    private sealed record TreeFile(string RelativePath, string Content);
 }

--- a/eng/tools/CreateBaselineUpdatePR/PRCreator.cs
+++ b/eng/tools/CreateBaselineUpdatePR/PRCreator.cs
@@ -407,15 +407,13 @@ public partial class PRCreator
     {
         if (await _gitClient.Repo.DoesBranchExistAsync(_gitClient.RepoUri, headBranch))
         {
-            // Orphan branch from a previously-closed PR. Delete and recreate so we start fresh.
-            try
-            {
-                await _gitClient.Repo.DeleteBranchAsync(_gitClient.RepoUri, headBranch);
-            }
-            catch (Exception ex)
-            {
-                Log.LogWarning($"Failed to delete orphan head branch '{headBranch}': {ex.Message}");
-            }
+            // Orphan branch from a previously-closed PR. Delete it so the upcoming
+            // CreateBranchAsync starts fresh from targetBranch. If deletion fails we MUST
+            // surface the error: silently swallowing it would let the no-op CreateBranchAsync
+            // (both GitHub's POST git/refs and DarcLib's AzDO client treat an existing ref
+            // as success) pass the post-create DoesBranchExistAsync probe, and the next
+            // CommitFilesWithNoCloningAsync would commit on top of stale content.
+            await _gitClient.Repo.DeleteBranchAsync(_gitClient.RepoUri, headBranch);
         }
 
         Log.LogInformation($"Creating branch '{headBranch}' from '{targetBranch}'.");

--- a/eng/tools/CreateBaselineUpdatePR/PRCreator.cs
+++ b/eng/tools/CreateBaselineUpdatePR/PRCreator.cs
@@ -72,7 +72,7 @@ public partial class PRCreator
         string prefix = desiredPath.Replace('\\', '/').TrimEnd('/') + "/";
         return [.. files.Select(f =>
         {
-            string relativePath = f.FilePath.StartsWith(prefix) ? f.FilePath[prefix.Length..] : f.FilePath;
+            string relativePath = f.FilePath.StartsWith(prefix, StringComparison.Ordinal) ? f.FilePath[prefix.Length..] : f.FilePath;
             // Decode base64 blobs (DarcLib's GitHub client returns text files with
             // ContentEncoding.Base64) so the in-memory tree is uniformly plain UTF-8 text.
             string content = f.ContentEncoding == ContentEncoding.Base64

--- a/eng/tools/CreateBaselineUpdatePR/PRCreator.cs
+++ b/eng/tools/CreateBaselineUpdatePR/PRCreator.cs
@@ -147,7 +147,7 @@ public partial class PRCreator
 
             // Find the key in the tree
             var originalTreeItem = tree
-                .Where(item => item.RelativePath.Contains(fileNameKey))
+                .Where(item => item.RelativePath.Contains(fileNameKey, StringComparison.Ordinal))
                 .FirstOrDefault();
 
             if (originalTreeItem != null)

--- a/eng/tools/CreateBaselineUpdatePR/Program.cs
+++ b/eng/tools/CreateBaselineUpdatePR/Program.cs
@@ -11,7 +11,9 @@ public class Program
 {
     public static readonly Argument<string> Repo = new("repo")
     {
-        Description = "The GitHub repository to create the PR in. Should be in the form '<owner>/<repo-name>'",
+        Description = "The URL of the repository to create the PR in. " +
+            "Supports GitHub (https://github.com/<owner>/<repo>) and " +
+            "Azure DevOps (https://dev.azure.com/<account>/<project>/_git/<repo>).",
         Arity = ArgumentArity.ExactlyOne
     };
 
@@ -47,11 +49,13 @@ public class Program
         DefaultValueFactory = _ => "main"
     };
 
-    public static readonly Option<string> GitHubToken = new("--github-token", "-g")
+    public static readonly Option<string?> Token = new("--token", "-k")
     {
-        Description = "The GitHub token to use to create the PR.",
+        Description = "The token used to authenticate to the target repository. " +
+            "Use a GitHub PAT for github.com URLs and an Azure DevOps PAT for dev.azure.com URLs. " +
+            "Falls back to the GIT_TOKEN environment variable.",
         Arity = ArgumentArity.ZeroOrOne,
-        DefaultValueFactory = _ => Environment.GetEnvironmentVariable("GH_TOKEN") ?? throw new ArgumentException("GitHub token not provided.")
+        DefaultValueFactory = _ => Environment.GetEnvironmentVariable("GIT_TOKEN")
     };
 
     public static readonly Option<LogLevel> Level = new("--log-level", "-l")
@@ -95,7 +99,7 @@ public class Program
             BuildId,
             Title,
             Branch,
-            GitHubToken
+            Token
         };
     }
 
@@ -107,19 +111,27 @@ public class Program
 
             try
             {
-                var creator = new PRCreator(result.GetValue(Repo)!, result.GetValue(GitHubToken)!);
+                string repoUri = result.GetValue(Repo)!;
+                string? token = result.GetValue(Token);
+                if (string.IsNullOrEmpty(token))
+                {
+                    throw new ArgumentException(
+                        "A token is required. Pass --token or set the GIT_TOKEN environment variable.");
+                }
+                GitClient client = GitClient.Create(repoUri, token);
+
+                var creator = new PRCreator(client, pipeline);
 
                 await creator.ExecuteAsync(
                     result.GetValue(OriginalFilesDirectory)!,
                     result.GetValue(UpdatedFilesDirectory)!,
                     result.GetValue(BuildId)!,
                     result.GetValue(Title)!,
-                    result.GetValue(Branch)!,
-                    pipeline);
+                    result.GetValue(Branch)!);
             }
             catch (Exception ex)
             {
-                Log.LogError(ex.Message);
+                Log.LogError(ex.ToString());
             }
         });
     }

--- a/eng/tools/CreateBaselineUpdatePR/Program.cs
+++ b/eng/tools/CreateBaselineUpdatePR/Program.cs
@@ -113,7 +113,7 @@ public class Program
             {
                 string repoUri = result.GetValue(Repo)!;
                 string? token = result.GetValue(Token);
-                if (string.IsNullOrEmpty(token))
+                if (string.IsNullOrWhiteSpace(token))
                 {
                     throw new ArgumentException(
                         "A token is required. Pass --token or set the GIT_TOKEN environment variable.");


### PR DESCRIPTION
The baseline-update PR tool previously only knew how to push to GitHub, so `internal/release` builds silently skipped PR creation entirely. The tool now targets the AzDO repo when running on `internal/release/*` branches, while public branches (`main`, `release/*`) continue to use GitHub.

## Implementation

- Replace Octokit with DarcLib's `IRemoteGitRepo` abstraction.

- Use a deterministic head branch name (`pr-baseline-{pipeline}-{sanitized-target}-{hash}`) so PR lookup can work via DarcLib's branch-only `SearchPullRequestsAsync` (DarcLib doesn't expose search-by-title).

- Pipeline YAML: two-level template (wrapper handles branch routing + token selection; runner invokes the tool with a single `GIT_TOKEN` env var). Public branches use `BotAccount-dotnet-sb-bot-pat`; `internal/release` uses a federated-identity-backed AzDO token. The two paths are gated by mutually-exclusive branch conditions so the wrong-provider secret is never in env scope.

## Differences vs. the prior Octokit-based implementation

- Provider: GitHub-only -> GitHub + AzDO.

- Head branch name: timestamp-based (new branch per run) -> deterministic per pipeline + target branch. Means existing open baseline PRs created by the prior tool will NOT be matched by the new branch-based lookup -- see "Deploy step" below.

- Pre-push merge: the Octokit tool merged target into the PR branch before pushing. DarcLib's `IRemoteGitRepo` abstraction doesn't expose a server-side merge primitive, and adding per-provider escapes for it isn't justified for this use case. Consequence: a long-lived baseline PR may show "behind target" in the PR UI.

Fixes dotnet/source-build#5352