### PR TITLE
Pin Node to 24.14.1 to work around intermittent native crashes

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -621,11 +621,13 @@ jobs:
 
   - ${{ if eq(parameters.targetOS, 'windows') }}:
     # Node is a toolset dependency to build aspnetcore
-    # Keep in sync with aspnetcore: https://github.com/dotnet/aspnetcore/blob/main/.azure/pipelines/jobs/default-build.yml (UseNode@1 "Install Node" step)
+    # Keep in sync with aspnetcore: https://github.com/dotnet/aspnetcore/blob/7d5309210d8f7bae8fa074da495e9d009d67f1b4/.azure/pipelines/ci.yml#L719-L722
+    # Pinned to 24.14.1 to work around npm ci exit code 57005 bug in Node 24.15.
+    # Tracking issue to revert: https://github.com/dotnet/aspnetcore/issues/66501
     - task: UseNode@1
-      displayName: Install Node 24.x
+      displayName: Install Node 24.14.1
       inputs:
-        version: 24.x
+        version: 24.14.1
 
     - ${{ if eq(parameters.signDac, 'true') }}:
       # TODO: Once we turn off the dotnet/runtime official build, move these templates into the VMR's eng folder.


### PR DESCRIPTION
Reverts dotnet/dotnet#6998, counterpart to https://github.com/dotnet/aspnetcore/pull/67402