### PR TITLE
[SignTool] Open PE files read-only with shared access during verification

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.SignTool/src/ContentUtil.cs
+++ b/src/arcade/src/Microsoft.DotNet.SignTool/src/ContentUtil.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.SignTool
         {
             try
             {
-                using (var stream = new FileStream(filePath, FileMode.Open))
+                using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                 using (var peReader = new PEReader(stream))
                 {
                     return peReader.PEHeaders.CorHeader != null;
@@ -81,7 +81,7 @@ namespace Microsoft.DotNet.SignTool
         {
             const int CROSSGEN_FLAG = 4;
 
-            using (var stream = new FileStream(filePath, FileMode.Open))
+            using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             using (var peReader = new PEReader(stream))
             {
                 return ((int)peReader.PEHeaders.CorHeader.Flags & CROSSGEN_FLAG) == CROSSGEN_FLAG;
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.SignTool
         {
             try
             {
-                using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
+                using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                 {
                     if (stream.Length < 4)
                         return ExecutableType.None;

--- a/src/arcade/src/Microsoft.DotNet.SignTool/src/VerifySignatures.cs
+++ b/src/arcade/src/Microsoft.DotNet.SignTool/src/VerifySignatures.cs
@@ -147,7 +147,11 @@ namespace Microsoft.DotNet.SignTool
 
         public static SigningStatus IsSignedPE(string filePath)
         {
-            using (var stream = new FileStream(filePath, FileMode.Open))
+            // Open read-only with a shared lock. Verification only reads PE headers, so
+            // requesting write access (the FileStream(path, FileMode) default) is unnecessary
+            // and causes a sharing violation when another process (e.g. an antimalware scanner)
+            // momentarily holds the freshly-built file open.
+            using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
                 return IsSignedPE(stream);
             }


### PR DESCRIPTION
## Problem

VMR Windows signing intermittently fails with a sharing violation while SignTool inventories files to sign. Example from `dotnet-unified-build` build [1464414](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1464414) (failed on both `Windows_x64` and `Windows_x86`, across retries), in the `cecil` repo's Sign step:

```
Sign.proj(74,5): error MSB4018: The "Microsoft.DotNet.SignTool.SignToolTask" task failed unexpectedly.
System.IO.IOException: The process cannot access the file
'...\src\cecil\artifacts\bin\Mono.Cecil\Release\netstandard2.0\Mono.Cecil.dll'
because it is being used by another process.
  at System.IO.FileStream..ctor(String path, FileMode mode)
  at Microsoft.DotNet.SignTool.VerifySignatures.IsSignedPE(String filePath)
  at Microsoft.DotNet.SignTool.Configuration.ExtractSignInfo(...)
  at Microsoft.DotNet.SignTool.Configuration.GenerateListOfFiles()
```

## Root cause

`VerifySignatures.IsSignedPE` (and the sibling read-only PE inspectors `ContentUtil.IsManaged` / `IsCrossgened` / `GetExecutableType`) opened the file with `new FileStream(path, FileMode.Open)`. That constructor defaults to **`FileAccess.ReadWrite`** and **`FileShare.Read`**.

These code paths only **read** PE headers, so requesting **write** access is unnecessary — and harmful. When another process (typically Microsoft Defender / antimalware real-time scanning the just-built binary) momentarily holds the file open with `FileShare.Read`, a new open that requests **write** access is denied with `ERROR_SHARING_VIOLATION`, surfacing as "being used by another process." The failure happens in the sequential file-inventory phase (`GenerateListOfFiles`), so SignTool is not holding the file itself — the unnecessary write request is what makes a transient external read-share collide.

## Fix

Open these read-only verification streams with `FileAccess.Read` and `FileShare.ReadWrite`. Read access is all the verification needs and is compatible with a concurrent scanner's read share; offering `FileShare.ReadWrite` tolerates other holders.

- `VerifySignatures.IsSignedPE`
- `ContentUtil.IsManaged`
- `ContentUtil.IsCrossgened`
- `ContentUtil.GetExecutableType` (already `FileAccess.Read`; widened the share mode for consistency)

This makes signature verification robust to antimalware/indexer file holds and removes a recurring source of flaky Windows signing failures.

> Note: this changes mirrored Arcade sources under `src/arcade/`. It should also be ported to `dotnet/arcade` so it isn't reverted by the next code flow.
