### PR TITLE
Clarify SignCheck skip reason for files that can't be PGP/Pkg/Mach-O verified

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.SignCheckLibrary/SignCheckResources.resx
+++ b/src/arcade/src/Microsoft.DotNet.SignCheckLibrary/SignCheckResources.resx
@@ -162,11 +162,26 @@
   <data name="DetailSignedStrongName" xml:space="preserve">
     <value>StrongName signed: {0}</value>
   </data>
-  <data name="DetailSkipped" xml:space="preserve">
-    <value>Skipped</value>
+  <data name="DetailSkippedFormat" xml:space="preserve">
+    <value>Skipped ({0})</value>
   </data>
-  <data name="DetailSkippedUnsupportedFileType" xml:space="preserve">
-    <value>Skipped (unsupported file type)</value>
+  <data name="SkipDetailArchiveInnerFormat" xml:space="preserve">
+    <value>{0}; {1}</value>
+  </data>
+  <data name="SkipReasonUnsupportedFileType" xml:space="preserve">
+    <value>unsupported file type</value>
+  </data>
+  <data name="SkipReasonNoPgpSignature" xml:space="preserve">
+    <value>no PGP signature available to verify</value>
+  </data>
+  <data name="SkipContentsVerified" xml:space="preserve">
+    <value>archive contents recursively verified</value>
+  </data>
+  <data name="SkipContentsNoRecursive" xml:space="preserve">
+    <value>archive contents not verified — run with --recursive to verify nested files</value>
+  </data>
+  <data name="SkipContentsPlatformUnsupported" xml:space="preserve">
+    <value>archive contents not verified — not supported on this platform</value>
   </data>
   <data name="DetailVerificationError" xml:space="preserve">
     <value>Verification error: {0}</value>

--- a/src/arcade/src/Microsoft.DotNet.SignCheckLibrary/Verification/ArchiveVerifier.cs
+++ b/src/arcade/src/Microsoft.DotNet.SignCheckLibrary/Verification/ArchiveVerifier.cs
@@ -23,12 +23,49 @@ namespace Microsoft.SignCheck.Verification
         protected abstract IEnumerable<ArchiveEntry> ReadArchiveEntries(string archivePath);
 
         /// <summary>
+        /// Whether this verifier can recurse into the archive's contents on the current
+        /// platform. Subclasses override to false when extraction is platform-gated (e.g.
+        /// PkgVerifier requires macOS, RpmVerifier requires Linux). When false, the skip
+        /// detail reports that contents weren't verified, and <see cref="VerifyContent"/>
+        /// will throw <see cref="PlatformNotSupportedException"/> from
+        /// <see cref="ReadArchiveEntries"/> which is handled by the caller.
+        /// </summary>
+        protected virtual bool ContentVerificationSupported => true;
+
+        /// <summary>
+        /// Builds a "Skipped (&lt;reason&gt;; &lt;contents&gt;)" detail string from
+        /// <paramref name="reason"/>, the current <see cref="VerifyRecursive"/> option,
+        /// and <see cref="ContentVerificationSupported"/>.
+        /// </summary>
+        private string BuildSkipDetail(string reason)
+        {
+            string contents;
+            if (!ContentVerificationSupported)
+            {
+                // Platform-unsupported wins over !VerifyRecursive: even with --recursive, this
+                // platform can't unpack the archive.
+                contents = SignCheckResources.SkipContentsPlatformUnsupported;
+            }
+            else if (!VerifyRecursive)
+            {
+                contents = SignCheckResources.SkipContentsNoRecursive;
+            }
+            else
+            {
+                contents = SignCheckResources.SkipContentsVerified;
+            }
+
+            return string.Format(SignCheckResources.DetailSkippedFormat,
+                string.Format(SignCheckResources.SkipDetailArchiveInnerFormat, reason, contents));
+        }
+
+        /// <summary>
         /// Verifies the signature of a supported file type.
         /// </summary>
         /// <param name="path">The path of the file to verify.</param>
         /// <param name="parent">The parent directory of the file.</param>
         /// <param name="virtualPath">The virtual path of the file.</param>
-        protected SignatureVerificationResult VerifySupportedFileType(string path, string parent, string virtualPath) 
+        protected SignatureVerificationResult VerifySupportedFileType(string path, string parent, string virtualPath)
         {
             try
             {
@@ -41,20 +78,24 @@ namespace Microsoft.SignCheck.Verification
                 VerifyContent(svr);
                 return svr;
             }
-            catch (PlatformNotSupportedException)
+            catch (PlatformNotSupportedException ex)
             {
-                // Verification is not supported on all platforms for all file types
-                return VerifyUnsupportedFileType(path, parent, virtualPath);
+                // The platform can't run this verifier's signature check (e.g. PGP off-Linux
+                // via gpg, .pkg off-macOS via MacOsPkg). Report the exception message as the
+                // reason in the composite skip detail — PNSEs thrown by verifiers here are
+                // already worded as user-facing fragments.
+                return VerifySkipped(path, parent, virtualPath, ex.Message);
             }
         }
 
         /// <summary>
-        /// Verifies the signature of an unsupported file type.
+        /// Reports an archive whose own signature wasn't verified. The composite skip detail
+        /// is built from <paramref name="reason"/> and the contents disposition (recursive
+        /// vs. not), and the archive's contents are still recursed into when possible.
         /// </summary>
-        protected SignatureVerificationResult VerifyUnsupportedFileType(string path, string parent, string virtualPath)
+        protected SignatureVerificationResult VerifySkipped(string path, string parent, string virtualPath, string reason)
         {
-            var svr = SignatureVerificationResult.UnsupportedFileTypeResult(path, parent, virtualPath);
-            string fullPath = svr.FullPath;
+            var svr = SignatureVerificationResult.UnsupportedFileTypeResult(path, parent, virtualPath, BuildSkipDetail(reason));
             svr.AddDetail(DetailKeys.File, SignCheckResources.DetailSigned, SignCheckResources.NA);
 
             VerifyContent(svr);
@@ -77,87 +118,89 @@ namespace Microsoft.SignCheck.Verification
         /// <param name="svr">The container result</param>
         protected void VerifyContent(SignatureVerificationResult svr)
         {
-            if (VerifyRecursive)
+            if (!VerifyRecursive)
             {
-                svr.IsDoNotUnpack = Exclusions.IsDoNotUnpack(
-                    svr.FullPath,
-                    Path.GetDirectoryName(svr.FullPath) ?? SignCheckResources.NA,
-                    svr.VirtualPath,
-                    svr.VirtualPath);
+                return;
+            }
 
-                if (svr.IsDoNotUnpack)
+            svr.IsDoNotUnpack = Exclusions.IsDoNotUnpack(
+                svr.FullPath,
+                Path.GetDirectoryName(svr.FullPath) ?? SignCheckResources.NA,
+                svr.VirtualPath,
+                svr.VirtualPath);
+
+            if (svr.IsDoNotUnpack)
+            {
+                Log.WriteMessage(LogVerbosity.Detailed, SignCheckResources.DiagSkippingArchiveExtraction, svr.FullPath);
+                return;
+            }
+
+            string tempPath = svr.TempPath;
+            CreateDirectory(tempPath);
+            Log.WriteMessage(LogVerbosity.Diagnostic, SignCheckResources.DiagExtractingFileContents, tempPath);
+            Dictionary<string, string> archiveMap = new Dictionary<string, string>();
+
+            try
+            {
+                foreach (ArchiveEntry archiveEntry in ReadArchiveEntries(svr.FullPath))
                 {
-                    Log.WriteMessage(LogVerbosity.Detailed, SignCheckResources.DiagSkippingArchiveExtraction, svr.FullPath);
-                    return;
-                }
-
-                string tempPath = svr.TempPath;
-                CreateDirectory(tempPath);
-                Log.WriteMessage(LogVerbosity.Diagnostic, SignCheckResources.DiagExtractingFileContents, tempPath);
-                Dictionary<string, string> archiveMap = new Dictionary<string, string>();
-
-                try
-                {
-                    foreach (ArchiveEntry archiveEntry in ReadArchiveEntries(svr.FullPath))
+                    if (archiveEntry.IsEmptyOrInvalid())
                     {
-                        if (archiveEntry.IsEmptyOrInvalid())
-                        {
-                            var result = SignatureVerificationResult.UnsupportedFileTypeResult(
-                                archiveEntry.RelativePath,
-                                svr.VirtualPath,
-                                Path.Combine(svr.VirtualPath, archiveEntry.RelativePath));
+                        var result = SignatureVerificationResult.UnsupportedFileTypeResult(
+                            archiveEntry.RelativePath,
+                            svr.VirtualPath,
+                            Path.Combine(svr.VirtualPath, archiveEntry.RelativePath));
 
-                            result.AddDetail(DetailKeys.Misc, "Empty or invalid archive entry");
-                            svr.NestedResults.Add(result);
-                            continue;
-                        }
-
-                        string aliasFullName = GenerateArchiveEntryAlias(archiveEntry, tempPath);
-                        if (File.Exists(aliasFullName))
-                        {
-                            Log.WriteMessage(LogVerbosity.Normal, SignCheckResources.FileAlreadyExists, aliasFullName);
-                        }
-                        else
-                        {
-                            CreateDirectory(Path.GetDirectoryName(aliasFullName));
-                            WriteArchiveEntry(archiveEntry, aliasFullName);
-                            archiveMap[archiveEntry.RelativePath] = aliasFullName;
-                        }
-                    }
-
-                    // We can only verify once everything is extracted. This is mainly because MSIs can have mutliple external CAB files
-                    // and we need to ensure they are extracted before we verify the MSIs.
-                    foreach (string fullName in archiveMap.Keys)
-                    {
-                        SignatureVerificationResult result;
-                        try
-                        {
-                            result = VerifyFile(archiveMap[fullName], svr.VirtualPath,
-                                Path.Combine(svr.VirtualPath, fullName), fullName);
-                        }
-                        catch (Exception e) when (e is not PlatformNotSupportedException)
-                        {
-                            result = SignatureVerificationResult.ErrorResult(
-                                archiveMap[fullName], svr.VirtualPath, Path.Combine(svr.VirtualPath, fullName), e);
-                        }
-
-                        // Tag the full path into the result detail
-                        result.AddDetail(DetailKeys.File, SignCheckResources.DetailFullName, fullName);
+                        result.AddDetail(DetailKeys.Misc, "Empty or invalid archive entry");
                         svr.NestedResults.Add(result);
+                        continue;
+                    }
+
+                    string aliasFullName = GenerateArchiveEntryAlias(archiveEntry, tempPath);
+                    if (File.Exists(aliasFullName))
+                    {
+                        Log.WriteMessage(LogVerbosity.Normal, SignCheckResources.FileAlreadyExists, aliasFullName);
+                    }
+                    else
+                    {
+                        CreateDirectory(Path.GetDirectoryName(aliasFullName));
+                        WriteArchiveEntry(archiveEntry, aliasFullName);
+                        archiveMap[archiveEntry.RelativePath] = aliasFullName;
                     }
                 }
-                catch (PlatformNotSupportedException)
+
+                // We can only verify once everything is extracted. This is mainly because MSIs can have mutliple external CAB files
+                // and we need to ensure they are extracted before we verify the MSIs.
+                foreach (string fullName in archiveMap.Keys)
                 {
-                    // Log the error and return an unsupported file type result
-                    // because some archive types are not supported on all platforms
-                    string parent = Path.GetDirectoryName(svr.FullPath) ?? SignCheckResources.NA;
-                    svr = SignatureVerificationResult.UnsupportedFileTypeResult(svr.FullPath, parent, svr.VirtualPath);
-                    svr.AddDetail(DetailKeys.File, SignCheckResources.DetailSigned, SignCheckResources.NA);
+                    SignatureVerificationResult result;
+                    try
+                    {
+                        result = VerifyFile(archiveMap[fullName], svr.VirtualPath,
+                            Path.Combine(svr.VirtualPath, fullName), fullName);
+                    }
+                    catch (Exception e) when (e is not PlatformNotSupportedException)
+                    {
+                        result = SignatureVerificationResult.ErrorResult(
+                            archiveMap[fullName], svr.VirtualPath, Path.Combine(svr.VirtualPath, fullName), e);
+                    }
+
+                    // Tag the full path into the result detail
+                    result.AddDetail(DetailKeys.File, SignCheckResources.DetailFullName, fullName);
+                    svr.NestedResults.Add(result);
                 }
-                finally
-                {
-                    DeleteDirectory(tempPath);
-                }
+            }
+            catch (PlatformNotSupportedException)
+            {
+                // Log the error and return an unsupported file type result
+                // because some archive types are not supported on all platforms
+                string parent = Path.GetDirectoryName(svr.FullPath) ?? SignCheckResources.NA;
+                svr = SignatureVerificationResult.UnsupportedFileTypeResult(svr.FullPath, parent, svr.VirtualPath);
+                svr.AddDetail(DetailKeys.File, SignCheckResources.DetailSigned, SignCheckResources.NA);
+            }
+            finally
+            {
+                DeleteDirectory(tempPath);
             }
         }
 

--- a/src/arcade/src/Microsoft.DotNet.SignCheckLibrary/Verification/MachOVerifier.cs
+++ b/src/arcade/src/Microsoft.DotNet.SignCheckLibrary/Verification/MachOVerifier.cs
@@ -23,7 +23,7 @@ namespace Microsoft.SignCheck.Verification
             {
                 if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
-                    throw new PlatformNotSupportedException($"Mach-O signature verification is only supported on macOS.");
+                    throw new PlatformNotSupportedException($"Mach-O signature verification is only supported on macOS");
                 }
 
                 using (FileStream fs = new FileStream(path, FileMode.Open, FileAccess.Read))
@@ -46,7 +46,14 @@ namespace Microsoft.SignCheck.Verification
             }
             catch (Exception ex) when (ex is PlatformNotSupportedException || ex is InvalidDataException)
             {
-                var svr = SignatureVerificationResult.UnsupportedFileTypeResult(path, parent, virtualPath);
+                // PNSE → off-macOS, use the exception message as the reason fragment;
+                // InvalidDataException → the file isn't actually a Mach-O, fall back to
+                // "unsupported file type".
+                string reason = ex is PlatformNotSupportedException
+                    ? ex.Message
+                    : SignCheckResources.SkipReasonUnsupportedFileType;
+                var svr = SignatureVerificationResult.UnsupportedFileTypeResult(path, parent, virtualPath,
+                    string.Format(SignCheckResources.DetailSkippedFormat, reason));
                 svr.AddDetail(DetailKeys.File, SignCheckResources.DetailSigned, SignCheckResources.NA);
                 return svr;
             }

--- a/src/arcade/src/Microsoft.DotNet.SignCheckLibrary/Verification/PgpVerifier.cs
+++ b/src/arcade/src/Microsoft.DotNet.SignCheckLibrary/Verification/PgpVerifier.cs
@@ -28,7 +28,8 @@ namespace Microsoft.SignCheck.Verification
 
         /// <summary>
         /// Verifies the signature of a file using a detached .sig file.
-        /// If the .sig file exists, verifies as a supported file type; otherwise, as unsupported.
+        /// If the .sig file exists, verifies as a supported file type; otherwise, reports the
+        /// PGP signature as skipped while still recursing into the archive's contents.
         /// </summary>
         protected SignatureVerificationResult VerifyDetachedSignature(string path, string parent, string virtualPath)
         {
@@ -36,7 +37,11 @@ namespace Microsoft.SignCheck.Verification
             {
                 return VerifySupportedFileType(path, parent, virtualPath);
             }
-            return VerifyUnsupportedFileType(path, parent, virtualPath);
+            // No detached .sig sidecar was shipped alongside the file (most .tar.gz/.deb/.rpm
+            // artifacts only carry one on the Linux package feeds). Report a clearer reason
+            // than the generic "unsupported file type" so users don't think the whole archive
+            // was an unrecognized format.
+            return VerifySkipped(path, parent, virtualPath, SignCheckResources.SkipReasonNoPgpSignature);
         }
 
         /// <summary>
@@ -56,7 +61,7 @@ namespace Microsoft.SignCheck.Verification
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                throw new PlatformNotSupportedException("Pgp verification is not supported on Windows.");
+                throw new PlatformNotSupportedException("PGP signature verification is only supported on Linux and macOS");
             }
 
             string tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());

--- a/src/arcade/src/Microsoft.DotNet.SignCheckLibrary/Verification/PkgVerifier.cs
+++ b/src/arcade/src/Microsoft.DotNet.SignCheckLibrary/Verification/PkgVerifier.cs
@@ -26,12 +26,18 @@ namespace Microsoft.SignCheck.Verification
 
         public override SignatureVerificationResult VerifySignature(string path, string parent, string virtualPath) 
             => VerifySupportedFileType(path, parent, virtualPath);
+
+        // .pkg unpacking goes through the macOS-only MacOsPkg tooling — see ReadArchiveEntries
+        // and IsSigned, both of which throw PlatformNotSupportedException off macOS. So when
+        // the file's own signature isn't verifiable on the current platform, the contents
+        // can't be either.
+        protected override bool ContentVerificationSupported => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
         
         protected override IEnumerable<ArchiveEntry> ReadArchiveEntries(string archivePath)
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                throw new PlatformNotSupportedException("The MacOsPkg tooling is only supported on macOS.");
+                throw new PlatformNotSupportedException(".pkg signature verification is only supported on macOS");
             }
 
             string extractionPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -68,7 +74,7 @@ namespace Microsoft.SignCheck.Verification
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                throw new PlatformNotSupportedException("The MacOsPkg tooling is only supported on macOS.");
+                throw new PlatformNotSupportedException(".pkg signature verification is only supported on macOS");
             }
 
             (bool result, string output, string error) = Utils.CaptureConsoleOutput(() =>

--- a/src/arcade/src/Microsoft.DotNet.SignCheckLibrary/Verification/RpmVerifier.cs
+++ b/src/arcade/src/Microsoft.DotNet.SignCheckLibrary/Verification/RpmVerifier.cs
@@ -19,7 +19,7 @@ namespace Microsoft.SignCheck.Verification
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                throw new PlatformNotSupportedException("RPM unpacking is only supported on Linux.");
+                throw new PlatformNotSupportedException("RPM signature verification is only supported on Linux");
             }
 
             using var stream = File.Open(archivePath, FileMode.Open);

--- a/src/arcade/src/Microsoft.DotNet.SignCheckLibrary/Verification/SignatureVerificationResult.cs
+++ b/src/arcade/src/Microsoft.DotNet.SignCheckLibrary/Verification/SignatureVerificationResult.cs
@@ -295,15 +295,23 @@ namespace Microsoft.SignCheck.Verification
         /// Creates a SignatureVerificationResult for an unsupported file type or file extension.
         /// </summary>
         /// <param name="path">The path to the file that is unsupported</param>
-        /// <returns>A SignatureVerificationResult indicating the file is unsupported..</returns>
+        /// <returns>A SignatureVerificationResult indicating the file is unsupported.</returns>
         public static SignatureVerificationResult UnsupportedFileTypeResult(string path, string parent, string virtualPath)
+            => UnsupportedFileTypeResult(path, parent, virtualPath,
+                string.Format(SignCheckResources.DetailSkippedFormat, SignCheckResources.SkipReasonUnsupportedFileType));
+
+        /// <summary>
+        /// Creates a SignatureVerificationResult for an unsupported file type or file extension
+        /// with a custom skip reason in the detail line.
+        /// </summary>
+        public static SignatureVerificationResult UnsupportedFileTypeResult(string path, string parent, string virtualPath, string skipDetail)
         {
             var signatureVerificationResult = new SignatureVerificationResult(path, parent, virtualPath)
             {
                 IsSkipped = true
             };
 
-            signatureVerificationResult.AddDetail(DetailKeys.File, SignCheckResources.DetailSkippedUnsupportedFileType);
+            signatureVerificationResult.AddDetail(DetailKeys.File, skipDetail);
 
             return signatureVerificationResult;
         }


### PR DESCRIPTION
## What

Replaces the misleading `Skipped (unsupported file type)` message in SignCheck output with a composable skip detail that clearly states *why* the file's own signature wasn't verified **and** what happened to the archive's nested contents:

```
Skipped (<reason>; <contents disposition>)
```

## Why

Today, any `.tar.gz` whose detached `.sig` sidecar isn't present (or where `gpg`/`MacOsPkg`/`codesign` can't run on the current platform) is reported as a flat `Skipped (unsupported file type)` — which reads as "the whole archive was ignored", when in fact `ArchiveVerifier.VerifyContent` still recurses into the archive when `--recursive` is enabled. This caused confusion when triaging signing-validation output on Windows for `.tar.gz` artifacts that only ship `.sig` files on the Linux package feeds.

## How

**Reason fragment** comes from one of two places:

- `PlatformNotSupportedException.Message` thrown by the verifier when its signature check can't run on the current platform. The existing PNSE messages were reworded as user-facing fragments (no trailing period, no internal jargon like "MacOsPkg tooling") so they can be reused for output.
- An explicit reason string passed to a new `VerifySkipped(path, parent, virtualPath, reason)` helper, used by `PgpVerifier` in the no-`.sig` path (the only case that isn't a PNSE).

**Contents disposition** is computed from `VerifyRecursive` and a new `ContentVerificationSupported` virtual that subclasses override when archive extraction itself is platform-gated. Branches:

- `archive contents recursively verified` — `--recursive` is on and the platform can unpack
- `archive contents not verified — run with --recursive to verify nested files`
- `archive contents not verified — not supported on this platform` — platform-unsupported wins over no-recursive, because even with `--recursive` the platform still can't unpack

`PkgVerifier` overrides `ContentVerificationSupported` to `RuntimeInformation.IsOSPlatform(OSPlatform.OSX)` so off-macOS the message correctly says contents weren't verified either.

`MachOVerifier` derives from `FileVerifier` (not `ArchiveVerifier`, no nested contents) and keeps a Mach-O-specific message for `PlatformNotSupportedException` while falling back to `Skipped (unsupported file type)` for `InvalidDataException` (file genuinely isn't Mach-O).

## Examples

| Scenario | Output |
|---|---|
| `.tar.gz` without `.sig`, `--recursive` on | `Skipped (no PGP signature available to verify; archive contents recursively verified)` |
| `.tar.gz` without `.sig`, `--recursive` off | `Skipped (no PGP signature available to verify; archive contents not verified — run with --recursive to verify nested files)` |
| `.pkg` on Windows, `--recursive` on | `Skipped (.pkg signature verification is only supported on macOS; archive contents not verified — not supported on this platform)` |
| Truly unknown file type | `Skipped (unsupported file type)` (unchanged) |

## Also

- Fixed a double-period typo in `UnsupportedFileTypeResult`'s XML doc comment.