### PR TITLE
Fix VMR sync: update aspire remote name

### DIFF
--- a/src/source-mappings.json
+++ b/src/source-mappings.json
@@ -62,7 +62,7 @@
         },
         {
             "name": "aspire",
-            "defaultRemote": "https://github.com/dotnet/aspire",
+            "defaultRemote": "https://github.com/microsoft/aspire",
             "exclude": [
                 "src/Aspire.Dashboard/**/*",
                 "samples/**/*"


### PR DESCRIPTION
VMR sync is failing with this error:

```
fail: Repository https://github.com/dotnet/aspire was not found!
fail: Pushing to the VMR failed. 
      Not all pushed commits are publicly available
```