### PR TITLE
Fix vstest rel/18.7 SCI 10.0.0 sync 

### DIFF
--- a/src/vstest/eng/Version.Details.props
+++ b/src/vstest/eng/Version.Details.props
@@ -13,7 +13,7 @@ This file should be imported by eng/Versions.props
     <MicrosoftDiagnosticsNETCoreClientPackageVersion>0.2.0-preview.26179.102</MicrosoftDiagnosticsNETCoreClientPackageVersion>
     <!-- dotnet-runtime dependencies -->
     <MicrosoftExtensionsDependencyModelPackageVersion>6.0.2</MicrosoftExtensionsDependencyModelPackageVersion>
-    <SystemCollectionsImmutablePackageVersion>9.0.11</SystemCollectionsImmutablePackageVersion>
+    <SystemCollectionsImmutablePackageVersion>10.0.0</SystemCollectionsImmutablePackageVersion>
     <!-- dotnet-symreader-converter dependencies -->
     <MicrosoftDiaSymReaderConverterPackageVersion>1.1.0-beta2-19575-01</MicrosoftDiaSymReaderConverterPackageVersion>
     <MicrosoftDiaSymReaderPdb2PdbPackageVersion>1.1.0-beta2-19575-01</MicrosoftDiaSymReaderPdb2PdbPackageVersion>

--- a/src/vstest/eng/Version.Details.xml
+++ b/src/vstest/eng/Version.Details.xml
@@ -21,9 +21,9 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
     </Dependency>
-    <Dependency Name="System.Collections.Immutable" Version="9.0.11">
+    <Dependency Name="System.Collections.Immutable" Version="10.0.0">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
+      <Sha>60629d14374c56f1cb51819049ad1fa529307f8d</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/src/vstest/eng/Version.Details.xml
+++ b/src/vstest/eng/Version.Details.xml
@@ -11,7 +11,6 @@
       <Sha>d70206844a95b337601237466bfc6cbb7d52d6d4</Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
     <Dependency Name="Microsoft.Extensions.DependencyModel" Version="6.0.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>

--- a/src/vstest/src/vstest.console/app.config
+++ b/src/vstest/src/vstest.console/app.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup useLegacyV2RuntimeActivationPolicy="true">
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
@@ -42,10 +42,13 @@
         <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
+
       <dependentAssembly>
         <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
+
+
     </assemblyBinding>
   </runtime>
   <appSettings>

--- a/src/vstest/src/vstest.console/app.config
+++ b/src/vstest/src/vstest.console/app.config
@@ -27,11 +27,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -40,22 +40,11 @@
 
       <dependentAssembly>
         <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
-
       <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1" />
-      </dependentAssembly>
-      
-      <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1" />
-      </dependentAssembly>
-      
-      <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.11" newVersion="6.0.0.11" />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
`System.Collections.Immutable` in vstest needs to be **10.0.0**, not `9.0.11`.

`rel/18.7` in microsoft/vstest is on SCI 10.0.0 and its binding redirects in all three product app.configs (`vstest.console`, `testhost.x86`, `datacollector`) point at `10.0.0.0`. The VMR copy currently says `9.0.11` in `Version.Details.xml`, so when `testhost.x86.exe` starts under an SDK built from this VMR it can't load `System.Collections.Immutable 10.0.0.0` and dies with `FileLoadException`. That's DevDiv bug 3015885 — `dotnet test --collect:"Code Coverage"` aborting under SDK `10.0.400-preview.0.26310.101`.

### How we got here

The previous codeflow PR #7018 was supposed to bring this bump over from `rel/18.7` and silently dropped it. `src/vstest/src/vstest.console/app.config` had been reformatted from a single-line blob to multi-line XML on the VMR side at some past point, so darc couldn't auto-merge. The PR was finished with `darc vmr resolve-conflict --unsafe`, which picked the VMR side for `vstest.console/app.config` and the rel/18.7 side for the other two. Net effect: `testhost.x86` and `datacollector` got the new `10.0.0.0` redirects, but `vstest.console`'s redirect stayed at `9.0.0.0` and `Version.Details.xml` stayed at `9.0.11`.

Source-build stayed green because nothing checked redirect↔package consistency — vstest PR #16092 had disabled `_VerifyNuGetPackages` under `DotNetBuild=true` the day before. And the VMR doesn't run vstest's acceptance tests, so the runtime failure didn't surface until the resulting SDK ran an end-to-end scenario.

### Changes

- `eng/Version.Details.xml` — SCI `9.0.11` → `10.0.0` (Sha matches `rel/18.8` and `main`).
- `eng/Version.Details.props` — declare `SystemCollectionsImmutablePackageVersion=10.0.0` and the `SystemCollectionsImmutableVersion` alias so the vstest csprojs resolve to `10.0.0`. (rel/18.7 declares this version with a `Versions.props` literal; the literal gets stripped in the VMR, which is why we declare it the Maestro way here instead.)
- `src/vstest/src/vstest.console/app.config` — restored byte-identical to rel/18.7. `testhost.x86/app.config` and `datacollector/app.config` were already byte-identical.

`rel/18.7` in microsoft/vstest is the source of truth for the product app.configs — they shouldn't drift in the VMR.

### Verify

Source-build CI on this PR is the verifier — if SCI 10.0.0 is reachable in the `release/10.0.4xx` closure, the build is green and the runtime mismatch goes away. The customer scenario is reproduced by running `dotnet test --collect:"Code Coverage"` with the affected SDK.

### Refs

- DevDiv 3015885
- microsoft/vstest#15723 — original SCI 10.0.0 bump on rel/18.7
- microsoft/vstest#15777 — orphan redirect cleanup on the same file
- microsoft/vstest#16092 — disabled the package↔redirect verifier in source-build mode
- dotnet/dotnet#7018 — codeflow PR that dropped the bump (commits `8fc8e4da` reset, `a2b63399` partial revert, `f8affeab` `resolve-conflict --unsafe`)
