### PR TITLE
Change RepoDotNetFinalVersionKind to 'unstable'

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,7 +16,7 @@
       'preview' produces assets with a '.final' branding suffix.
       'release' produces assets without a branding suffix.
     -->
-    <RepoDotNetFinalVersionKind>repodefault</RepoDotNetFinalVersionKind>
+    <RepoDotNetFinalVersionKind>unstable</RepoDotNetFinalVersionKind>
 
     <!-- Arcade features -->
     <UseVSTestRunner>true</UseVSTestRunner>


### PR DESCRIPTION
To counter msbuild which already stabilized its vs18.9 branch that inserts into 4xx. Fixes consumption in sdk: https://github.com/dotnet/sdk/pull/55202

Needs fix: https://github.com/dotnet/dotnet/pull/7623