### PR TITLE
Fix SignCheck signing-validation issues (cabinet.dll on non-Windows, DAC exclusions, verbose build output, MSB4181, source-build strong-name)

### DIFF
--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -28,6 +28,11 @@ Newtonsoft.Json.dll;; IGNORE-STRONG-NAME
 Spectre.Console.dll;; IGNORE-STRONG-NAME
 *.mibc;; IGNORE-STRONG-NAME, .mibc files are not strong-named
 
+;; Source-build only public-signs its outputs, so binaries inside the source-built
+;; intermediate/SDK tarballs carry a valid public key but a placeholder strong-name signature.
+Private.SourceBuilt.Artifacts.*.tar.gz*;; IGNORE-STRONG-NAME, source-build intermediate artifacts are public-signed only
+dotnet-sdk-*-centos.*-x64.tar.gz*;; IGNORE-STRONG-NAME, source-built SDK is public-signed only
+
 ;; ## Not Unpacked ##
 dotnet-source-*.tar.gz;; DO-NOT-UNPACK
 

--- a/eng/signing-validation.proj
+++ b/eng/signing-validation.proj
@@ -249,9 +249,6 @@
     <Message Text="   %(_DoNotSignViolationResult.Identity)"
       Importance="High"
       Condition="'@(_DoNotSignViolationResult)' != ''" />
-
-    <Error Text="SignCheck detected signing issues. See logs for details."
-      Condition="'@(_UnsignedSignCheckResult)' != '' or '@(_DoNotSignViolationResult)' != ''" />
   </Target>
 
   <Target Name="Execute"

--- a/eng/signing-validation.proj
+++ b/eng/signing-validation.proj
@@ -154,8 +154,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <SignCheckExclusionItem Include="mscordaccore.dll;;DAC_SIGNED_FILE, DAC signing is done only on 1xx-band release branches" />
-      <SignCheckExclusionItem Include="mscordbi.dll;;DAC_SIGNED_FILE, DAC signing is done only on 1xx-band release branches" />
+      <!-- Escape the ';' as '%3B' so MSBuild does not treat them as item separators; the
+           exclusions file format requires 'filename;;comment' on a single line. -->
+      <SignCheckExclusionItem Include="mscordaccore.dll%3B%3BDAC_SIGNED_FILE, DAC signing is done only on 1xx-band release branches" />
+      <SignCheckExclusionItem Include="mscordbi.dll%3B%3BDAC_SIGNED_FILE, DAC signing is done only on 1xx-band release branches" />
     </ItemGroup>
 
     <Copy
@@ -196,13 +198,21 @@
     <PropertyGroup>
       <_SignCheckErrorLogExists>$([System.IO.File]::Exists('$(SignCheckErrorLog)'))</_SignCheckErrorLogExists>
       <_SignCheckErrorLogContent Condition="'$(_SignCheckErrorLogExists)' == 'true'">$([System.IO.File]::ReadAllText('$(SignCheckErrorLog)').Trim())</_SignCheckErrorLogContent>
+      <!--
+        SignCheck writes the terse 'Signing issues found' marker to the error log whenever it
+        detects unsigned or DO-NOT-SIGN files. That is an expected outcome, not a task failure,
+        and the actual offending files are listed with full details from the results XML below.
+        Strip the marker so that only genuine errors (e.g. a crash or startup failure) remain and
+        cause an early failure that would otherwise hide the per-file report.
+      -->
+      <_SignCheckFatalError>$(_SignCheckErrorLogContent.Replace('Signing issues found', '').Trim())</_SignCheckFatalError>
     </PropertyGroup>
 
     <Error Text="SignCheck error log not found at '$(SignCheckErrorLog)'. SignCheck likely failed to start or crashed before producing output."
       Condition="'$(_SignCheckErrorLogExists)' != 'true'" />
 
     <Error Text="SignCheck reported errors. See '$(SignCheckErrorLog)' for details:%0A$(_SignCheckErrorLogContent)"
-      Condition="'$(_SignCheckErrorLogContent)' != ''" />
+      Condition="'$(_SignCheckFatalError)' != ''" />
 
     <Error Text="SignCheck did not process any files."
       Condition="Exists('$(SignCheckLog)') and $([System.IO.File]::ReadAllText('$(SignCheckLog)').Contains('No files were processed'))" />
@@ -210,16 +220,20 @@
     <Error Text="SignCheck results XML file not found: $(SignCheckResultsXmlFile)"
       Condition="!Exists('$(SignCheckResultsXmlFile)')" />
 
+    <!--
+      Select the full <File> elements (not just @Name) so the report includes the AuthentiCode and
+      StrongName details captured in the results XML, matching the pre-migration output.
+    -->
     <XmlPeek
       XmlInputPath="$(SignCheckResultsXmlFile)"
-      Query="//File[contains(@Outcome, 'Unsigned')]/@Name"
+      Query="//File[contains(@Outcome, 'Unsigned')]"
       Condition="Exists('$(SignCheckResultsXmlFile)')">
       <Output TaskParameter="Result" ItemName="_UnsignedSignCheckResult" />
     </XmlPeek>
 
     <XmlPeek
       XmlInputPath="$(SignCheckResultsXmlFile)"
-      Query="//File[contains(@Error, 'matches a DO-NOT-SIGN exclusion and is signed')]/@Name"
+      Query="//File[contains(@Error, 'matches a DO-NOT-SIGN exclusion and is signed')]"
       Condition="Exists('$(SignCheckResultsXmlFile)')">
       <Output TaskParameter="Result" ItemName="_DoNotSignViolationResult" />
     </XmlPeek>

--- a/src/arcade/src/Microsoft.DotNet.SignCheckLibrary/Logging/Log.cs
+++ b/src/arcade/src/Microsoft.DotNet.SignCheckLibrary/Logging/Log.cs
@@ -25,11 +25,14 @@ namespace Microsoft.SignCheck.Logging
             private set;
         }
 
-        public Log(string logFile, string errorFile, string resultsFile, LogVerbosity verbosity)
+        public Log(string logFile, string errorFile, string resultsFile, LogVerbosity verbosity, bool consoleOutput = true)
         {
             _loggers = new List<ILogger>();
             Add(new FileLogger(verbosity, logFile, errorFile, resultsFile));
-            Add(new ConsoleLogger(verbosity));
+            if (consoleOutput)
+            {
+                Add(new ConsoleLogger(verbosity));
+            }
             Verbosity = verbosity;
         }
 

--- a/src/arcade/src/Microsoft.DotNet.SignCheckLibrary/Options.cs
+++ b/src/arcade/src/Microsoft.DotNet.SignCheckLibrary/Options.cs
@@ -35,5 +35,12 @@ namespace Microsoft.SignCheck
         public LogVerbosity Verbosity { get; set; } = LogVerbosity.Normal;
 
         public string ExclusionsFile { get; set; }
+
+        /// <summary>
+        /// When <see langword="true"/> (the default), SignCheck writes its per-file results to the console.
+        /// Hosts that only consume the log and results files (e.g. the MSBuild task) can set this to
+        /// <see langword="false"/> to avoid flooding the build output with every processed file.
+        /// </summary>
+        public bool ConsoleOutput { get; set; } = true;
     }
 }

--- a/src/arcade/src/Microsoft.DotNet.SignCheckLibrary/SignCheckRunner.cs
+++ b/src/arcade/src/Microsoft.DotNet.SignCheckLibrary/SignCheckRunner.cs
@@ -70,7 +70,7 @@ namespace Microsoft.SignCheck
         {
             Options = options;
 
-            Log = new Log(options.LogFile, options.ErrorLogFile, options.ResultsXmlFile, options.Verbosity);
+            Log = new Log(options.LogFile, options.ErrorLogFile, options.ResultsXmlFile, options.Verbosity, options.ConsoleOutput);
 
             if (Options.FileStatus != null && Options.FileStatus.Count() > 0)
             {

--- a/src/arcade/src/Microsoft.DotNet.SignCheckLibrary/Verification/ExeVerifier.cs
+++ b/src/arcade/src/Microsoft.DotNet.SignCheckLibrary/Verification/ExeVerifier.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Microsoft.SignCheck.Logging;
 using Microsoft.SignCheck.Verification.BurnBundle;
 
@@ -22,7 +23,10 @@ namespace Microsoft.SignCheck.Verification
             // Let the base class take care of verifying the AuthentiCode/StrongName
             SignatureVerificationResult svr = base.VerifySignature(path, parent, virtualPath);
 
-            if (VerifyRecursive)
+            // Burn bundle payloads are packed in CAB containers, which can only be extracted using the
+            // native cabinet.dll that ships with Windows. On other platforms we skip recursive verification;
+            // the containing executable's Authenticode signature is still verified above.
+            if (VerifyRecursive && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 if (PEHeader.ImageSectionHeaders.Select(s => s.SectionName).Contains(".wixburn"))
                 {

--- a/src/arcade/src/Microsoft.DotNet.SignCheckTask/SignCheckTask.cs
+++ b/src/arcade/src/Microsoft.DotNet.SignCheckTask/SignCheckTask.cs
@@ -66,6 +66,9 @@ namespace SignCheckTask
                 LogFile = LogFile,
                 ErrorLogFile = ErrorLogFile,
                 ResultsXmlFile = ResultsXmlFile,
+                // The task consumes the log and results files directly, so suppress the per-file
+                // console output that would otherwise flood the build log with every processed file.
+                ConsoleOutput = false,
             };
 
             List<string> inputFiles = new List<string>();
@@ -112,6 +115,16 @@ namespace SignCheckTask
 
             var sc = new SignCheckRunner(options);
             int result = sc.Run();
+
+            // SignCheck signals signing issues (and internal failures) through a non-zero exit
+            // code without logging an MSBuild error. Surface a real error here so the build fails
+            // meaningfully instead of the generic MSB4181. The detailed per-file report is produced
+            // by the calling project from the results XML.
+            if (result != 0)
+            {
+                Log.LogError("SignCheck reported signing issues. See the SignCheck logs for details.");
+            }
+
             return result == 0;
         }
     }


### PR DESCRIPTION
This PR bundles a few related fixes to VMR signing validation / SignCheck that were found while testing signing validation on the release branch.

### 1. Skip Burn bundle CAB extraction on non-Windows
`ExeVerifier` unconditionally tried to extract Burn bundle containers, which CAB-unpacks via the native Windows-only `cabinet.dll` and throws `DllNotFoundException` on Linux/macOS. Guarded the Burn extraction so it only runs on Windows (moved the OS check into the `VerifyRecursive` branch).

### 2. Fix DAC exclusion entries being split across lines
The dynamically-appended `mscordaccore.dll`/`mscordbi.dll` exclusions used a raw `;;` in the `SignCheckExclusionItem` `Include` value. MSBuild treats `;` as an item separator, so each entry was written to the generated exclusions file as two separate lines instead of the required `filename;;comment` single-line format, breaking those DAC exclusions when DAC signing is disabled. Escaped the separators as `%3B`.

### 3. Restore detailed signing-validation output and stop flooding the build log
Since signing validation moved to the in-proc `SignCheckTask`, the SignCheck `ConsoleLogger` writes every processed file to stdout, which MSBuild echoes into the build log (thousands of `Signed: True` lines), and the per-file `AuthentiCode`/`StrongName` details of the offending files were no longer surfaced.

- Added an `Options.ConsoleOutput` flag (default `true`, so the standalone tool is unchanged); the MSBuild task sets it to `false` since it consumes `signcheck.log`/`signcheck.xml` directly.
- `ProcessSignCheckResults` no longer fails early on the terse "Signing issues found" marker (an expected outcome), only on a genuine error remaining after stripping it, so the per-file report runs.
- The report now selects the full `<File>` elements from the results XML instead of only `@Name`, restoring the `AuthentiCode`/`StrongName` details for each offending file.

### 4. Fail with a real error instead of MSB4181
When SignCheck finds signing issues it returns a non-zero exit code but does not log an MSBuild error, so the build failed with the generic `MSB4181` ("task returned false but did not log an error"). The task now logs a real error at the `SignCheck.Run()` call site when the result is non-zero, and the now-redundant catch-all `<Error>` in `ProcessSignCheckResults` was removed (the per-file report is still produced).

### 5. Ignore strong-name failures inside source-build tarballs
Source-build only public-signs its outputs, so binaries inside the source-built intermediate and SDK tarballs (`Private.SourceBuilt.Artifacts.*.tar.gz`, `dotnet-sdk-*-centos.*-x64.tar.gz`) carry a valid public key but a placeholder (zero-filled) strong-name signature. SignCheck's full strong-name verification correctly rejects these, producing false "unsigned" failures. Added `IGNORE-STRONG-NAME` exclusions for those tarballs.
