### PR TITLE
Disable Native AOT for SDK tools when building with the Mono runtime

### DIFF
--- a/src/aspnetcore/eng/Build.props
+++ b/src/aspnetcore/eng/Build.props
@@ -186,7 +186,7 @@
                         Condition=" '$(BuildMainlyReferenceProviders)' != 'true' " />
         <DotNetProjects Include="$(RepoRoot)src\Tools\NativeAot\aspnetcoretools\aspnetcoretools.csproj"
                         Exclude="@(ProjectToBuild);@(ProjectToExclude);$(RepoRoot)**\bin\**\*;$(RepoRoot)**\obj\**\*"
-                        Condition=" '$(BuildMainlyReferenceProviders)' != 'true' " />
+                        Condition=" '$(BuildMainlyReferenceProviders)' != 'true' and '$(DotNetBuildUseMonoRuntime)' != 'true' " />
         <!-- Only build the composite R2R runtime pack when we will actually ship it -->
         <DotNetProjects Include="$(RepoRoot)src\Framework\App.Runtime\src\aspnetcore-runtime-composite.proj"
                         Condition=" '$(BuildMainlyReferenceProviders)' != 'true' and '$(TargetOsName)' != 'win' " />

--- a/src/aspnetcore/src/Tools/NativeAot/aspnetcoretools/aspnetcoretools.csproj
+++ b/src/aspnetcore/src/Tools/NativeAot/aspnetcoretools/aspnetcoretools.csproj
@@ -7,6 +7,8 @@
     <PackAsTool>true</PackAsTool>
     <IsShippingPackage>false</IsShippingPackage>
     <ExcludeFromSourceOnlyBuild>false</ExcludeFromSourceOnlyBuild>
+    <!-- Native AOT requires the CoreCLR runtime; the aggregate executable cannot be produced when building with the Mono runtime. -->
+    <ExcludeFromSourceOnlyBuild Condition="'$(DotNetBuildUseMonoRuntime)' == 'true'">true</ExcludeFromSourceOnlyBuild>
     <PublishAot>true</PublishAot>
     <NativeLib>Shared</NativeLib>
     <EnablePreviewFeatures>true</EnablePreviewFeatures>

--- a/src/aspnetcore/src/Tools/dotnet-dev-certs/src/dotnet-dev-certs.csproj
+++ b/src/aspnetcore/src/Tools/dotnet-dev-certs/src/dotnet-dev-certs.csproj
@@ -12,7 +12,7 @@
     <ExcludeFromSourceOnlyBuild>false</ExcludeFromSourceOnlyBuild>
   </PropertyGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(DotNetBuildUseMonoRuntime)' != 'true'">
     <PublishAot>true</PublishAot>
     <RuntimeIdentifiers Condition="'$(DotNetBuild)' != 'true'">$(BundledToolTargetRuntimeIdentifiers)</RuntimeIdentifiers>
     <RuntimeIdentifiers Condition="'$(DotNetBuild)' == 'true'">$(TargetRuntimeIdentifier)</RuntimeIdentifiers>

--- a/src/aspnetcore/src/Tools/dotnet-user-jwts/src/dotnet-user-jwts.csproj
+++ b/src/aspnetcore/src/Tools/dotnet-user-jwts/src/dotnet-user-jwts.csproj
@@ -13,7 +13,7 @@
     <ExcludeFromSourceOnlyBuild>false</ExcludeFromSourceOnlyBuild>
   </PropertyGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(DotNetBuildUseMonoRuntime)' != 'true'">
     <PublishAot>true</PublishAot>
     <RuntimeIdentifiers Condition="'$(DotNetBuild)' != 'true'">$(BundledToolTargetRuntimeIdentifiers)</RuntimeIdentifiers>
     <RuntimeIdentifiers Condition="'$(DotNetBuild)' == 'true'">$(TargetRuntimeIdentifier)</RuntimeIdentifiers>

--- a/src/aspnetcore/src/Tools/dotnet-user-secrets/src/dotnet-user-secrets.csproj
+++ b/src/aspnetcore/src/Tools/dotnet-user-secrets/src/dotnet-user-secrets.csproj
@@ -13,7 +13,7 @@
     <ExcludeFromSourceOnlyBuild>false</ExcludeFromSourceOnlyBuild>
   </PropertyGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(DotNetBuildUseMonoRuntime)' != 'true'">
     <PublishAot>true</PublishAot>
     <RuntimeIdentifiers Condition="'$(DotNetBuild)' != 'true'">$(BundledToolTargetRuntimeIdentifiers)</RuntimeIdentifiers>
     <RuntimeIdentifiers Condition="'$(DotNetBuild)' == 'true'">$(TargetRuntimeIdentifier)</RuntimeIdentifiers>

--- a/src/sdk/src/Layout/redist/targets/BundledDotnetTools.targets
+++ b/src/sdk/src/Layout/redist/targets/BundledDotnetTools.targets
@@ -9,7 +9,26 @@
 
   <ItemGroup Condition="'$(IncludeAspNetCoreRuntime)' != 'false'">
     <BundledDotnetTool Include="aspnetcoretools"
+                       Condition="'$(DotNetBuildUseMonoRuntime)' != 'true'"
                        Version="$(MicrosoftAspNetCoreAppRefPackageVersion)"
+                       ObsoletesCliTool="Microsoft.Extensions.SecretManager.Tools"
+                       RidSpecificPackageRids="$(AspNetCoreRidSpecificToolPackageRids)"
+                       RidSpecificPackageVersion="$(MicrosoftAspNetCoreAppRefPackageVersion)" />
+    <!-- Native AOT requires the CoreCLR runtime; the Mono runtime build cannot publish the Native AOT aggregate executable, so bundle the individual tools instead. -->
+    <!-- RID-specific tool packages are produced by aspnetcore and use the current aspnetcore package version. -->
+    <BundledDotnetTool Include="dotnet-dev-certs"
+                       Condition="'$(DotNetBuildUseMonoRuntime)' == 'true'"
+                       Version="$(DotnetDevCertsPackageVersion)"
+                       RidSpecificPackageRids="$(AspNetCoreRidSpecificToolPackageRids)"
+                       RidSpecificPackageVersion="$(MicrosoftAspNetCoreAppRefPackageVersion)" />
+    <BundledDotnetTool Include="dotnet-user-jwts"
+                       Condition="'$(DotNetBuildUseMonoRuntime)' == 'true'"
+                       Version="$(DotnetUserJwtsPackageVersion)"
+                       RidSpecificPackageRids="$(AspNetCoreRidSpecificToolPackageRids)"
+                       RidSpecificPackageVersion="$(MicrosoftAspNetCoreAppRefPackageVersion)" />
+    <BundledDotnetTool Include="dotnet-user-secrets"
+                       Condition="'$(DotNetBuildUseMonoRuntime)' == 'true'"
+                       Version="$(DotnetUserSecretsPackageVersion)"
                        ObsoletesCliTool="Microsoft.Extensions.SecretManager.Tools"
                        RidSpecificPackageRids="$(AspNetCoreRidSpecificToolPackageRids)"
                        RidSpecificPackageVersion="$(MicrosoftAspNetCoreAppRefPackageVersion)" />
@@ -33,7 +52,7 @@
           Condition="'@(BundledDotnetTool)' != ''">
     <ItemGroup>
       <_RidSpecificBundledDotnetTool Include="@(BundledDotnetTool)"
-                                      Condition="'%(BundledDotnetTool.RidSpecificPackageRids)' != ''">
+                                      Condition="'$(DotNetBuildUseMonoRuntime)' != 'true' and '%(BundledDotnetTool.RidSpecificPackageRids)' != ''">
         <ToolId>%(BundledDotnetTool.Identity)</ToolId>
         <ToolVersion>%(BundledDotnetTool.RidSpecificPackageVersion)</ToolVersion>
         <ToolVersion Condition="'%(BundledDotnetTool.RidSpecificPackageVersion)' == ''">%(BundledDotnetTool.Version)</ToolVersion>


### PR DESCRIPTION
PR #7300 enabled PublishAot unconditionally for the aspnetcore SDK tools (dotnet-dev-certs, dotnet-user-jwts, dotnet-user-secrets and the aspnetcoretools Native AOT aggregate). Native AOT requires the CoreCLR runtime, so the Mono source-build leg
(SB_CentOSStream10_Mono_Offline_MsftSdk_x64) fails with NU1102 when it tries to restore the ILCompiler/NativeAOT packs that a Mono build never produces.

Gate AOT on the runtime flavor: when DotNetBuildUseMonoRuntime is true, skip AOT and fall back to the framework-dependent tools (the pre-#7300 behavior). CoreCLR builds -- Microsoft and source-build alike -- are unaffected and keep the AOT-compiled tools from #7300.