### PR TITLE
Fix milestone workflow skipping codeflow PRs with >300 files

### DIFF
--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -6,7 +6,12 @@ on:
     branches:
       - 'main'
       - 'release/**'
-    paths: ['src/source-manifest.json']
+    # NOTE: Intentionally NO `paths:` filter here. GitHub omits the changed-files
+    # list from the pull_request webhook payload when a PR modifies more than 300
+    # files, which makes `paths` filters silently fail to match — the workflow
+    # never runs for large codeflow PRs (e.g. dotnet/dotnet#7184, 415 files).
+    # Instead, the job below always runs on merged PRs and the script no-ops
+    # when src/source-manifest.json was not changed (see extractChildPRs).
   workflow_dispatch:
     inputs:
       dry-run:


### PR DESCRIPTION
## Problem

The `apply-milestones.yml` workflow did not auto-run for [#7184](https://github.com/dotnet/dotnet/pull/7184) (415 changed files); it had to be triggered manually.

GitHub omits the changed-files list from the `pull_request` webhook payload when a PR modifies **more than 300 files**. As a result the trigger-level `paths: ['src/source-manifest.json']` filter cannot match and the workflow is **silently skipped** for large codeflow PRs. Smaller codeflow PRs are unaffected, which is why only some were missed.

Ref: https://github.com/orgs/community/discussions/38082

## Fix

Remove the trigger-level `paths:` filter. The job's script already re-validates the manifest change via the paginated `listFiles` API (`extractChildPRs`) and no-ops when `src/source-manifest.json` was not changed, so dropping the filter is safe — it just guarantees large PRs are evaluated. This is the GitHub-recommended workaround for the 300-file payload limit.

## Skipped PRs found

Several past codeflow PRs (>300 files) were skipped by this bug; they are being milestoned manually via `workflow_dispatch`.