### PR TITLE
[release/10.0.4xx] Capture WER LocalDumps for crossgen2 (port of #7279, diagnose dotnet/runtime#125699)

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -517,6 +517,24 @@ jobs:
           serviceConnectionName: 'diagnostics-esrp-kvcertuser-pme'
 
 
+    # Enable WER LocalDumps for crossgen2.exe so a crash dump is captured if it
+    # FailFasts during the SDK crossgen layout step. Diagnoses dotnet/runtime#125699,
+    # which has hit several times at GetAllowSynthesis+0x31 with no captured dump.
+    # Dumps land under artifacts/log so they ride out via the existing
+    # 'Prepare BuildLogs staging directory' CopyFiles step (artifacts/log/**) and
+    # then the 'Publish BuildLogs' artifact.
+    - pwsh: |
+        $dumpDir = "${{ variables.sourcesPath }}\artifacts\log\crossgen2-dumps"
+        New-Item -ItemType Directory -Force -Path $dumpDir | Out-Null
+        $key = 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\crossgen2.exe'
+        New-Item -Path $key -Force | Out-Null
+        Set-ItemProperty -Path $key -Name DumpFolder -Type ExpandString -Value $dumpDir
+        Set-ItemProperty -Path $key -Name DumpType   -Type DWord        -Value 2  # MiniDumpWithFullMemory
+        Set-ItemProperty -Path $key -Name DumpCount  -Type DWord        -Value 3
+        Write-Host "WER LocalDumps configured for crossgen2.exe -> $dumpDir"
+      displayName: Enable WER LocalDumps for crossgen2
+      continueOnError: true
+
     - script: build.cmd
         $(baseArguments)
         $(signArguments)


### PR DESCRIPTION
## What

Forward-port of #7279 to `release/10.0.4xx`.

## Why

[dotnet/runtime#125699](https://github.com/dotnet/runtime/issues/125699) is the crossgen2 FailFast at `ProfileDataManager.GetAllowSynthesis+0x31` during the SDK crossgen layout step. The most recent recurrence — [build 3001312, 2026-06-16, `Windows_x64`](https://dev.azure.com/dnceng/internal/_build/results?buildId=3001312) — was on **this** branch, so it's the obvious port target.

## Difference vs main

On `release/10.0.4xx`, `BuildLogs` is populated post-build via a `CopyFiles@2` step (`artifacts/log/**`) with `CleanTargetFolder: true`, rather than via `templateContext.outputs` on `$(Build.ArtifactStagingDirectory)/BuildLogs`. Writing dumps to the staging directory would get wiped, so on this branch the dump path is `$(sourcesPath)\artifacts\log\crossgen2-dumps\`. The existing `artifacts/log/**` glob then carries them out into the BuildLogs artifact unchanged.

Everything else (DumpType 2 / DumpCount 3 / `continueOnError: true`) is identical to #7279.

> [!NOTE]
> Drafted with AI (GitHub Copilot) assistance.
