### PR TITLE
[no review, do not merge, for validation] Make restore process state resettable + run RestoreTask in the main process (retire the #13315 transient-TaskHost workaround)

### DIFF
--- a/src/msbuild/src/Build.UnitTests/BackEnd/TaskRouter_IntegrationTests.cs
+++ b/src/msbuild/src/Build.UnitTests/BackEnd/TaskRouter_IntegrationTests.cs
@@ -385,20 +385,23 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         }
 
         [Fact]
-        public void RequiresTransientTaskHost_ReturnsTrueForRestoreTask()
+        public void NeedsTaskHostInMultiThreadedMode_RestoreTask_RunsInMainProcess()
         {
-            TaskRouter.RequiresTransientTaskHost(typeof(NuGet.Build.Tasks.RestoreTask)).ShouldBeTrue();
+            // RestoreTask resets its own static state, so it runs in the main process (no TaskHost) despite having
+            // no MSBuildMultiThreadableTaskAttribute.
+            TaskRouter.NeedsTaskHostInMultiThreadedMode(typeof(NuGet.Build.Tasks.RestoreTask)).ShouldBeFalse();
         }
 
         [Fact]
-        public void RequiresTransientTaskHost_ReturnsFalseForRegularTask()
+        public void NeedsTaskHostInMultiThreadedMode_RegularNonEnlightenedTask_NeedsTaskHost()
         {
-            TaskRouter.RequiresTransientTaskHost(typeof(NonEnlightenedTestTask)).ShouldBeFalse();
-            TaskRouter.RequiresTransientTaskHost(typeof(AttributeTestTask)).ShouldBeFalse();
+            // A regular task without the attribute is still isolated in a TaskHost sidecar.
+            TaskRouter.NeedsTaskHostInMultiThreadedMode(typeof(NonEnlightenedTestTask)).ShouldBeTrue();
+            TaskRouter.NeedsTaskHostInMultiThreadedMode(typeof(AttributeTestTask)).ShouldBeFalse();
         }
 
         [Fact]
-        public void RequiresTransientTaskHost_RoutedToTaskHost_InMultiThreadedMode()
+        public void RestoreTask_RunsInMainProcess_InMultiThreadedMode()
         {
             string projectContent = $@"
 <Project>
@@ -432,12 +435,12 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             BuildResult result = buildManager.Build(buildParameters, buildRequestData);
 
             result.OverallResult.ShouldBe(BuildResultCode.Success);
-            TaskRouterTestHelper.AssertTaskUsedTaskHost(logger, "RestoreTask");
+            TaskRouterTestHelper.AssertTaskRanInProcess(logger, "RestoreTask");
             logger.FullLog.ShouldContain("RestoreTask executed");
         }
 
         [Fact]
-        public void RequiresTransientTaskHost_RoutedToTaskHost_InServerMode()
+        public void RestoreTask_RunsInMainProcess_InServerMode()
         {
             string projectContent = $@"
 <Project>
@@ -475,12 +478,12 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
             BuildResult result = buildManager.Build(buildParameters, buildRequestData);
 
             result.OverallResult.ShouldBe(BuildResultCode.Success);
-            TaskRouterTestHelper.AssertTaskUsedTaskHost(logger, "RestoreTask");
+            TaskRouterTestHelper.AssertTaskRanInProcess(logger, "RestoreTask");
             logger.FullLog.ShouldContain("RestoreTask executed");
         }
 
         [Fact]
-        public void RequiresTransientTaskHost_GetsFreshProcess_OnEachInvocation_InMultiThreadedMode()
+        public void RestoreTask_RunsInSameProcess_AcrossBuilds_InMultiThreadedMode()
         {
             string projectContent = $@"
 <Project>
@@ -491,7 +494,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
     </Target>
 </Project>";
 
-            string projectFile = Path.Combine(_testProjectsDir, "RestoreTaskFreshProcess.proj");
+            string projectFile = Path.Combine(_testProjectsDir, "RestoreTaskSameProcess.proj");
             File.WriteAllText(projectFile, projectContent);
 
             var logger = new MockLogger(_output);
@@ -500,10 +503,6 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 MultiThreaded = true,
                 Loggers = [logger],
                 DisableInProcNode = false,
-
-                // Reuse must stay ON so we test the workaround, not natural process death.
-                // With reuse off the test cannot distinguish "transient TaskHost (workaround)"
-                // from "sidecar TaskHost that happened to die between builds".
                 EnableNodeReuse = true,
             };
 
@@ -514,25 +513,25 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 ["TestTarget"],
                 null);
 
-            // Two separate Build cycles. The workaround forces nodeReuse=false on the spawned
-            // TaskHost so it dies at EndBuild, giving the next Build a fresh process.
+            // Two separate Build cycles. RestoreTask now runs in the main (in-proc) process and relies on NuGet's
+            // per-restore reset rather than process death, so both builds execute it in the SAME process.
             BuildManager buildManager = BuildManager.DefaultBuildManager;
             BuildResult result1 = buildManager.Build(buildParameters, buildRequestData);
             BuildResult result2 = buildManager.Build(buildParameters, buildRequestData);
 
             result1.OverallResult.ShouldBe(BuildResultCode.Success);
             result2.OverallResult.ShouldBe(BuildResultCode.Success);
-            TaskRouterTestHelper.AssertTaskUsedTaskHost(logger, "RestoreTask");
+            TaskRouterTestHelper.AssertTaskRanInProcess(logger, "RestoreTask");
 
             int[] pids = ExtractReportedPids(logger.FullLog);
 
             pids.Length.ShouldBe(2, $"Expected two RestoreTask invocations to log a PID. Log:{Environment.NewLine}{logger.FullLog}");
-            pids[0].ShouldNotBe(pids[1], "Each build must spawn a fresh TaskHost so NuGet static state cannot leak across builds.");
-            pids.ShouldNotContain(Process.GetCurrentProcess().Id, "TaskHost should be out-of-process from the test runner.");
+            pids[0].ShouldBe(pids[1], "RestoreTask now runs in the main process across builds; its static state is reset per restore rather than reclaimed by process death.");
+            pids[0].ShouldBe(Process.GetCurrentProcess().Id, "RestoreTask runs in the main (in-proc) process.");
         }
 
         [Fact]
-        public void RequiresTransientTaskHost_GetsFreshProcess_OnEachInvocation_InServerMode()
+        public void RestoreTask_RunsInSameProcess_AcrossBuilds_InServerMode()
         {
             string projectContent = $@"
 <Project>
@@ -543,7 +542,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
     </Target>
 </Project>";
 
-            string projectFile = Path.Combine(_testProjectsDir, "RestoreTaskFreshProcessServer.proj");
+            string projectFile = Path.Combine(_testProjectsDir, "RestoreTaskSameProcessServer.proj");
             File.WriteAllText(projectFile, projectContent);
 
             var logger = new MockLogger(_output);
@@ -552,8 +551,6 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 MultiThreaded = false,
                 Loggers = [logger],
                 DisableInProcNode = false,
-
-                // Reuse must stay ON so we test the workaround, not natural process death.
                 EnableNodeReuse = true,
 
                 // Simulate running under the MSBuild Server.
@@ -567,21 +564,19 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
                 ["TestTarget"],
                 null);
 
-            // Two separate Build cycles. The workaround forces nodeReuse=false on the spawned
-            // TaskHost so it dies at EndBuild, giving the next Build a fresh process.
             BuildManager buildManager = BuildManager.DefaultBuildManager;
             BuildResult result1 = buildManager.Build(buildParameters, buildRequestData);
             BuildResult result2 = buildManager.Build(buildParameters, buildRequestData);
 
             result1.OverallResult.ShouldBe(BuildResultCode.Success);
             result2.OverallResult.ShouldBe(BuildResultCode.Success);
-            TaskRouterTestHelper.AssertTaskUsedTaskHost(logger, "RestoreTask");
+            TaskRouterTestHelper.AssertTaskRanInProcess(logger, "RestoreTask");
 
             int[] pids = ExtractReportedPids(logger.FullLog);
 
             pids.Length.ShouldBe(2, $"Expected two RestoreTask invocations to log a PID. Log:{Environment.NewLine}{logger.FullLog}");
-            pids[0].ShouldNotBe(pids[1], "Each build must spawn a fresh TaskHost so NuGet static state cannot leak across builds.");
-            pids.ShouldNotContain(Process.GetCurrentProcess().Id, "TaskHost should be out-of-process from the test runner.");
+            pids[0].ShouldBe(pids[1], "RestoreTask now runs in the long-lived host process across builds; its static state is reset per restore.");
+            pids[0].ShouldBe(Process.GetCurrentProcess().Id, "RestoreTask runs in the main (in-proc) process.");
         }
 
         private static int[] ExtractReportedPids(string log)
@@ -596,7 +591,7 @@ namespace Microsoft.Build.Engine.UnitTests.BackEnd
         }
 
         [Fact]
-        public void RequiresTransientTaskHost_RunsInProcess_WhenNoMTOrServer()
+        public void RestoreTask_RunsInProcess_WhenNoMTOrServer()
         {
             string projectContent = $@"
 <Project>

--- a/src/msbuild/src/Build/BackEnd/Components/RequestBuilder/TaskRouter.cs
+++ b/src/msbuild/src/Build/BackEnd/Components/RequestBuilder/TaskRouter.cs
@@ -49,6 +49,15 @@ namespace Microsoft.Build.BackEnd
     {
         ArgumentNullException.ThrowIfNull(taskType);
 
+        // NuGet's RestoreTask is not annotated as multi-threadable, but it now resets its own process-wide static
+        // state at the start and end of every restore (via NuGet's reset registry). It therefore runs in the main
+        // process rather than an isolated TaskHost: the reset keeps the long-lived process clean across restores,
+        // which replaces the previous transient-TaskHost workaround for https://github.com/dotnet/msbuild/issues/13315.
+        if (RunsInMainProcessDespiteNoAttribute(taskType))
+        {
+            return false;
+        }
+
         // Tasks without the thread-safety attribute need isolation in a TaskHost sidecar
         return !HasMultiThreadableTaskAttribute(taskType);
     }
@@ -84,34 +93,24 @@ namespace Microsoft.Build.BackEnd
         }
 
         /// <summary>
-        /// Full name of a task whose static singleton state makes it unsafe to run in a
-        /// long-lived sidecar TaskHost (which persists across invocations). Such tasks must
-        /// instead run in an explicit (transient) TaskHost that terminates after execution,
-        /// ensuring static state is cleaned up.
-        /// This is a temporary workaround until the task authors fix their static state issues.
-        /// See https://github.com/dotnet/msbuild/issues/13315
+        /// Full name of a task that runs in the main process in multi-threaded / long-lived-host mode even though it
+        /// carries no <c>MSBuildMultiThreadableTaskAttribute</c>. NuGet's <c>RestoreTask</c> qualifies because it
+        /// resets its own process-wide static state around every restore, so it neither needs a sidecar TaskHost for
+        /// isolation nor the transient (per-invocation) TaskHost that previously worked around its static-state leak
+        /// (https://github.com/dotnet/msbuild/issues/13315). Matched by full name, not assembly identity, consistent
+        /// with the attribute detection above.
         /// </summary>
-        private const string TaskRequiringTransientTaskHostFullName = "NuGet.Build.Tasks.RestoreTask";
+        private const string MainProcessTaskFullName = "NuGet.Build.Tasks.RestoreTask";
 
         /// <summary>
-        /// Determines if a task must be routed to an explicit (transient) TaskHost rather than
-        /// a reusable sidecar, because its static singleton state would leak across invocations.
-        /// Such tasks should run in a TaskHost that terminates after execution so all static
-        /// state is cleaned up.
+        /// Determines whether the task is the known restore entry point that runs in the main process despite having
+        /// no multi-threadable attribute (see <see cref="MainProcessTaskFullName" />).
         /// </summary>
         /// <param name="taskType">The type of the task to evaluate.</param>
-        /// <returns>True if the task requires a transient TaskHost; false otherwise.</returns>
-        public static bool RequiresTransientTaskHost(Type taskType)
+        /// <returns>True if the task runs in the main process; false otherwise.</returns>
+        private static bool RunsInMainProcessDespiteNoAttribute(Type taskType)
         {
-            ArgumentNullException.ThrowIfNull(taskType);
-
-            string? fullName = taskType.FullName;
-            if (fullName is null)
-            {
-                return false;
-            }
-
-            return string.Equals(fullName, TaskRequiringTransientTaskHostFullName, StringComparison.Ordinal);
+            return string.Equals(taskType.FullName, MainProcessTaskFullName, StringComparison.Ordinal);
         }
 
         /// <summary>

--- a/src/msbuild/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
+++ b/src/msbuild/src/Build/Instance/TaskFactories/AssemblyTaskFactory.cs
@@ -336,23 +336,6 @@ namespace Microsoft.Build.BackEnd
                 }
             }
 
-            // Workaround for tasks whose static singleton state would leak across invocations
-            // (e.g., NuGet RestoreTask). In MT mode or when MSBuild server is active, these tasks
-            // must run in a transient (non-sidecar) TaskHost so static state is cleaned up after
-            // each invocation. See https://github.com/dotnet/msbuild/issues/13315
-            bool forceTransientTaskHost = false;
-            if (_loadedType?.Type != null && TaskRouter.RequiresTransientTaskHost(_loadedType.Type))
-            {
-                bool isMultiThreaded = buildComponentHost?.BuildParameters?.MultiThreaded == true;
-                bool isLongLivedHost = buildComponentHost?.BuildParameters?.IsLongLivedHost == true;
-
-                if (isMultiThreaded || isLongLivedHost)
-                {
-                    useTaskFactory = true;
-                    forceTransientTaskHost = true;
-                }
-            }
-
             taskLoggingContext?.TargetLoggingContext?.ProjectLoggingContext?.ProjectTelemetry?.AddTaskExecution(GetType().FullName, isTaskHost: useTaskFactory);
 
             if (useTaskFactory)
@@ -367,9 +350,7 @@ namespace Microsoft.Build.BackEnd
                 // If the task host factory is explicitly requested, do not act as a sidecar task host.
                 // This is important as customers use task host factories for short lived tasks to release
                 // potential locks.
-                // Also disable sidecar for tasks that require a transient TaskHost so their
-                // static state is cleaned up between invocations.
-                bool useSidecarTaskHost = !forceTransientTaskHost && !(_factoryIdentityParameters.TaskHostFactoryExplicitlyRequested ?? false);
+                bool useSidecarTaskHost = !(_factoryIdentityParameters.TaskHostFactoryExplicitlyRequested ?? false);
 
                 TaskHostTask task = new(
                     taskLocation,

--- a/src/nuget-client/build/Shared/NuGetFeatureFlags.cs
+++ b/src/nuget-client/build/Shared/NuGetFeatureFlags.cs
@@ -12,8 +12,18 @@ namespace NuGet.Shared
         internal const string UseSystemTextJsonDeserializationSwitchName = "NuGet.UseSystemTextJsonDeserialization";
         internal const string UseSystemTextJsonDeserializationEnvVar = "NUGET_USE_SYSTEM_TEXT_JSON_DESERIALIZATION";
 
-        private static readonly Lazy<bool> _isSystemTextJsonDeserializationEnabledByEnvironment =
+        static NuGetFeatureFlags()
+        {
+            NuGetProcessState.RegisterResetAction(NuGetProcessState.ResetKey.StartRestore, ResetCache);
+        }
+
+        private static Lazy<bool> _isSystemTextJsonDeserializationEnabledByEnvironment =
             new Lazy<bool>(() => IsSystemTextJsonDeserializationEnabledByEnvironment(EnvironmentVariableWrapper.Instance));
+
+        /// <summary>Re-reads <c>NUGET_USE_SYSTEM_TEXT_JSON_DESERIALIZATION</c> from the current environment.</summary>
+        internal static void ResetCache() =>
+            _isSystemTextJsonDeserializationEnabledByEnvironment =
+                new Lazy<bool>(() => IsSystemTextJsonDeserializationEnabledByEnvironment(EnvironmentVariableWrapper.Instance));
 
         /// <summary>Feature switch for System.Text.Json deserialization. Defaults to <see langword="false"/> (Newtonsoft is the default).</summary>
         [FeatureSwitchDefinition(UseSystemTextJsonDeserializationSwitchName)]

--- a/src/nuget-client/src/NuGet.Core/NuGet.Build.Tasks.Console/Program.cs
+++ b/src/nuget-client/src/NuGet.Core/NuGet.Build.Tasks.Console/Program.cs
@@ -60,6 +60,11 @@ namespace NuGet.Build.Tasks.Console
 
                 NuGet.Common.Migrations.MigrationRunner.Run();
 
+                // This out-of-proc static-graph restore process is spawned fresh per restore (it is one-shot), so
+                // there is no stale state to clear today; this is the correct place for the start-of-restore reset
+                // and keeps it symmetric with the in-proc restore tasks should the process ever be reused.
+                NuGet.Common.NuGetProcessState.Reset(NuGet.Common.NuGetProcessState.ResetKey.StartRestore);
+
                 // Parse command-line arguments
                 if (!TryParseArguments(args, () => System.Console.OpenStandardInput(), System.Console.Error, out (Dictionary<string, string> Options, FileInfo MSBuildExeFilePath, string EntryProjectFilePath, Dictionary<string, string> MSBuildGlobalProperties) arguments))
                 {

--- a/src/nuget-client/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/nuget-client/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -36,6 +36,44 @@ namespace NuGet.Build.Tasks
 {
     public static class BuildTasksUtility
     {
+        private static readonly object ProcessStateResetGate = new object();
+
+        private static readonly object ProcessStateResetSentinelKey = new object();
+
+        /// <summary>
+        /// Re-reads NuGet's environment-derived process state (<see cref="NuGetProcessState.ResetKey.StartRestore" />)
+        /// at most once per build on each MSBuild node.
+        /// </summary>
+        /// <remarks>
+        /// Restore runs many tasks per project, in parallel and across worker nodes, so the start-of-restore reset
+        /// must run exactly once on a given node rather than once per task. The guard is scoped to the current build
+        /// via the MSBuild registered-task-object registry: the first task to reach it performs the reset and records
+        /// a build-lifetime sentinel; later tasks on the same node observe the sentinel and skip. When a node is
+        /// reused for a subsequent build the sentinel is gone, so the environment is re-read again. The reset itself
+        /// is idempotent, so the rare engine without <see cref="IBuildEngine4" /> simply resets unconditionally.
+        /// </remarks>
+        internal static void ResetProcessStateOncePerBuild(IBuildEngine buildEngine)
+        {
+            if (buildEngine is IBuildEngine4 buildEngine4)
+            {
+                lock (ProcessStateResetGate)
+                {
+                    if (buildEngine4.GetRegisteredTaskObject(ProcessStateResetSentinelKey, RegisteredTaskObjectLifetime.Build) != null)
+                    {
+                        return;
+                    }
+
+                    NuGetProcessState.Reset(NuGetProcessState.ResetKey.StartRestore);
+
+                    buildEngine4.RegisterTaskObject(ProcessStateResetSentinelKey, ProcessStateResetSentinelKey, RegisteredTaskObjectLifetime.Build, allowEarlyCollection: false);
+                }
+            }
+            else
+            {
+                NuGetProcessState.Reset(NuGetProcessState.ResetKey.StartRestore);
+            }
+        }
+
         /// <summary>
         /// Add all restorable projects to the restore list.
         /// This is the behavior for --recursive

--- a/src/nuget-client/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectStyleTask.cs
+++ b/src/nuget-client/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectStyleTask.cs
@@ -46,6 +46,11 @@ namespace NuGet.Build.Tasks
 
         public override bool Execute()
         {
+            // This is the first restore-specific NuGet task to run for each project, on the entry node and on every
+            // worker node, so it is where a reused process re-reads its environment-derived caches. The call is
+            // guarded to run at most once per build on each node even though projects invoke this task in parallel.
+            BuildTasksUtility.ResetProcessStateOncePerBuild(BuildEngine);
+
             var log = new MSBuildLogger(Log);
 
             var result = BuildTasksUtility.GetProjectRestoreStyle(RestoreProjectStyle, HasPackageReferenceItems, MSBuildProjectDirectory, MSBuildProjectName, log);

--- a/src/nuget-client/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/nuget-client/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -145,6 +145,11 @@ namespace NuGet.Build.Tasks
 
             NuGet.Common.Migrations.MigrationRunner.Run();
 
+            // Re-read environment-derived caches at the start of this restore so a reused process observes the current
+            // environment. This normally happens in the first restore task on each node (GetRestoreProjectStyleTask);
+            // the call here is a guarded backstop that no-ops if that task already reset this node for this build.
+            BuildTasksUtility.ResetProcessStateOncePerBuild(BuildEngine);
+
             try
             {
                 return ExecuteAsync(log).Result;
@@ -159,6 +164,12 @@ namespace NuGet.Build.Tasks
             {
                 ExceptionUtilities.LogException(e, log);
                 return false;
+            }
+            finally
+            {
+                // End of restore on the entry node: tear down plugin processes that the per-build process exit used to
+                // reclaim. RestoreTask runs once per restore, so this needs no parallel-invocation guard.
+                NuGet.Common.NuGetProcessState.Reset(NuGet.Common.NuGetProcessState.ResetKey.EndRestore);
             }
         }
 

--- a/src/nuget-client/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/nuget-client/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -26,6 +26,11 @@ namespace NuGet.Commands
     /// </summary>
     public class SourceRepositoryDependencyProvider : IRemoteDependencyProvider
     {
+        static SourceRepositoryDependencyProvider()
+        {
+            NuGet.Common.NuGetProcessState.RegisterResetAction(NuGet.Common.NuGetProcessState.ResetKey.StartRestore, ResetCache);
+        }
+
         private readonly object _lock = new object();
         private readonly SourceRepository _sourceRepository;
         private readonly ILogger _logger;
@@ -41,7 +46,18 @@ namespace NuGet.Commands
         private readonly TaskResultCache<LibraryRange, LibraryIdentity> _libraryMatchCache = new();
 
         // Limiting concurrent requests to limit the amount of files open at a time.
-        private readonly static SemaphoreSlim _throttle = GetThrottleSemaphoreSlim(EnvironmentVariableWrapper.Instance);
+        private static SemaphoreSlim _throttle = GetThrottleSemaphoreSlim(EnvironmentVariableWrapper.Instance);
+
+        /// <summary>
+        /// Recreates the shared concurrency throttle from the current environment (<c>NUGET_CONCURRENCY_LIMIT</c>),
+        /// disposing the previous one. The caller must ensure no restore is in flight.
+        /// </summary>
+        internal static void ResetCache()
+        {
+            SemaphoreSlim previous = Interlocked.Exchange(ref _throttle, GetThrottleSemaphoreSlim(EnvironmentVariableWrapper.Instance));
+            previous?.Dispose();
+        }
+
         internal static SemaphoreSlim GetThrottleSemaphoreSlim(IEnvironmentVariableReader env)
         {
             // Determine default concurrency limit based on operating system constraints.

--- a/src/nuget-client/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
+++ b/src/nuget-client/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
@@ -30,6 +30,22 @@ namespace NuGet.Common
 
         internal static IEnvironmentVariableReader EnvironmentVariableReader { get; set; } = EnvironmentVariableWrapper.Instance;
 
+        static ConcurrencyUtilities()
+        {
+            NuGetProcessState.RegisterResetAction(NuGetProcessState.ResetKey.StartRestore, ResetEnvironmentCaches);
+        }
+
+        /// <summary>
+        /// Clears the environment-derived caches (the delete-on-close opt-in and the lock-file base path) so they
+        /// are re-read from the current environment on next use. The base path also derives from the NuGet temp
+        /// directory; callers should reset <see cref="NuGetEnvironment" /> as well.
+        /// </summary>
+        internal static void ResetEnvironmentCaches()
+        {
+            _useDeleteOnClose = null;
+            _basePath = null;
+        }
+
         public async static Task<T> ExecuteWithFileLockedAsync<T>(string filePath,
             Func<CancellationToken, Task<T>> action,
             CancellationToken token)

--- a/src/nuget-client/src/NuGet.Core/NuGet.Common/Logging/ExceptionLogger.cs
+++ b/src/nuget-client/src/NuGet.Core/NuGet.Common/Logging/ExceptionLogger.cs
@@ -7,9 +7,15 @@ namespace NuGet.Common
 {
     public class ExceptionLogger
     {
+        static ExceptionLogger()
+        {
+            NuGetProcessState.RegisterResetAction(NuGetProcessState.ResetKey.StartRestore, ResetInstance);
+        }
+
         public ExceptionLogger(IEnvironmentVariableReader reader)
         {
-            // We can cache this value since environment variables should be fixed during runtime.
+            // We can cache this value since environment variables should be fixed during a restore. In a host that
+            // reuses the process across builds, ResetInstance re-reads it at the start of the next restore.
             ShowStack = ShouldShowStack(reader);
         }
 
@@ -36,6 +42,12 @@ namespace NuGet.Common
             return string.Equals(rawShowStack.Trim(), "true", StringComparison.OrdinalIgnoreCase);
         }
 
-        public static ExceptionLogger Instance { get; } = new ExceptionLogger(EnvironmentVariableWrapper.Instance);
+        public static ExceptionLogger Instance { get; private set; } = new ExceptionLogger(EnvironmentVariableWrapper.Instance);
+
+        /// <summary>
+        /// Recreates <see cref="Instance" /> from the current environment so a reused process observes the
+        /// current <c>NUGET_SHOW_STACK</c> value on the next restore.
+        /// </summary>
+        internal static void ResetInstance() => Instance = new ExceptionLogger(EnvironmentVariableWrapper.Instance);
     }
 }

--- a/src/nuget-client/src/NuGet.Core/NuGet.Common/NuGetProcessState.cs
+++ b/src/nuget-client/src/NuGet.Core/NuGet.Common/NuGetProcessState.cs
@@ -1,0 +1,79 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+
+namespace NuGet.Common
+{
+    /// <summary>
+    /// A small, generic registry in the lowest-common NuGet assembly. Any NuGet code can contribute a reset
+    /// action for a <see cref="ResetKey" />, and a caller (restore) can execute all actions for one key. This is
+    /// the only public surface for the feature: each cache or resource stays internal to its own type and simply
+    /// registers a delegate (typically from its static constructor); restore invokes them by key so a host that
+    /// reuses the process across builds behaves as if it had started fresh.
+    /// </summary>
+    public static class NuGetProcessState
+    {
+        /// <summary>The reset points restore drives.</summary>
+        public enum ResetKey
+        {
+            /// <summary>
+            /// State that must be refreshed at the start of a restore - chiefly caches derived from
+            /// environment variables, which may have changed since a previous build in a reused process.
+            /// </summary>
+            StartRestore,
+
+            /// <summary>
+            /// State that must be torn down at the end of a restore - chiefly live OS resources (such as plugin
+            /// processes) that the "process dies after each build" model relied on process exit to reclaim.
+            /// </summary>
+            EndRestore,
+        }
+
+        private static readonly ConcurrentDictionary<ResetKey, ConcurrentBag<Action>> ResetActions =
+            new ConcurrentDictionary<ResetKey, ConcurrentBag<Action>>();
+
+        /// <summary>
+        /// Registers a reset action for <paramref name="key" />. Actions accumulate (a keyed list), so each
+        /// contributor registers once - typically from a type's static constructor.
+        /// </summary>
+        /// <param name="key">The reset point, <see cref="ResetKey.StartRestore" /> or <see cref="ResetKey.EndRestore" />.</param>
+        /// <param name="resetAction">The action that re-reads / clears / tears down the state.</param>
+        public static void RegisterResetAction(ResetKey key, Action resetAction)
+        {
+            if (resetAction == null)
+            {
+                throw new ArgumentNullException(nameof(resetAction));
+            }
+
+            ResetActions.GetOrAdd(key, _ => new ConcurrentBag<Action>()).Add(resetAction);
+        }
+
+        /// <summary>
+        /// Executes every reset action registered for <paramref name="key" />. Best-effort and isolated: a
+        /// failure in one action does not prevent the others from running.
+        /// </summary>
+        public static void Reset(ResetKey key)
+        {
+            if (!ResetActions.TryGetValue(key, out ConcurrentBag<Action>? actions))
+            {
+                return;
+            }
+
+            foreach (Action action in actions)
+            {
+                try
+                {
+                    action();
+                }
+#pragma warning disable CA1031 // Do not catch general exception types - resets are best-effort and isolated.
+                catch (Exception ex)
+#pragma warning restore CA1031
+                {
+                    System.Diagnostics.Debug.WriteLine($"NuGetProcessState reset action for '{key}' failed: {ex}");
+                }
+            }
+        }
+    }
+}

--- a/src/nuget-client/src/NuGet.Core/NuGet.Common/PathUtil/NuGetEnvironment.cs
+++ b/src/nuget-client/src/NuGet.Core/NuGet.Common/PathUtil/NuGetEnvironment.cs
@@ -24,11 +24,28 @@ namespace NuGet.Common
         private const string DotNetHome = "DOTNET_CLI_HOME";
 #endif
 
-        private static readonly Lazy<string> _getHome = new Lazy<string>(() => GetHome());
+        private static Lazy<string> _getHome = new Lazy<string>(() => GetHome());
 
         private static string _nuGetTempDirectory = null;
 
         private static readonly ConcurrentDictionary<NuGetFolderPath, string> Cache = new ConcurrentDictionary<NuGetFolderPath, string>();
+
+        static NuGetEnvironment()
+        {
+            NuGetProcessState.RegisterResetAction(NuGetProcessState.ResetKey.StartRestore, ResetEnvironmentCaches);
+        }
+
+        /// <summary>
+        /// Clears the cached, environment-derived paths (home directory, NuGet temp directory, and resolved
+        /// folder paths) so they are recomputed from the current environment on next use. Intended for a host
+        /// that reuses the process across builds.
+        /// </summary>
+        internal static void ResetEnvironmentCaches()
+        {
+            _getHome = new Lazy<string>(() => GetHome());
+            _nuGetTempDirectory = null;
+            Cache.Clear();
+        }
 
         internal static string NuGetTempDirectory
         {

--- a/src/nuget-client/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
+++ b/src/nuget-client/src/NuGet.Core/NuGet.Common/PublicAPI.Unshipped.txt
@@ -1,3 +1,9 @@
 #nullable enable
 NuGet.Common.NuGetLogCode.NU1512 = 1512 -> NuGet.Common.NuGetLogCode
 NuGet.Common.NuGetLogCode.NU5502 = 5502 -> NuGet.Common.NuGetLogCode
+NuGet.Common.NuGetProcessState
+NuGet.Common.NuGetProcessState.ResetKey
+NuGet.Common.NuGetProcessState.ResetKey.EndRestore = 1 -> NuGet.Common.NuGetProcessState.ResetKey
+NuGet.Common.NuGetProcessState.ResetKey.StartRestore = 0 -> NuGet.Common.NuGetProcessState.ResetKey
+static NuGet.Common.NuGetProcessState.RegisterResetAction(NuGet.Common.NuGetProcessState.ResetKey key, System.Action! resetAction) -> void
+static NuGet.Common.NuGetProcessState.Reset(NuGet.Common.NuGetProcessState.ResetKey key) -> void

--- a/src/nuget-client/src/NuGet.Core/NuGet.Configuration/Proxy/ProxyCache.cs
+++ b/src/nuget-client/src/NuGet.Core/NuGet.Configuration/Proxy/ProxyCache.cs
@@ -27,7 +27,12 @@ namespace NuGet.Configuration
 
         // It's not likely that http proxy settings are set in machine wide settings,
         // so not passing machine wide settings to Settings.LoadDefaultSettings() should be fine.
-        private static readonly Lazy<ProxyCache> _instance = new Lazy<ProxyCache>(() => FromDefaultSettings());
+        private static Lazy<ProxyCache> _instance = new Lazy<ProxyCache>(() => FromDefaultSettings());
+
+        static ProxyCache()
+        {
+            NuGetProcessState.RegisterResetAction(NuGetProcessState.ResetKey.StartRestore, ResetCache);
+        }
 
         private static ProxyCache FromDefaultSettings()
         {
@@ -37,6 +42,13 @@ namespace NuGet.Configuration
         }
 
         public static ProxyCache Instance => _instance.Value;
+
+        /// <summary>
+        /// Re-reads proxy settings (the <c>http_proxy</c> family of environment variables and nuget.config) by
+        /// discarding the cached instance, so a process reused across builds observes the current proxy
+        /// configuration and does not retain previously cached proxy credentials.
+        /// </summary>
+        internal static void ResetCache() => _instance = new Lazy<ProxyCache>(() => FromDefaultSettings());
 
         public Guid Version { get; private set; } = Guid.NewGuid();
 

--- a/src/nuget-client/src/NuGet.Core/NuGet.Credentials/DefaultCredentialServiceUtility.cs
+++ b/src/nuget-client/src/NuGet.Core/NuGet.Credentials/DefaultCredentialServiceUtility.cs
@@ -18,6 +18,22 @@ namespace NuGet.Credentials
     public static class DefaultCredentialServiceUtility
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     {
+        static DefaultCredentialServiceUtility()
+        {
+            NuGetProcessState.RegisterResetAction(NuGetProcessState.ResetKey.StartRestore, ResetCredentialService);
+        }
+
+        /// <summary>
+        /// Discards the process-wide credential service and its delegating logger so a process reused across builds
+        /// rebuilds them for the next restore (with the current interactivity, settings, and credential providers)
+        /// instead of reusing the first build's instance and its cached credentials.
+        /// </summary>
+        internal static void ResetCredentialService()
+        {
+            HttpHandlerResourceV3.CredentialService = null;
+            DelegatingLogger = null;
+        }
+
         /// <summary>
         /// Sets-up the CredentialService and all of its providers.
         /// It always updates the logger the CredentialService and its children own,

--- a/src/nuget-client/src/NuGet.Core/NuGet.Credentials/PreviewFeatureSettings.cs
+++ b/src/nuget-client/src/NuGet.Core/NuGet.Credentials/PreviewFeatureSettings.cs
@@ -12,6 +12,11 @@ namespace NuGet.Credentials
     /// </summary>
     public static class PreviewFeatureSettings
     {
+        static PreviewFeatureSettings()
+        {
+            NuGet.Common.NuGetProcessState.RegisterResetAction(NuGet.Common.NuGetProcessState.ResetKey.StartRestore, ResetCache);
+        }
+
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public const string DefaultCredentialsAfterCredentialProvidersEnvironmentVariableName
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
@@ -25,6 +30,10 @@ namespace NuGet.Credentials
         /// </summary>
         public static bool DefaultCredentialsAfterCredentialProviders { get; set; }
             = GetFlagFromEnvironmentVariable(DefaultCredentialsAfterCredentialProvidersEnvironmentVariableName);
+
+        /// <summary>Re-reads <c>NUGET_CREDENTIAL_PROVIDER_OVERRIDE_DEFAULT</c> from the current environment.</summary>
+        internal static void ResetCache()
+            => DefaultCredentialsAfterCredentialProviders = GetFlagFromEnvironmentVariable(DefaultCredentialsAfterCredentialProvidersEnvironmentVariableName);
 
         private static bool GetFlagFromEnvironmentVariable(string variableName)
         {

--- a/src/nuget-client/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
+++ b/src/nuget-client/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
@@ -19,10 +19,18 @@ namespace NuGet.ProjectModel
 {
     public class DependencyGraphSpec
     {
+        static DependencyGraphSpec()
+        {
+            NuGet.Common.NuGetProcessState.RegisterResetAction(NuGet.Common.NuGetProcessState.ResetKey.StartRestore, ResetCache);
+        }
+
         /// <summary>
         /// Allows a user to enable the legacy SHA512 hash function for dgSpec files which is used by no-op.
         /// </summary>
         private static bool? UseLegacyHashFunction;
+
+        /// <summary>Clears the cached legacy-hash env flag so it is re-read on the next construction.</summary>
+        internal static void ResetCache() => UseLegacyHashFunction = null;
 
         private const string DGSpecFileNameExtension = "{0}.nuget.dgspec.json";
 

--- a/src/nuget-client/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceResourceProvider.cs
+++ b/src/nuget-client/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSourceResourceProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
 
@@ -28,6 +29,17 @@ namespace NuGet.Protocol
         /// The throttle to apply to all <see cref="HttpSource"/> HTTP requests.
         /// </summary>
         public static IThrottle? Throttle { get; set; }
+
+        static HttpSourceResourceProvider()
+        {
+            NuGetProcessState.RegisterResetAction(NuGetProcessState.ResetKey.StartRestore, ResetThrottle);
+        }
+
+        /// <summary>
+        /// Clears the process-wide HTTP request throttle (set per restore from <c>NUGET_CONCURRENCY_LIMIT</c> or the
+        /// disable-parallel option) so it does not leak from one restore to the next in a reused process.
+        /// </summary>
+        internal static void ResetThrottle() => Throttle = null;
 
         public HttpSourceResourceProvider()
             : base(typeof(HttpSourceResource),

--- a/src/nuget-client/src/NuGet.Core/NuGet.Protocol/NuGetTestMode.cs
+++ b/src/nuget-client/src/NuGet.Core/NuGet.Protocol/NuGetTestMode.cs
@@ -14,9 +14,13 @@ namespace NuGet.Protocol.Core.Types
         {
             // cached for the life-time of the app domain
             Enabled = FromEnvironmentVariable();
+            NuGet.Common.NuGetProcessState.RegisterResetAction(NuGet.Common.NuGetProcessState.ResetKey.StartRestore, ResetCache);
         }
 
         public static bool Enabled { get; private set; }
+
+        /// <summary>Re-reads <c>NuGetTestModeEnabled</c> from the current environment.</summary>
+        internal static void ResetCache() => Enabled = FromEnvironmentVariable();
 
         private static bool FromEnvironmentVariable()
         {

--- a/src/nuget-client/src/NuGet.Core/NuGet.Protocol/Plugins/PluginManager.cs
+++ b/src/nuget-client/src/NuGet.Core/NuGet.Protocol/Plugins/PluginManager.cs
@@ -24,8 +24,30 @@ namespace NuGet.Protocol.Plugins
     /// </summary>
     public sealed class PluginManager : IPluginManager, IDisposable
     {
-        private static readonly Lazy<IPluginManager> _lazy = new Lazy<IPluginManager>(() => new PluginManager());
+        static PluginManager()
+        {
+            // The plugin processes must not outlive the build that started them; tear them down at end of restore.
+            NuGet.Common.NuGetProcessState.RegisterResetAction(NuGet.Common.NuGetProcessState.ResetKey.EndRestore, ResetSharedInstance);
+        }
+
+        private static Lazy<IPluginManager> _lazy = new Lazy<IPluginManager>(() => new PluginManager());
         public static IPluginManager Instance => _lazy.Value;
+
+        /// <summary>
+        /// Disposes the current shared <see cref="Instance" /> - terminating any running plugin processes and their
+        /// idle/keep-alive timers - and resets it so the next access lazily creates a fresh instance. Registered
+        /// under <see cref="NuGet.Common.NuGetProcessState.ResetKey.EndRestore" /> and invoked by restore at the end of a
+        /// restore. No-op when no instance has been created.
+        /// </summary>
+        private static void ResetSharedInstance()
+        {
+            Lazy<IPluginManager> previous = System.Threading.Interlocked.Exchange(ref _lazy, new Lazy<IPluginManager>(() => new PluginManager()));
+
+            if (previous.IsValueCreated && previous.Value is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
 
         private ConnectionOptions _connectionOptions;
         private Lazy<IPluginDiscoverer> _discoverer;

--- a/src/nuget-client/src/NuGet.Core/NuGet.Protocol/Utility/PackageIdValidator.cs
+++ b/src/nuget-client/src/NuGet.Core/NuGet.Protocol/Utility/PackageIdValidator.cs
@@ -12,7 +12,16 @@ namespace NuGet.Protocol
     {
         private const string DisableValidationEnvVar = "NUGET_DISABLE_PACKAGEID_VALIDATION";
 
-        private static readonly Lazy<bool> IsValidationDisabled = new Lazy<bool>(() =>
+        static PackageIdValidator()
+        {
+            NuGetProcessState.RegisterResetAction(NuGetProcessState.ResetKey.StartRestore, ResetCache);
+        }
+
+        private static Lazy<bool> IsValidationDisabled = new Lazy<bool>(() =>
+            IsPackageIdValidationDisabled(EnvironmentVariableWrapper.Instance));
+
+        /// <summary>Re-reads <c>NUGET_DISABLE_PACKAGEID_VALIDATION</c> from the current environment.</summary>
+        internal static void ResetCache() => IsValidationDisabled = new Lazy<bool>(() =>
             IsPackageIdValidationDisabled(EnvironmentVariableWrapper.Instance));
 
         /// <summary>

--- a/src/nuget-client/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/BuildTasksUtilityResetProcessStateTests.cs
+++ b/src/nuget-client/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/BuildTasksUtilityResetProcessStateTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace NuGet.Build.Tasks.Test
+{
+    /// <summary>
+    /// Verifies the build-scoped guard that performs the start-of-build process-state reset at most once per node per
+    /// build. The guard registers a build-lifetime sentinel exactly when it resets, so the number of
+    /// <see cref="TestBuildEngine.RegisterTaskObjectCount" /> registrations equals the number of resets performed.
+    /// Counting per engine keeps these tests isolated from other test classes that also trigger the reset.
+    /// </summary>
+    public class BuildTasksUtilityResetProcessStateTests
+    {
+        [Fact]
+        public void ResetProcessStateOncePerBuild_WithSameBuildEngine_ResetsOnlyOnce()
+        {
+            var buildEngine = new TestBuildEngine();
+
+            for (int i = 0; i < 5; i++)
+            {
+                BuildTasksUtility.ResetProcessStateOncePerBuild(buildEngine);
+            }
+
+            buildEngine.RegisterTaskObjectCount.Should().Be(1, "the build-scoped guard resets once per node per build");
+        }
+
+        [Fact]
+        public void ResetProcessStateOncePerBuild_WithNewBuildEngine_ResetsAgain()
+        {
+            // A fresh TestBuildEngine models a reused node whose build-lifetime registry was cleared between builds.
+            var firstBuild = new TestBuildEngine();
+            var secondBuild = new TestBuildEngine();
+
+            BuildTasksUtility.ResetProcessStateOncePerBuild(firstBuild);
+            BuildTasksUtility.ResetProcessStateOncePerBuild(secondBuild);
+
+            firstBuild.RegisterTaskObjectCount.Should().Be(1);
+            secondBuild.RegisterTaskObjectCount.Should().Be(1, "a reused node re-reads the environment on each subsequent build");
+        }
+
+        [Fact]
+        public void ResetProcessStateOncePerBuild_WithParallelInvocations_ResetsOnce()
+        {
+            var buildEngine = new TestBuildEngine();
+
+            Parallel.For(0, 256, _ => BuildTasksUtility.ResetProcessStateOncePerBuild(buildEngine));
+
+            buildEngine.RegisterTaskObjectCount.Should().Be(1, "parallel per-project invocations on the same node must not each reset");
+        }
+    }
+}

--- a/src/nuget-client/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/TestBuildEngine.cs
+++ b/src/nuget-client/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/TestBuildEngine.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 using Microsoft.Build.Framework;
 using NuGet.Common;
 using NuGet.Test.Utility;
@@ -23,6 +24,14 @@ namespace NuGet.Build.Tasks.Test
         public TestLogger TestLogger = new TestLogger();
 
         private readonly IReadOnlyDictionary<string, string> _globalProperties;
+
+        private readonly Dictionary<object, object> _registeredTaskObjects = new Dictionary<object, object>();
+
+        /// <summary>
+        /// Number of times <see cref="RegisterTaskObject" /> was called on this engine. The reset guard registers its
+        /// build-lifetime sentinel exactly when it performs a reset, so this counts how many resets actually ran.
+        /// </summary>
+        public int RegisterTaskObjectCount;
 
         public TestBuildEngine()
         {
@@ -53,7 +62,13 @@ namespace NuGet.Build.Tasks.Test
 
         public IReadOnlyDictionary<string, string> GetGlobalProperties() => _globalProperties;
 
-        public object GetRegisteredTaskObject(object key, RegisteredTaskObjectLifetime lifetime) => throw new NotImplementedException();
+        public object GetRegisteredTaskObject(object key, RegisteredTaskObjectLifetime lifetime)
+        {
+            lock (_registeredTaskObjects)
+            {
+                return _registeredTaskObjects.TryGetValue(key, out object value) ? value : null;
+            }
+        }
 
         public void LogCustomEvent(CustomBuildEventArgs e)
         {
@@ -119,9 +134,28 @@ namespace NuGet.Build.Tasks.Test
 
         public void Reacquire() => throw new NotImplementedException();
 
-        public void RegisterTaskObject(object key, object obj, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection) => throw new NotImplementedException();
+        public void RegisterTaskObject(object key, object obj, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection)
+        {
+            lock (_registeredTaskObjects)
+            {
+                Interlocked.Increment(ref RegisterTaskObjectCount);
+                _registeredTaskObjects[key] = obj;
+            }
+        }
 
-        public object UnregisterTaskObject(object key, RegisteredTaskObjectLifetime lifetime) => throw new NotImplementedException();
+        public object UnregisterTaskObject(object key, RegisteredTaskObjectLifetime lifetime)
+        {
+            lock (_registeredTaskObjects)
+            {
+                if (_registeredTaskObjects.TryGetValue(key, out object value))
+                {
+                    _registeredTaskObjects.Remove(key);
+                    return value;
+                }
+
+                return null;
+            }
+        }
 
         public void Yield() => throw new NotImplementedException();
     }

--- a/src/nuget-client/test/NuGet.Core.Tests/NuGet.Common.Test/NuGetProcessStateTests.cs
+++ b/src/nuget-client/test/NuGet.Core.Tests/NuGet.Common.Test/NuGetProcessStateTests.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace NuGet.Common.Test
+{
+    public class NuGetProcessStateTests
+    {
+        [Fact]
+        public void Reset_StartRestore_RereadsShowStackFromEnvironment()
+        {
+            string? original = Environment.GetEnvironmentVariable("NUGET_SHOW_STACK");
+            try
+            {
+                // Touch ExceptionLogger so its static constructor registers its reset for StartRestore.
+                _ = ExceptionLogger.Instance;
+
+                Environment.SetEnvironmentVariable("NUGET_SHOW_STACK", "true");
+                NuGetProcessState.Reset(NuGetProcessState.ResetKey.StartRestore);
+                Assert.True(ExceptionLogger.Instance.ShowStack);
+
+                // Simulate a process reused for a new build whose environment no longer sets the flag.
+                Environment.SetEnvironmentVariable("NUGET_SHOW_STACK", null);
+                NuGetProcessState.Reset(NuGetProcessState.ResetKey.StartRestore);
+                Assert.False(ExceptionLogger.Instance.ShowStack);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("NUGET_SHOW_STACK", original);
+                NuGetProcessState.Reset(NuGetProcessState.ResetKey.StartRestore);
+            }
+        }
+
+        [Fact]
+        public void Reset_RunsAllActionsForKey_AndIsolatesFailures()
+        {
+            int ran = 0;
+            NuGetProcessState.RegisterResetAction(NuGetProcessState.ResetKey.StartRestore, () => throw new InvalidOperationException("boom"));
+            NuGetProcessState.RegisterResetAction(NuGetProcessState.ResetKey.StartRestore, () => ran++);
+
+            NuGetProcessState.Reset(NuGetProcessState.ResetKey.StartRestore);
+
+            // The throwing action did not prevent the counting action from running.
+            Assert.True(ran >= 1);
+        }
+    }
+}

--- a/src/nuget-client/test/NuGet.Core.Tests/NuGet.Configuration.Test/ProxyCacheTests.cs
+++ b/src/nuget-client/test/NuGet.Core.Tests/NuGet.Configuration.Test/ProxyCacheTests.cs
@@ -166,5 +166,19 @@ namespace NuGet.Configuration.Test
                 Assert.Equal(password, credentials.Password);
             }
         }
+
+        [Fact]
+        public void ResetCache_DiscardsCachedInstance()
+        {
+            // Arrange
+            ProxyCache first = ProxyCache.Instance;
+
+            // Act
+            ProxyCache.ResetCache();
+            ProxyCache second = ProxyCache.Instance;
+
+            // Assert: a process reused across builds rebuilds the proxy cache from the current environment/config.
+            Assert.NotSame(first, second);
+        }
     }
 }

--- a/src/nuget-client/test/NuGet.Core.Tests/NuGet.Credentials.Test/DefaultCredentialServiceUtilityTests.cs
+++ b/src/nuget-client/test/NuGet.Core.Tests/NuGet.Credentials.Test/DefaultCredentialServiceUtilityTests.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Protocol;
+using Xunit;
+
+namespace NuGet.Credentials.Test
+{
+    public class DefaultCredentialServiceUtilityTests
+    {
+        [Fact]
+        public void ResetCredentialService_ClearsPinnedCredentialService()
+        {
+            Lazy<ICredentialService> original = HttpHandlerResourceV3.CredentialService;
+            try
+            {
+                HttpHandlerResourceV3.CredentialService = null;
+                DefaultCredentialServiceUtility.SetupDefaultCredentialService(NullLogger.Instance, nonInteractive: true);
+                Assert.NotNull(HttpHandlerResourceV3.CredentialService);
+
+                DefaultCredentialServiceUtility.ResetCredentialService();
+
+                // A reused process must rebuild the credential service for the next restore (with the current
+                // interactivity, settings and providers) instead of pinning the first build's instance.
+                Assert.Null(HttpHandlerResourceV3.CredentialService);
+            }
+            finally
+            {
+                HttpHandlerResourceV3.CredentialService = original;
+            }
+        }
+    }
+}

--- a/src/nuget-client/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSourceResourceProviderTests.cs
+++ b/src/nuget-client/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSourceResourceProviderTests.cs
@@ -65,5 +65,24 @@ namespace NuGet.Protocol.Tests
             Assert.NotNull(httpSourceResource);
             Assert.Equal(maxHttpRequestsPerSource, sourceRepository.PackageSource.MaxHttpRequestsPerSource);
         }
+
+        [Fact]
+        public void ResetThrottle_ClearsThrottle()
+        {
+            IThrottle? original = HttpSourceResourceProvider.Throttle;
+            try
+            {
+                HttpSourceResourceProvider.Throttle = SemaphoreSlimThrottle.CreateBinarySemaphore();
+
+                HttpSourceResourceProvider.ResetThrottle();
+
+                // A per-restore throttle must not leak into the next restore on a reused process.
+                Assert.Null(HttpSourceResourceProvider.Throttle);
+            }
+            finally
+            {
+                HttpSourceResourceProvider.Throttle = original;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Make `dotnet restore` safe to run in a **reused** MSBuild process (multi-threaded MSBuild / MSBuild Server), by two complementary changes that are only fully correct **together**:

1. **`src/nuget-client`** — a generic keyed reset registry, `NuGet.Common.NuGetProcessState`, that resets restore's process-wide static state at the start and end of every restore (port of [JanProvaznik/NuGet.Client#10](https://github.com/JanProvaznik/NuGet.Client/pull/10)).
2. **`src/msbuild`** — route `NuGet.Build.Tasks.RestoreTask` to the **main process** in multi-threaded / long-lived-host mode, **retiring** the transient-TaskHost workaround for [dotnet/msbuild#13315](https://github.com/dotnet/msbuild/issues/13315).

## Background: the problem and the existing workaround

`dotnet restore` runs in a process that exits after the build, so process exit reclaims everything restore touches: environment/config-derived caches, plugin child processes, the HTTP throttle, proxy and credential services. In a long-lived host the main process survives across builds, so that state **leaks**: stale caches, leaked plugin processes, and credential/proxy services pinned with the first build's settings (a correctness and security concern).

MSBuild currently works around this in `TaskRouter`/`AssemblyTaskFactory`: `RestoreTask` is forced into a **transient TaskHost** that terminates after each invocation, so process exit still reclaims its static state. That comment calls it *"a temporary workaround until the task authors fix their static state issues"* ([dotnet/msbuild#13315](https://github.com/dotnet/msbuild/issues/13315)). **This PR is that fix** — so the workaround is removed.

## Analysis of the static-state work (and why this fixes all of it)

A whole-program, **cross-assembly interprocedural** reachability analysis was run from the restore task entry points: **13 assemblies, ~7,267 reachable methods**. It catalogued every reachable static field/property and every "lingering process-state sink" (child processes, env edits/reads, timers, static event subscriptions). Three NuGet designs were measured against that inventory:

- **[#8](https://github.com/JanProvaznik/NuGet.Client/pull/8) (`NuGetTraits`)** — centralized environment reads + an end-of-build cleanup. Reset 8 items; 8 gaps.
- **[#9](https://github.com/JanProvaznik/NuGet.Client/pull/9)** — completed the env/path/throttle residual on top of [#8](https://github.com/JanProvaznik/NuGet.Client/pull/8). Reset 14; 4 intentional gaps.
- **[#10](https://github.com/JanProvaznik/NuGet.Client/pull/10) (ported here)** — a **minimal** generic keyed reset registry; no centralization. Each cache/resource stays internal and **self-registers** an internal reset; restore invokes them by key. [#10](https://github.com/JanProvaznik/NuGet.Client/pull/10) subsumes [#8](https://github.com/JanProvaznik/NuGet.Client/pull/8)+[#9](https://github.com/JanProvaznik/NuGet.Client/pull/9).

**Reset points** (`NuGetProcessState.ResetKey`):
- `StartRestore` — re-read environment/config-derived caches (they freeze on first use and would otherwise be stale in a reused process).
- `EndRestore` — tear down live OS resources (plugin processes) that process-exit used to reclaim.

**Coverage** (validated against the report) — all twelve resets are present in this PR: `StartRestore` resets `NuGetEnvironment`, `ConcurrencyUtilities`, `ExceptionLogger`, `NuGetFeatureFlags` (NuGet.Common/Shared), `ProxyCache` (NuGet.Configuration), `DefaultCredentialServiceUtility` credential-service (NuGet.Credentials), `PreviewFeatureSettings`, `HttpSourceResourceProvider` throttle, `NuGetTestMode`, `PackageIdValidator` (NuGet.Protocol), `DependencyGraphSpec` (NuGet.ProjectModel), and the `SourceRepositoryDependencyProvider` throttle (NuGet.Commands); `EndRestore` disposes plugins via `PluginManager`. The only unreset statics are intentional and documented: `X509ChainBuildPolicyFactory.Policy` (experimental), `PluginLogger.DefaultInstance` (debug-only), two `*.Testable.Default` test seams; the `ProtocolDiagnostics` static events are raise-sites only (subscribers are external hosts), so not a leak under `dotnet restore`.

**Why the MSBuild change makes this sufficient.** The reset registry is a per-process coordination point: it only works if restore runs in **one** coherent, long-lived process where the state and its reset are co-located. The previous workaround instead kept restore's state in a **dying** transient TaskHost — which made the reset registry pointless (a process that dies each invocation never reuses state). Routing `RestoreTask` to the **main** process, and relying on `StartRestore`/`EndRestore` to scrub its state around each restore, is what lets the persistent host reuse one process safely:

> [#10](https://github.com/JanProvaznik/NuGet.Client/pull/10) makes restore's process state **resettable**; routing `RestoreTask` to the main process (and removing the transient-host workaround) makes that reset **load-bearing** — the persistent main process is returned to a clean slate around every restore, exactly as a fresh per-build process used to be.

That is why the pair resolves the full static-state inventory, and why the two changes must ship together.

## Changes

**`src/msbuild`**
- `TaskRouter.NeedsTaskHostInMultiThreadedMode` now returns `false` (main process) for the type whose full name is `NuGet.Build.Tasks.RestoreTask`, matched by name (not assembly identity), consistent with the existing attribute detection.
- The `RequiresTransientTaskHost` special case and its `forceTransientTaskHost` handling in `AssemblyTaskFactory` are removed (the [dotnet/msbuild#13315](https://github.com/dotnet/msbuild/issues/13315) workaround is retired).
- `TaskRouter` integration tests inverted: RestoreTask now runs **in-process** in MT and Server modes and in the **same** process across builds (its static state is reset per restore rather than reclaimed by process death).

**`src/nuget-client`**
- `NuGetProcessState` registry (the only new public API) + per-owner internal self-registrations; once-per-build guard (`BuildTasksUtility.ResetProcessStateOncePerBuild`, scoped via MSBuild's build-lifetime registered-task-object registry) wired into `GetRestoreProjectStyleTask` (the first restore task on every node), `RestoreTask` (backstop + `EndRestore` in `finally`), and the static-graph `Console` entry.

## Testing notes

- Included: NuGet unit tests (registry once-per-build / parallel-invocation guard; proxy / HTTP-throttle / credential-service resets) and inverted MSBuild `TaskRouter` integration tests (RestoreTask in-process, same-process-across-builds, MT + Server).

### End-to-end validation (✅ passed) — two-PAT credential-leak scenario

Reproduced the exact scenario from [dotnet/msbuild#13660](https://github.com/dotnet/msbuild/pull/13660) (the temporary workaround this PR retires) against a **coordinated VMR build of this PR**.

**Setup**
- SDK: `dotnet-unified-build` of `refs/pull/7311/merge` (dnceng-public build `1477414`), `dotnet-sdk-11.0.100-ci-win-x64`. Verified to carry both halves: MSBuild `RunsInMainProcessDespiteNoAttribute` present and `RequiresTransientTaskHost` **gone**; NuGet `NuGetProcessState` / `ResetProcessStateOncePerBuild` present.
- Feed/package: `Microsoft.VisualStudio.OpenTelemetry` from the private DevDiv `vssdk` Azure Artifacts feed (auth required), via the Azure Artifacts Credential Provider plugin (so `PluginManager` + the credential service are exercised).
- Host: MSBuild Server (`DOTNET_CLI_USE_MSBUILD_SERVER=1` + `MSBUILDUSESERVER=1`) so one process services both restores back-to-back. Two short-lived PATs (A, B) minted/revoked via the ADO REST API; a fresh `RestorePackagesPath` per restore forces a real re-download + re-auth (`RestoreForce=true`, `RestoreNoHttpCache=true`).

**Procedure & outcome**

| Step | Result |
|---|---|
| Restore #1 with PAT-A | **OK** (7.4 s, real auth) |
| Revoke PAT-A, confirm rejected on the flat2 endpoint | **confirmed (HTTP 401)** |
| Restore #2 with PAT-B, **same** server process | **OK** (11.8 s, real re-download/re-auth) |
| Same MSBuild server across #1/#2 | **YES** — `MSBuild.exe /nodemode:8`, PID stable (corroborated by `MSBUILDDEBUGCOMM` comm-trace log for that PID) |
| RestoreTask routing | ran **in-process in the server** (binlog: 1 `RestoreTask`, not under a TaskHost) — confirms the leak-prone path is genuinely exercised |

**Verdict: no leak.** On `main` this scenario returns `error NU1301: 401 (Unauthorized)` on restore #2 (the revoked PAT-A leaks from the cached plugin in the long-lived process). With this PR, RestoreTask runs in the persistent server process (workaround retired) yet restore #2 still succeeds with PAT-B — the reset registry (`StartRestore` credential reset + `EndRestore` plugin teardown) refreshes credentials in the reused process. Same correctness as the #13660 workaround, without killing the process each restore.

> Not yet covered: a `/mt` multithreaded run of the same scenario, and the non-RestoreTask restore "satellite" tasks (e.g. `GetRestoreSettingsTask`) that run in a reused sidecar TaskHost and read environment-derived caches — their refresh rides on `GetRestoreProjectStyleTask`'s once-per-build reset in that sidecar and is not separately validated here.

> The NuGet half is hand-applied to `src/nuget-client` for review/coordination; it is tracked in [JanProvaznik/NuGet.Client#10](https://github.com/JanProvaznik/NuGet.Client/pull/10) and its canonical path into the VMR is the NuGet source mirror once that change merges upstream, which would supersede these edits on the next sync.
