### PR TITLE
[release/10.0.4xx] Update symbol publishing exclusions for roslyn libsqlite3mc.so

### DIFF
--- a/eng/SymbolPublishingExclusionsFile.txt
+++ b/eng/SymbolPublishingExclusionsFile.txt
@@ -5,6 +5,6 @@ tools/x86_arm/mscordaccore.dll
 tools/x86_arm/mscordbi.dll
 tools/x64_arm64/mscordaccore.dll
 tools/x64_arm64/mscordbi.dll
-tools/net10.0/linux-musl-arm/libe_sqlite3.so
-tools/net10.0/linux-musl-arm64/libe_sqlite3.so
-tools/net10.0/linux-musl-x64/libe_sqlite3.so
+tools/net10.0/linux-musl-arm/libsqlite3mc.so
+tools/net10.0/linux-musl-arm64/libsqlite3mc.so
+tools/net10.0/linux-musl-x64/libsqlite3mc.so


### PR DESCRIPTION
Backport of https://github.com/dotnet/dotnet/pull/7425