### PR TITLE
Set execute bit on bundled Native AOT SDK tool executables

### DIFF
--- a/src/sdk/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/sdk/src/Layout/redist/targets/GenerateLayout.targets
@@ -583,6 +583,16 @@
     <!-- Make dotnet-aot native shared library executable (only if it exists for this RID) -->
     <Exec Command="chmod 755 $(OutputPath)$(_DotnetAotNativeLibName)"
           Condition="Exists('$(OutputPath)$(_DotnetAotNativeLibName)')" />
+    <!-- The 'aspnetcoretools' aggregate ships native AOT SDK tool executables
+         (dotnet-dev-certs, dotnet-user-jwts, dotnet-user-secrets). Their nupkg does
+         not carry the Unix execute bit, and the blanket 'chmod 644' above clears it,
+         so re-add execute permission; the SDK execs these tools directly. -->
+    <ItemGroup>
+      <_BundledAotToolExecutable Include="$(OutputPath)DotnetTools/aspnetcoretools/**/dotnet-*"
+                                 Exclude="$(OutputPath)DotnetTools/aspnetcoretools/**/*.*" />
+    </ItemGroup>
+    <Exec Command="chmod 755 '%(_BundledAotToolExecutable.FullPath)'"
+          Condition="'@(_BundledAotToolExecutable)' != ''" />
   </Target>
 
   <Target Name="DeleteSymbolsFromPublishDir" DependsOnTargets="GenerateCliRuntimeConfigurationFiles">


### PR DESCRIPTION
The 'aspnetcoretools' aggregate ships native AOT SDK tool executables (dotnet-dev-certs, dotnet-user-jwts, dotnet-user-secrets). Their nupkg does not carry the Unix execute bit, and ChmodPublishDir's blanket 'chmod 644' clears any bit before the SDK is laid out, so the tools shipped as -rw-r--r-- and failed at runtime with 'Permission denied' (errno 13) when the SDK execs them directly.

Re-add execute permission for these executables in ChmodPublishDir, mirroring the existing Roslyn/MSBuild apphost and dotnet-aot native lib chmods.