### PR TITLE
Add **/.dotnet/ to allowed binaries for nested SDK bootstrap dirs

### DIFF
--- a/eng/allowed-sb-binaries.txt
+++ b/eng/allowed-sb-binaries.txt
@@ -6,6 +6,7 @@
 # Well known non-checked in infrastructure
 artifacts/
 .dotnet/
+**/.dotnet/
 .git/
 .packages/
 prereqs/packages/


### PR DESCRIPTION
## Summary

Adds `**/.dotnet/` to the allowed source-build binaries list to fix BinaryScan test failures on shortstack build legs.

## Root Cause (verified from build logs)

SDK code flow PR #7064 (merged June 5) introduced `src/sdk/eng/configure-toolset.sh`, which calls `dotnetup sdk install` to pre-install a bootstrap SDK into `src/sdk/.dotnet/`. This directory **never existed before** — the passing build [2990093](https://dev.azure.com/dnceng/internal/_build/results?buildId=2990093) (June 2) has zero references to `src/sdk/.dotnet` or `configure-toolset` in its logs.

In the first failing build [2993249](https://dev.azure.com/dnceng/internal/_build/results?buildId=2993249) (June 5), the sequence is:

1. **18:43:18** — `configure-toolset.sh` runs `dotnetup sdk install` → creates `src/sdk/.dotnet/` with a full SDK (2623 binaries)
2. **18:44:08** — `init-detect-binaries.proj` runs the binary scan, finds all 2623 binaries unmatched
3. **19:06:41** — `BinaryScanTest.ScanForBinaries` reads the report and fails

`configure-toolset.sh` has a `from_vmr == true` guard that should skip the install in VMR builds, but it's not taking effect in the shortstack build context.

The existing exclusion `.dotnet/` in `allowed-sb-binaries.txt` only matches the root-level `.dotnet/` directory. The nested `src/sdk/.dotnet/` is not covered.

## Fix

Adding `**/.dotnet/` matches `.dotnet/` directories at any depth. Verified locally that `Microsoft.Extensions.FileSystemGlobbing.Matcher` correctly matches paths like `src/sdk/.dotnet/sdk/.../file.dll` with this pattern.

## Open questions

- Should the deeper fix be ensuring `from_vmr` is properly set when `configure-toolset.sh` runs in shortstack builds, so the `dotnetup` install is skipped entirely?
- Or should the binary scan run before any SDK bootstrap steps?

cc @dotnet/source-build @dotnet/dotnet-cli