### PR TITLE
Work around license scan timeout by scanning source-build-assets serially

### DIFF
--- a/eng/pipelines/templates/stages/vmr-license-scan.yml
+++ b/eng/pipelines/templates/stages/vmr-license-scan.yml
@@ -23,20 +23,37 @@ stages:
           local name="$1"
           local repoPath="$2"
           local scanIgnorePatterns="${3:-}"
+          local scanProcessCount="${4:-}"
           if [ ! -z "$matrix" ]; then
             matrix="$matrix,"
           fi
-          matrix="$matrix \"$name\": { \"repoPath\": \"$repoPath\", \"scanIgnorePatterns\": \"$scanIgnorePatterns\" }"
+          matrix="$matrix \"$name\": { \"repoPath\": \"$repoPath\", \"scanIgnorePatterns\": \"$scanIgnorePatterns\", \"scanProcessCount\": \"$scanProcessCount\" }"
         }
 
         # Repos whose src/ subdirectories should be scanned as separate jobs.
         # The repo root is also scanned with --ignore to skip subdirectories covered by sub-scans.
         splitRepos="source-build-assets"
 
+        # Repos that should scan with a reduced number of scancode processes. This is
+        # independent of splitRepos. Their large, text-heavy content deadlocks scancode's
+        # multiprocessing pool at the end of a scan, so they are scanned serially (0 disables
+        # multiprocessing). Other repos use the test's default. Flows through the matrix.
+        serialScanRepos="source-build-assets"
+        serialScanProcessCount=0
+
+        # Returns the scancode --processes value for a repo, or empty to use the test's default.
+        getScanProcessCount() {
+          local repoName="$1"
+          if echo "$serialScanRepos" | grep -qw "$repoName"; then
+            echo "$serialScanProcessCount"
+          fi
+        }
+
         # If the repo name is provided, only scan that repo.
         if [ ! -z "$specificRepoName" ]; then
           repoName="$specificRepoName"
           dir="$vmrSrcDir/$specificRepoName"
+          scanProcessCount=$(getScanProcessCount "$repoName")
 
           if echo "$splitRepos" | grep -qw "$repoName"; then
             ignorePatterns=""
@@ -48,17 +65,18 @@ stages:
                   ignorePatterns="$ignorePatterns "
                 fi
                 ignorePatterns="$ignorePatterns$subdirName"
-                addMatrixEntry "${repoName}_${subdirName}" "$subdir"
+                addMatrixEntry "${repoName}_${subdirName}" "$subdir" "" "$scanProcessCount"
               fi
             done
-            addMatrixEntry "$repoName" "$dir" "$ignorePatterns"
+            addMatrixEntry "$repoName" "$dir" "$ignorePatterns" "$scanProcessCount"
           else
-            addMatrixEntry "$repoName" "$dir"
+            addMatrixEntry "$repoName" "$dir" "" "$scanProcessCount"
           fi
         else
           for dir in "$vmrSrcDir"/*/
           do
             repoName=$(basename "$dir")
+            scanProcessCount=$(getScanProcessCount "$repoName")
 
             if echo "$splitRepos" | grep -qw "$repoName"; then
               # Root scan: skip subdirectories that are covered by sub-scans
@@ -73,12 +91,12 @@ stages:
                     ignorePatterns="$ignorePatterns "
                   fi
                   ignorePatterns="$ignorePatterns$subdirName"
-                  addMatrixEntry "${repoName}_${subdirName}" "$subdir"
+                  addMatrixEntry "${repoName}_${subdirName}" "$subdir" "" "$scanProcessCount"
                 fi
               done
-              addMatrixEntry "$repoName" "$dir" "$ignorePatterns"
+              addMatrixEntry "$repoName" "$dir" "$ignorePatterns" "$scanProcessCount"
             else
-              addMatrixEntry "$repoName" "$dir"
+              addMatrixEntry "$repoName" "$dir" "" "$scanProcessCount"
             fi
           done
         fi
@@ -116,6 +134,7 @@ stages:
         -clp:v=m
         /p:SourceBuildTestsLicenseScanPath=$(repoPath)
         "/p:SourceBuildTestsLicenseScanIgnorePatterns=$(scanIgnorePatterns)"
+        /p:SourceBuildTestsLicenseScanProcessCount=$(scanProcessCount)
         /p:TargetRid=linux-x64
         /p:PortableTargetRid=linux-x64
         /p:SkipPrepareSdkArchive=true

--- a/eng/pipelines/vmr-license-scan.yml
+++ b/eng/pipelines/vmr-license-scan.yml
@@ -65,7 +65,6 @@ extends:
     containers:
       azurelinuxSourceBuildTestContainer:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-source-build-test-amd64
-        options: '--memory=12g'
     sdl:
       sourceAnalysisPool:
           name: NetCore1ESPool-Svc-Internal

--- a/test/Microsoft.DotNet.SourceBuild.Tests/Config.cs
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/Config.cs
@@ -21,6 +21,8 @@ internal static class Config
     public static string? CustomPackagesPath => (string)AppContext.GetData(ConfigSwitchPrefix + nameof(CustomPackagesPath))!;
     public static string? LicenseScanPath => (string)AppContext.GetData(ConfigSwitchPrefix + nameof(LicenseScanPath))!;
     public static string? LicenseScanIgnorePatterns => (string)AppContext.GetData(ConfigSwitchPrefix + nameof(LicenseScanIgnorePatterns))!;
+    public static int? LicenseScanProcessCount =>
+        int.TryParse((string?)AppContext.GetData(ConfigSwitchPrefix + nameof(LicenseScanProcessCount)), out int processCount) ? processCount : null;
     public static string? MsftSdkTarballPath => (string)AppContext.GetData(ConfigSwitchPrefix + nameof(MsftSdkTarballPath))!;
     public static string? PoisonReportPath => (string)AppContext.GetData(ConfigSwitchPrefix + nameof(PoisonReportPath))!;
     public static string? SdkTarballPath => (string)AppContext.GetData(ConfigSwitchPrefix + nameof(SdkTarballPath))!;

--- a/test/Microsoft.DotNet.SourceBuild.Tests/LicenseScanTests.cs
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/LicenseScanTests.cs
@@ -155,6 +155,12 @@ public class LicenseScanTests : TestBase
         // Indicates how long until a timeout occurs for scanning a given file
         const int FileScanTimeoutSeconds = 1800;
 
+        // Number of parallel processes scancode should use. Large, text-heavy repos can
+        // deadlock scancode's multiprocessing pool at the end of a scan, so the pipeline
+        // scans them serially by passing 0. Default to 4 when not specified by the pipeline.
+        const int DefaultProcessCount = 4;
+        int processCount = Config.LicenseScanProcessCount ?? DefaultProcessCount;
+
         string scancodeResultsPath = Path.Combine(Config.LogsDirectory, "scancode-results.json");
 
         // Combine default and additional ignore patterns
@@ -170,7 +176,7 @@ public class LicenseScanTests : TestBase
         string ignoreOptions = string.Join(" ", allIgnorePatterns.Select(pattern => $"--ignore {pattern}"));
         ExecuteHelper.ExecuteProcessValidateExitCode(
             "scancode",
-            $"--license --processes 4 --timeout {FileScanTimeoutSeconds} --strip-root --only-findings {ignoreOptions} --json-pp {scancodeResultsPath} {Config.LicenseScanPath}",
+            $"--license --processes {processCount} --timeout {FileScanTimeoutSeconds} --strip-root --only-findings {ignoreOptions} --json-pp {scancodeResultsPath} {Config.LicenseScanPath}",
             OutputHelper);
 
         JsonDocument doc = JsonDocument.Parse(File.ReadAllText(scancodeResultsPath));

--- a/test/Microsoft.DotNet.SourceBuild.Tests/Microsoft.DotNet.SourceBuild.Tests.csproj
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/Microsoft.DotNet.SourceBuild.Tests.csproj
@@ -77,6 +77,10 @@
                                       Condition="'$(SourceBuildTestsLicenseScanIgnorePatterns)' != ''">
         <Value>$(SourceBuildTestsLicenseScanIgnorePatterns)</Value>
       </RuntimeHostConfigurationOption>
+      <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).LicenseScanProcessCount"
+                                      Condition="'$(SourceBuildTestsLicenseScanProcessCount)' != ''">
+        <Value>$(SourceBuildTestsLicenseScanProcessCount)</Value>
+      </RuntimeHostConfigurationOption>
       <RuntimeHostConfigurationOption Include="$(MSBuildProjectName).MsftSdkTarballPath">
         <Value>$(MsftSdkTarballPath)</Value>
       </RuntimeHostConfigurationOption>


### PR DESCRIPTION
The license scan pipeline has been failing frequently with a timeout. scancode deadlocks its multiprocessing pool at the end of a scan on the large, text-heavy source-build-assets content, causing the job to hang past its timeout.

Scan the affected content serially to avoid the deadlock:
- Make the scancode `--processes` count pipeline-driven per matrix leg. An independent `serialScanRepos` list (source-build-assets) flows a process count of 0 through the matrix to the test, disabling scancode multiprocessing for those legs; all other repos use the test's default of 4.
- Remove the `--memory` container cap in `vmr-license-scan.yml` so the scan is no longer memory-throttled.

Fixes https://github.com/dotnet/source-build/issues/5470