### PR TITLE
Remove unused Release-Pipeline variable group from VMR compare

### DIFF
--- a/eng/pipelines/templates/stages/vmr-compare.yml
+++ b/eng/pipelines/templates/stages/vmr-compare.yml
@@ -66,7 +66,6 @@ stages:
   displayName: VMR Comparison
   variables:
   - template: ../variables/vmr-build.yml
-  - group: Release-Pipeline
   - group: DotNetBot-GitHub-AllBranches
   jobs:
   - ${{ if ne(parameters.comparisonType, 'signing') }}:


### PR DESCRIPTION
## Summary

Removes the `Release-Pipeline` variable group from `eng/pipelines/templates/stages/vmr-compare.yml`.

## Why

The `Release-Pipeline` variable group is an Azure Key Vault-backed group that fetches **all** secrets from EngKeyVault on every build — including `dn-bot-all-drop-rw-code-rw-release-all`. This PAT was migrated to WIF in PR #6485, so the pipeline no longer uses it. However, because the variable group is still linked, the PAT continues to show as 'in use' in audit logs.

The only secret this pipeline actually needs from a variable group is `BotAccount-dotnet-bot-repo-PAT`, which is already provided by `DotNetBot-GitHub-AllBranches`.

## Impact

- Stops unnecessary PAT fetching from Key Vault
- Unblocks final deprecation of `dn-bot-all-drop-rw-code-rw-release-all`

Part of: https://dev.azure.com/dnceng/internal/_workitems/edit/10105