### PR TITLE
Update WiX toolset

### DIFF
--- a/src/arcade/Directory.Packages.props
+++ b/src/arcade/Directory.Packages.props
@@ -11,7 +11,7 @@
     <!-- Keep Microsoft.Data.Services.Client package version in sync with Microsoft.Data.OData -->
     <MicrosoftDataServicesClientVersion>5.8.4</MicrosoftDataServicesClientVersion>
     <MicrosoftSignedWixVersion>3.14.1-9323.2545153</MicrosoftSignedWixVersion>
-    <MicrosoftWixToolsetSdkVersion>5.0.2-dotnet.2811440</MicrosoftWixToolsetSdkVersion>
+    <MicrosoftWixToolsetSdkVersion>5.0.2-dotnet.3009129</MicrosoftWixToolsetSdkVersion>
     <!-- Overwrite XUnitVersion/XUnitAnalyzersVersion/XUnitRunnerConsoleVersion/XUnitRunnerVisualStudioVersion that comes from the Arcade SDK to be in sync as Arcade doesn't use a live Arcade SDK.
          Keep in sync with DefaultVersions.props. -->
     <XUnitVersion>2.9.3</XUnitVersion>

--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -99,7 +99,7 @@
     <MicrosoftManifestToolCrossPlatformVersion Condition="'$(MicrosoftManifestToolCrossPlatformVersion)' == ''">2.1.3</MicrosoftManifestToolCrossPlatformVersion>
     <MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion Condition="'$(MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion)' == ''">1.1.286</MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion>
     <MicrosoftSignedWixVersion Condition="'$(MicrosoftSignedWixVersion)' == ''">3.14.1-9323.2545153</MicrosoftSignedWixVersion>
-    <MicrosoftWixToolsetSdkVersion Condition="'$(MicrosoftWixToolsetSdkVersion)' == ''">5.0.2-dotnet.2811440</MicrosoftWixToolsetSdkVersion>
+    <MicrosoftWixToolsetSdkVersion Condition="'$(MicrosoftWixToolsetSdkVersion)' == ''">5.0.2-dotnet.3009129</MicrosoftWixToolsetSdkVersion>
   </PropertyGroup>
 
   <!-- RestoreSources overrides - defines DotNetRestoreSources variable if available -->

--- a/src/aspnetcore/global.json
+++ b/src/aspnetcore/global.json
@@ -32,6 +32,6 @@
     "Microsoft.DotNet.SharedFramework.Sdk": "10.0.0-beta.26316.108",
     "Microsoft.Build.NoTargets": "3.7.0",
     "Microsoft.Build.Traversal": "3.4.0",
-    "Microsoft.WixToolset.Sdk": "5.0.2-dotnet.2811440"
+    "Microsoft.WixToolset.Sdk": "5.0.2-dotnet.3009129"
   }
 }

--- a/src/runtime/eng/Versions.props
+++ b/src/runtime/eng/Versions.props
@@ -177,11 +177,11 @@
     <MicrosoftSymbolStoreVersion>1.0.406601</MicrosoftSymbolStoreVersion>
     <!-- sdk version, for testing workloads -->
     <!-- WiX 5+ dependencies for MSI generation -->
-    <MicrosoftWixVersion>5.0.2-dotnet.2811440</MicrosoftWixVersion>
-    <MicrosoftWixToolsetUIWixextVersion>5.0.2-dotnet.2811440</MicrosoftWixToolsetUIWixextVersion>
-    <MicrosoftWixToolsetDependencyWixextVersion>5.0.2-dotnet.2811440</MicrosoftWixToolsetDependencyWixextVersion>
-    <MicrosoftWixToolsetUtilWixextVersion>5.0.2-dotnet.2811440</MicrosoftWixToolsetUtilWixextVersion>
-    <MicrosoftWixToolsetBalWixextVersion>5.0.2-dotnet.2811440</MicrosoftWixToolsetBalWixextVersion>
-    <MicrosoftWixToolsetHeatVersion>5.0.2-dotnet.2811440</MicrosoftWixToolsetHeatVersion>
+    <MicrosoftWixVersion>5.0.2-dotnet.3009129</MicrosoftWixVersion>
+    <MicrosoftWixToolsetUIWixextVersion>5.0.2-dotnet.3009129</MicrosoftWixToolsetUIWixextVersion>
+    <MicrosoftWixToolsetDependencyWixextVersion>5.0.2-dotnet.3009129</MicrosoftWixToolsetDependencyWixextVersion>
+    <MicrosoftWixToolsetUtilWixextVersion>5.0.2-dotnet.3009129</MicrosoftWixToolsetUtilWixextVersion>
+    <MicrosoftWixToolsetBalWixextVersion>5.0.2-dotnet.3009129</MicrosoftWixToolsetBalWixextVersion>
+    <MicrosoftWixToolsetHeatVersion>5.0.2-dotnet.3009129</MicrosoftWixToolsetHeatVersion>
   </PropertyGroup>
 </Project>

--- a/src/windowsdesktop/eng/Versions.props
+++ b/src/windowsdesktop/eng/Versions.props
@@ -35,7 +35,7 @@
     <!-- wcf -->
     <SystemServiceModelVersion>8.1.2</SystemServiceModelVersion>
   <!-- WiX -->
-  <MicrosoftWixToolsetSdkVersion>5.0.2-dotnet.2811440</MicrosoftWixToolsetSdkVersion>
+  <MicrosoftWixToolsetSdkVersion>5.0.2-dotnet.3009129</MicrosoftWixToolsetSdkVersion>
     
     <!-- Transport package version for VS insertion packages is defined in Version.Details.props -->
   </PropertyGroup>

--- a/src/windowsdesktop/global.json
+++ b/src/windowsdesktop/global.json
@@ -23,6 +23,6 @@
     "Microsoft.Build.NoTargets": "3.7.0",
     "Microsoft.Build.Traversal": "3.4.0",
     "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25509.106",
-    "Microsoft.WixToolset.Sdk": "5.0.2-dotnet.2811440"
+    "Microsoft.WixToolset.Sdk": "5.0.2-dotnet.3009129"
   }
 }


### PR DESCRIPTION
# Description

Update the WiX toolset. The new build includes a fix to address a regression related to deferred uninstalls.

Fixes https://github.com/dotnet/aspnetcore/issues/67128

This was approved by tactics over email. The actual fix is [here](https://dev.azure.com/dnceng/internal/_git/dotnet-wix/pullrequest/62408)

# Notes

Because the fix changes the bootstrapper application logic, the fix will only be applicable after two consecutive versions that include the fix have been shipped. Any previous installation of .NET 10 with the regression will still result in the behavior described in the linked issue because the older version of .NET will detect the upgrade related bundle of the newer version and still write the RunOnce key. We cannot fix installs that have shipped and already installed on users' machines.

