### PR TITLE
Remove hard requirement on nodereuse=false on CI

### DIFF
--- a/src/arcade/eng/common/tools.ps1
+++ b/src/arcade/eng/common/tools.ps1
@@ -741,13 +741,6 @@ function MSBuild() {
       Write-PipelineTelemetryError -Category 'Build' -Message 'Binary log must be enabled in CI build, or explicitly opted-out from with the -excludeCIBinarylog switch.'
       ExitWithExitCode 1
     }
-
-    # Node reuse must be disabled in CI builds unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
-    # Internal testing only; this env var will be replaced with a switch (https://github.com/dotnet/arcade/issues/17013) and must not be depended on.
-    if ($nodeReuse -and $env:MSBUILD_NODEREUSE_ENABLED -ne "1") {
-      Write-PipelineTelemetryError -Category 'Build' -Message 'Node reuse must be disabled in CI build.'
-      ExitWithExitCode 1
-    }
   }
 
   $buildTool = InitializeBuildTool

--- a/src/arcade/eng/common/tools.sh
+++ b/src/arcade/eng/common/tools.sh
@@ -496,13 +496,6 @@ function MSBuild {
       Write-PipelineTelemetryError -category 'Build'  "Binary log must be enabled in CI build, or explicitly opted-out from with the -noBinaryLog switch."
       ExitWithExitCode 1
     fi
-
-    # Node reuse must be disabled in CI builds unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
-    # Internal testing only; this env var will be replaced with a switch (https://github.com/dotnet/arcade/issues/17013) and must not be depended on.
-    if [[ "$node_reuse" == true && "${MSBUILD_NODEREUSE_ENABLED:-}" != "1" ]]; then
-      Write-PipelineTelemetryError -category 'Build'  "Node reuse must be disabled in CI build."
-      ExitWithExitCode 1
-    fi
   fi
 
   InitializeBuildTool

--- a/src/arcade/eng/common/tools.sh
+++ b/src/arcade/eng/common/tools.sh
@@ -493,7 +493,7 @@ function DotNet {
 function MSBuild {
   if [[ "$ci" == true ]]; then
     if [[ "$binary_log" != true && "$exclude_ci_binary_log" != true ]]; then
-      Write-PipelineTelemetryError -category 'Build'  "Binary log must be enabled in CI build, or explicitly opted-out from with the -noBinaryLog switch."
+      Write-PipelineTelemetryError -category 'Build'  "Binary log must be enabled in CI build, or explicitly opted-out from with the --excludeCIBinarylog switch."
       ExitWithExitCode 1
     fi
   fi


### PR DESCRIPTION
We just discussed in our msbuild sync that nodereuse=false in CI isn't what we recommend and document for our customers to use.

While there are still cases when it makes sense, forbidding it in the eng/common build scripts is wrong.