### PR TITLE
Propagate dotnet.exe exit code from eng/common/dotnet.ps1

### DIFF
--- a/eng/common/dotnet.ps1
+++ b/eng/common/dotnet.ps1
@@ -8,4 +8,5 @@ $dotnetRoot = InitializeDotNetCli -install:$true
 if ($args.count -gt 0) {
   $env:DOTNET_NOLOGO=1
   & "$dotnetRoot\dotnet.exe" $args
+  ExitWithExitCode $LASTEXITCODE
 }

--- a/src/arcade/eng/common/dotnet.ps1
+++ b/src/arcade/eng/common/dotnet.ps1
@@ -8,4 +8,5 @@ $dotnetRoot = InitializeDotNetCli -install:$true
 if ($args.count -gt 0) {
   $env:DOTNET_NOLOGO=1
   & "$dotnetRoot\dotnet.exe" $args
+  ExitWithExitCode $LASTEXITCODE
 }


### PR DESCRIPTION
When a CI step invokes `eng/common/dotnet.cmd ...` on Windows (e.g. signing validation), a non-zero exit from `dotnet.exe` is silently dropped and the step is marked green even when the build failed. Reproduces in https://github.com/dotnet/dotnet/pull/6019: on Mac/Linux, a failing `dotnet build` correctly fails the AzDO step (yellow with `continueOnError: true`); on Windows the same failure shows as green ✓.

## Root cause

On Windows the invocation chain is:

```
AzDO pwsh task
  → pwsh.exe
    → dotnet.cmd
      → powershell.exe -command "& dotnet.ps1 ..."
        → dotnet.exe build ...
```

`dotnet.ps1`:
```powershell
if ($args.count -gt 0) {
  $env:DOTNET_NOLOGO=1
  & "$dotnetRoot\dotnet.exe" $args
}
```

When `dotnet.exe` returns 1:
1. `$LASTEXITCODE` inside `dotnet.ps1` is 1.
2. The script ends with a native invocation and no `exit $LASTEXITCODE`, so the spawned `powershell.exe` exits **0**.
3. `dotnet.cmd` reads `%ErrorLevel%` (= 0 from the `powershell.exe` call) and does `exit /b 0`.
4. The outer pwsh script sees a successful invocation and the AzDO step is **green**.

`dotnet.sh` is unaffected because bash propagates the last command's exit status by default.

## Fix

Call `ExitWithExitCode $LASTEXITCODE` after invoking `dotnet.exe`, matching the convention already used by the other `eng/common/*.ps1` scripts that invoke native tools (`msbuild.ps1`, `sdk-task.ps1`, `build.ps1`, `dotnet-install.ps1`, etc.).

Patched in two places:

- `src/arcade/eng/common/dotnet.ps1` — the upstream-flowing source of truth.
- `eng/common/dotnet.ps1` — the VMR top-level copy, so the fix takes effect in VMR pipelines immediately. Per-repo copies under `src/*/eng/common/` will pick this up via arcade code flow.
