### PR TITLE
Add opt-in CI MSBuild node reuse via DotNetBuildNodeReuse property

### DIFF
--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -221,7 +221,8 @@
     <EnvironmentVariables Include="MSBUILD_MT_ENABLED=1" />
   </ItemGroup>
 
-  <!-- Enable MSBuild node reuse when DotNetBuildNodeReuse is set and the repository hasn't opted out.
+  <!-- NOTE: This is for internal testing only; real CI should not have node reuse.
+       Enable MSBuild node reuse when DotNetBuildNodeReuse is set and the repository hasn't opted out.
        By default CI builds force nodeReuse=false; opting in keeps the worker MSBuild nodes alive
        between invocations. A repository can opt out by setting <UseNodeReuse>false</UseNodeReuse>. -->
   <ItemGroup Condition="'$(DotNetBuildNodeReuse)' == 'true' and '$(UseNodeReuse)' != 'false'">

--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -222,6 +222,7 @@
   </ItemGroup>
 
   <!-- NOTE: This is for internal testing only; real CI should not have node reuse.
+       Follow-up to replace this env var with a proper switch: https://github.com/dotnet/arcade/issues/17013
        Enable MSBuild node reuse when DotNetBuildNodeReuse is set and the repository hasn't opted out.
        By default CI builds force nodeReuse=false; opting in keeps the worker MSBuild nodes alive
        between invocations. A repository can opt out by setting <UseNodeReuse>false</UseNodeReuse>. -->

--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -221,6 +221,13 @@
     <EnvironmentVariables Include="MSBUILD_MT_ENABLED=1" />
   </ItemGroup>
 
+  <!-- Enable MSBuild node reuse when DotNetBuildNodeReuse is set and the repository hasn't opted out.
+       By default CI builds force nodeReuse=false; opting in keeps the worker MSBuild nodes alive
+       between invocations. A repository can opt out by setting <UseNodeReuse>false</UseNodeReuse>. -->
+  <ItemGroup Condition="'$(DotNetBuildNodeReuse)' == 'true' and '$(UseNodeReuse)' != 'false'">
+    <EnvironmentVariables Include="MSBUILD_NODEREUSE_ENABLED=1" />
+  </ItemGroup>
+
   <ItemGroup  Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <EnvironmentVariables Include="NuGetAudit=false" />
   </ItemGroup>

--- a/src/arcade/eng/common/build.ps1
+++ b/src/arcade/eng/common/build.ps1
@@ -174,6 +174,7 @@ try {
       $binaryLog = $true
     }
     # Disable node reuse on CI unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
+    # Internal testing only; this env var will be replaced with a switch (https://github.com/dotnet/arcade/issues/17013) and must not be depended on.
     if ($env:MSBUILD_NODEREUSE_ENABLED -ne "1") {
       $nodeReuse = $false
     }

--- a/src/arcade/eng/common/build.ps1
+++ b/src/arcade/eng/common/build.ps1
@@ -173,7 +173,10 @@ try {
     if (-not $excludeCIBinarylog) {
       $binaryLog = $true
     }
-    $nodeReuse = $false
+    # Disable node reuse on CI unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
+    if ($env:MSBUILD_NODEREUSE_ENABLED -ne "1") {
+      $nodeReuse = $false
+    }
   }
 
   if (-not [string]::IsNullOrEmpty($binaryLogName)) {

--- a/src/arcade/eng/common/build.sh
+++ b/src/arcade/eng/common/build.sh
@@ -214,6 +214,7 @@ fi
 
 if [[ "$ci" == true ]]; then
   # Disable node reuse on CI unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
+  # Internal testing only; this env var will be replaced with a switch (https://github.com/dotnet/arcade/issues/17013) and must not be depended on.
   if [[ "${MSBUILD_NODEREUSE_ENABLED:-}" != "1" ]]; then
     node_reuse=false
   fi

--- a/src/arcade/eng/common/build.sh
+++ b/src/arcade/eng/common/build.sh
@@ -213,7 +213,10 @@ if [[ -z "$configuration" ]]; then
 fi
 
 if [[ "$ci" == true ]]; then
-  node_reuse=false
+  # Disable node reuse on CI unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
+  if [[ "${MSBUILD_NODEREUSE_ENABLED:-}" != "1" ]]; then
+    node_reuse=false
+  fi
   if [[ "$exclude_ci_binary_log" == false ]]; then
     binary_log=true
   fi

--- a/src/arcade/eng/common/msbuild.ps1
+++ b/src/arcade/eng/common/msbuild.ps1
@@ -14,7 +14,10 @@ Param(
 
 try {
   if ($ci) {
-    $nodeReuse = $false
+    # Disable node reuse on CI unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
+    if ($env:MSBUILD_NODEREUSE_ENABLED -ne "1") {
+      $nodeReuse = $false
+    }
   }
 
   MSBuild @extraArgs

--- a/src/arcade/eng/common/msbuild.ps1
+++ b/src/arcade/eng/common/msbuild.ps1
@@ -15,6 +15,7 @@ Param(
 try {
   if ($ci) {
     # Disable node reuse on CI unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
+    # Internal testing only; this env var will be replaced with a switch (https://github.com/dotnet/arcade/issues/17013) and must not be depended on.
     if ($env:MSBUILD_NODEREUSE_ENABLED -ne "1") {
       $nodeReuse = $false
     }

--- a/src/arcade/eng/common/msbuild.sh
+++ b/src/arcade/eng/common/msbuild.sh
@@ -51,7 +51,10 @@ done
 . "$scriptroot/tools.sh"
 
 if [[ "$ci" == true ]]; then
-  node_reuse=false
+  # Disable node reuse on CI unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
+  if [[ "${MSBUILD_NODEREUSE_ENABLED:-}" != "1" ]]; then
+    node_reuse=false
+  fi
 fi
 
 MSBuild $extra_args

--- a/src/arcade/eng/common/msbuild.sh
+++ b/src/arcade/eng/common/msbuild.sh
@@ -52,6 +52,7 @@ done
 
 if [[ "$ci" == true ]]; then
   # Disable node reuse on CI unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
+  # Internal testing only; this env var will be replaced with a switch (https://github.com/dotnet/arcade/issues/17013) and must not be depended on.
   if [[ "${MSBUILD_NODEREUSE_ENABLED:-}" != "1" ]]; then
     node_reuse=false
   fi

--- a/src/arcade/eng/common/tools.ps1
+++ b/src/arcade/eng/common/tools.ps1
@@ -743,6 +743,7 @@ function MSBuild() {
     }
 
     # Node reuse must be disabled in CI builds unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
+    # Internal testing only; this env var will be replaced with a switch (https://github.com/dotnet/arcade/issues/17013) and must not be depended on.
     if ($nodeReuse -and $env:MSBUILD_NODEREUSE_ENABLED -ne "1") {
       Write-PipelineTelemetryError -Category 'Build' -Message 'Node reuse must be disabled in CI build.'
       ExitWithExitCode 1

--- a/src/arcade/eng/common/tools.ps1
+++ b/src/arcade/eng/common/tools.ps1
@@ -742,7 +742,8 @@ function MSBuild() {
       ExitWithExitCode 1
     }
 
-    if ($nodeReuse) {
+    # Node reuse must be disabled in CI builds unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
+    if ($nodeReuse -and $env:MSBUILD_NODEREUSE_ENABLED -ne "1") {
       Write-PipelineTelemetryError -Category 'Build' -Message 'Node reuse must be disabled in CI build.'
       ExitWithExitCode 1
     }

--- a/src/arcade/eng/common/tools.sh
+++ b/src/arcade/eng/common/tools.sh
@@ -498,6 +498,7 @@ function MSBuild {
     fi
 
     # Node reuse must be disabled in CI builds unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
+    # Internal testing only; this env var will be replaced with a switch (https://github.com/dotnet/arcade/issues/17013) and must not be depended on.
     if [[ "$node_reuse" == true && "${MSBUILD_NODEREUSE_ENABLED:-}" != "1" ]]; then
       Write-PipelineTelemetryError -category 'Build'  "Node reuse must be disabled in CI build."
       ExitWithExitCode 1

--- a/src/arcade/eng/common/tools.sh
+++ b/src/arcade/eng/common/tools.sh
@@ -497,7 +497,8 @@ function MSBuild {
       ExitWithExitCode 1
     fi
 
-    if [[ "$node_reuse" == true ]]; then
+    # Node reuse must be disabled in CI builds unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
+    if [[ "$node_reuse" == true && "${MSBUILD_NODEREUSE_ENABLED:-}" != "1" ]]; then
       Write-PipelineTelemetryError -category 'Build'  "Node reuse must be disabled in CI build."
       ExitWithExitCode 1
     fi


### PR DESCRIPTION
Makes MSBuild **node reuse opt-in** on CI via a property, instead of unconditionally removing the `nodeReuse=false` opt-outs (the original experiment in #6838). Follows the design of the existing `-mt` / `DotNetBuildMT` mechanism.

### What it does

- **`repo-projects/Directory.Build.props`** - when `/p:DotNetBuildNodeReuse=true` is passed (and a repo hasn't set `UseNodeReuse=false`), export `MSBUILD_NODEREUSE_ENABLED=1` to the inner repo build.
- **`src/arcade/eng/common` `build` / `msbuild` / `tools` scripts** - only force `nodeReuse=false` on CI when `MSBUILD_NODEREUSE_ENABLED != 1`, and gate the *"Node reuse must be disabled in CI build"* guard the same way.

Default CI behavior is **unchanged** (node reuse stays disabled) unless the property is passed:

``
./build.sh --ci ... /p:DotNetBuildNodeReuse=true
``

### Scope

Per review feedback on #6838, only the **outgoing Arcade source** is edited:

- `src/arcade/eng/common/**` is copied into the inner repo builds by the `UpdateEngCommonFiles` target (for every repo except the bootstrap-arcade ones), so the source-build product repos pick up the gating at build time.
- The root `/eng/common` copy is a **tooling file** (it must flow from `dotnet/arcade`; the VMR `ChangeValidation` step rejects manual edits to it), so it is intentionally **not** edited here. It will pick up the change once it flows from Arcade.
- No per-repo `src/*/eng/common` mirrors are touched (they are regenerated during the build).

> Note: because `src/arcade` is a mirrored mapping, these `eng/common` edits will back-flow to `dotnet/arcade` on merge.

### Validation

- The opt-in was exercised on the **source-build CI leg** (via `extraPropertiesStage2: /p:DotNetBuildNodeReuse=true`) in an earlier revision of this PR; the `SB_*` source-build stage-1 and stage-2 legs **passed** with node reuse enabled. That experiment commit was reverted to keep this PR focused/mergeable.
- `bash -n` passes on all modified `.sh` scripts; the PowerShell parser passes on all modified `.ps1` scripts.