### PR TITLE
Sign NativeAOT'd aspnetcore dotnet tools with MacDeveloperHarden

### DIFF
--- a/src/sdk/eng/Signing.props
+++ b/src/sdk/eng/Signing.props
@@ -104,6 +104,8 @@
     <FileSignInfo Condition="'$(TargetOS)' == 'osx'" Include="csc;vbc;VBCSCompiler" CertificateName="MacDeveloperHarden" />
     <!-- MSBuild apphost -->
     <FileSignInfo Condition="'$(TargetOS)' == 'osx'" Include="MSBuild" CertificateName="MacDeveloperHarden" />
+    <!-- NativeAOT'd aspnetcore dotnet tools -->
+    <FileSignInfo Condition="'$(TargetOS)' == 'osx'" Include="dotnet-dev-certs;dotnet-user-secrets;dotnet-user-jwts" CertificateName="MacDeveloperHarden" />
   </ItemGroup>
 
   <!-- Filter out any test packages from ItemsToSign -->


### PR DESCRIPTION
The dotnet-dev-certs, dotnet-user-secrets, and dotnet-user-jwts tools are NativeAOT-compiled native executables on macOS, but they were not being signed with the MacDeveloperHarden certificate. As a result, Apple notarization failed with errors that the binaries were not signed, the signature did not include a secure timestamp, and the executables did not have the hardened runtime enabled.

Add them to the FileSignInfo list alongside the existing Roslyn (csc/vbc/ VBCSCompiler) and MSBuild apphost entries.

Fixes https://github.com/dotnet/dotnet/issues/7194