### PR TITLE
Fix stray apostrophe in --with-sdk path leaking from set -x into ##vso

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -683,7 +683,7 @@ jobs:
         displayName: Install dependencies
     - ${{ if eq(parameters.buildSourceOnly, 'true') }}:
       - script: |
-          set -ex
+          set -e
 
           customPrepArgs="-c ${{ parameters.configuration }}"
           prepSdk=true
@@ -774,21 +774,22 @@ jobs:
              customPrepArgs="${customPrepArgs} --with-packages $(previouslySourceBuiltArtifactsDir)"
              additionalBuildArgs="${additionalBuildArgs} --with-packages $(previouslySourceBuiltArtifactsDir)"
           fi
-          
-          echo "Prep arguments: $customPrepArgs"
-          echo "Additional build arguments: $additionalBuildArgs"
 
           if [[ -n "$additionalBuildArgs" ]]; then
+            echo "Additional build arguments: $additionalBuildArgs"
             echo "##vso[task.setvariable variable=additionalBuildArgs]$additionalBuildArgs"
           fi
 
+          echo ""
+          echo "=== Prep the Build ==="
+          echo "Running ./prep-source-build.sh $customPrepArgs"
           ./prep-source-build.sh $customPrepArgs
         displayName: Prep the Build
         workingDirectory: $(sourcesPath)
     - ${{ if ne(parameters.skipBuild, 'true') }}:
 
       - script: |
-          set -ex
+          set -e
           echo "=== System info: disk ==="
           df -h
 
@@ -800,7 +801,6 @@ jobs:
             cat /proc/meminfo
           fi
 
-          echo "=== Build ==="
           customEnvVars=""
           customPreBuildArgs=""
           customBuildArgs="$(baseArguments)"
@@ -884,6 +884,9 @@ jobs:
             echo "Current hard limit (ulimit -Hn): $(ulimit -Hn 2>/dev/null || echo 'unknown')" >&2
           fi
 
+          echo ""
+          echo "=== Build ==="
+          echo "Running $customPreBuildArgs ./build.sh $buildArgs"
           $customPreBuildArgs ./build.sh $buildArgs
         displayName: Build
         workingDirectory: $(sourcesPath)
@@ -913,7 +916,7 @@ jobs:
           displayName: Copy Test NuGet Config for Smoke Tests
 
       - script: |
-          set -ex
+          set -e
 
           customPreBuildArgs=''
           customBuildArgs="--test --excludeCIBinarylog /bl:artifacts/log/Release/Test.binlog $(baseArguments)"
@@ -947,6 +950,9 @@ jobs:
             echo "  Hard nofile limit: $(ulimit -Hn 2>/dev/null || echo 'unknown')"
           fi
 
+          echo ""
+          echo "=== Run Tests ==="
+          echo "Running $customPreBuildArgs ./build.sh $buildArgs"
           $customPreBuildArgs ./build.sh $buildArgs
 
         displayName: Run Tests


### PR DESCRIPTION
The "Prep the Build" script ran under `set -ex`. With xtrace active, bash writes a single-quoted trace line for each command to stderr, e.g.:

```
+ echo '##vso[task.setvariable variable=additionalBuildArgs]--with-sdk /__w/_temp/previously-source-built-sdk'
```

Azure Pipelines parses `##vso[...]` directives from stderr too, so it picked up the trace line and captured the trailing single quote as part of the variable value. This only failed intermittently, likely depending on whether the stderr trace line or the real stdout echo got processed last by the agent. When the trace line won, the bogus value leaked into `$(additionalBuildArgs)` in the Build step and broke `build.sh`'s `cd -P "$2"`:

```
cd: /__w/_temp/previously-source-built-sdk': No such file or directory
```

Note the trailing `'` at the end which was part of the variable.

Drop `-x` from the prep/build/test scripts (keeping `-e`) and add explicit echo lines for the commands being run so logs stay useful.

See: https://learn.microsoft.com/en-us/azure/devops/pipelines/troubleshooting/troubleshooting?view=azure-devops#variables-having--single-quote-appended