### PR TITLE
Enable AOT-compiled SDK tools in source-build

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.targets
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.targets
@@ -58,4 +58,20 @@
     <Copyright>$(CopyrightMicrosoft)</Copyright>
   </PropertyGroup>
 
+  <!--
+    In source-build, the SDK ships native binaries with embedded debug symbols (no separate
+    symbol files and no .gnu_debuglink); this is enforced for every native ELF in the SDK by the
+    source-build native-symbol validation. Native AOT defaults StripSymbols to true on non-Windows,
+    which strips its output into a separate file and adds a .gnu_debuglink section. Disable stripping
+    for any project that publishes with Native AOT so the produced binary retains embedded DWARF.
+    This is the AOT analog of the KeepNativeSymbols=true that source-build uses for native
+    (CMake-built) binaries. Scoped to PublishAot projects so non-AOT builds are unaffected, and only
+    applies in source-build (DotNetBuildSourceOnly); Microsoft builds still strip and ship separate
+    symbols. Imported via Sdk.targets (after the project sets PublishAot) so the condition is known.
+    See https://github.com/dotnet/source-build/issues/5567.
+  -->
+  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(PublishAot)' == 'true'">
+    <StripSymbols>false</StripSymbols>
+  </PropertyGroup>
+
 </Project>

--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.targets
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.targets
@@ -59,19 +59,16 @@
   </PropertyGroup>
 
   <!--
-    In source-build, the SDK ships native binaries with embedded debug symbols (no separate
-    symbol files and no .gnu_debuglink); this is enforced for every native ELF in the SDK by the
-    source-build native-symbol validation. Native AOT defaults StripSymbols to true on non-Windows,
-    which strips its output into a separate file and adds a .gnu_debuglink section. Disable stripping
-    for any project that publishes with Native AOT so the produced binary retains embedded DWARF.
-    This is the AOT analog of the KeepNativeSymbols=true that source-build uses for native
-    (CMake-built) binaries. Scoped to PublishAot projects so non-AOT builds are unaffected, and only
-    applies in source-build (DotNetBuildSourceOnly); Microsoft builds still strip and ship separate
-    symbols. Imported via Sdk.targets (after the project sets PublishAot) so the condition is known.
-    See https://github.com/dotnet/source-build/issues/5567.
+    Source-build does not strip symbols from native binaries during the build; the binaries are
+    produced with embedded symbols and the distro packaging process is responsible for stripping
+    the symbols out of the shipping binaries and archiving those symbols separately. Native AOT
+    defaults StripSymbols to true on non-Windows, which would strip its output during the build;
+    align StripSymbols with KeepNativeSymbols so AOT-published binaries keep their symbols like
+    other native (CMake-built) binaries in source-build.
   -->
-  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(PublishAot)' == 'true'">
-    <StripSymbols>false</StripSymbols>
+  <PropertyGroup>
+    <KeepNativeSymbols Condition="'$(KeepNativeSymbols)' == '' and '$(DotNetBuildSourceOnly)' == 'true'">true</KeepNativeSymbols>
+    <StripSymbols Condition="'$(KeepNativeSymbols)' == 'true'">false</StripSymbols>
   </PropertyGroup>
 
 </Project>

--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetingPacks.BeforeCommonTargets.targets
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetingPacks.BeforeCommonTargets.targets
@@ -100,15 +100,28 @@
 
   <!--
     When .NET gets built from source, make the SDK aware there are bootstrap packages
-    for Microsoft.NETCore.App.Runtime.<rid> and Microsoft.NETCore.App.Crossgen2.<rid>.
+    for Microsoft.NETCore.App.Runtime.<rid> (including the NativeAOT-labeled runtime pack),
+    Microsoft.NETCore.App.Crossgen2.<rid>, and the ILCompiler packs
+    (runtime.<rid>.Microsoft.DotNet.ILCompiler / Microsoft.NETCore.App.Runtime.NativeAOT.<rid>).
+    The on-disk previous SDK does not list the build's non-portable RID in these RID sets, so
+    append it in-memory here. This allows publishing for the non-portable RID (e.g. self-contained,
+    ReadyToRun, and AOT) to validate and restore the matching source-built packs.
+
+    Use $(TargetRid) (the build's non-portable RID, e.g. centos.10-x64), not
+    $(NETCoreSdkRuntimeIdentifier). In a stage 1 source-build leg the previous SDK is the Microsoft
+    portable SDK, whose $(NETCoreSdkRuntimeIdentifier) is the portable RID (e.g. linux-x64) and would
+    not unblock publishing for the build's non-portable RID.
   -->
   <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <KnownRuntimePack Update="@(KnownRuntimePack->WithMetadataValue('Identity', 'Microsoft.NETCore.App'))">
-      <RuntimePackRuntimeIdentifiers>%(RuntimePackRuntimeIdentifiers);$(NETCoreSdkRuntimeIdentifier)</RuntimePackRuntimeIdentifiers>
+      <RuntimePackRuntimeIdentifiers>%(RuntimePackRuntimeIdentifiers);$(TargetRid)</RuntimePackRuntimeIdentifiers>
     </KnownRuntimePack>
     <KnownCrossgen2Pack Update="@(KnownCrossgen2Pack->WithMetadataValue('Identity', 'Microsoft.NETCore.App.Crossgen2'))">
-      <Crossgen2RuntimeIdentifiers>%(Crossgen2RuntimeIdentifiers);$(NETCoreSdkRuntimeIdentifier)</Crossgen2RuntimeIdentifiers>
+      <Crossgen2RuntimeIdentifiers>%(Crossgen2RuntimeIdentifiers);$(TargetRid)</Crossgen2RuntimeIdentifiers>
     </KnownCrossgen2Pack>
+    <KnownILCompilerPack Update="@(KnownILCompilerPack->WithMetadataValue('Identity', 'Microsoft.DotNet.ILCompiler'))">
+      <ILCompilerRuntimeIdentifiers>%(ILCompilerRuntimeIdentifiers);$(TargetRid)</ILCompilerRuntimeIdentifiers>
+    </KnownILCompilerPack>
   </ItemGroup>
 
   <!--

--- a/src/aspnetcore/eng/Build.props
+++ b/src/aspnetcore/eng/Build.props
@@ -186,7 +186,7 @@
                         Condition=" '$(BuildMainlyReferenceProviders)' != 'true' " />
         <DotNetProjects Include="$(RepoRoot)src\Tools\NativeAot\aspnetcoretools\aspnetcoretools.csproj"
                         Exclude="@(ProjectToBuild);@(ProjectToExclude);$(RepoRoot)**\bin\**\*;$(RepoRoot)**\obj\**\*"
-                        Condition=" '$(BuildMainlyReferenceProviders)' != 'true' and '$(DotNetBuildSourceOnly)' != 'true' " />
+                        Condition=" '$(BuildMainlyReferenceProviders)' != 'true' " />
         <!-- Only build the composite R2R runtime pack when we will actually ship it -->
         <DotNetProjects Include="$(RepoRoot)src\Framework\App.Runtime\src\aspnetcore-runtime-composite.proj"
                         Condition=" '$(BuildMainlyReferenceProviders)' != 'true' and '$(TargetOsName)' != 'win' " />

--- a/src/aspnetcore/src/Tools/NativeAot/aspnetcoretools/aspnetcoretools.csproj
+++ b/src/aspnetcore/src/Tools/NativeAot/aspnetcoretools/aspnetcoretools.csproj
@@ -6,13 +6,13 @@
     <PackageId>aspnetcoretools</PackageId>
     <PackAsTool>true</PackAsTool>
     <IsShippingPackage>false</IsShippingPackage>
-    <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
-    <PublishAot Condition="'$(DotNetBuildSourceOnly)' != 'true'">true</PublishAot>
+    <ExcludeFromSourceOnlyBuild>false</ExcludeFromSourceOnlyBuild>
+    <PublishAot>true</PublishAot>
     <NativeLib>Shared</NativeLib>
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
     <RuntimeIdentifiers Condition="'$(DotNetBuild)' != 'true' and '$(DotNetBuildSourceOnly)' != 'true'">$(BundledToolTargetRuntimeIdentifiers)</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="'$(DotNetBuild)' == 'true' and '$(DotNetBuildSourceOnly)' != 'true'">$(TargetRuntimeIdentifier)</RuntimeIdentifiers>
-    <RuntimeIdentifier Condition="'$(PublishAot)' == 'true' and '$(DotNetBuildSourceOnly)' != 'true' and '$(RuntimeIdentifier)' == '' and '$(TargetRuntimeIdentifier)' != ''">$(TargetRuntimeIdentifier)</RuntimeIdentifier>
+    <RuntimeIdentifiers Condition="'$(DotNetBuild)' == 'true'">$(TargetRuntimeIdentifier)</RuntimeIdentifiers>
+    <RuntimeIdentifier Condition="'$(PublishAot)' == 'true' and '$(RuntimeIdentifier)' == '' and '$(TargetRuntimeIdentifier)' != ''">$(TargetRuntimeIdentifier)</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(PublishAot)' == 'true' and '$(DotNetBuildSourceOnly)' != 'true' and '$(RuntimeIdentifier)' == ''">$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifier>
     <NoWarn>$(NoWarn);CS2008</NoWarn>
   </PropertyGroup>

--- a/src/aspnetcore/src/Tools/dotnet-dev-certs/src/dotnet-dev-certs.csproj
+++ b/src/aspnetcore/src/Tools/dotnet-dev-certs/src/dotnet-dev-certs.csproj
@@ -12,7 +12,7 @@
     <ExcludeFromSourceOnlyBuild>false</ExcludeFromSourceOnlyBuild>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+  <PropertyGroup>
     <PublishAot>true</PublishAot>
     <RuntimeIdentifiers Condition="'$(DotNetBuild)' != 'true'">$(BundledToolTargetRuntimeIdentifiers)</RuntimeIdentifiers>
     <RuntimeIdentifiers Condition="'$(DotNetBuild)' == 'true'">$(TargetRuntimeIdentifier)</RuntimeIdentifiers>

--- a/src/aspnetcore/src/Tools/dotnet-user-jwts/src/dotnet-user-jwts.csproj
+++ b/src/aspnetcore/src/Tools/dotnet-user-jwts/src/dotnet-user-jwts.csproj
@@ -13,7 +13,7 @@
     <ExcludeFromSourceOnlyBuild>false</ExcludeFromSourceOnlyBuild>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+  <PropertyGroup>
     <PublishAot>true</PublishAot>
     <RuntimeIdentifiers Condition="'$(DotNetBuild)' != 'true'">$(BundledToolTargetRuntimeIdentifiers)</RuntimeIdentifiers>
     <RuntimeIdentifiers Condition="'$(DotNetBuild)' == 'true'">$(TargetRuntimeIdentifier)</RuntimeIdentifiers>

--- a/src/aspnetcore/src/Tools/dotnet-user-secrets/src/dotnet-user-secrets.csproj
+++ b/src/aspnetcore/src/Tools/dotnet-user-secrets/src/dotnet-user-secrets.csproj
@@ -13,7 +13,7 @@
     <ExcludeFromSourceOnlyBuild>false</ExcludeFromSourceOnlyBuild>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
+  <PropertyGroup>
     <PublishAot>true</PublishAot>
     <RuntimeIdentifiers Condition="'$(DotNetBuild)' != 'true'">$(BundledToolTargetRuntimeIdentifiers)</RuntimeIdentifiers>
     <RuntimeIdentifiers Condition="'$(DotNetBuild)' == 'true'">$(TargetRuntimeIdentifier)</RuntimeIdentifiers>

--- a/src/runtime/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
+++ b/src/runtime/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
@@ -9,6 +9,15 @@
 
     <_originalTargetOS>$(RuntimeIdentifier.SubString(0, $(RuntimeIdentifier.LastIndexOf('-'))))</_originalTargetOS>
     <_originalTargetOS Condition="'$(_targetsNonPortableSdkRid)' == 'true'">$(NETCoreSdkPortableRuntimeIdentifier.SubString(0, $(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))))</_originalTargetOS>
+    <!--
+      In a source-build leg the bootstrap SDK may be portable (so $(NETCoreSdkRuntimeIdentifier) is the
+      portable RID), yet we build for the non-portable target RID ($(TargetRid), e.g. centos.10-x64).
+      The SDK already resolves the host ILCompiler pack and the target NativeAOT runtime pack correctly
+      for that case, but the target OS derived from the RID (e.g. 'centos') is not a valid ILC target OS.
+      Map it to the portable base OS (e.g. 'linux'), mirroring the non-portable SDK RID handling above,
+      without altering the host/target pack names (those must match what the SDK resolved).
+    -->
+    <_originalTargetOS Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(RuntimeIdentifier)' == '$(TargetRid)' and '$(RuntimeIdentifier)' != '$(NETCoreSdkPortableRuntimeIdentifier)'">$(NETCoreSdkPortableRuntimeIdentifier.SubString(0, $(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))))</_originalTargetOS>
     <_originalTargetOS Condition="$(_originalTargetOS.Contains('.'))">$(_originalTargetOS.SubString(0, $(_originalTargetOS.IndexOf('.'))))</_originalTargetOS>
     <_originalTargetOS Condition="$(_originalTargetOS.StartsWith('win'))">win</_originalTargetOS>
 

--- a/src/runtime/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
+++ b/src/runtime/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
@@ -10,14 +10,14 @@
     <_originalTargetOS>$(RuntimeIdentifier.SubString(0, $(RuntimeIdentifier.LastIndexOf('-'))))</_originalTargetOS>
     <_originalTargetOS Condition="'$(_targetsNonPortableSdkRid)' == 'true'">$(NETCoreSdkPortableRuntimeIdentifier.SubString(0, $(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))))</_originalTargetOS>
     <!--
-      In a source-build leg the bootstrap SDK may be portable (so $(NETCoreSdkRuntimeIdentifier) is the
-      portable RID), yet we build for the non-portable target RID ($(TargetRid), e.g. centos.10-x64).
-      The SDK already resolves the host ILCompiler pack and the target NativeAOT runtime pack correctly
-      for that case, but the target OS derived from the RID (e.g. 'centos') is not a valid ILC target OS.
-      Map it to the portable base OS (e.g. 'linux'), mirroring the non-portable SDK RID handling above,
-      without altering the host/target pack names (those must match what the SDK resolved).
+      A non-portable RID (e.g. 'centos.10-x64') yields a version-qualified OS token ('centos.10')
+      that is not a valid ILC target OS. This happens when the running SDK is portable, so the RID is
+      not the SDK's own RID handled above, yet publishing targets a non-portable RID. Map the
+      version-qualified token to the portable base OS the SDK reports (e.g. 'linux'), mirroring the
+      non-portable SDK RID handling above. The SDK still resolves the host/target packs by the full
+      RID; only the ILC target OS needs normalizing.
     -->
-    <_originalTargetOS Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(RuntimeIdentifier)' == '$(TargetRid)' and '$(RuntimeIdentifier)' != '$(NETCoreSdkPortableRuntimeIdentifier)'">$(NETCoreSdkPortableRuntimeIdentifier.SubString(0, $(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))))</_originalTargetOS>
+    <_originalTargetOS Condition="'$(_targetsNonPortableSdkRid)' != 'true' and $(_originalTargetOS.Contains('.'))">$(NETCoreSdkPortableRuntimeIdentifier.SubString(0, $(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))))</_originalTargetOS>
     <_originalTargetOS Condition="$(_originalTargetOS.Contains('.'))">$(_originalTargetOS.SubString(0, $(_originalTargetOS.IndexOf('.'))))</_originalTargetOS>
     <_originalTargetOS Condition="$(_originalTargetOS.StartsWith('win'))">win</_originalTargetOS>
 

--- a/src/sdk/src/Layout/redist/targets/BundledDotnetTools.targets
+++ b/src/sdk/src/Layout/redist/targets/BundledDotnetTools.targets
@@ -9,26 +9,7 @@
 
   <ItemGroup Condition="'$(IncludeAspNetCoreRuntime)' != 'false'">
     <BundledDotnetTool Include="aspnetcoretools"
-                       Condition="'$(DotNetBuildSourceOnly)' != 'true'"
                        Version="$(MicrosoftAspNetCoreAppRefPackageVersion)"
-                       ObsoletesCliTool="Microsoft.Extensions.SecretManager.Tools"
-                       RidSpecificPackageRids="$(AspNetCoreRidSpecificToolPackageRids)"
-                       RidSpecificPackageVersion="$(MicrosoftAspNetCoreAppRefPackageVersion)" />
-    <!-- Source-only builds do not publish the Native AOT aggregate executable. -->
-    <!-- RID-specific tool packages are produced by aspnetcore and use the current aspnetcore package version. -->
-    <BundledDotnetTool Include="dotnet-dev-certs"
-                       Condition="'$(DotNetBuildSourceOnly)' == 'true'"
-                       Version="$(DotnetDevCertsPackageVersion)"
-                       RidSpecificPackageRids="$(AspNetCoreRidSpecificToolPackageRids)"
-                       RidSpecificPackageVersion="$(MicrosoftAspNetCoreAppRefPackageVersion)" />
-    <BundledDotnetTool Include="dotnet-user-jwts"
-                       Condition="'$(DotNetBuildSourceOnly)' == 'true'"
-                       Version="$(DotnetUserJwtsPackageVersion)"
-                       RidSpecificPackageRids="$(AspNetCoreRidSpecificToolPackageRids)"
-                       RidSpecificPackageVersion="$(MicrosoftAspNetCoreAppRefPackageVersion)" />
-    <BundledDotnetTool Include="dotnet-user-secrets"
-                       Condition="'$(DotNetBuildSourceOnly)' == 'true'"
-                       Version="$(DotnetUserSecretsPackageVersion)"
                        ObsoletesCliTool="Microsoft.Extensions.SecretManager.Tools"
                        RidSpecificPackageRids="$(AspNetCoreRidSpecificToolPackageRids)"
                        RidSpecificPackageVersion="$(MicrosoftAspNetCoreAppRefPackageVersion)" />
@@ -52,7 +33,7 @@
           Condition="'@(BundledDotnetTool)' != ''">
     <ItemGroup>
       <_RidSpecificBundledDotnetTool Include="@(BundledDotnetTool)"
-                                      Condition="'$(DotNetBuildSourceOnly)' != 'true' and '%(BundledDotnetTool.RidSpecificPackageRids)' != ''">
+                                      Condition="'%(BundledDotnetTool.RidSpecificPackageRids)' != ''">
         <ToolId>%(BundledDotnetTool.Identity)</ToolId>
         <ToolVersion>%(BundledDotnetTool.RidSpecificPackageVersion)</ToolVersion>
         <ToolVersion Condition="'%(BundledDotnetTool.RidSpecificPackageVersion)' == ''">%(BundledDotnetTool.Version)</ToolVersion>


### PR DESCRIPTION
The SDK bundles three ASP.NET Core CLI tools (dotnet-dev-certs, dotnet-user-jwts, dotnet-user-secrets) as a Native AOT aggregate, but AOT publishing of these tools only worked in the Microsoft build. In source-build it failed in two ways: restore could not find a portable-RID runtime pack (`NU1102`), and once scoped to the build's non-portable RID the previous SDK rejected the project with `NETSDK1203` ("Ahead-of-time compilation is not supported for the target runtime identifier"). The root cause is that every repo in the VMR builds against a previous SDK; in a stage 1 source-build leg that SDK is the Microsoft portable SDK, whose bundled props do not list the build's non-portable RID (e.g. `centos.10-x64`) in the ILCompiler/runtime-pack RID sets and whose packs/ folder has no NativeAOT pack for that RID.

Teach the previous SDK about the source-built non-portable RID and unblock AOT publishing, then ship the resulting aggregate in source-build. Fixes dotnet/source-build#5567.

Also dependent on https://github.com/dotnet/dotnet/pull/7297