### PR TITLE
Make aspnetcore npm ci restore robust to transient failures

### DIFF
--- a/src/aspnetcore/eng/Npm.Workspace.nodeproj
+++ b/src/aspnetcore/eng/Npm.Workspace.nodeproj
@@ -138,8 +138,11 @@
   <Target Name="Restore" Inputs="@(NpmInputFiles)" Outputs="@(NpmOutputFiles)">
     <Message Text="Restoring NPM packages..." Importance="high" />
 
+    <!-- Run 'npm ci' through a retry wrapper to tolerate transient network
+         failures (e.g. ECONNRESET) that npm's built-in fetch-retries does not
+         reliably recover from. -->
     <Exec
-      Command="npm ci"
+      Command="node $(MSBuildThisFileDirectory)scripts/npm/npm-ci-retry.mjs"
       WorkingDirectory="$(NpmWorkspaceRoot)"
       EnvironmentVariables="$(_NpmAdditionalEnvironmentVariables)"
       />

--- a/src/aspnetcore/eng/scripts/npm/npm-ci-retry.mjs
+++ b/src/aspnetcore/eng/scripts/npm/npm-ci-retry.mjs
@@ -1,0 +1,36 @@
+// Runs `npm ci` with retries to mitigate transient network failures.
+//
+// npm's built-in fetch retry (configured via fetch-retries in .npmrc) does not
+// reliably recover from errors that occur while reading a response body, such as
+// "Invalid response body while trying to fetch ... read ECONNRESET". Those
+// failures surface as a non-zero exit from `npm ci` and would otherwise fail the
+// build non-deterministically. Wrapping the command in a retry loop makes the
+// restore step robust against these transient registry/network hiccups.
+import { execSync } from 'child_process';
+
+const maxAttempts = 5;
+const baseDelayMs = 15000;
+
+function sleep(ms) {
+  // Synchronous sleep so we can pause between attempts without async plumbing.
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+  try {
+    console.log(`Running 'npm ci' (attempt ${attempt}/${maxAttempts})...`);
+    execSync('npm ci', { stdio: 'inherit' });
+    process.exit(0);
+  } catch (error) {
+    console.error(`'npm ci' failed on attempt ${attempt}/${maxAttempts}: ${error.message}`);
+
+    if (attempt === maxAttempts) {
+      console.error(`'npm ci' failed after ${maxAttempts} attempts.`);
+      process.exit(1);
+    }
+
+    const delayMs = baseDelayMs * attempt;
+    console.log(`Retrying 'npm ci' in ${delayMs / 1000} seconds...`);
+    sleep(delayMs);
+  }
+}


### PR DESCRIPTION
## Summary

Makes the aspnetcore `npm ci` restore step resilient to transient `npm ci` failures that non-deterministically break the VMR build.

The `Restore` target in `src/aspnetcore/eng/Npm.Workspace.nodeproj` invokes `npm ci` directly. When `npm ci` exits non-zero for a transient reason, the whole multi-hour unified build fails and must be manually re-run. Observed manifestations:

- **`ECONNRESET` / "Invalid response body while trying to fetch ..."** while pulling packages from the `dotnet-public-npm` feed. `.npmrc` already sets `fetch-retries=5`, but npm's built-in retry does **not** reliably recover from errors that occur *while reading the response body* — so a single body-read reset fails the command.
- **`npm ci` exiting with code `57005` (0xDEAD)** — an abnormal Node/Windows exit with no network diagnostic.

## Fix

Wrap `npm ci` in a small cross-platform node retry helper, `src/aspnetcore/eng/scripts/npm/npm-ci-retry.mjs`, and call it from the `Restore` target instead of invoking `npm ci` directly.

- Retries up to 5 attempts with linear backoff (15s × attempt).
- Retries on **any** non-zero exit, so it covers both the network (`ECONNRESET`) and abnormal-exit (`0xDEAD`) cases above.
- `npm ci` is a clean install, so re-running between attempts is safe.
- Node is already a build prerequisite and is used by the neighboring `pack-workspace.mjs` scripts, so no new dependency is introduced.

## Expected impact

I analyzed every `dotnet-unified-build` run on `main` and `release/*` queued in the last 30 days (internal pipeline, definition 1330), across **all** result types, inspecting **every** attempt (final + all retried `previousAttempts` timelines) for an aspnetcore `npm ci` failure:

| Denominator | Builds | npm-ci failures | % |
|---|---|---|---|
| All builds (any result) | 283 | 2 | **0.71%** |
| Non-green only (failed + partiallySucceeded) | 251 | 2 | 0.80% |
| Failed only | 166 | 2 | 1.2% |

The two covered builds:

- `3007299` (release/11.0.1xx-preview6) — exit 1, `ECONNRESET` / "Invalid response body"
- `2992464` (release/11.0.1xx-preview5) — exit `57005` (0xDEAD)

Notes:
- Both failures occurred on the **final** attempt — neither was already absorbed by an existing leg retry, so this is net-new coverage.
- Each occurrence is a full build failure requiring a manual rerun, so the per-incident cost is high even though the rate is modest.
- The change is low risk: it only retries a clean `npm ci` and changes no package manifests.

## Note on canonical location

This file is mirrored from [dotnet/aspnetcore](https://github.com/dotnet/aspnetcore) (`eng/Npm.Workspace.nodeproj`, `eng/scripts/npm/`). The durable fix should also land upstream so it survives code flow; this PR is raised against the VMR per request.
