### PR TITLE
Use default ProviderKey for Desktop bundle

### DIFF
--- a/src/windowsdesktop/src/windowsdesktop/src/bundle/Wix.targets
+++ b/src/windowsdesktop/src/windowsdesktop/src/bundle/Wix.targets
@@ -126,25 +126,15 @@
   </Target>
 
   <Target Name="GenerateUpgradeCode" AfterTargets="SetInstallerInfo">
-    <!-- Generate architecture-specific ProviderKey (different per architecture for SxS installations) -->
-    <PropertyGroup>
-      <ProviderKeySeed>$(UpgradeCodeSeed) $(TargetArchitecture) $(MajorVersion).$(MinorVersion)</ProviderKeySeed>
-    </PropertyGroup>
-    <GenerateGuidFromName Name="$(ProviderKeySeed)">
-      <Output TaskParameter="GeneratedGuid" PropertyName="GeneratedProviderKey" />
-    </GenerateGuidFromName>
-
     <!-- Generate architecture-specific UpgradeCode (different per architecture for SxS) -->
     <GenerateGuidFromName Name="$(UpgradeCodeSeedWithArch)">
       <Output TaskParameter="GeneratedGuid" PropertyName="GeneratedUpgradeCode" />
     </GenerateGuidFromName>
 
     <PropertyGroup>
-      <DefineConstants>$(DefineConstants);ProviderKey={$(GeneratedProviderKey)}</DefineConstants>
       <DefineConstants>$(DefineConstants);UpgradeCode={$(GeneratedUpgradeCode)}</DefineConstants>
     </PropertyGroup>
 
-    <Message Text="Generated ProviderKey for $(TargetArchitecture): {$(GeneratedProviderKey)} from seed '$(ProviderKeySeed)'" Importance="high" />
     <Message Text="Generated UpgradeCode for $(TargetArchitecture) v$(MajorVersion).$(MinorVersion): {$(GeneratedUpgradeCode)} from seed '$(UpgradeCodeSeedWithArch)'" Importance="high" />
   </Target>
 

--- a/src/windowsdesktop/src/windowsdesktop/src/bundle/bundle.wxs
+++ b/src/windowsdesktop/src/windowsdesktop/src/bundle/bundle.wxs
@@ -3,7 +3,6 @@
           Manufacturer="$(Manufacturer)" 
           Version="$(BundleVersion)" 
           UpgradeCode="$(UpgradeCode)"
-          ProviderKey="$(ProviderKey)"
           AboutUrl="https://aka.ms/dotnet-windows-desktop"
           Compressed="yes">
 


### PR DESCRIPTION
# Overview

The Desktop Runtime bundle generates an explicit provider key instead of using the default which matches the bundle registration code. This can result in blocking the removal of a previous install. As shown below, the provider key and dependent (bundle registration code) are not the same.

<img width="916" height="87" alt="image" src="https://github.com/user-attachments/assets/2ed381c7-df66-4b6a-9640-5405e3a1084d" />

# Customer Impact

When the deferred removal key is set to `nextSession`, the old version of the runtime is not removed because there are multiple dependents. The screenshot below shows that the 10.0.2 and 10.0.9 installs are registered against the same provider.

<img width="944" height="85" alt="image" src="https://github.com/user-attachments/assets/30e02302-a84c-458a-a01c-447e6c759635" />

This also results in overwriting the provider data when attempting to perform an out-of-order installs. This scenario is supported to allow ISVs to redist runtimes with their software. If a user already has a newer runtime installed, we do not want the ISV install to fail.

# Regression

Yes, this is a regression from .NET 9.0

# Testing

Manually verified. Below is a screenshot from a dev build showing that the provider key and dependent now match

<img width="905" height="112" alt="image" src="https://github.com/user-attachments/assets/2b6e0541-488c-47a3-ac3b-ecd32ad92357" />
