### PR TITLE
Capture WER LocalDumps for crossgen2 on Windows VMR builds (diagnose dotnet/runtime#125699)

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -637,6 +637,23 @@ jobs:
           scriptRoot: '${{ variables.sourcesPath }}/src/runtime/eng/native/signing'
 
 
+    # Enable WER LocalDumps for crossgen2.exe so a crash dump is captured if it
+    # FailFasts during the SDK crossgen layout step. Diagnoses dotnet/runtime#125699,
+    # which has hit several times at GetAllowSynthesis+0x31 with no captured dump.
+    # Dumps land under BuildLogs and ride out via the existing 'Publish BuildLogs'
+    # 1ES output above (condition: succeededOrFailed()).
+    - pwsh: |
+        $dumpDir = "$(Build.ArtifactStagingDirectory)\BuildLogs\crossgen2-dumps"
+        New-Item -ItemType Directory -Force -Path $dumpDir | Out-Null
+        $key = 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\crossgen2.exe'
+        New-Item -Path $key -Force | Out-Null
+        Set-ItemProperty -Path $key -Name DumpFolder -Type ExpandString -Value $dumpDir
+        Set-ItemProperty -Path $key -Name DumpType   -Type DWord        -Value 2  # MiniDumpWithFullMemory
+        Set-ItemProperty -Path $key -Name DumpCount  -Type DWord        -Value 3
+        Write-Host "WER LocalDumps configured for crossgen2.exe -> $dumpDir"
+      displayName: Enable WER LocalDumps for crossgen2
+      continueOnError: true
+
     - script: build.cmd
         $(baseArguments)
         $(signArguments)


### PR DESCRIPTION
## Why

[dotnet/runtime#125699](https://github.com/dotnet/runtime/issues/125699) tracks an intermittent crash of the *shipped* `crossgen2` during the SDK crossgen layout step (`Crossgen.targets(171,5)`). Each recurrence FailFasts at the exact same site:

```
   at ILCompiler.ProfileDataManager.GetAllowSynthesis(Compilation, MethodDesc, Boolean&) + 0x31
   at Internal.JitInterface.CorInfoImpl.getPgoInstrumentationResults(...) + 0xab
   ...
```

with the symptom alternating between `NullReferenceException` and `AccessViolation` — the classic signature of heap/GC corruption rather than a logic bug at that line. So far the crash has only been observed in `dotnet-unified-build` legs (VMR), across multiple branches and on both `Windows_x86` and `Windows_x64`:

| Date       | Build | Branch                          | Leg          | Error       |
|------------|-------|---------------------------------|--------------|-------------|
| 2026-03-18 | [1339370](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1339370) (public) | VMR PR `dotnet/dotnet#5533` | Windows_x86  | AV           |
| 2026-05-20 | 2979463 (internal) | `internal/release/10.0.109`     | Windows_x86  | NRE          |
| 2026-06-16 | 3001312 (internal) | `release/10.0.4xx`              | Windows_x64  | AV           |

**No crash dump was captured in any of these runs** — only the textual stack — so we have no way to inspect heap state, thread context, or the offending `MethodDesc`. Without a dump, root-causing this is essentially blocked.

## What this PR does

Adds a pre-build step on the Windows leg of `vmr-build.yml` that configures Windows Error Reporting LocalDumps for `crossgen2.exe`:

* Dump folder: `$(Build.ArtifactStagingDirectory)\BuildLogs\crossgen2-dumps`
* `DumpType = 2` (MiniDumpWithFullMemory — needed because we suspect heap corruption)
* `DumpCount = 3`

The dumps ride out via the existing **Publish BuildLogs** 1ES output (`condition: succeededOrFailed()` on `$(Build.ArtifactStagingDirectory)/BuildLogs`), so no new artifact publish is required.

## Cost when crossgen2 doesn't crash

Zero — WER only writes dumps on actual unhandled failfast/AV. The registry write itself takes < 100 ms. `continueOnError: true` keeps the build robust if a non-admin agent ever runs the leg.

## How to remove

Once a dump is captured and `dotnet/runtime#125699` is root-caused, revert this commit.

> [!NOTE]
> Drafted with AI (GitHub Copilot) assistance.
