### PR TITLE
Ignore spurious SBoM/component-detection warnings

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -108,6 +108,29 @@ extends:
         suppressionsFile: $(Build.SourcesDirectory)/.config/CredScanSuppressions.json
       componentgovernance:
         useExecutionTargetAsUserSteps: true
+        # Ignore directories that produce spurious SBoM/component-detection warnings.
+        #
+        #   artifacts/bin/Microsoft.DotNet.SourceBuild.Tests          -> "Failed to process NuGet lockfile" on OmniSharp test project.assets.json files.
+        #   artifacts/obj/toolset/Publish/artifacts-layout            -> "Error parsing NuGet component" on generated toolset .nupkg files.
+        #   src/arcade/src/Microsoft.DotNet.SignTool.Tests/Resources  -> "Error parsing NuGet component" on fake/unsigned .nupkg test resources.
+        #   src/sdk/test/TestAssets/TestPackages                      -> "The file doesn't appear to be a Dockerfile" on template test assets.
+        #   src/wpf/.tools                                            -> "The file doesn't appear to be a Dockerfile" on vendored strawberry-perl's dockerfile.pm.
+        #
+        # Note: Keep these in sync with the sbom.additionalComponentDetectorArgs below.
+        ignoreDirectories: |
+          artifacts/bin/Microsoft.DotNet.SourceBuild.Tests,
+          artifacts/obj/toolset/Publish/artifacts-layout,
+          src/arcade/src/Microsoft.DotNet.SignTool.Tests/Resources,
+          src/sdk/test/TestAssets/TestPackages,
+          src/wpf/.tools
+      sbom:
+        # The "Generate SBoM Manifest" task is separate from the Component Governance scan above
+        # and does NOT honor componentgovernance.ignoreDirectories. It runs the same Component
+        # Detection engine, but directory exclusions must be passed via its component detector args
+        # (--DirectoryExclusionList, which takes semicolon-separated glob patterns).
+        #
+        # Note: Keep these in sync with componentgovernance.ignoreDirectories above.
+        additionalComponentDetectorArgs: '--DirectoryExclusionList artifacts/bin/Microsoft.DotNet.SourceBuild.Tests;artifacts/obj/toolset/Publish/artifacts-layout;src/arcade/src/Microsoft.DotNet.SignTool.Tests/Resources;src/sdk/test/TestAssets/TestPackages;src/wpf/.tools'
       autobaseline:
         isMainPipeline: true
 


### PR DESCRIPTION
Add directory exclusions for the Component Governance scan (componentgovernance.ignoreDirectories) and the Generate SBoM Manifest task (sbom.additionalComponentDetectorArgs --DirectoryExclusionList), covering build outputs and test assets that produce non-actionable component-detection warnings.