### PR TITLE
[release/10.0.3xx] Rebrand to patch 3

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,7 +4,7 @@
     <VersionMajor>10</VersionMajor>
     <VersionMinor>0</VersionMinor>
     <VersionSDKMinor>3</VersionSDKMinor>
-    <VersionSDKMinorPatch>2</VersionSDKMinorPatch>
+    <VersionSDKMinorPatch>3</VersionSDKMinorPatch>
     <VersionFeature>$([System.String]::Copy('$(VersionSDKMinorPatch)').PadLeft(2, '0'))</VersionFeature>
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionSDKMinor)$(VersionFeature)</VersionPrefix>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>


### PR DESCRIPTION
Increment patch version 2 -> 3 on release/10.0.3xx

Sets prerelease label to 'servicing' and iteration to empty string.