### PR TITLE
Migrate devdiv/dotnet-core-internal-tooling to WIF service connection

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -603,8 +603,10 @@ jobs:
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(parameters.buildSourceOnly, 'True')) }}:
     # Authenticate with service connections to be able to pull packages to external nuget feeds.
     - task: NuGetAuthenticate@1
+      displayName: Authenticate devdiv/dotnet-core-internal-tooling feed (WIF)
       inputs:
-        nuGetServiceConnections: devdiv/dotnet-core-internal-tooling
+        azureDevOpsServiceConnection: dnceng-devdiv-dotnet-core-internal-tooling-feed-rw-wif
+        feedUrl: https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json
     - task: NuGetAuthenticate@1
       displayName: Authenticate devdiv/Engineering feed (WIF)
       inputs:

--- a/src/vstest/eng/restore-internal-tools.yml
+++ b/src/vstest/eng/restore-internal-tools.yml
@@ -1,7 +1,8 @@
 steps:
   - task: NuGetAuthenticate@1
     inputs:
-      nuGetServiceConnections: 'devdiv/dotnet-core-internal-tooling'
+      azureDevOpsServiceConnection: dnceng-devdiv-dotnet-core-internal-tooling-feed-rw-wif
+      feedUrl: https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json
       forceReinstallCredentialProvider: true
 
   - script: $(Build.SourcesDirectory)\eng\RestoreInternal.cmd


### PR DESCRIPTION
## Summary

Replace PAT-backed externalnugetfeed SC with WIF-based azureDevOpsServiceConnection for the devdiv/dotnet-core-internal-tooling NuGet feed.

## Motivation

Part of PAT disable policy migration ([dnceng WI 10124](https://dnceng.visualstudio.com/internal/_workitems/edit/10124)).

## Changes

- **Before:** nuGetServiceConnections: 'devdiv/dotnet-core-internal-tooling' (PAT-based ExternalNuGetFeed SC)
- **After:** azureDevOpsServiceConnection + feedUrl (WIF SC backed by Entra app)

## New Service Connection

- **Name:** dnceng-devdiv-dotnet-core-internal-tooling-feed-rw-wif
- **Type:** workloadidentityuser
- **Target:** https://pkgs.dev.azure.com/devdiv/_packaging/dotnet-core-internal-tooling/nuget/v3/index.json

Same pattern as the devdiv/engineering feed migration (dotnet/roslyn#83918, dotnet/dotnet#6902).
