### PR TITLE
Correctly set executable bit for aspnetcoretools

### DIFF
--- a/src/sdk/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/sdk/src/Layout/redist/targets/GenerateLayout.targets
@@ -588,8 +588,9 @@
          not carry the Unix execute bit, and the blanket 'chmod 644' above clears it,
          so re-add execute permission; the SDK execs these tools directly. -->
     <ItemGroup>
-      <_BundledAotToolExecutable Include="$(OutputPath)DotnetTools/aspnetcoretools/**/dotnet-*"
-                                 Exclude="$(OutputPath)DotnetTools/aspnetcoretools/**/*.*" />
+      <_BundledAotToolExecutable Include="$(OutputPath)DotnetTools/aspnetcoretools/**/dotnet-*" />
+      <_BundledAotToolExecutable Remove="@(_BundledAotToolExecutable)"
+                                 Condition="'%(Extension)' != ''" />
     </ItemGroup>
     <Exec Command="chmod 755 '%(_BundledAotToolExecutable.FullPath)'"
           Condition="'@(_BundledAotToolExecutable)' != ''" />


### PR DESCRIPTION
https://github.com/dotnet/aspnetcore/issues/67508

`Exclude="**/*.*"` empties the ItemGroup because MSBuild's `FileMatcher` treats `*.*` with DOS-legacy semantics — it matches *any* filename, not just those containing a `.`. So extensionless files like `dotnet-dev-certs` get excluded too.
