### PR TITLE
Fix baseline-update PRs re-writing empty baselines to a lone newline

### DIFF
--- a/eng/tools/CreateBaselineUpdatePR/PRCreator.cs
+++ b/eng/tools/CreateBaselineUpdatePR/PRCreator.cs
@@ -447,13 +447,18 @@ public partial class PRCreator
 
         foreach (var (path, modifiedItem) in modifiedByPath)
         {
-            // Compare the raw content. Whitespace-only differences (line-ending or trailing-newline
-            // changes) are legitimate baseline updates for this tool and must be captured in the PR,
-            // so they are intentionally NOT normalized away here. A commit that turns out to be empty
-            // after GitFile's own content rewrite is caught later by CommitIntroducesTargetChangesAsync.
-            if (!originalByPath.TryGetValue(path, out var originalItem) || originalItem.Content != modifiedItem.Content)
+            // Build the file exactly as it will be committed. DarcLib's GitFile constructor folds
+            // Environment.NewLine to '\n' and always appends a trailing '\n' (so empty content
+            // becomes "\n"); the committed bytes can therefore differ from the raw content. Detect
+            // changes by comparing the original against the modified content in that same committed
+            // form, otherwise a 0-byte baseline (whose committed form is "\n") is perpetually
+            // re-written to "\n", producing a spurious no-op diff on every run. Real whitespace/
+            // line-ending differences are still captured because both sides are normalized identically.
+            GitFile candidate = new(prefix + path, modifiedItem.Content);
+            if (!originalByPath.TryGetValue(path, out var originalItem)
+                || new GitFile(prefix + path, originalItem.Content).Content != candidate.Content)
             {
-                changes.Add(new GitFile(prefix + path, modifiedItem.Content));
+                changes.Add(candidate);
             }
         }
 


### PR DESCRIPTION
`CreateBaselineUpdatePR`'s `ComputeChangeSet` compared the target file content (read through DarcLib's `GitFile`, which folds `Environment.NewLine` to `\n` and always appends a trailing `\n`) against the freshly published artifact content (read raw via `File.ReadAllText`). For a 0-byte baseline such as an empty `MsftToSbSdkAssemblyVersions.diff`, the original read back as `\n` while the new artifact was "", so they never compared equal and the tool committed a 1-byte `\n` over the 0-byte file on every run -- a spurious, perpetual no-op diff.

Compare both sides in the exact form `GitFile` will commit them (run the original through the same `GitFile` constructor) so trailing-newline-only differences that `GitFile` would erase anyway are no longer treated as changes. Genuine content or interior line-ending differences are still captured because both sides are normalized identically.