### PR TITLE
Fix solaris build with gcc toolchain

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
@@ -118,7 +118,14 @@
       -->
       <_NativeVersionFileContents>
 <![CDATA[
-static char sccsid[] __attribute__((used,retain)) = "@(#)Version $(FileVersion)$(_SourceBuildInfo)";
+#if defined(__clang__) || (defined(__GNUC__) && !defined(TARGET_SUNOS))
+#define RETAIN __attribute__((used, retain))
+#else
+#define RETAIN __attribute__((used))
+__asm__(".pushsection .init_array; .reloc ., R_X86_64_NONE, sccsid; .popsection");
+#endif
+
+static char sccsid[] RETAIN = "@(#)Version $(FileVersion)$(_SourceBuildInfo)";
  ]]>
       </_NativeVersionFileContents>
     </PropertyGroup>

--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
@@ -118,11 +118,11 @@
       -->
       <_NativeVersionFileContents>
 <![CDATA[
-#if defined(__clang__) || (defined(__GNUC__) && !defined(TARGET_SUNOS))
-#define RETAIN __attribute__((used, retain))
-#else
+#if defined(__GNUC__) && !defined(__clang__) && defined(TARGET_SUNOS)
 #define RETAIN __attribute__((used))
 __asm__(".pushsection .init_array; .reloc ., R_X86_64_NONE, sccsid; .popsection");
+#else
+#define RETAIN __attribute__((used, retain))
 #endif
 
 static char sccsid[] RETAIN = "@(#)Version $(FileVersion)$(_SourceBuildInfo)";

--- a/src/deployment-tools/eng/native/build-commons.sh
+++ b/src/deployment-tools/eng/native/build-commons.sh
@@ -122,11 +122,11 @@ build_native()
         else
             # Generate the dummy version.c and runtime_version.h, but only if they didn't exist to make sure we don't trigger unnecessary rebuild
             __versionSourceContent=$(cat <<'EOF'
-#if defined(__clang__) || (defined(__GNUC__) && !defined(TARGET_SUNOS))
-#define RETAIN __attribute__((used, retain))
-#else
+#if defined(__GNUC__) && !defined(__clang__) && defined(TARGET_SUNOS)
 #define RETAIN __attribute__((used))
 __asm__(".pushsection .init_array; .reloc ., R_X86_64_NONE, sccsid; .popsection");
+#else
+#define RETAIN __attribute__((used, retain))
 #endif
 
 static char sccsid[] RETAIN = "@(#)No version information produced";

--- a/src/deployment-tools/eng/native/build-commons.sh
+++ b/src/deployment-tools/eng/native/build-commons.sh
@@ -121,11 +121,21 @@ build_native()
             fi
         else
             # Generate the dummy version.c and runtime_version.h, but only if they didn't exist to make sure we don't trigger unnecessary rebuild
-            __versionSourceLine="static char sccsid[] __attribute__((used,retain)) = \"@(#)No version information produced\";"
+            __versionSourceContent=$(cat <<'EOF'
+#if defined(__clang__) || (defined(__GNUC__) && !defined(TARGET_SUNOS))
+#define RETAIN __attribute__((used, retain))
+#else
+#define RETAIN __attribute__((used))
+__asm__(".pushsection .init_array; .reloc ., R_X86_64_NONE, sccsid; .popsection");
+#endif
+
+static char sccsid[] RETAIN = "@(#)No version information produced";
+EOF
+)
             if [[ -e "$__versionSourceFile" ]]; then
-                read existingVersionSourceLine < "$__versionSourceFile"
+                existingVersionSourceContent="$(cat "$__versionSourceFile")"
             fi
-            if [[ "$__versionSourceLine" != "$existingVersionSourceLine" ]]; then
+            if [[ "$__versionSourceContent" != "$existingVersionSourceContent" ]]; then
                 cat << EOF > $runtimeVersionHeaderFile
 #define RuntimeAssemblyMajorVersion 0
 #define RuntimeAssemblyMinorVersion 0
@@ -138,7 +148,7 @@ build_native()
 #define RuntimeProductPatchVersion 0
 #define RuntimeProductVersion
 EOF
-                echo "$__versionSourceLine" > "$__versionSourceFile"
+                printf '%s\n' "$__versionSourceContent" > "$__versionSourceFile"
             fi
         fi
 

--- a/src/diagnostics/eng/native/version/_version.c
+++ b/src/diagnostics/eng/native/version/_version.c
@@ -1,11 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if defined(__clang__) || (defined(__GNUC__) && !defined(TARGET_SUNOS))
-#define RETAIN __attribute__((used, retain))
-#else
+#if defined(__GNUC__) && !defined(__clang__) && defined(TARGET_SUNOS)
 #define RETAIN __attribute__((used))
 __asm__(".pushsection .init_array; .reloc ., R_X86_64_NONE, sccsid; .popsection");
+#else
+#define RETAIN __attribute__((used, retain))
 #endif
 
 static char sccsid[] RETAIN = "@(#)No version information produced";

--- a/src/diagnostics/eng/native/version/_version.c
+++ b/src/diagnostics/eng/native/version/_version.c
@@ -1,4 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-static char sccsid[] __attribute__((used,retain)) = "@(#)No version information produced";
+#if defined(__clang__) || (defined(__GNUC__) && !defined(TARGET_SUNOS))
+#define RETAIN __attribute__((used, retain))
+#else
+#define RETAIN __attribute__((used))
+__asm__(".pushsection .init_array; .reloc ., R_X86_64_NONE, sccsid; .popsection");
+#endif
+
+static char sccsid[] RETAIN = "@(#)No version information produced";

--- a/src/diagnostics/eng/native/version/copy_version_files.sh
+++ b/src/diagnostics/eng/native/version/copy_version_files.sh
@@ -11,7 +11,7 @@ for path in "${__VersionFolder}/"*{.h,.c}; do
         # update commit
         commit="$(git rev-parse HEAD 2>/dev/null)"
         commit="${commit:-N/A}"
-        substitute="$(printf 'static char sccsid[] __attribute__((used,retain)) = "@(#)Version N/A @Commit: %s";\n' "$commit")"
+        substitute="$(printf 'static char sccsid[] RETAIN = "@(#)Version N/A @Commit: %s";\n' "$commit")"
         version_file_contents="$(cat "$path" | sed "s|^static.*|$substitute|")"
         version_file_destination="$__RepoRoot/artifacts/obj/_version.c"
         current_contents=

--- a/src/runtime/eng/native/version/_version.c
+++ b/src/runtime/eng/native/version/_version.c
@@ -1,11 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if defined(__clang__) || (defined(__GNUC__) && !defined(TARGET_SUNOS))
-#define RETAIN __attribute__((used, retain))
-#else
+#if defined(__GNUC__) && !defined(__clang__) && defined(TARGET_SUNOS)
 #define RETAIN __attribute__((used))
 __asm__(".pushsection .init_array; .reloc ., R_X86_64_NONE, sccsid; .popsection");
+#else
+#define RETAIN __attribute__((used, retain))
 #endif
 
 static char sccsid[] RETAIN = "@(#)No version information produced";

--- a/src/runtime/eng/native/version/_version.c
+++ b/src/runtime/eng/native/version/_version.c
@@ -1,4 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-static char sccsid[] __attribute__((used,retain)) = "@(#)No version information produced";
+#if defined(__clang__) || (defined(__GNUC__) && !defined(TARGET_SUNOS))
+#define RETAIN __attribute__((used, retain))
+#else
+#define RETAIN __attribute__((used))
+__asm__(".pushsection .init_array; .reloc ., R_X86_64_NONE, sccsid; .popsection");
+#endif
+
+static char sccsid[] RETAIN = "@(#)No version information produced";

--- a/src/runtime/eng/native/version/copy_version_files.ps1
+++ b/src/runtime/eng/native/version/copy_version_files.ps1
@@ -7,7 +7,7 @@ Get-ChildItem -Path "$VersionFolder" -Filter "_version.*" | ForEach-Object {
         # For _version.c, update the commit ID if it has changed from the last build.
         $commit = (git rev-parse HEAD 2>$null)
         if (-not $commit) { $commit = "N/A" }
-        $substitute = "static char sccsid[] __attribute__((used,retain)) = `"@(#)Version N/A @Commit: $commit`";"
+        $substitute = "static char sccsid[] RETAIN = `"@(#)Version N/A @Commit: $commit`";"
         $version_file_contents = Get-Content -Path $path | ForEach-Object { $_ -replace "^static.*", $substitute }
         $version_file_destination = "$RepoRoot\\artifacts\\obj\\_version.c"
         $current_contents = ""

--- a/src/runtime/eng/native/version/copy_version_files.sh
+++ b/src/runtime/eng/native/version/copy_version_files.sh
@@ -11,7 +11,7 @@ for path in "${__VersionFolder}/"*{.h,.c}; do
         # update commit
         commit="$(git rev-parse HEAD 2>/dev/null)"
         commit="${commit:-N/A}"
-        substitute="$(printf 'static char sccsid[] __attribute__((used,retain)) = "@(#)Version N/A @Commit: %s";\n' "$commit")"
+        substitute="$(printf 'static char sccsid[] RETAIN = "@(#)Version N/A @Commit: %s";\n' "$commit")"
         version_file_contents="$(cat "$path" | sed "s|^static.*|$substitute|")"
         version_file_destination="$__RepoRoot/artifacts/obj/_version.c"
         current_contents=

--- a/src/runtime/src/mono/CMakeLists.txt
+++ b/src/runtime/src/mono/CMakeLists.txt
@@ -858,11 +858,11 @@ if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
 else()
   if(NOT EXISTS "${VERSION_FILE_PATH}")
     file(WRITE "${VERSION_FILE_PATH}"
-      "#if defined(__clang__) || (defined(__GNUC__) && !defined(TARGET_SUNOS))\n"
-      "#define RETAIN __attribute__((used, retain))\n"
-      "#else\n"
+      "#if defined(__GNUC__) && !defined(__clang__) && defined(TARGET_SUNOS)\n"
       "#define RETAIN __attribute__((used))\n"
       "__asm__(\".pushsection .init_array; .reloc ., R_X86_64_NONE, sccsid; .popsection\");\n"
+      "#else\n"
+      "#define RETAIN __attribute__((used, retain))\n"
       "#endif\n"
       "\n"
       "static char sccsid[] RETAIN = \"@(#)Version 42.42.42.42424 @Commit: AAA\";\n")

--- a/src/runtime/src/mono/CMakeLists.txt
+++ b/src/runtime/src/mono/CMakeLists.txt
@@ -857,7 +857,15 @@ if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
   endif()
 else()
   if(NOT EXISTS "${VERSION_FILE_PATH}")
-    file(WRITE "${VERSION_FILE_PATH}" "static char sccsid[] __attribute__((used,retain)) = \"@(#)Version 42.42.42.42424 @Commit: AAA\";\n")
+    file(WRITE "${VERSION_FILE_PATH}"
+      "#if defined(__clang__) || (defined(__GNUC__) && !defined(TARGET_SUNOS))\n"
+      "#define RETAIN __attribute__((used, retain))\n"
+      "#else\n"
+      "#define RETAIN __attribute__((used))\n"
+      "__asm__(\".pushsection .init_array; .reloc ., R_X86_64_NONE, sccsid; .popsection\");\n"
+      "#endif\n"
+      "\n"
+      "static char sccsid[] RETAIN = \"@(#)Version 42.42.42.42424 @Commit: AAA\";\n")
   endif()
 endif()
 if (NOT EXISTS "${RUNTIME_VERSION_HEADER_PATH}")


### PR DESCRIPTION
It regressed in https://github.com/dotnet/dotnet/pull/6830. On illumos, the compiler _recognizes_ `retain` as a valid token but the actual codegen throws:

```
 [7/1783] Building CXX object Corehost.Static/hostmisc/CMakeFiles/hostmisc.dir/utils.cpp.o
  FAILED: Corehost.Static/hostmisc/CMakeFiles/hostmisc.dir/utils.cpp.o 
  /crossrootfs/x64/bin/x86_64-illumos-g++ --sysroot=/crossrootfs/x64 -DBUILDENV_DEBUG=1 -DDEBUG -DDISABLE_CONTRACTS -DHOST_64BIT -DHOST_AMD64 -DHOST_UNIX -DTARGET_64BIT -DTARGET_AMD64 -DTARGET_ILLUMOS -DTARGET_SUNOS -DTARGET_UNIX -DURTBLDENV_FRIENDLY=Debug -D_DBG -D_DEBUG -D_FILE_OFFSET_BITS=64 -D_POSIX_PTHREAD_SEMANTICS -D_REENTRANT -D_TIME_BITS=64 -D_XPG4_2 -D__EXTENSIONS__ -I/runtime/src/native -I/runtime/src/native/inc -I/runtime/src/native/corehost/apphost/static/.. -I/runtime/src/native/corehost/apphost/static/../.. -I/runtime/src/native/corehost/apphost/static/../../hostmisc -I/runtime/src/native/corehost/apphost/static/../../json -I/runtime/src/native/libs/System.IO.Compression.Native -I/runtime/src/native/libs/Common -I/runtime/artifacts/obj -I/runtime/artifacts/obj/coreclr/illumos.x64.Debug/Corehost.Static/hostmisc -I/runtime/src/native/corehost/hostmisc -I/runtime/artifacts/obj/coreclr/illumos.x64.Debug/inc/corehost -isystem /crossrootfs/x64/include -fstack-protector -g -std=gnu++17 -fPIC -O0 -Wall -g -fno-omit-frame-pointer -fno-strict-overflow -fno-strict-aliasing -fstack-protector-strong -Werror -Wno-unused-variable -Wno-unused-value -Wno-unused-function -Wno-tautological-compare -Wno-unknown-pragmas -Wimplicit-fallthrough -Wvla -Wno-invalid-offsetof -Wno-unused-but-set-variable -ffp-contract=off -fno-rtti -Wno-uninitialized -Wno-strict-aliasing -Wno-array-bounds -Wno-misleading-indentation -Wno-stringop-overflow -Wno-restrict -Wno-stringop-truncation -Wno-class-memaccess -faligned-new -fsigned-char -fvisibility=hidden -ffunction-sections -fdata-sections -MD -MT Corehost.Static/hostmisc/CMakeFiles/hostmisc.dir/utils.cpp.o -MF Corehost.Static/hostmisc/CMakeFiles/hostmisc.dir/utils.cpp.o.d -o Corehost.Static/hostmisc/CMakeFiles/hostmisc.dir/utils.cpp.o -c /runtime/src/native/corehost/hostmisc/utils.cpp
  In file included from /runtime/src/native/corehost/hostmisc/utils.cpp:10:
  /runtime/artifacts/obj/_version.c:1:49: error: 'retain' attribute ignored [-Werror=attributes]
      1 | static char sccsid[] __attribute__((used,retain)) = "@(#)Version 42.42.42.42424";
        |                                                 ^
  cc1plus: all warnings being treated as errors
  [8/1783] Building C object libs-native/System.IO.Compression.Native/CMakeFiles/System.IO.Compression.Native-Static.dir/pal_zlib.c.o
  [9/1783] Building C object _deps/fetchzlibng-build/CMakeFiles/zlib.dir/arch/generic/adler32_fold_c.c.o
  [10/1783] Building CXX object Corehost.Static/hostmisc/CMakeFiles/hostmisc.dir/pal.unix.cpp.o
```

The distinction that parser recognizes it and codegen doesn't was important because I used idiomatic `#if __has_attribute(retain)` but that branch was taken instead of `#else` on this system; therefore I ended up with clang||(gcc&&sunos) check.