### PR TITLE
Fix vstest rel/18.6 SCI 10.0.0 sync on 10.0.3xx

### DIFF
--- a/src/vstest/eng/Version.Details.props
+++ b/src/vstest/eng/Version.Details.props
@@ -13,7 +13,7 @@ This file should be imported by eng/Versions.props
     <MicrosoftDiagnosticsNETCoreClientPackageVersion>0.2.0-preview.26179.102</MicrosoftDiagnosticsNETCoreClientPackageVersion>
     <!-- dotnet-runtime dependencies -->
     <MicrosoftExtensionsDependencyModelPackageVersion>6.0.2</MicrosoftExtensionsDependencyModelPackageVersion>
-    <SystemCollectionsImmutablePackageVersion>9.0.11</SystemCollectionsImmutablePackageVersion>
+    <SystemCollectionsImmutablePackageVersion>10.0.0</SystemCollectionsImmutablePackageVersion>
     <!-- dotnet-symreader-converter dependencies -->
     <MicrosoftDiaSymReaderConverterPackageVersion>1.1.0-beta2-19575-01</MicrosoftDiaSymReaderConverterPackageVersion>
     <MicrosoftDiaSymReaderPdb2PdbPackageVersion>1.1.0-beta2-19575-01</MicrosoftDiaSymReaderPdb2PdbPackageVersion>

--- a/src/vstest/eng/Version.Details.xml
+++ b/src/vstest/eng/Version.Details.xml
@@ -20,9 +20,9 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
     </Dependency>
-    <Dependency Name="System.Collections.Immutable" Version="9.0.11">
+    <Dependency Name="System.Collections.Immutable" Version="10.0.0">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
+      <Sha>60629d14374c56f1cb51819049ad1fa529307f8d</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>


### PR DESCRIPTION
Same situation #7192 fixed on 4xx, now on 3xx.

692691f removed the System.Collections.Immutable 10.0.0 pin from vstest Versions.props, but Version.Details.xml/.props still pin 9.0.11 while vstest.console app.config redirects every SCI load to 10.0.0.0. That mismatch is the FileLoadException class of bug.

Bumps SCI to 10.0.0 (Sha 60629d14) to match. No app.config change needed - 3xx already redirects to 10.0.0.0.