### PR TITLE
Allow codeflow milestones to be created as closed (opt-in per repo)

### DIFF
--- a/.github/milestone-config.json
+++ b/.github/milestone-config.json
@@ -12,5 +12,8 @@
     "dotnet/xdt",
     "microsoft/vstest",
     "nuget/nuget.client"
+  ],
+  "closedMilestoneRepos": [
+    "dotnet/runtime"
   ]
 }

--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -131,6 +131,13 @@ jobs:
             const config = JSON.parse(fs.readFileSync('.github/milestone-config.json', 'utf8'));
             const OPTED_OUT_REPOS = new Set(config.optedOutRepos.map(r => r.toLowerCase()));
 
+            // Repos that want their milestones created in the "closed" state.
+            // Some repos (e.g. dotnet/runtime) don't use preview milestones for
+            // triage, so creating them closed prevents contributors from being
+            // tempted to add issues to them. The GitHub API still allows this
+            // workflow to assign PRs to a closed milestone.
+            const CLOSED_MILESTONE_REPOS = new Set((config.closedMilestoneRepos || []).map(r => r.toLowerCase()));
+
             // --- Constants: 7 previews, 2 RCs per release ---
             const MAX_PREVIEWS = 7;
 
@@ -419,21 +426,22 @@ jobs:
               }
 
               if (!milestone) {
+                const milestoneState = CLOSED_MILESTONE_REPOS.has(`${owner}/${repo}`.toLowerCase()) ? 'closed' : 'open';
                 if (DRY_RUN) {
-                  core.info(`[DRY RUN] Would create milestone "${milestoneName}" in ${owner}/${repo}`);
+                  core.info(`[DRY RUN] Would create ${milestoneState} milestone "${milestoneName}" in ${owner}/${repo}`);
                   return -1;  // Sentinel value for dry run
                 }
-                core.info(`Creating milestone "${milestoneName}" in ${owner}/${repo}`);
+                core.info(`Creating ${milestoneState} milestone "${milestoneName}" in ${owner}/${repo}`);
                 try {
                   const { data: created } = await octokit.rest.issues.createMilestone({
-                    owner, repo, title: milestoneName,
+                    owner, repo, title: milestoneName, state: milestoneState,
                   });
                   return created.number;
                 } catch (e) {
                   // Handle race condition — another run may have created it
                   if (e.status === 422) {
                     const retryMilestones = await octokit.paginate(octokit.rest.issues.listMilestones, {
-                      owner, repo, state: 'open', per_page: 100,
+                      owner, repo, state: 'all', per_page: 100,
                     });
                     milestone = retryMilestones.find(m => m.title === milestoneName);
                     if (milestone) return milestone.number;


### PR DESCRIPTION
## Summary

Adds support for creating auto-applied codeflow milestones in the **closed** state for repos that opt in.

dotnet/runtime doesn't traditionally use preview milestones for triage and asked that milestones created by `apply-milestones.yml` be created **closed**, so contributors aren't tempted to add issues to those preview milestones.

## Changes

- **`.github/milestone-config.json`**: new `closedMilestoneRepos` list (mirrors the existing `optedOutRepos` list), with `dotnet/runtime` added.
- **`.github/workflows/apply-milestones.yml`**:
  - Repos in `closedMilestoneRepos` get their milestone created with `state: 'closed'`; all other repos continue to get `state: 'open'` (default).
  - The create-race retry lookup is widened to `state: 'all'` so a milestone created concurrently in either state is still found.

## API support

This is fully supported by the GitHub REST API:
- [Create a milestone](https://docs.github.com/en/rest/issues/milestones) accepts `state: open|closed`.
- Assigning a PR/issue to a closed milestone via the issues update API is allowed — only the web UI hides closed milestones from its dropdown; the REST API accepts any valid milestone number. So PRs still get milestoned correctly.

Existing milestones are unaffected (state is only set at creation time).