### PR TITLE
Quote paths with spaces in MSBuild bootstrap InstallDotNetCoreTask

### DIFF
--- a/src/msbuild/src/MSBuild.Bootstrap.Utils/Tasks/InstallDotNetCoreTask.cs
+++ b/src/msbuild/src/MSBuild.Bootstrap.Utils/Tasks/InstallDotNetCoreTask.cs
@@ -118,7 +118,7 @@ namespace MSBuild.Bootstrap.Utils.Tasks
         {
             if (!IsWindows)
             {
-                int exitCode = ExecuteTool("/bin/chmod", string.Empty, $"+x {scriptPath}");
+                int exitCode = ExecuteTool("/bin/chmod", string.Empty, $"+x \"{scriptPath}\"");
                 if (exitCode != 0)
                 {
                     Log.LogError($"Install-scripts can not be made executable due to the errors reported above.");
@@ -154,9 +154,10 @@ namespace MSBuild.Bootstrap.Utils.Tasks
         {
             string scriptExtension = IsWindows ? "ps1" : "sh";
             string scriptPath = Path.Combine(DotNetInstallScriptRootPath, $"{ScriptName}.{scriptExtension}");
+            string installDir = InstallDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
             string scriptArgs = IsWindows
-                ? $"-NoProfile -ExecutionPolicy Bypass -File {scriptPath} -Version {Version} -InstallDir {InstallDir}"
-                : $"{scriptPath} --version {Version} --install-dir {InstallDir}";
+                ? $"-NoProfile -ExecutionPolicy Bypass -File \"{scriptPath}\" -Version {Version} -InstallDir \"{installDir}\""
+                : $"\"{scriptPath}\" --version {Version} --install-dir \"{installDir}\"";
 
             return new ScriptExecutionSettings($"{ScriptName}.{scriptExtension}", scriptPath, scriptArgs);
         }


### PR DESCRIPTION
## Summary

Fixes MSBuild bootstrap `Install-scripts was not executed successfully` failure on Windows when `DotNetRoot` resolves to a path with spaces (e.g., `C:\Program Files\dotnet\`).

## Root Cause

When 1ES build agents have SDK 10.0.300 installed system-wide at `C:\Program Files\dotnet\`, arcade's provisioning skips `.dotnet` setup since the version is already present. This causes `$(DotNetRoot)` to resolve to `C:\Program Files\dotnet\` instead of the repo-local `.dotnet\` directory.

`InstallDotNetCoreTask` passes the script path unquoted to PowerShell's `-File` parameter:

```
powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:\Program Files\dotnet\dotnet-install.ps1 ...
```

PowerShell splits on the space and tries to interpret `C:\Program` as the script file:

```
Processing -File 'C:\Program' failed because the file does not have a '.ps1' extension.
```

This was confirmed by downloading the binlog from a failing PR build (build 1450966) and finding:
- `DotNetInstallScriptRootPath = C:\Program Files\dotnet\`
- `Processing -File 'C:\Program' failed because the file does not have a '.ps1' extension.`

## Fix

Quote `scriptPath` and `InstallDir` in the command argument strings for both Windows and Unix, and also quote the `chmod` argument.

Same class of fix as #3737.

## Impact

- **Currently broken**: All Windows legs on `release/10.0.4xx` official and PR builds (builds 2992647, 1450748, 1450966, 1451266)
- **Will break**: `main` and other branches when their agents get updated with system-wide SDK 10.0.300

This PR targets `main` so the fix backflows to all branches. Cherry-pick to `release/10.0.4xx` recommended for immediate unblock.