### PR TITLE
Update symbol publishing exclusions for roslyn libsqlite3mc.so

### DIFF
--- a/eng/SymbolPublishingExclusionsFile.txt
+++ b/eng/SymbolPublishingExclusionsFile.txt
@@ -5,6 +5,9 @@ tools/x86_arm/mscordaccore.dll
 tools/x86_arm/mscordbi.dll
 tools/x64_arm64/mscordaccore.dll
 tools/x64_arm64/mscordbi.dll
-tools/net10.0/linux-musl-arm64/libe_sqlite3.so
-tools/net10.0/linux-musl-arm/libe_sqlite3.so
-tools/net10.0/linux-musl-x64/libe_sqlite3.so
+tools/net10.0/linux-musl-arm64/libsqlite3mc.so
+tools/net11.0/linux-musl-arm64/libsqlite3mc.so
+tools/net10.0/linux-musl-arm/libsqlite3mc.so
+tools/net11.0/linux-musl-arm/libsqlite3mc.so
+tools/net10.0/linux-musl-x64/libsqlite3mc.so
+tools/net11.0/linux-musl-x64/libsqlite3mc.so


### PR DESCRIPTION
## Summary

Roslyn's `roslyn-language-server` switched its SQLite native dependency from `libe_sqlite3.so` to `libsqlite3mc.so`. The new binary lacks an ELF BuildID, so symbol publishing in the **Maestro Build Promotion** pipeline rejects it with `Invalid ELF BuildID '<null>'`, failing the promotion build.

This updates the VMR root `eng/SymbolPublishingExclusionsFile.txt`:
- **Removes** the `libe_sqlite3.so` exclusions (added in #4628 for the roslyn build host; roslyn no longer ships this binary).
- **Adds** `libsqlite3mc.so` exclusions, mirroring [dotnet/roslyn's own `eng/SymbolPublishingExclusionsFile.txt`](https://github.com/dotnet/roslyn/blob/main/eng/SymbolPublishingExclusionsFile.txt) (net10.0 + net11.0 for the musl-arm64 / musl-arm / musl-x64 RIDs).

## Failing build

[Maestro Build Promotion #3008784](https://dev.azure.com/dnceng/internal/_build/results?buildId=3008784) — promoting `dotnet-dotnet` build `20260625.25` (BAR 320350) to **.NET 11.0.1xx SDK Preview 6**:

```
PublishArtifactsInManifest.proj(127,5): error : [.../roslyn-language-server.linux-musl-x64.5.9.0-1.26325.125.symbols.nupkg] Invalid ELF BuildID '<null>' for ...\tools\net10.0\linux-musl-x64\libsqlite3mc.so
PublishArtifactsInManifest.proj(127,5): error : [.../roslyn-language-server.linux-musl-arm64.5.9.0-1.26325.125.symbols.nupkg] Invalid ELF BuildID '<null>' for ...\tools\net10.0\linux-musl-arm64\libsqlite3mc.so
```

Same class of failure as #4624 (fixed by #4628), now for `libsqlite3mc.so`.

Fixes #7423