### PR TITLE
Add libsqlite3mc.so to symbol publishing exclusions

### DIFF
--- a/eng/SymbolPublishingExclusionsFile.txt
+++ b/eng/SymbolPublishingExclusionsFile.txt
@@ -8,3 +8,5 @@ tools/x64_arm64/mscordbi.dll
 tools/net10.0/linux-musl-arm64/libe_sqlite3.so
 tools/net10.0/linux-musl-arm/libe_sqlite3.so
 tools/net10.0/linux-musl-x64/libe_sqlite3.so
+tools/net10.0/linux-musl-x64/libsqlite3mc.so
+tools/net10.0/linux-musl-arm64/libsqlite3mc.so


### PR DESCRIPTION
The roslyn-language-server symbols packages now include `libsqlite3mc.so` (replacing `libe_sqlite3.so`) on linux-musl-x64 and linux-musl-arm64. This binary has no ELF BuildID, causing **all internal builds** to fail at the Darc promotion step since June 25.

Similar to the fix in PR #4628 for `libe_sqlite3.so`.

**Impact**: Unblocks all internal main, preview6, and 10.0.4xx builds.

Promotion build failure examples:
- https://dev.azure.com/dnceng/internal/_build/results?buildId=3008835
- https://dev.azure.com/dnceng/internal/_build/results?buildId=3008328