### PR TITLE
[release/10.0.3xx] Quote spaced dotnet paths in bootstrap, sdk overlay, and build-server shutdown

### DIFF
--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -803,7 +803,7 @@
 
       Don't run when source building to prevent the build from hanging indefinitely - https://github.com/dotnet/source-build/issues/4796
     -->
-    <Exec Command="$(DotNetTool) build-server shutdown --vbcscompiler"
+    <Exec Command="&quot;$(DotNetTool)&quot; build-server shutdown --vbcscompiler"
           Condition="'$(DotNetBuildSourceOnly)' != 'true'"
           EnvironmentVariables="NUGET_PACKAGES=$(RepoArtifactsPackageCache)"
           IgnoreStandardErrorWarningFormat="true"

--- a/src/msbuild/src/MSBuild.Bootstrap.Utils/Tasks/InstallDotNetCoreTask.cs
+++ b/src/msbuild/src/MSBuild.Bootstrap.Utils/Tasks/InstallDotNetCoreTask.cs
@@ -154,11 +154,30 @@ namespace MSBuild.Bootstrap.Utils.Tasks
         {
             string scriptExtension = IsWindows ? "ps1" : "sh";
             string scriptPath = Path.Combine(DotNetInstallScriptRootPath, $"{ScriptName}.{scriptExtension}");
+            // On Windows the native command-line parser treats a backslash before the closing quote as
+            // escaping it (e.g. "C:\dir\" becomes C:\dir"), so trim a trailing separator before quoting.
+            string installDir = TrimTrailingDirectorySeparators(InstallDir);
             string scriptArgs = IsWindows
-                ? $"-NoProfile -ExecutionPolicy Bypass -File {scriptPath} -Version {Version} -InstallDir {InstallDir}"
-                : $"{scriptPath} --version {Version} --install-dir {InstallDir}";
+                ? $"-NoProfile -ExecutionPolicy Bypass -File \"{scriptPath}\" -Version {Version} -InstallDir \"{installDir}\""
+                : $"\"{scriptPath}\" --version {Version} --install-dir \"{installDir}\"";
 
             return new ScriptExecutionSettings($"{ScriptName}.{scriptExtension}", scriptPath, scriptArgs);
+        }
+
+        /// <summary>
+        /// Trims trailing directory separators while preserving a path root (e.g. "C:\").
+        /// </summary>
+        private static string TrimTrailingDirectorySeparators(string path)
+        {
+            string root = Path.GetPathRoot(path) ?? string.Empty;
+            while (path.Length > root.Length &&
+                   (path[path.Length - 1] == Path.DirectorySeparatorChar ||
+                    path[path.Length - 1] == Path.AltDirectorySeparatorChar))
+            {
+                path = path.Substring(0, path.Length - 1);
+            }
+
+            return path;
         }
 
         /// <summary>

--- a/src/sdk/src/Layout/redist/targets/OverlaySdkOnLKG.targets
+++ b/src/sdk/src/Layout/redist/targets/OverlaySdkOnLKG.targets
@@ -9,7 +9,7 @@
 
     <!-- Get stage 0 SDK version without having to duplicate the LKG SDK property between the global.json
     and a property. -->
-    <Exec Command="$(DotnetTool) --version" ConsoleToMsbuild="true">
+    <Exec Command="&quot;$(DotnetTool)&quot; --version" ConsoleToMsbuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="Stage0SdkVersion"/>
     </Exec>
 


### PR DESCRIPTION
## Summary

Cherry-picks the three spaced-path quoting fixes from #7061 (release/10.0.4xx) to **release/10.0.3xx**.

## Why 10.0.3xx is affected (and 10.0.1xx is not)

The new `windows.vs2026.amd64` agent image (2026.0529) ships SDK **10.0.300** at `C:\Program Files\dotnet`. When a branch's `global.json` matches that version, arcade reuses the machine-wide (spaced) install as `DOTNET_INSTALL_DIR`/`DotNetRoot`/`DotnetTool` instead of provisioning the repo-local `.dotnet`, exposing latent unquoted-path bugs.

| Branch | `global.json` SDK | Matches image (10.0.300)? | Affected |
|---|---|---|---|
| release/10.0.1xx | 10.0.108 | No | **No** — verified green on the new image (build 2992755, local `.dotnet`) |
| release/10.0.3xx | **10.0.300** | **Yes** | **Yes** — will break like 10.0.4xx once it lands on a 0529 agent |
| release/10.0.4xx | 10.0.300 | Yes | Yes (already broken) |

10.0.3xx hasn't been bitten yet only because its latest build happened to run on the old (0522) image; the next 0529 agent will hit it.

## The three fixes (each a cherry-pick from #7061)

1. **msbuild** `InstallDotNetCoreTask.cs` — quote the dotnet-install script path and install dir; root-preserving trim of a trailing separator so a quoted path ending in `\` doesn't escape the closing quote. (PowerShell `-File 'C:\Program'` parse error.)
2. **sdk** `OverlaySdkOnLKG.targets` — quote `$(DotnetTool) --version` (cmd `C:\Program` → exit 9009). Matches dotnet/sdk `main`.
3. **VMR** `repo-projects/Directory.Build.targets` — quote `$(DotNetTool) build-server shutdown` (masked by `IgnoreExitCode="true"`, but leaves the compiler server running → CleanupRepo file-lock errors).

## Notes

- **10.0.1xx: no PR** — not required (verified). If its `global.json` is ever bumped to 10.0.300, it would need the same fixes.
- Relationship to lewing's PRs: #7075 (main) and #7076 (10.0.4xx) carry the **msbuild** fix only. This PR additionally carries the **sdk** and **VMR** fixes for 10.0.3xx. The msbuild commit here can be coordinated/closed if lewing opens a dedicated 10.0.3xx msbuild cherry-pick.
- Durable fixes should also flow through dotnet/msbuild and dotnet/sdk so the VMR source-copies don't revert; the VMR `Directory.Build.targets` change is VMR-authored and durable here.
- Full investigation: #7061 and its comments.
