### PR TITLE
Scope milestoning workflow concurrency to individual PR

### DIFF
--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -28,7 +28,7 @@ permissions:
 # exists", which would leave those PRs un-milestoned. Per-PR grouping ensures
 # every PR's run executes and is never auto-cancelled by an unrelated PR.
 concurrency:
-  group: milestone-${{ github.event.pull_request.number || inputs.pr-number }}
+  group: milestone-${{ github.event.pull_request.number || github.event.inputs['pr-number'] }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -22,8 +22,13 @@ permissions:
   contents: read
   pull-requests: read
 
+# Scope concurrency to the individual PR being processed so that runs for
+# different PRs never share a group. A shared (e.g. per-branch) group causes
+# GitHub to cancel older pending runs with "a higher priority waiting request
+# exists", which would leave those PRs un-milestoned. Per-PR grouping ensures
+# every PR's run executes and is never auto-cancelled by an unrelated PR.
 concurrency:
-  group: milestone-${{ github.event.pull_request.base.ref || github.ref_name }}
+  group: milestone-${{ github.event.pull_request.number || inputs.pr-number }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Problem

Runs of the `Apply milestones to codeflow PRs` workflow are being auto-cancelled with *"a higher priority waiting request exists"* (e.g. [run 26941863130](https://github.com/dotnet/dotnet/actions/runs/26941863130)). When a run is cancelled this way, the relevant PR never gets milestoned.

The cause is the concurrency group, which was keyed on the **base branch**:

```yaml
group: milestone-${{ github.event.pull_request.base.ref || github.ref_name }}
```

Every codeflow PR merged into the same branch (e.g. `main`) shares the single group `milestone-main`. Even with `cancel-in-progress: false`, GitHub only keeps one running + one pending run per group and cancels any older pending run, leaving those PRs un-milestoned.

## Fix

Each run only milestones its own PR, so there's no need to serialize across different PRs. Scope the concurrency group to the individual PR number instead:

```yaml
group: milestone-${{ github.event.pull_request.number || inputs.pr-number }}
```

Different PRs now land in distinct concurrency groups and can never cancel one another, so every run executes. `cancel-in-progress: false` is retained so the rare case of two runs for the *same* PR serializes instead of cancelling.