### PR TITLE
Use VMR root SetupNugetSources.ps1 in Setup Internal Feeds step

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -572,9 +572,10 @@ jobs:
         script: |
           # Always use the VMR root's SetupNugetSources.ps1 rather than each inner repo's copy.
           # The inner repo scripts dot-source that repo's eng/common/tools.ps1, which in turn imports
-          # the repo's configure-toolset.ps1. For src/sdk that triggers an unintended dotnetup bootstrap
-          # SDK install (see https://github.com/dotnet/dotnet/issues/7112). The root script only operates
+          # the repo's configure-toolset.ps1. The root script only operates
           # on the NuGet.config path passed to it, so it works for every repo.
+          # It's also convenient to use that so that changes don't need to be replicated on every
+          # inner repo's eng/common/ layout.
           $setupScript = Join-Path "$(sourcesPath)" "eng/common/SetupNugetSources.ps1"
 
           function Setup-NuGetFeeds($repoDir, $description) {

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -570,8 +570,14 @@ jobs:
       inputs:
         targetType: 'inline'
         script: |
+          # Always use the VMR root's SetupNugetSources.ps1 rather than each inner repo's copy.
+          # The inner repo scripts dot-source that repo's eng/common/tools.ps1, which in turn imports
+          # the repo's configure-toolset.ps1. For src/sdk that triggers an unintended dotnetup bootstrap
+          # SDK install (see https://github.com/dotnet/dotnet/issues/7112). The root script only operates
+          # on the NuGet.config path passed to it, so it works for every repo.
+          $setupScript = Join-Path "$(sourcesPath)" "eng/common/SetupNugetSources.ps1"
+
           function Setup-NuGetFeeds($repoDir, $description) {
-            $setupScript = Join-Path $repoDir "eng/common/SetupNugetSources.ps1"
             # Search for nuget.config using "Filter" to allow for case-insensitive matching.
             $nugetConfigFile = Get-ChildItem -Path $repoDir -Filter "nuget.config" -File | Select-Object -First 1
             $nugetConfig = if ($nugetConfigFile) { $nugetConfigFile.FullName } else { Join-Path $repoDir "NuGet.config" }


### PR DESCRIPTION
## Problem

All `main` VMR official builds have been broken since June 5 with `MSB4216` (`GenerateSdkRuntimeIdentifierChain` task host failure). Root cause: an **unintended `dotnetup` bootstrap SDK install** pollutes the `src/sdk` source tree before the real build runs.

## Root cause

The **Setup Internal Feeds** step (internal builds only) loops over every `src/<repo>` and invokes *that repo's* copy of `eng/common/SetupNugetSources.ps1`:

```powershell
$setupScript = Join-Path $repoDir "eng/common/SetupNugetSources.ps1"
```

Each inner script dot-sources its own `eng/common/tools.ps1`, which imports the repo's `eng/configure-toolset.ps1`. For `src/sdk` that script unconditionally calls `InstallBootstrapSdkWithDotnetup`, installing an SDK via `dotnetup` into `src/sdk/.dotnet`/`src/sdk/artifacts/.dotnetup` (visible in `binary-report/NewBinaries.txt`). The `from_vmr` guard inside `configure-toolset` is correct, but in this bare `pwsh` task `tools.ps1` defaults (`restore=true`, `fromVMR=false`) defeat it.

## Fix

Resolve the setup script **once** to the **VMR root** `eng/common/SetupNugetSources.ps1` and pass each repo's `NuGet.config` to it. The root script only operates on the config path argument, and the VMR root has **no** `configure-toolset.ps1`, so dot-sourcing the root `tools.ps1` imports nothing harmful — no `dotnetup`. Feed-setup behavior is otherwise identical.

Fixes #7112