### PR TITLE
Use direct NuGet.Frameworks reference on .NET Core

### DIFF
--- a/src/msbuild/documentation/NETFramework-NGEN.md
+++ b/src/msbuild/documentation/NETFramework-NGEN.md
@@ -94,7 +94,8 @@ When this happens, the cost of JITting `Microsoft.Build.NuGetSdkResolver` will b
 ## NuGet.Frameworks
 
 When evaluating certain property functions, MSBuild requires functionality from `NuGet.Frameworks.dll`, which is not part of MSBuild proper.
-The assembly is loaded lazily from a path calculated based on the environment where MSBuild is running and the functionality is invoked
+
+On .NET Framework, the assembly is loaded lazily from a path calculated based on the environment where MSBuild is running and the functionality is invoked
 via reflection. Similar to the NuGet resolver, the version is changing and it is not easy to know it statically at MSBuild's build time.
 But, since there are only a handful of APIs used by MSBuild and they take simple types such as strings and versions, this has been
 addressed by loading the assembly into a separate AppDomain. The AppDomain's config file is created in memory on the fly to contain the
@@ -105,6 +106,10 @@ of cross-domain calls. The former is orders of magnitude smaller that the startu
 the types moved across the AppDomain boundary do not require expensive marshaling. Additionally, the requirement to execute code in multiple
 AppDomains necessitates the use of `LoaderOptimization.MultiDomain` for loading all assemblies domain-neutral. This may come with run-time
 cost for certain code patterns, although none has been measured in MSBuild scenarios.
+
+On .NET (Core), MSBuild takes a direct compile-time reference to `NuGet.Frameworks` and calls it through strongly-typed APIs, avoiding both
+the reflection overhead and the AppDomain machinery. .NET SDK construction deploys `NuGet.Frameworks.dll` next to `MSBuild.dll` and
+makes `MSBuild.deps.json` coherent.
 
 ## Task assemblies
 

--- a/src/msbuild/eng/Version.Details.xml
+++ b/src/msbuild/eng/Version.Details.xml
@@ -110,6 +110,12 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>7b306e34463421cef2816352743b943c6547dfab</Sha>
     </Dependency>
+    <!-- This is the NuGet.* package family. NuGet.Frameworks is also pulled in via this
+         version on .NET Core, where Microsoft.Build takes a direct compile-time PackageReference
+         to it (PrivateAssets="all", so we don't repackage the binary and the API doesn't appear
+         in our public surface). At runtime we still bind to whatever NuGet.Frameworks.dll the
+         host SDK ships, so per the toolset-vs-product test in dotnet/arcade-services'
+         docs/Darc.md this is a toolset dependency, not a product one. -->
     <Dependency Name="NuGet.Build.Tasks" Version="7.9.0-rc.17">
       <Uri>https://github.com/nuget/nuget.client</Uri>
       <Sha>f2eaca2cd2baa4209e69da89c6d232f42174f6dc</Sha>

--- a/src/msbuild/src/Build/Microsoft.Build.csproj
+++ b/src/msbuild/src/Build/Microsoft.Build.csproj
@@ -78,6 +78,23 @@
     <PackageReference Include="System.Text.Encoding.CodePages" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
+    <!-- On .NET Core, take a direct compile-time reference to NuGet.Frameworks so that
+         property functions in NuGetFrameworkWrapper can call into it without reflection.
+
+         Note that this is intentionally a compile-time reference only. At run time MSBuild
+         always loads the NuGet.Frameworks.dll that ships in the host SDK directory next to
+         MSBuild.dll, which is typically a NEWER version than the one we reference here,
+         because the MSBuild repo updates NuGet only weekly, and should consume the same
+         NuGet channel that is flowing to SDK. That's similar to the old reflection-based
+         path. This introduces some risk of version drift, but the members we call have been
+         stable in NuGet.Frameworks for many years.
+
+         On .NET Framework we still load NuGet.Frameworks dynamically into a secondary
+         AppDomain for NGEN reasons; see documentation/NETFramework-NGEN.md. -->
+    <PackageReference Include="NuGet.Frameworks" PrivateAssets="all" />
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Include="..\Shared\CanonicalError.cs">
       <Link>BackEnd\Components\RequestBuilder\IntrinsicTasks\CanonicalError.cs</Link>
@@ -197,6 +214,8 @@
     <Compile Include="Logging\TargetConsoleConfiguration.cs" />
     <Compile Include="Utilities\ImmutableCollectionsExtensions.cs" />
     <Compile Include="Utilities\NuGetFrameworkWrapper.cs" />
+    <Compile Include="Utilities\NuGetFrameworkWrapper.Reflection.cs" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
+    <Compile Include="Utilities\NuGetFrameworkWrapper.Direct.cs" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'" />
     <Compile Include="ObjectModelRemoting\ConstructionObjectLinks\ProjectUsingTaskParameterElementLink.cs" />
     <Compile Include="ObjectModelRemoting\ExternalProjectsProvider.cs" />
     <Compile Include="ObjectModelRemoting\LinkedObjectFactory.cs" />

--- a/src/msbuild/src/Build/Utilities/NuGetFrameworkWrapper.Direct.cs
+++ b/src/msbuild/src/Build/Utilities/NuGetFrameworkWrapper.Direct.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using NuGet.Frameworks;
+
+namespace Microsoft.Build.Evaluation;
+
+// Direct-reference partial: NuGet.Frameworks is referenced at compile time and called
+// without reflection, avoiding the per-call MethodInfo.Invoke cost of the reflection path.
+internal sealed partial class NuGetFrameworkWrapper
+{
+    private NuGetFrameworkWrapper()
+    { }
+
+    public static NuGetFrameworkWrapper CreateInstance() => new();
+
+    private static NuGetFramework Parse(string tfm) => NuGetFramework.Parse(tfm);
+
+    public string GetTargetFrameworkIdentifier(string tfm) => Parse(tfm).Framework;
+
+    public string GetTargetFrameworkVersion(string tfm, int minVersionPartCount) =>
+        GetNonZeroVersionParts(Parse(tfm).Version, minVersionPartCount);
+
+    public string GetTargetPlatformIdentifier(string tfm) => Parse(tfm).Platform;
+
+    public string GetTargetPlatformVersion(string tfm, int minVersionPartCount) =>
+        GetNonZeroVersionParts(Parse(tfm).PlatformVersion, minVersionPartCount);
+
+    public bool IsCompatible(string target, string candidate) =>
+        DefaultCompatibilityProvider.Instance.IsCompatible(Parse(target), Parse(candidate));
+
+    public string FilterTargetFrameworks(string incoming, string filter) =>
+        FilterTargetFrameworks<NuGetFramework, NuGetFrameworkAdapter>(incoming, filter, default);
+
+    private readonly struct NuGetFrameworkAdapter : ITfmAdapter<NuGetFramework>
+    {
+        public NuGetFramework Parse(string tfm) => NuGetFramework.Parse(tfm);
+        public string GetFramework(NuGetFramework parsed) => parsed.Framework;
+        public bool GetAllFrameworkVersions(NuGetFramework parsed) => parsed.AllFrameworkVersions;
+        public Version GetVersion(NuGetFramework parsed) => parsed.Version;
+    }
+}

--- a/src/msbuild/src/Build/Utilities/NuGetFrameworkWrapper.Reflection.cs
+++ b/src/msbuild/src/Build/Utilities/NuGetFrameworkWrapper.Reflection.cs
@@ -1,0 +1,212 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+
+#nullable disable
+
+namespace Microsoft.Build.Evaluation
+{
+    // Reflection-based partial: NuGet.Frameworks is loaded by reflection into a separate
+    // AppDomain for NGEN reasons. See documentation/NETFramework-NGEN.md.
+    internal sealed partial class NuGetFrameworkWrapper : MarshalByRefObject
+    {
+        private const string NuGetFrameworksAssemblyName = "NuGet.Frameworks";
+        private const string NuGetFrameworksFileName = NuGetFrameworksAssemblyName + ".dll";
+
+        /// <summary>
+        /// Methods, properties, and objects used from the NuGet.Frameworks assembly.
+        /// </summary>
+        private MethodInfo ParseMethod;
+        private MethodInfo IsCompatibleMethod;
+        private object DefaultCompatibilityProvider;
+        private PropertyInfo FrameworkProperty;
+        private PropertyInfo VersionProperty;
+        private PropertyInfo PlatformProperty;
+        private PropertyInfo PlatformVersionProperty;
+        private PropertyInfo AllFrameworkVersionsProperty;
+
+        /// <summary>
+        /// Public constructor for cross-domain activation only. Use <see cref="CreateInstance"/> to instantiate.
+        /// </summary>
+        public NuGetFrameworkWrapper()
+        { }
+
+        /// <summary>
+        /// Initialized this instance. May run in a separate AppDomain.
+        /// </summary>
+        /// <param name="assemblyName">The NuGet.Frameworks to be loaded or null to load by path.</param>
+        /// <param name="assemblyFilePath">The file path from which NuGet.Frameworks should be loaded of <paramref name="assemblyName"/> is null.</param>
+        public void Initialize(AssemblyName assemblyName, string assemblyFilePath)
+        {
+            Assembly NuGetAssembly;
+            if (assemblyName != null)
+            {
+                // This will load the assembly into the default load context if possible, and fall back to LoadFrom context.
+                NuGetAssembly = Assembly.Load(assemblyName);
+            }
+            else
+            {
+                NuGetAssembly = Assembly.LoadFile(assemblyFilePath);
+            }
+
+            var NuGetFramework = NuGetAssembly.GetType("NuGet.Frameworks.NuGetFramework");
+            var NuGetFrameworkCompatibilityProvider = NuGetAssembly.GetType("NuGet.Frameworks.CompatibilityProvider");
+            var NuGetFrameworkDefaultCompatibilityProvider = NuGetAssembly.GetType("NuGet.Frameworks.DefaultCompatibilityProvider");
+            ParseMethod = NuGetFramework.GetMethod("Parse", [typeof(string)]);
+            IsCompatibleMethod = NuGetFrameworkCompatibilityProvider.GetMethod("IsCompatible");
+            DefaultCompatibilityProvider = NuGetFrameworkDefaultCompatibilityProvider.GetMethod("get_Instance").Invoke(null, Array.Empty<object>());
+            FrameworkProperty = NuGetFramework.GetProperty("Framework");
+            VersionProperty = NuGetFramework.GetProperty("Version");
+            PlatformProperty = NuGetFramework.GetProperty("Platform");
+            PlatformVersionProperty = NuGetFramework.GetProperty("PlatformVersion");
+            AllFrameworkVersionsProperty = NuGetFramework.GetProperty("AllFrameworkVersions");
+        }
+
+        private object Parse(string tfm)
+        {
+            return ParseMethod.Invoke(null, [tfm]);
+        }
+
+        public string GetTargetFrameworkIdentifier(string tfm)
+        {
+            return FrameworkProperty.GetValue(Parse(tfm)) as string;
+        }
+
+        public string GetTargetFrameworkVersion(string tfm, int minVersionPartCount)
+        {
+            var version = VersionProperty.GetValue(Parse(tfm)) as Version;
+            return GetNonZeroVersionParts(version, minVersionPartCount);
+        }
+
+        public string GetTargetPlatformIdentifier(string tfm)
+        {
+            return PlatformProperty.GetValue(Parse(tfm)) as string;
+        }
+
+        public string GetTargetPlatformVersion(string tfm, int minVersionPartCount)
+        {
+            var version = PlatformVersionProperty.GetValue(Parse(tfm)) as Version;
+            return GetNonZeroVersionParts(version, minVersionPartCount);
+        }
+
+        public bool IsCompatible(string target, string candidate)
+        {
+            return Convert.ToBoolean(IsCompatibleMethod.Invoke(DefaultCompatibilityProvider, [Parse(target), Parse(candidate)]));
+        }
+
+        public string FilterTargetFrameworks(string incoming, string filter) =>
+            FilterTargetFrameworks<object, ReflectionTfmAdapter>(incoming, filter, new ReflectionTfmAdapter(this));
+
+        private readonly struct ReflectionTfmAdapter : ITfmAdapter<object>
+        {
+            private readonly NuGetFrameworkWrapper _wrapper;
+            public ReflectionTfmAdapter(NuGetFrameworkWrapper wrapper) => _wrapper = wrapper;
+            public object Parse(string tfm) => _wrapper.Parse(tfm);
+            public string GetFramework(object parsed) => _wrapper.FrameworkProperty.GetValue(parsed) as string;
+            public bool GetAllFrameworkVersions(object parsed) => Convert.ToBoolean(_wrapper.AllFrameworkVersionsProperty.GetValue(parsed));
+            public Version GetVersion(object parsed) => _wrapper.VersionProperty.GetValue(parsed) as Version;
+        }
+
+        /// <summary>
+        /// A null-returning InitializeLifetimeService to give the proxy an infinite lease time.
+        /// </summary>
+        public override object InitializeLifetimeService() => null;
+
+        /// <summary>
+        /// Creates <see cref="AppDomainSetup"/> suitable for loading Microsoft.Build, NuGet.Frameworks, and dependencies.
+        /// See https://github.com/dotnet/msbuild/blob/main/documentation/NETFramework-NGEN.md#nugetframeworks for the motivation
+        /// to use a separate AppDomain.
+        /// </summary>
+        private static AppDomainSetup CreateAppDomainSetup(AssemblyName assemblyName, string assemblyPath)
+        {
+            byte[] publicKeyToken = assemblyName.GetPublicKeyToken();
+            StringBuilder publicKeyTokenString = new(publicKeyToken.Length * 2);
+            for (int i = 0; i < publicKeyToken.Length; i++)
+            {
+                publicKeyTokenString.Append(publicKeyToken[i].ToString("x2", CultureInfo.InvariantCulture));
+            }
+
+            // Create an app.config for the AppDomain. We expect the AD to host the currently executing assembly Microsoft.Build,
+            // NuGet.Frameworks, and Framework assemblies. It is important to use the same binding redirects that were used when
+            // NGENing MSBuild for the native images to be used.
+            string configuration = $"""
+<?xml version="1.0" encoding="utf-8"?>
+  <configuration>
+    <runtime>
+      <DisableFXClosureWalk enabled="true" />
+      <DeferFXClosureWalk enabled="true" />
+      <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+        {(Environment.Is64BitProcess ? _bindingRedirects64 : _bindingRedirects32)}
+        <dependentAssembly>
+          <assemblyIdentity name="{NuGetFrameworksAssemblyName}" publicKeyToken="{publicKeyTokenString}" culture="{assemblyName.CultureName}" />
+          <codeBase version="{assemblyName.Version}" href="{assemblyPath}" />
+        </dependentAssembly>
+      </assemblyBinding>
+    </runtime>
+  </configuration>
+""";
+
+            AppDomainSetup appDomainSetup = AppDomain.CurrentDomain.SetupInformation;
+            appDomainSetup.SetConfigurationBytes(Encoding.UTF8.GetBytes(configuration));
+            return appDomainSetup;
+        }
+
+        public static NuGetFrameworkWrapper CreateInstance()
+        {
+            // Resolve the location of the NuGet.Frameworks assembly
+            string assemblyDirectory = BuildEnvironmentHelper.Instance.Mode == BuildEnvironmentMode.VisualStudio ?
+                Path.Combine(BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory, "Common7", "IDE", "CommonExtensions", "Microsoft", "NuGet") :
+                BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory;
+
+            string assemblyPath = Path.Combine(assemblyDirectory, NuGetFrameworksFileName);
+
+            NuGetFrameworkWrapper instance = null;
+            AssemblyName assemblyName = null;
+            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10) &&
+                (BuildEnvironmentHelper.Instance.RunningInMSBuildExe || BuildEnvironmentHelper.Instance.RunningInVisualStudio))
+            {
+                // If we are running in MSBuild.exe or VS, we can load the assembly with Assembly.Load, which enables
+                // the runtime to bind to the native image, eliminating some non-trivial JITting cost. Devenv.exe knows how to
+                // load the assembly by name. In MSBuild.exe, however, we don't know the version of the assembly statically so
+                // we create a separate AppDomain with the right binding redirects.
+                try
+                {
+                    assemblyName = AssemblyName.GetAssemblyName(assemblyPath);
+                    if (assemblyName != null && BuildEnvironmentHelper.Instance.RunningInMSBuildExe)
+                    {
+                        AppDomainSetup appDomainSetup = CreateAppDomainSetup(assemblyName, assemblyPath);
+                        if (appDomainSetup != null)
+                        {
+                            AppDomain appDomain = AppDomain.CreateDomain(nameof(NuGetFrameworkWrapper), null, appDomainSetup);
+                            instance = (NuGetFrameworkWrapper)appDomain.CreateInstanceAndUnwrap(Assembly.GetExecutingAssembly().FullName, typeof(NuGetFrameworkWrapper).FullName);
+                        }
+                    }
+                }
+                catch
+                {
+                    // If anything goes wrong just fall back to loading into current AD by path.
+                    instance = null;
+                    assemblyName = null;
+                }
+            }
+            try
+            {
+                instance ??= new NuGetFrameworkWrapper();
+                instance.Initialize(assemblyName, assemblyPath);
+
+                return instance;
+            }
+            catch (Exception ex)
+            {
+                throw new InternalErrorException(string.Format(AssemblyResources.GetString("NuGetAssemblyNotFound"), assemblyDirectory), ex);
+            }
+        }
+    }
+}

--- a/src/msbuild/src/Build/Utilities/NuGetFrameworkWrapper.cs
+++ b/src/msbuild/src/Build/Utilities/NuGetFrameworkWrapper.cs
@@ -1,254 +1,95 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
 using System.Collections.Generic;
-#if FEATURE_APPDOMAIN
-using System.Globalization;
-#endif
-using System.IO;
-using System.Linq;
-using System.Reflection;
 using System.Text;
-using Microsoft.Build.Framework;
-using Microsoft.Build.Shared;
 
-#nullable disable
+namespace Microsoft.Build.Evaluation;
 
-namespace Microsoft.Build.Evaluation
+/// <summary>
+/// Wraps the <c>NuGet.Frameworks</c> assembly for use during evaluation. On .NET (Core) the
+/// assembly is referenced directly at compile time; on .NET Framework it is loaded by
+/// reflection into a separate AppDomain for NGEN reasons (see
+/// <see href="https://github.com/dotnet/msbuild/blob/main/documentation/NETFramework-NGEN.md"/>).
+/// This partial holds the implementation-independent helpers shared by both paths.
+/// </summary>
+internal sealed partial class NuGetFrameworkWrapper
 {
     /// <summary>
-    /// Wraps the NuGet.Frameworks assembly, which is referenced by reflection and optionally loaded into a separate AppDomain for performance.
+    /// Formats <paramref name="version"/> with at least <paramref name="minVersionPartCount"/>
+    /// components, trimming any trailing zero parts beyond that minimum.
     /// </summary>
-    internal sealed partial class NuGetFrameworkWrapper
-#if FEATURE_APPDOMAIN
-        : MarshalByRefObject
-#endif
+    private static string GetNonZeroVersionParts(Version version, int minVersionPartCount)
     {
-        private const string NuGetFrameworksAssemblyName = "NuGet.Frameworks";
-        private const string NuGetFrameworksFileName = NuGetFrameworksAssemblyName + ".dll";
+        var nonZeroVersionParts = version.Revision == 0 ? version.Build == 0 ? version.Minor == 0 ? 1 : 2 : 3 : 4;
+        return version.ToString(Math.Max(nonZeroVersionParts, minVersionPartCount));
+    }
 
-        /// <summary>
-        /// Methods, properties, and objects used from the NuGet.Frameworks assembly.
-        /// </summary>
-        private MethodInfo ParseMethod;
-        private MethodInfo IsCompatibleMethod;
-        private object DefaultCompatibilityProvider;
-        private PropertyInfo FrameworkProperty;
-        private PropertyInfo VersionProperty;
-        private PropertyInfo PlatformProperty;
-        private PropertyInfo PlatformVersionProperty;
-        private PropertyInfo AllFrameworkVersionsProperty;
+    /// <summary>
+    /// Tiny adapter the shared <see cref="FilterTargetFrameworks{TParsed, TAdapter}"/> helper
+    /// uses to read TFM properties without committing to a concrete NuGet.Frameworks type.
+    /// The Core branch supplies a strongly-typed adapter over <c>NuGetFramework</c>; the
+    /// .NET Framework branch supplies a reflection-based adapter over <c>object</c>.
+    /// </summary>
+    private interface ITfmAdapter<TParsed>
+    {
+        TParsed Parse(string tfm);
+        string GetFramework(TParsed parsed);
+        bool GetAllFrameworkVersions(TParsed parsed);
+        Version GetVersion(TParsed parsed);
+    }
 
-        /// <summary>
-        /// Public constructor for cross-domain activation only. Use <see cref="CreateInstance"/> to instantiate.
-        /// </summary>
-        public NuGetFrameworkWrapper()
-        { }
+    /// <summary>
+    /// Filters <paramref name="incoming"/> down to the entries compatible with any entry in
+    /// <paramref name="filter"/>, where "compatible" means same framework identifier (case
+    /// insensitive) and either both sides match all versions or the parsed versions are equal.
+    /// Constraining <typeparamref name="TAdapter"/> to a value type lets the JIT specialize and
+    /// devirtualize the adapter calls, so the shared body has the same runtime profile as the
+    /// inlined per-target implementation it replaced.
+    /// </summary>
+    private static string FilterTargetFrameworks<TParsed, TAdapter>(string incoming, string filter, TAdapter adapter)
+        where TAdapter : struct, ITfmAdapter<TParsed>
+    {
+        IEnumerable<(string originalTfm, TParsed parsedTfm)> incomingFrameworks = ParseTfms(incoming, adapter);
+        IEnumerable<(string originalTfm, TParsed parsedTfm)> filterFrameworks = [..ParseTfms(filter, adapter)];
+        StringBuilder tfmList = new StringBuilder();
 
-        /// <summary>
-        /// Initialized this instance. May run in a separate AppDomain.
-        /// </summary>
-        /// <param name="assemblyName">The NuGet.Frameworks to be loaded or null to load by path.</param>
-        /// <param name="assemblyFilePath">The file path from which NuGet.Frameworks should be loaded of <paramref name="assemblyName"/> is null.</param>
-        public void Initialize(AssemblyName assemblyName, string assemblyFilePath)
+        // An incoming target framework from 'incoming' is kept if it is compatible with any of the desired target frameworks on 'filter'.
+        foreach (var l in incomingFrameworks)
         {
-            Assembly NuGetAssembly;
-            if (assemblyName != null)
+            bool keep = false;
+            foreach (var r in filterFrameworks)
             {
-                // This will load the assembly into the default load context if possible, and fall back to LoadFrom context.
-                NuGetAssembly = Assembly.Load(assemblyName);
-            }
-            else
-            {
-                NuGetAssembly = Assembly.LoadFile(assemblyFilePath);
-            }
-
-            var NuGetFramework = NuGetAssembly.GetType("NuGet.Frameworks.NuGetFramework");
-            var NuGetFrameworkCompatibilityProvider = NuGetAssembly.GetType("NuGet.Frameworks.CompatibilityProvider");
-            var NuGetFrameworkDefaultCompatibilityProvider = NuGetAssembly.GetType("NuGet.Frameworks.DefaultCompatibilityProvider");
-            ParseMethod = NuGetFramework.GetMethod("Parse", [typeof(string)]);
-            IsCompatibleMethod = NuGetFrameworkCompatibilityProvider.GetMethod("IsCompatible");
-            DefaultCompatibilityProvider = NuGetFrameworkDefaultCompatibilityProvider.GetMethod("get_Instance").Invoke(null, Array.Empty<object>());
-            FrameworkProperty = NuGetFramework.GetProperty("Framework");
-            VersionProperty = NuGetFramework.GetProperty("Version");
-            PlatformProperty = NuGetFramework.GetProperty("Platform");
-            PlatformVersionProperty = NuGetFramework.GetProperty("PlatformVersion");
-            AllFrameworkVersionsProperty = NuGetFramework.GetProperty("AllFrameworkVersions");
-        }
-
-        private object Parse(string tfm)
-        {
-            return ParseMethod.Invoke(null, [tfm]);
-        }
-
-        public string GetTargetFrameworkIdentifier(string tfm)
-        {
-            return FrameworkProperty.GetValue(Parse(tfm)) as string;
-        }
-
-        public string GetTargetFrameworkVersion(string tfm, int minVersionPartCount)
-        {
-            var version = VersionProperty.GetValue(Parse(tfm)) as Version;
-            return GetNonZeroVersionParts(version, minVersionPartCount);
-        }
-
-        public string GetTargetPlatformIdentifier(string tfm)
-        {
-            return PlatformProperty.GetValue(Parse(tfm)) as string;
-        }
-
-        public string GetTargetPlatformVersion(string tfm, int minVersionPartCount)
-        {
-            var version = PlatformVersionProperty.GetValue(Parse(tfm)) as Version;
-            return GetNonZeroVersionParts(version, minVersionPartCount);
-        }
-
-        public bool IsCompatible(string target, string candidate)
-        {
-            return Convert.ToBoolean(IsCompatibleMethod.Invoke(DefaultCompatibilityProvider, [Parse(target), Parse(candidate)]));
-        }
-
-        private string GetNonZeroVersionParts(Version version, int minVersionPartCount)
-        {
-            var nonZeroVersionParts = version.Revision == 0 ? version.Build == 0 ? version.Minor == 0 ? 1 : 2 : 3 : 4;
-            return version.ToString(Math.Max(nonZeroVersionParts, minVersionPartCount));
-        }
-
-        public string FilterTargetFrameworks(string incoming, string filter)
-        {
-            IEnumerable<(string originalTfm, object parsedTfm)> incomingFrameworks = ParseTfms(incoming);
-            IEnumerable<(string originalTfm, object parsedTfm)> filterFrameworks = ParseTfms(filter);
-            StringBuilder tfmList = new StringBuilder();
-
-            // An incoming target framework from 'incoming' is kept if it is compatible with any of the desired target frameworks on 'filter'
-            foreach (var l in incomingFrameworks)
-            {
-                if (filterFrameworks.Any(r =>
-                        (FrameworkProperty.GetValue(l.parsedTfm) as string).Equals(FrameworkProperty.GetValue(r.parsedTfm) as string, StringComparison.OrdinalIgnoreCase) &&
-                        (((Convert.ToBoolean(AllFrameworkVersionsProperty.GetValue(l.parsedTfm))) && (Convert.ToBoolean(AllFrameworkVersionsProperty.GetValue(r.parsedTfm)))) ||
-                         ((VersionProperty.GetValue(l.parsedTfm) as Version) == (VersionProperty.GetValue(r.parsedTfm) as Version)))))
+                if (adapter.GetFramework(l.parsedTfm).Equals(adapter.GetFramework(r.parsedTfm), StringComparison.OrdinalIgnoreCase) &&
+                    ((adapter.GetAllFrameworkVersions(l.parsedTfm) && adapter.GetAllFrameworkVersions(r.parsedTfm)) ||
+                     adapter.GetVersion(l.parsedTfm) == adapter.GetVersion(r.parsedTfm)))
                 {
-                    if (tfmList.Length == 0)
-                    {
-                        tfmList.Append(l.originalTfm);
-                    }
-                    else
-                    {
-                        tfmList.Append($";{l.originalTfm}");
-                    }
+                    keep = true;
+                    break;
                 }
             }
 
-            return tfmList.ToString();
-
-            IEnumerable<(string originalTfm, object parsedTfm)> ParseTfms(string desiredTargetFrameworks)
+            if (keep)
             {
-                return desiredTargetFrameworks.Split([';'], StringSplitOptions.RemoveEmptyEntries).Select(tfm =>
+                if (tfmList.Length > 0)
                 {
-                    (string originalTfm, object parsedTfm) parsed = (tfm, Parse(tfm));
-                    return parsed;
-                });
+                    tfmList.Append(';');
+                }
+
+                tfmList.Append(l.originalTfm);
             }
         }
 
-#if FEATURE_APPDOMAIN
-        /// <summary>
-        /// A null-returning InitializeLifetimeService to give the proxy an infinite lease time.
-        /// </summary>
-        public override object InitializeLifetimeService() => null;
+        return tfmList.ToString();
 
-        /// <summary>
-        /// Creates <see cref="AppDomainSetup"/> suitable for loading Microsoft.Build, NuGet.Frameworks, and dependencies.
-        /// See https://github.com/dotnet/msbuild/blob/main/documentation/NETFramework-NGEN.md#nugetframeworks for the motivation
-        /// to use a separate AppDomain.
-        /// </summary>
-        private static AppDomainSetup CreateAppDomainSetup(AssemblyName assemblyName, string assemblyPath)
+        static IEnumerable<(string originalTfm, TParsed parsedTfm)> ParseTfms(string desiredTargetFrameworks, TAdapter adapter)
         {
-            byte[] publicKeyToken = assemblyName.GetPublicKeyToken();
-            StringBuilder publicKeyTokenString = new(publicKeyToken.Length * 2);
-            for (int i = 0; i < publicKeyToken.Length; i++)
+            foreach (string tfm in desiredTargetFrameworks.Split([';'], StringSplitOptions.RemoveEmptyEntries))
             {
-                publicKeyTokenString.Append(publicKeyToken[i].ToString("x2", CultureInfo.InvariantCulture));
-            }
-
-            // Create an app.config for the AppDomain. We expect the AD to host the currently executing assembly Microsoft.Build,
-            // NuGet.Frameworks, and Framework assemblies. It is important to use the same binding redirects that were used when
-            // NGENing MSBuild for the native images to be used.
-            string configuration = $"""
-<?xml version="1.0" encoding="utf-8"?>
-  <configuration>
-    <runtime>
-      <DisableFXClosureWalk enabled="true" />
-      <DeferFXClosureWalk enabled="true" />
-      <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-        {(Environment.Is64BitProcess ? _bindingRedirects64 : _bindingRedirects32)}
-        <dependentAssembly>
-          <assemblyIdentity name="{NuGetFrameworksAssemblyName}" publicKeyToken="{publicKeyTokenString}" culture="{assemblyName.CultureName}" />
-          <codeBase version="{assemblyName.Version}" href="{assemblyPath}" />
-        </dependentAssembly>
-      </assemblyBinding>
-    </runtime>
-  </configuration>
-""";
-
-            AppDomainSetup appDomainSetup = AppDomain.CurrentDomain.SetupInformation;
-            appDomainSetup.SetConfigurationBytes(Encoding.UTF8.GetBytes(configuration));
-            return appDomainSetup;
-        }
-#endif
-
-        public static NuGetFrameworkWrapper CreateInstance()
-        {
-            // Resolve the location of the NuGet.Frameworks assembly
-            string assemblyDirectory = BuildEnvironmentHelper.Instance.Mode == BuildEnvironmentMode.VisualStudio ?
-                Path.Combine(BuildEnvironmentHelper.Instance.VisualStudioInstallRootDirectory, "Common7", "IDE", "CommonExtensions", "Microsoft", "NuGet") :
-                BuildEnvironmentHelper.Instance.CurrentMSBuildToolsDirectory;
-
-            string assemblyPath = Path.Combine(assemblyDirectory, NuGetFrameworksFileName);
-
-            NuGetFrameworkWrapper instance = null;
-            AssemblyName assemblyName = null;
-#if FEATURE_APPDOMAIN
-            if (ChangeWaves.AreFeaturesEnabled(ChangeWaves.Wave17_10) &&
-                (BuildEnvironmentHelper.Instance.RunningInMSBuildExe || BuildEnvironmentHelper.Instance.RunningInVisualStudio))
-            {
-                // If we are running in MSBuild.exe or VS, we can load the assembly with Assembly.Load, which enables
-                // the runtime to bind to the native image, eliminating some non-trivial JITting cost. Devenv.exe knows how to
-                // load the assembly by name. In MSBuild.exe, however, we don't know the version of the assembly statically so
-                // we create a separate AppDomain with the right binding redirects.
-                try
-                {
-                    assemblyName = AssemblyName.GetAssemblyName(assemblyPath);
-                    if (assemblyName != null && BuildEnvironmentHelper.Instance.RunningInMSBuildExe)
-                    {
-                        AppDomainSetup appDomainSetup = CreateAppDomainSetup(assemblyName, assemblyPath);
-                        if (appDomainSetup != null)
-                        {
-                            AppDomain appDomain = AppDomain.CreateDomain(nameof(NuGetFrameworkWrapper), null, appDomainSetup);
-                            instance = (NuGetFrameworkWrapper)appDomain.CreateInstanceAndUnwrap(Assembly.GetExecutingAssembly().FullName, typeof(NuGetFrameworkWrapper).FullName);
-                        }
-                    }
-                }
-                catch
-                {
-                    // If anything goes wrong just fall back to loading into current AD by path.
-                    instance = null;
-                    assemblyName = null;
-                }
-            }
-#endif
-            try
-            {
-                instance ??= new NuGetFrameworkWrapper();
-                instance.Initialize(assemblyName, assemblyPath);
-
-                return instance;
-            }
-            catch (Exception ex)
-            {
-                throw new InternalErrorException(string.Format(AssemblyResources.GetString("NuGetAssemblyNotFound"), assemblyDirectory), ex);
+                yield return (tfm, adapter.Parse(tfm));
             }
         }
     }
 }
+


### PR DESCRIPTION
Port of dotnet/msbuild#14047 into the VMR.

### Changes

On .NET Core, `Microsoft.Build` takes a direct compile-time `PackageReference` to `NuGet.Frameworks` (`PrivateAssets="all"`, so no new public package dependency) and calls it through normal method calls instead of reflection — avoiding the per-call `MethodInfo`/`PropertyInfo` overhead in `NuGetFrameworkWrapper`. At runtime MSBuild still binds to whatever `NuGet.Frameworks.dll` the host SDK ships.

The `#if NETFRAMEWORK` path is unchanged in behavior: it still loads `NuGet.Frameworks` into a secondary AppDomain with synthesized binding redirects so the NGEN native image is used. Shared logic (`GetNonZeroVersionParts`, plus `FilterTargetFrameworks` via a struct adapter constrained on `ITfmAdapter<TParsed>`) lives in a new partial, and the two implementations are split into `NuGetFrameworkWrapper.Direct.cs` and `NuGetFrameworkWrapper.Reflection.cs`.

### Notes

- Applied via `darc vmr cherry-pick` of the squashed PR diff, so the `src/msbuild/` content matches the upstream PR exactly (6 files, +349/−223).
- This is a preview port; the change will land normally via codeflow once dotnet/msbuild#14047 merges. `source-manifest.json` is intentionally left untouched.
- Not built locally (full VMR build); relying on CI for validation.