### PR TITLE
Fix deferred uninstalls

### DIFF
--- a/src/arcade/Directory.Packages.props
+++ b/src/arcade/Directory.Packages.props
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <MicrosoftCciVersion>4.0.0-rc3-24214-00</MicrosoftCciVersion>
     <MicrosoftSignedWixVersion>3.14.1-11131.2940454</MicrosoftSignedWixVersion>
-    <MicrosoftWixToolsetSdkVersion>6.0.3-dotnet.4</MicrosoftWixToolsetSdkVersion>
+    <MicrosoftWixToolsetSdkVersion>6.0.3-dotnet.6</MicrosoftWixToolsetSdkVersion>
     <!-- Overwrite XUnitVersion/XUnitAnalyzersVersion/XUnitRunnerConsoleVersion/XUnitRunnerVisualStudioVersion/MicrosoftTestingPlatformVersion that comes from the Arcade SDK to be in sync as Arcade doesn't use a live Arcade SDK.
          Keep in sync with DefaultVersions.props. -->
     <XUnitVersion>2.9.3</XUnitVersion>

--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -103,7 +103,7 @@
     <MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion Condition="'$(MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion)' == ''">1.1.286</MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion>
     <MicrosoftSignedWixVersion Condition="'$(MicrosoftSignedWixVersion)' == ''">3.14.1-9323.2545153</MicrosoftSignedWixVersion>
     <!-- minor-patch-only: WiX major upgrades (e.g. WiX 4/5/6) require coordinated manual changes; only take minor/patch bumps. -->
-    <MicrosoftWixToolsetSdkVersion Condition="'$(MicrosoftWixToolsetSdkVersion)' == ''">6.0.3-dotnet.4</MicrosoftWixToolsetSdkVersion>
+    <MicrosoftWixToolsetSdkVersion Condition="'$(MicrosoftWixToolsetSdkVersion)' == ''">6.0.3-dotnet.6</MicrosoftWixToolsetSdkVersion>
     <MicrosoftDotNetBaselinesTasksVersion Condition="'$(MicrosoftDotNetBaselinesTasksVersion)' == ''">$(ArcadeSdkVersion)</MicrosoftDotNetBaselinesTasksVersion>
     <MicrosoftDotNetSignCheckTaskVersion Condition="'$(MicrosoftDotNetSignCheckTaskVersion)' == ''">$(ArcadeSdkVersion)</MicrosoftDotNetSignCheckTaskVersion>
   </PropertyGroup>

--- a/src/aspnetcore/global.json
+++ b/src/aspnetcore/global.json
@@ -27,6 +27,6 @@
     "Microsoft.DotNet.SharedFramework.Sdk": "11.0.0-beta.26322.110",
     "Microsoft.Build.NoTargets": "3.7.0",
     "Microsoft.Build.Traversal": "3.4.0",
-    "Microsoft.WixToolset.Sdk": "6.0.3-dotnet.4"
+    "Microsoft.WixToolset.Sdk": "6.0.3-dotnet.6"
   }
 }

--- a/src/runtime/eng/Versions.props
+++ b/src/runtime/eng/Versions.props
@@ -180,12 +180,12 @@
     <MicrosoftExtensionsLoggingVersion>3.1.7</MicrosoftExtensionsLoggingVersion>
     <MicrosoftSymbolStoreVersion>1.0.406601</MicrosoftSymbolStoreVersion>
     <!-- WiX 5+ dependencies for MSI generation -->
-    <MicrosoftWixVersion>6.0.3-dotnet.4</MicrosoftWixVersion>
-    <MicrosoftWixToolsetUIWixextVersion>6.0.3-dotnet.4</MicrosoftWixToolsetUIWixextVersion>
-    <MicrosoftWixToolsetDependencyWixextVersion>6.0.3-dotnet.4</MicrosoftWixToolsetDependencyWixextVersion>
-    <MicrosoftWixToolsetUtilWixextVersion>6.0.3-dotnet.4</MicrosoftWixToolsetUtilWixextVersion>
-    <MicrosoftWixToolsetBalWixextVersion>6.0.3-dotnet.4</MicrosoftWixToolsetBalWixextVersion>
-    <MicrosoftWixToolsetHeatVersion>6.0.3-dotnet.4</MicrosoftWixToolsetHeatVersion>
+    <MicrosoftWixVersion>6.0.3-dotnet.6</MicrosoftWixVersion>
+    <MicrosoftWixToolsetUIWixextVersion>6.0.3-dotnet.6</MicrosoftWixToolsetUIWixextVersion>
+    <MicrosoftWixToolsetDependencyWixextVersion>6.0.3-dotnet.6</MicrosoftWixToolsetDependencyWixextVersion>
+    <MicrosoftWixToolsetUtilWixextVersion>6.0.3-dotnet.6</MicrosoftWixToolsetUtilWixextVersion>
+    <MicrosoftWixToolsetBalWixextVersion>6.0.3-dotnet.6</MicrosoftWixToolsetBalWixextVersion>
+    <MicrosoftWixToolsetHeatVersion>6.0.3-dotnet.6</MicrosoftWixToolsetHeatVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/sdk/global.json
+++ b/src/sdk/global.json
@@ -25,7 +25,7 @@
     "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26311.113",
     "Microsoft.Build.NoTargets": "3.7.134",
     "Microsoft.Build.Traversal": "4.1.82",
-    "Microsoft.WixToolset.Sdk": "6.0.3-dotnet.4",
+    "Microsoft.WixToolset.Sdk": "6.0.3-dotnet.6",
     "MSTest.Sdk": "4.3.0-preview.26325.12"
   },
   "test": {

--- a/src/windowsdesktop/global.json
+++ b/src/windowsdesktop/global.json
@@ -22,6 +22,6 @@
     "Microsoft.DotNet.SharedFramework.Sdk": "11.0.0-beta.26258.110",
     "Microsoft.Build.NoTargets": "3.7.0",
     "Microsoft.Build.Traversal": "3.4.0",
-    "Microsoft.WixToolset.Sdk": "6.0.3-dotnet.4"
+    "Microsoft.WixToolset.Sdk": "6.0.3-dotnet.6"
   }
 }

--- a/src/windowsdesktop/src/windowsdesktop/src/bundle/Wix.targets
+++ b/src/windowsdesktop/src/windowsdesktop/src/bundle/Wix.targets
@@ -125,25 +125,15 @@
   </Target>
 
   <Target Name="GenerateUpgradeCode" AfterTargets="SetInstallerInfo">
-    <!-- Generate architecture-specific ProviderKey (different per architecture for SxS installations) -->
-    <PropertyGroup>
-      <ProviderKeySeed>$(UpgradeCodeSeed) $(TargetArchitecture) $(MajorVersion).$(MinorVersion)</ProviderKeySeed>
-    </PropertyGroup>
-    <GenerateGuidFromName Name="$(ProviderKeySeed)">
-      <Output TaskParameter="GeneratedGuid" PropertyName="GeneratedProviderKey" />
-    </GenerateGuidFromName>
-
     <!-- Generate architecture-specific UpgradeCode (different per architecture for SxS) -->
     <GenerateGuidFromName Name="$(UpgradeCodeSeedWithArch)">
       <Output TaskParameter="GeneratedGuid" PropertyName="GeneratedUpgradeCode" />
     </GenerateGuidFromName>
 
     <PropertyGroup>
-      <DefineConstants>$(DefineConstants);ProviderKey={$(GeneratedProviderKey)}</DefineConstants>
       <DefineConstants>$(DefineConstants);UpgradeCode={$(GeneratedUpgradeCode)}</DefineConstants>
     </PropertyGroup>
 
-    <Message Text="Generated ProviderKey for $(TargetArchitecture): {$(GeneratedProviderKey)} from seed '$(ProviderKeySeed)'" Importance="high" />
     <Message Text="Generated UpgradeCode for $(TargetArchitecture) v$(MajorVersion).$(MinorVersion): {$(GeneratedUpgradeCode)} from seed '$(UpgradeCodeSeedWithArch)'" Importance="high" />
   </Target>
 

--- a/src/windowsdesktop/src/windowsdesktop/src/bundle/bundle.wxs
+++ b/src/windowsdesktop/src/windowsdesktop/src/bundle/bundle.wxs
@@ -3,7 +3,6 @@
           Manufacturer="$(Manufacturer)" 
           Version="$(BundleVersion)" 
           UpgradeCode="$(UpgradeCode)"
-          ProviderKey="$(ProviderKey)"
           AboutUrl="https://aka.ms/dotnet-windows-desktop"
           Compressed="yes">
 


### PR DESCRIPTION
Updating the toolset to include the fixed bootstrapper application and fixing desktop to use the default provider key for bundles. This is a port of all the recent fixes we made for .NET 10 and WiX 5.
