### PR TITLE
[release/10.0.1xx] Bump patch version to 10.0.11

### DIFF
--- a/src/aspnetcore/eng/Versions.props
+++ b/src/aspnetcore/eng/Versions.props
@@ -9,7 +9,7 @@
   <PropertyGroup Label="Version settings">
     <AspNetCoreMajorVersion>10</AspNetCoreMajorVersion>
     <AspNetCoreMinorVersion>0</AspNetCoreMinorVersion>
-    <AspNetCorePatchVersion>10</AspNetCorePatchVersion>
+    <AspNetCorePatchVersion>11</AspNetCorePatchVersion>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <IdentityModelVersion Condition="'$(IsIdentityModelTestJob)' != 'true'">8.0.1</IdentityModelVersion>
     <IdentityModelVersion Condition="'$(IsIdentityModelTestJob)' == 'true'">*-*</IdentityModelVersion>

--- a/src/command-line-api/eng/Versions.props
+++ b/src/command-line-api/eng/Versions.props
@@ -4,7 +4,7 @@
 
 <!-- Repo Version Information -->
   <PropertyGroup>
-    <VersionPrefix>2.0.10</VersionPrefix>
+    <VersionPrefix>2.0.11</VersionPrefix>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <!-- Allowed values: '', 'prerelease', 'release'. Set to 'release' when stabilizing. -->

--- a/src/efcore/eng/Versions.props
+++ b/src/efcore/eng/Versions.props
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="Version.Details.props" Condition="Exists('Version.Details.props')" />
   <PropertyGroup Label="Version settings">
-    <VersionPrefix>10.0.10</VersionPrefix>
+    <VersionPrefix>10.0.11</VersionPrefix>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>

--- a/src/emsdk/eng/Versions.props
+++ b/src/emsdk/eng/Versions.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <MajorVersion>10</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>10</PatchVersion>
+    <PatchVersion>11</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>

--- a/src/fsharp/eng/Versions.props
+++ b/src/fsharp/eng/Versions.props
@@ -18,7 +18,7 @@
     <!-- F# Version components -->
     <FSMajorVersion>10</FSMajorVersion>
     <FSMinorVersion>0</FSMinorVersion>
-    <FSBuildVersion>110</FSBuildVersion>
+    <FSBuildVersion>111</FSBuildVersion>
     <FSRevisionVersion>0</FSRevisionVersion>
     <!-- -->
     <!-- F# Language version -->

--- a/src/runtime/eng/Versions.props
+++ b/src/runtime/eng/Versions.props
@@ -4,7 +4,7 @@
     <!-- File version numbers -->
     <MajorVersion>10</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>10</PatchVersion>
+    <PatchVersion>11</PatchVersion>
     <!-- The .NET product branding version -->
     <ProductVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</ProductVersion>
     <PackageVersionNet9>9.0.$([MSBuild]::Add($(PatchVersion),12))</PackageVersionNet9>

--- a/src/sdk/eng/Versions.props
+++ b/src/sdk/eng/Versions.props
@@ -7,7 +7,7 @@
     <VersionMajor>10</VersionMajor>
     <VersionMinor>0</VersionMinor>
     <VersionSDKMinor>1</VersionSDKMinor>
-    <VersionSDKMinorPatch>10</VersionSDKMinorPatch>
+    <VersionSDKMinorPatch>11</VersionSDKMinorPatch>
     <VersionFeature>$([System.String]::Copy('$(VersionSDKMinorPatch)').PadLeft(2, '0'))</VersionFeature>
     <!-- This property powers the SdkAnalysisLevel property in end-user MSBuild code.
          It should always be the hundreds-value of the current SDK version, never any

--- a/src/sourcelink/eng/Versions.props
+++ b/src/sourcelink/eng/Versions.props
@@ -3,7 +3,7 @@
   <Import Project="Version.Details.props" />
 
   <PropertyGroup>
-    <VersionPrefix>10.0.110</VersionPrefix>
+    <VersionPrefix>10.0.111</VersionPrefix>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <!-- Allowed values: '', 'prerelease', 'release'. Set to 'release' when stabilizing. -->

--- a/src/symreader/eng/Versions.props
+++ b/src/symreader/eng/Versions.props
@@ -3,7 +3,7 @@
   <Import Project="Version.Details.props" />
 
   <PropertyGroup>
-    <VersionPrefix>2.2.10</VersionPrefix>
+    <VersionPrefix>2.2.11</VersionPrefix>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <!-- Allowed values: '', 'prerelease', 'release'. Set to 'release' when stabilizing. -->

--- a/src/templating/eng/Versions.props
+++ b/src/templating/eng/Versions.props
@@ -3,7 +3,7 @@
   <Import Project="Version.Details.props" />
 
   <PropertyGroup>
-    <VersionPrefix>10.0.110</VersionPrefix>
+    <VersionPrefix>10.0.111</VersionPrefix>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <!-- Allowed values: '', 'prerelease', 'release'. Set to 'release' when stabilizing. -->

--- a/src/windowsdesktop/eng/Versions.props
+++ b/src/windowsdesktop/eng/Versions.props
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <MajorVersion>10</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>10</PatchVersion>
+    <PatchVersion>11</PatchVersion>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <!-- Allowed values: '', 'prerelease', 'release'. Set to 'release' when stabilizing. -->

--- a/src/winforms/eng/Versions.props
+++ b/src/winforms/eng/Versions.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <MajorVersion>10</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>10</PatchVersion>
+    <PatchVersion>11</PatchVersion>
     <!-- version in our package name #.#.#-below.#####.## -->
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>

--- a/src/wpf/eng/Versions.props
+++ b/src/wpf/eng/Versions.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <MajorVersion>10</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>10</PatchVersion>
+    <PatchVersion>11</PatchVersion>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>

--- a/src/xdt/eng/Versions.props
+++ b/src/xdt/eng/Versions.props
@@ -3,7 +3,7 @@
   <Import Project="Version.Details.props" />
 
   <PropertyGroup>
-    <VersionPrefix>3.2.10</VersionPrefix>
+    <VersionPrefix>3.2.11</VersionPrefix>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration></PreReleaseVersionIteration>
     <!-- Allowed values: '', 'prerelease', 'release'. Set to 'release' when stabilizing. -->


### PR DESCRIPTION
Increment patch version for 14 repositories on release/10.0.1xx

Updated repositories:
- aspnetcore: 10 → 11
- command-line-api: 10 → 11
- efcore: 10 → 11
- emsdk: 10 → 11
- runtime: 10 → 11
- windowsdesktop: 10 → 11
- wpf: 10 → 11
- winforms: 10 → 11
- sdk: 10 → 11
- templating: 110 → 111
- fsharp: 110 → 111
- sourcelink: 110 → 111
- xdt: 10 → 11
- symreader: 10 → 11

Sets prerelease label to 'servicing' and iteration to empty string.