### PR TITLE
[release/10.0.3xx] Validate signing of source asset

### DIFF
--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -28,6 +28,9 @@ Newtonsoft.Json.dll;; IGNORE-STRONG-NAME
 Spectre.Console.dll;; IGNORE-STRONG-NAME
 *.mibc;; IGNORE-STRONG-NAME, .mibc files are not strong-named
 
+;; ## Not Unpacked ##
+dotnet-source-*.tar.gz;; DO-NOT-UNPACK
+
 ;; ## MACH-O ##
 *.dwarf;; Debugging symbols, https://github.com/dotnet/source-build/issues/4994#issuecomment-2768803544
 libbootstrapper*.o;; Not executables, https://github.com/dotnet/runtime/issues/114701#issuecomment-2807546040

--- a/eng/pipelines/templates/steps/vmr-validate-signing.yml
+++ b/eng/pipelines/templates/steps/vmr-validate-signing.yml
@@ -37,8 +37,6 @@ steps:
       xcrun simctl runtime delete all
     displayName: Reclaim disk space from unused simulator runtimes
 
-# Include "**SB_CentOSStream*_Offline_${{ parameters.sbBuildSuffix }}_x64_Artifacts/**/Release/source-build/dotnet-source-*"
-# once https://github.com/dotnet/arcade/issues/16034 has been resolved.
 - task: DownloadPipelineArtifact@2
   displayName: Download Vertical Build Artifacts
   continueOnError: ${{ parameters.continueOnError }}
@@ -51,6 +49,7 @@ steps:
       **Windows_*_Artifacts/**
       **SB_CentOSStream*_Offline_${{ parameters.sbBuildSuffix }}_x64_Artifacts/**/Release/source-build/dotnet-sdk-*.tar.gz
       **SB_CentOSStream*_Offline_${{ parameters.sbBuildSuffix }}_x64_Artifacts/**/Release/source-build/Private.SourceBuilt.Artifacts.*.tar.gz
+      **SB_CentOSStream*_Offline_${{ parameters.sbBuildSuffix }}_x64_Artifacts/**/Release/source-build/dotnet-source-*
     downloadPath: '${{ parameters.signCheckFilesDirectory }}'
 
 # This is necessary whenever we want to publish/restore to an AzDO private feed


### PR DESCRIPTION
Backport of #5328 to `release/10.0.3xx`.

Only the source-asset validation enablement (commit 2146f1f) is backported. The follow-up MSB4120 fix (d272e6a) is omitted because it patches the signing-validation.proj rewrite from #6019, which is not present on release branches. The new `dotnet-source-*` download pattern was adapted to use `sbBuildSuffix` to match this branch's convention.

cc @ellahathaway