### PR TITLE
Clean up source index intermediate files to save disk space

### DIFF
--- a/eng/pipelines/templates/steps/source-index-stage1.yml
+++ b/eng/pipelines/templates/steps/source-index-stage1.yml
@@ -127,3 +127,12 @@ steps:
       } else {
         Write-Host "No source index output to upload."
       }
+
+- pwsh: |
+    $baseDir = "${{ parameters.sourceIndexBaseDir }}"
+    if (Test-Path $baseDir) {
+      Write-Host "Cleaning up source index intermediate files at $baseDir"
+      Remove-Item -Path $baseDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+  displayName: "Source Index: Clean up intermediate files"
+  condition: and(always(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['SourceIndexForce'], 'true')))


### PR DESCRIPTION
Removes the `.source-index` temp directory (installed .NET SDK, the BinLogToSln/UploadIndexStage1 tools, and the stage1 output) after the source-index stage1 step completes.

These intermediates can consume significant disk space on the build agent, so this adds a final cleanup step that runs with `always()` (even if the upload fails) and only on the same branches/conditions as the rest of the template.