### PR TITLE
Remove duplicate chmod from Crossgen.targets

### DIFF
--- a/src/sdk/src/Layout/redist/targets/Crossgen.targets
+++ b/src/sdk/src/Layout/redist/targets/Crossgen.targets
@@ -219,11 +219,6 @@
     <!-- Move symbols to separate folder, they are not included in the layout but are published separately -->
     <Move SourceFiles="@(PdbsToMove)"
           DestinationFiles="@(PdbsToMove->'$(ArtifactsSymStoreDirectory)/sdk/$(Version)/%(RecursiveDir)%(Filename)%(Extension)')" />
-
-    <Exec Command="find $(InstallerOutputDirectory) -type d -exec chmod 755 {} \;" Condition="'$(OSName)' != 'win'" />
-    <Exec Command="find $(InstallerOutputDirectory) -type f -exec chmod 644 {} \;" Condition="'$(OSName)' != 'win'" />
-    <Exec Command="chmod 755 $(InstallerOutputDirectory)Roslyn/bincore/%(_RoslynAppHost.Filename)" Condition="'$(OSName)' != 'win'" />
-    <Exec Command="chmod 755 $(InstallerOutputDirectory)%(_MSBuildAppHost.Filename)" Condition="'$(OSName)' != 'win'" />
   </Target>
 
 </Project>


### PR DESCRIPTION
We're already doing it in ChmodPublishDir in GenerateLayout.targets and this would overwrite the permissions again.

Follow-up to #7520.
Addresses https://github.com/dotnet/aspnetcore/issues/67508