### PR TITLE
[DO NOT MERGE] CI SDK build for zip FileAccess changes (dotnet/runtime#129698)

### DIFF
--- a/src/runtime/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.Async.cs
+++ b/src/runtime/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.Async.cs
@@ -91,7 +91,7 @@ public static partial class ZipFileExtensions
             FileStream fs = new FileStream(extractPath, fileStreamOptions);
             await using (fs.ConfigureAwait(false))
             {
-                Stream es = await source.OpenAsync(cancellationToken).ConfigureAwait(false);
+                Stream es = await source.OpenAsync(FileAccess.Read, cancellationToken).ConfigureAwait(false);
                 await using (es.ConfigureAwait(false))
                 {
                     await es.CopyToAsync(fs, cancellationToken).ConfigureAwait(false);

--- a/src/runtime/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
+++ b/src/runtime/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
@@ -81,7 +81,7 @@ namespace System.IO.Compression
             {
                 using (FileStream fs = new FileStream(extractPath, fileStreamOptions))
                 {
-                    using (Stream es = source.Open())
+                    using (Stream es = source.Open(FileAccess.Read))
                         es.CopyTo(fs);
                 }
 

--- a/src/runtime/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
+++ b/src/runtime/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
@@ -48,7 +48,7 @@ public partial class ZipArchiveEntry
     /// <list type="bullet">
     /// <item><description><see cref="ZipArchiveMode.Read"/>: Only <see cref="FileAccess.Read"/> is allowed.</description></item>
     /// <item><description><see cref="ZipArchiveMode.Create"/>: <see cref="FileAccess.Write"/> and <see cref="FileAccess.ReadWrite"/> are allowed (both write-only).</description></item>
-    /// <item><description><see cref="ZipArchiveMode.Update"/>: All values are allowed. <see cref="FileAccess.Read"/> reads directly from the archive. <see cref="FileAccess.Write"/> discards existing content and provides an empty writable stream. <see cref="FileAccess.ReadWrite"/> loads existing content into memory (equivalent to <see cref="OpenAsync(CancellationToken)"/>).</description></item>
+    /// <item><description><see cref="ZipArchiveMode.Update"/>: All values are allowed. <see cref="FileAccess.Read"/> provides a read-only stream over the entry's current content, including any modifications made in the current session. <see cref="FileAccess.Write"/> discards existing content and provides an empty writable stream. <see cref="FileAccess.ReadWrite"/> loads existing content into memory (equivalent to <see cref="OpenAsync(CancellationToken)"/>).</description></item>
     /// </list>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="access"/> is not a valid <see cref="FileAccess"/> value.</exception>
@@ -83,6 +83,17 @@ public partial class ZipArchiveEntry
                 switch (access)
                 {
                     case FileAccess.Read:
+                        // Reads in Update mode must observe content written earlier in this session and
+                        // treat a newly created entry as empty. Only an unmodified entry that already
+                        // exists in the archive can be read directly without loading it into memory.
+                        if (_storedUncompressedData is not null || !_originallyInArchive)
+                        {
+                            if (_currentlyOpenForWrite)
+                                throw new IOException(SR.UpdateModeOneStream);
+
+                            MemoryStream uncompressedData = await GetUncompressedDataAsync(cancellationToken).ConfigureAwait(false);
+                            return new MemoryStream(uncompressedData.GetBuffer(), 0, (int)uncompressedData.Length, writable: false);
+                        }
                         return await OpenInReadModeAsync(checkOpenable: true, cancellationToken).ConfigureAwait(false);
                     case FileAccess.Write:
                         return await OpenInUpdateModeAsync(loadExistingContent: false, cancellationToken).ConfigureAwait(false);

--- a/src/runtime/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/runtime/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -389,7 +389,7 @@ namespace System.IO.Compression
         /// <list type="bullet">
         /// <item><description><see cref="ZipArchiveMode.Read"/>: Only <see cref="FileAccess.Read"/> is allowed.</description></item>
         /// <item><description><see cref="ZipArchiveMode.Create"/>: <see cref="FileAccess.Write"/> and <see cref="FileAccess.ReadWrite"/> are allowed (both write-only).</description></item>
-        /// <item><description><see cref="ZipArchiveMode.Update"/>: All values are allowed. <see cref="FileAccess.Read"/> reads directly from the archive. <see cref="FileAccess.Write"/> discards existing content and provides an empty writable stream. <see cref="FileAccess.ReadWrite"/> loads existing content into memory (equivalent to <see cref="Open()"/>).</description></item>
+        /// <item><description><see cref="ZipArchiveMode.Update"/>: All values are allowed. <see cref="FileAccess.Read"/> provides a read-only stream over the entry's current content, including any modifications made in the current session. <see cref="FileAccess.Write"/> discards existing content and provides an empty writable stream. <see cref="FileAccess.ReadWrite"/> loads existing content into memory (equivalent to <see cref="Open()"/>).</description></item>
         /// </list>
         /// </remarks>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="access"/> is not a valid <see cref="FileAccess"/> value.</exception>
@@ -423,6 +423,11 @@ namespace System.IO.Compression
                     switch (access)
                     {
                         case FileAccess.Read:
+                            // Reads in Update mode must observe content written earlier in this session and
+                            // treat a newly created entry as empty. Only an unmodified entry that already
+                            // exists in the archive can be read directly without loading it into memory.
+                            if (_storedUncompressedData is not null || !_originallyInArchive)
+                                return OpenInUpdateModeForRead();
                             return OpenInReadMode(checkOpenable: true);
                         case FileAccess.Write:
                             return OpenInUpdateMode(loadExistingContent: false);
@@ -903,6 +908,20 @@ namespace System.IO.Compression
             return new WrappedStream(_storedUncompressedData, this,
                 onClosed: thisRef => thisRef!._currentlyOpenForWrite = false,
                 notifyEntryOnWrite: true);
+        }
+
+        // Returns a read-only, seekable view over the entry's current uncompressed buffer in Update mode.
+        // It reflects modifications made earlier in the current session (and is empty for a freshly created
+        // entry), unlike OpenInReadMode which reads the original bytes directly from the archive. The stream
+        // shares the underlying buffer with the entry rather than copying it, so it is not isolated from later
+        // in-place writes; callers are expected to finish reading before reopening the entry for writing.
+        private MemoryStream OpenInUpdateModeForRead()
+        {
+            if (_currentlyOpenForWrite)
+                throw new IOException(SR.UpdateModeOneStream);
+
+            MemoryStream uncompressedData = GetUncompressedData();
+            return new MemoryStream(uncompressedData.GetBuffer(), 0, (int)uncompressedData.Length, writable: false);
         }
 
         /// <summary>

--- a/src/runtime/src/libraries/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
+++ b/src/runtime/src/libraries/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
@@ -2272,6 +2272,222 @@ namespace System.IO.Compression.Tests
             await DisposeZipArchive(async, readArchive);
         }
 
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public static async Task OpenWithFileAccess_UpdateMode_ReadAccess_ReflectsInSessionModifications(bool async)
+        {
+            const string entryName = "first.txt";
+            const string newContent = "Updated content within the same session";
+            byte[] newData = System.Text.Encoding.UTF8.GetBytes(newContent);
+
+            using MemoryStream ms = await StreamHelpers.CreateTempCopyStream(zfile("normal.zip"));
+
+            ZipArchive archive = await CreateZipArchive(async, ms, ZipArchiveMode.Update, leaveOpen: true);
+            ZipArchiveEntry entry = archive.GetEntry(entryName);
+            Assert.NotNull(entry);
+
+            using (Stream writeStream = async ? await entry.OpenAsync(FileAccess.Write) : entry.Open(FileAccess.Write))
+            {
+                writeStream.Write(newData, 0, newData.Length);
+            }
+
+            // Reading the same entry within the session must observe the pending modification, not the
+            // original archived content.
+            using (Stream readStream = async ? await entry.OpenAsync(FileAccess.Read) : entry.Open(FileAccess.Read))
+            {
+                Assert.True(readStream.CanRead);
+                Assert.True(readStream.CanSeek);
+                Assert.Equal(newData.Length, readStream.Length);
+
+                using StreamReader reader = new StreamReader(readStream);
+                Assert.Equal(newContent, reader.ReadToEnd());
+            }
+
+            await DisposeZipArchive(async, archive);
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public static async Task OpenWithFileAccess_UpdateMode_ReadAccess_NewEntry_IsEmpty(bool async)
+        {
+            const string entryName = "brand_new.txt";
+
+            using MemoryStream ms = new MemoryStream();
+
+            ZipArchive archive = await CreateZipArchive(async, ms, ZipArchiveMode.Update, leaveOpen: true);
+            ZipArchiveEntry entry = archive.CreateEntry(entryName);
+
+            // Reading an entry that was created in this session (and never written to) returns an empty
+            // stream instead of attempting to read non-existent archived data.
+            using (Stream readStream = async ? await entry.OpenAsync(FileAccess.Read) : entry.Open(FileAccess.Read))
+            {
+                Assert.True(readStream.CanRead);
+                Assert.True(readStream.CanSeek);
+                Assert.Equal(0, readStream.Length);
+
+                using StreamReader reader = new StreamReader(readStream);
+                Assert.Equal(string.Empty, reader.ReadToEnd());
+            }
+
+            await DisposeZipArchive(async, archive);
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public static async Task OpenWithFileAccess_UpdateMode_ReadAccess_CompressedUnmodified_IsForwardOnly(bool async)
+        {
+            const string entryName = "compressed.txt";
+            string content = new string('a', 1024);
+            byte[] data = System.Text.Encoding.UTF8.GetBytes(content);
+
+            using MemoryStream ms = new MemoryStream();
+
+            ZipArchive seed = await CreateZipArchive(async, ms, ZipArchiveMode.Update, leaveOpen: true);
+            ZipArchiveEntry seedEntry = seed.CreateEntry(entryName, CompressionLevel.Optimal);
+            using (Stream seedStream = async ? await seedEntry.OpenAsync(FileAccess.Write) : seedEntry.Open(FileAccess.Write))
+            {
+                seedStream.Write(data, 0, data.Length);
+            }
+            await DisposeZipArchive(async, seed);
+
+            ms.Position = 0;
+            ZipArchive archive = await CreateZipArchive(async, ms, ZipArchiveMode.Update, leaveOpen: true);
+            ZipArchiveEntry entry = archive.GetEntry(entryName);
+            Assert.NotNull(entry);
+
+            // An unmodified compressed entry read in Update mode streams straight from the deflate
+            // decompressor, so the returned stream is forward-only (not seekable).
+            using (Stream readStream = async ? await entry.OpenAsync(FileAccess.Read) : entry.Open(FileAccess.Read))
+            {
+                Assert.True(readStream.CanRead);
+                Assert.False(readStream.CanWrite);
+                Assert.False(readStream.CanSeek);
+                Assert.Equal(content, ReadAllText(readStream));
+            }
+
+            await DisposeZipArchive(async, archive);
+        }
+
+        public static IEnumerable<object[]> OpenWithFileAccess_UpdateMode_SequentialOpens_Data()
+        {
+            foreach (bool async in new[] { true, false })
+            {
+                foreach (FileAccess first in new[] { FileAccess.Read, FileAccess.Write, FileAccess.ReadWrite })
+                {
+                    foreach (FileAccess second in new[] { FileAccess.Read, FileAccess.Write, FileAccess.ReadWrite })
+                    {
+                        yield return new object[] { async, first, second };
+                    }
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(OpenWithFileAccess_UpdateMode_SequentialOpens_Data))]
+        public static async Task OpenWithFileAccess_UpdateMode_SequentialOpens(bool async, FileAccess firstAccess, FileAccess secondAccess)
+        {
+            const string entryName = "data.txt";
+            const string originalContent = "The original entry contents.";
+            const string replacementContent = "Replacement written in this session.";
+            byte[] replacementData = System.Text.Encoding.UTF8.GetBytes(replacementContent);
+
+            using MemoryStream ms = new MemoryStream();
+
+            // Seed an archive that already contains the entry (stored, so direct reads are seekable).
+            ZipArchive seed = await CreateZipArchive(async, ms, ZipArchiveMode.Update, leaveOpen: true);
+            ZipArchiveEntry seedEntry = seed.CreateEntry(entryName, CompressionLevel.NoCompression);
+            using (Stream seedStream = async ? await seedEntry.OpenAsync(FileAccess.Write) : seedEntry.Open(FileAccess.Write))
+            {
+                byte[] originalData = System.Text.Encoding.UTF8.GetBytes(originalContent);
+                seedStream.Write(originalData, 0, originalData.Length);
+            }
+            await DisposeZipArchive(async, seed);
+
+            ms.Position = 0;
+            ZipArchive archive = await CreateZipArchive(async, ms, ZipArchiveMode.Update, leaveOpen: true);
+            ZipArchiveEntry entry = archive.GetEntry(entryName);
+            Assert.NotNull(entry);
+
+            // A read-only first open leaves the content unchanged; a writing first open replaces it.
+            string expectedAfterFirst = firstAccess == FileAccess.Read ? originalContent : replacementContent;
+
+            using (Stream first = async ? await entry.OpenAsync(firstAccess) : entry.Open(firstAccess))
+            {
+                switch (firstAccess)
+                {
+                    case FileAccess.Read:
+                        Assert.True(first.CanRead);
+                        Assert.False(first.CanWrite);
+                        Assert.Equal(originalContent, ReadAllText(first));
+                        break;
+                    case FileAccess.Write:
+                        // At the archive-entry level a write access stream discards existing content and
+                        // exposes an empty, fully capable in-memory stream (read restrictions are layered on
+                        // top by higher-level callers such as System.IO.Packaging).
+                        Assert.True(first.CanWrite);
+                        Assert.True(first.CanSeek);
+                        Assert.Equal(0, first.Length);
+                        first.Write(replacementData, 0, replacementData.Length);
+                        break;
+                    case FileAccess.ReadWrite:
+                        Assert.True(first.CanRead);
+                        Assert.True(first.CanWrite);
+                        Assert.Equal(originalContent, ReadAllText(first));
+                        first.SetLength(0);
+                        first.Write(replacementData, 0, replacementData.Length);
+                        break;
+                }
+            }
+
+            using (Stream second = async ? await entry.OpenAsync(secondAccess) : entry.Open(secondAccess))
+            {
+                switch (secondAccess)
+                {
+                    case FileAccess.Read:
+                        Assert.True(second.CanRead);
+                        Assert.False(second.CanWrite);
+                        Assert.True(second.CanSeek);
+                        Assert.Equal(expectedAfterFirst.Length, second.Length);
+                        Assert.Equal(expectedAfterFirst, ReadAllText(second));
+                        break;
+                    case FileAccess.ReadWrite:
+                        Assert.True(second.CanRead);
+                        Assert.True(second.CanWrite);
+                        Assert.True(second.CanSeek);
+                        Assert.Equal(expectedAfterFirst.Length, second.Length);
+                        Assert.Equal(expectedAfterFirst, ReadAllText(second));
+                        break;
+                    case FileAccess.Write:
+                        Assert.True(second.CanWrite);
+                        Assert.True(second.CanSeek);
+                        Assert.Equal(0, second.Length);
+                        break;
+                }
+            }
+
+            // A write-only second open discards the content; otherwise the entry keeps what the first open left.
+            string expectedFinal = secondAccess == FileAccess.Write ? string.Empty : expectedAfterFirst;
+
+            await DisposeZipArchive(async, archive);
+
+            ms.Position = 0;
+            ZipArchive verifyArchive = await CreateZipArchive(async, ms, ZipArchiveMode.Read);
+            ZipArchiveEntry verifyEntry = verifyArchive.GetEntry(entryName);
+            Assert.NotNull(verifyEntry);
+            using (Stream verifyStream = async ? await verifyEntry.OpenAsync() : verifyEntry.Open())
+            {
+                Assert.Equal(expectedFinal, ReadAllText(verifyStream));
+            }
+            await DisposeZipArchive(async, verifyArchive);
+        }
+
+        private static string ReadAllText(Stream stream)
+        {
+            using MemoryStream copy = new MemoryStream();
+            stream.CopyTo(copy);
+            return System.Text.Encoding.UTF8.GetString(copy.ToArray());
+        }
+
         public static IEnumerable<object[]> OpenWithFileAccess_InvalidAccess_Throws_Data()
         {
             foreach (bool async in new[] { true, false })

--- a/src/runtime/src/libraries/System.IO.Packaging/src/System/IO/Packaging/InterleavedZipPackagePartStream.PieceDirectory.cs
+++ b/src/runtime/src/libraries/System.IO.Packaging/src/System/IO/Packaging/InterleavedZipPackagePartStream.PieceDirectory.cs
@@ -219,7 +219,7 @@ namespace System.IO.Packaging
 
                 pieceStreamInfo.Stream.Dispose();
                 pieceStreamInfo.Stream = _zipStreamManager.Open(_sortedPieceInfoList[pieceNumber].ZipArchiveEntry,
-                                                                _fileAccess);
+                                                                _fileAccess, requireSeekableStream: true);
                 return pieceStreamInfo.Stream;
             }
 
@@ -358,8 +358,8 @@ namespace System.IO.Packaging
                     long newStartOffset = checked(currentPieceStreamInfo.StartOffset + currentPieceStreamInfo.Stream.Length);
 
                     // Compute pieceInfoStream.Stream.
-                    Stream pieceStream = _zipStreamManager.Open(_sortedPieceInfoList[pieceNumber].ZipArchiveEntry,
-                                                                _fileAccess);
+                    Stream pieceStream = _zipStreamManager.Open(_sortedPieceInfoList[i].ZipArchiveEntry,
+                                                                _fileAccess, requireSeekableStream: true);
 
                     // Update _pieceStreamInfoArray.
                     _indexOfLastPieceStreamInfoAccessed = i;
@@ -439,7 +439,7 @@ namespace System.IO.Packaging
                 // (In other cases, create on demand, as usual.)
                 if (lastPiece == 0)
                 {
-                    Stream pieceStream = _zipStreamManager.Open(newLastPieceDescriptor.ZipArchiveEntry, _fileAccess);
+                    Stream pieceStream = _zipStreamManager.Open(newLastPieceDescriptor.ZipArchiveEntry, _fileAccess, requireSeekableStream: true);
                     _indexOfLastPieceStreamInfoAccessed = 0;
 
                     // The list should be empty at this point

--- a/src/runtime/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipPackagePart.cs
+++ b/src/runtime/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipPackagePart.cs
@@ -25,17 +25,21 @@ namespace System.IO.Packaging
         {
             if (_zipArchiveEntry != null)
             {
-                // Reset the stream when FileMode.Create is specified.  Since ZipArchiveEntry only
-                // ever supports opening once when the backing archive is in Create mode, we'll avoid
-                // calling SetLength since the stream returned won't be seekable. You could still open
-                // an archive in Update mode then call part.GetStream(FileMode.Create), in which case
-                // we'll want this call to SetLength.
+                // Reset the stream when FileMode.Create is specified. When the backing archive is in
+                // Create mode, ZipArchiveEntry only ever supports opening once, so there is nothing to
+                // reset. When the archive is in Update mode, the existing content must be discarded.
                 if (streamFileMode == FileMode.Create && _zipArchiveEntry.Archive.Mode != ZipArchiveMode.Create)
                 {
+#if NET11_0_OR_GREATER
+                    // Opening with discardExistingContent skips decompressing and loading the existing
+                    // content into memory only to truncate it.
+                    return _zipStreamManager.Open(_zipArchiveEntry, streamFileAccess, discardExistingContent: true);
+#else
                     using (var tempStream = _zipStreamManager.Open(_zipArchiveEntry, streamFileAccess))
                     {
                         tempStream.SetLength(0);
                     }
+#endif
                 }
 
                 var stream = _zipStreamManager.Open(_zipArchiveEntry, streamFileAccess);

--- a/src/runtime/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipStreamManager.cs
+++ b/src/runtime/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipStreamManager.cs
@@ -22,7 +22,7 @@ namespace System.IO.Packaging
             _packageFileAccess = packageFileAccess;
         }
 
-        public Stream Open(ZipArchiveEntry zipArchiveEntry, FileAccess streamFileAccess)
+        public Stream Open(ZipArchiveEntry zipArchiveEntry, FileAccess streamFileAccess, bool discardExistingContent = false, bool requireSeekableStream = false)
         {
             bool canRead = true;
             bool canWrite = true;
@@ -81,7 +81,25 @@ namespace System.IO.Packaging
                     break;
             }
 
-            Stream ns = zipArchiveEntry.Open();
+            // Choose the most efficient way to open the entry based on how the returned stream will be used.
+            // In Update mode the parameterless Open() decompresses and loads the whole entry into memory:
+            //  - When the entry will be overwritten (discardExistingContent, e.g. FileMode.Create), open with
+            //    FileAccess.Write to discard the existing content without loading it just to truncate it.
+            //  - When the caller only reads (canRead && !canWrite), open with FileAccess.Read to stream directly
+            //    from the archive instead of buffering the whole entry in memory. NOTE: for compressed entries
+            //    the resulting stream is forward-only (not seekable) and reflects the on-disk content only, so
+            //    callers that need to seek (e.g. the interleaved part reader) opt out via requireSeekableStream.
+            Stream ns;
+#if NET11_0_OR_GREATER
+            ns = (_zipArchive.Mode, discardExistingContent, canRead, canWrite, requireSeekableStream) switch
+            {
+                (ZipArchiveMode.Update, true, _, _, _) => zipArchiveEntry.Open(FileAccess.Write),
+                (ZipArchiveMode.Update, false, true, false, false) => zipArchiveEntry.Open(FileAccess.Read),
+                _ => zipArchiveEntry.Open(),
+            };
+#else
+            ns = zipArchiveEntry.Open();
+#endif
             return new ZipWrappingStream(zipArchiveEntry, ns, _packageFileMode, _packageFileAccess, canRead, canWrite);
         }
     }

--- a/src/runtime/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipWrappingStream.cs
+++ b/src/runtime/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipWrappingStream.cs
@@ -119,12 +119,22 @@ namespace System.IO.Packaging
         {
             get
             {
-                // ZipArchiveEntry's read stream doesn't provide a length since it's a raw DeflateStream
-                // Return length from the archive entry.
+#if NET11_0_OR_GREATER
+                // Read-only streams may read directly from the archive. Prefer the stream's own length
+                // when it can report one (a seekable in-memory or stored-entry stream); fall back to the
+                // entry's uncompressed size only for forward-only compressed read streams, whose raw
+                // decompressor cannot report a length.
+                if (!_canWrite)
+                    return _baseStream.CanSeek ? _baseStream.Length : _zipArchiveEntry.Length;
+                return _baseStream.Length;
+#else
+                // ZipArchiveEntry's read stream doesn't provide a length since it's a raw decompressor.
+                // Return the length from the archive entry for streams that read directly from the archive.
                 if (_packageFileAccess == FileAccess.Read)
                     return _zipArchiveEntry.Length;
                 else
                     return _baseStream.Length;
+#endif
             }
         }
 

--- a/src/runtime/src/libraries/System.IO.Packaging/tests/Tests.cs
+++ b/src/runtime/src/libraries/System.IO.Packaging/tests/Tests.cs
@@ -62,6 +62,45 @@ namespace System.IO.Packaging.Tests
             }
         }
 
+        [Theory]
+        [InlineData(FileAccess.Write)]
+        [InlineData(FileAccess.ReadWrite)]
+        public void GetStreamCreate_OverwritesExistingPartContentWithoutLeftoverBytes(FileAccess overwriteAccess)
+        {
+            FileInfo file = GetTempFileInfoWithExtension(".zip");
+            Uri partUri = PackUriHelper.CreatePartUri(new Uri("MyFile.bin", UriKind.Relative));
+            byte[] original = Enumerable.Repeat((byte)'A', 5000).ToArray();
+            byte[] replacement = Enumerable.Repeat((byte)'B', 10).ToArray();
+
+            using (Package package = Package.Open(file.FullName, FileMode.Create, FileAccess.ReadWrite))
+            {
+                PackagePart part = package.CreatePart(partUri, System.Net.Mime.MediaTypeNames.Application.Octet);
+                using Stream s = part.GetStream(FileMode.Create, FileAccess.Write);
+                s.Write(original, 0, original.Length);
+            }
+
+            using (Package package = Package.Open(file.FullName, FileMode.Open, FileAccess.ReadWrite))
+            {
+                PackagePart part = package.GetPart(partUri);
+                using Stream s = part.GetStream(FileMode.Create, overwriteAccess);
+
+                // The optimized discard path must still yield a seekable, empty, length-reporting stream.
+                Assert.True(s.CanSeek);
+                Assert.Equal(0L, s.Length);
+
+                s.Write(replacement, 0, replacement.Length);
+            }
+
+            using (Package package = Package.Open(file.FullName, FileMode.Open, FileAccess.Read))
+            {
+                PackagePart part = package.GetPart(partUri);
+                using Stream s = part.GetStream(FileMode.Open, FileAccess.Read);
+                using MemoryStream actual = new MemoryStream();
+                s.CopyTo(actual);
+                Assert.Equal(replacement, actual.ToArray());
+            }
+        }
+
         [Fact]
         public void T201_FileFormatException()
         {


### PR DESCRIPTION
**Do not merge / do not review.** This is a throwaway draft PR whose only purpose is to have the VMR CI build a full .NET SDK containing the runtime changes from dotnet/runtime PR #129698 ("Use granular `FileAccess` for zip entry operations"), so those changes can be validated end-to-end (e.g. against the Open XML SDK test suite).

### What this contains
A single squashed commit migrating the runtime library changes into `src/runtime`:

- `System.IO.Compression`: `ZipArchiveEntry.Open(FileAccess)` and related plumbing.
- `System.IO.Packaging`: uses the granular `FileAccess` overload (`ZipStreamManager`, `ZipPackagePart`, `InterleavedZipPackagePartStream`, `ZipWrappingStream`) so that reading/writing a single part while a package is open for editing avoids unnecessary work.

10 files under `src/runtime/src/libraries/System.IO.Compression` and `System.IO.Packaging`.

### Source of truth
dotnet/runtime#129698 (branch `zip-open-fileaccess`).

> [!NOTE]
> This pull request was created with the assistance of GitHub Copilot.