### PR TITLE
Fix reproducibility pipeline creating a single shared PR for both jobs

### DIFF
--- a/eng/pipelines/templates/jobs/reproducibility-test.yml
+++ b/eng/pipelines/templates/jobs/reproducibility-test.yml
@@ -144,3 +144,4 @@ jobs:
           originalFilesDirectory: test/Microsoft.DotNet.Reproducibility.Tests/assets
           updatedFilesDirectory: $(Build.StagingDirectory)/BuildLogs
           pullRequestTitle: ${{ parameters.pullRequestTitle }}
+          identifier: ${{ parameters.buildType }}

--- a/eng/pipelines/templates/steps/create-baseline-update-pr.yml
+++ b/eng/pipelines/templates/steps/create-baseline-update-pr.yml
@@ -23,6 +23,12 @@ parameters:
   type: string
   default: Update Test Baselines
 
+# Optional discriminator forwarded to the runner so multiple jobs of the same pipeline
+# targeting the same branch produce distinct PRs.
+- name: identifier
+  type: string
+  default: ''
+
 # Two separate invocations of the underlying runner, gated by mutually-exclusive
 # branch conditions. This is defensive programming to ensure that an internal
 # branch isn't accidentally pushed to a public repository.
@@ -37,6 +43,7 @@ steps:
       originalFilesDirectory: ${{ parameters.originalFilesDirectory }}
       updatedFilesDirectory: ${{ parameters.updatedFilesDirectory }}
       pullRequestTitle: ${{ parameters.pullRequestTitle }}
+      identifier: ${{ parameters.identifier }}
 
 - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/') }}:
   - task: AzureCLI@2
@@ -69,3 +76,4 @@ steps:
       originalFilesDirectory: ${{ parameters.originalFilesDirectory }}
       updatedFilesDirectory: ${{ parameters.updatedFilesDirectory }}
       pullRequestTitle: ${{ parameters.pullRequestTitle }}
+      identifier: ${{ parameters.identifier }}

--- a/eng/pipelines/templates/steps/run-baseline-update-pr-tool.yml
+++ b/eng/pipelines/templates/steps/run-baseline-update-pr-tool.yml
@@ -34,6 +34,12 @@ parameters:
   type: string
   default: Update Test Baselines
 
+# Optional discriminator folded into the generated PR head branch name so that multiple
+# jobs of the same pipeline targeting the same branch produce distinct PRs.
+- name: identifier
+  type: string
+  default: ''
+
 steps:
   - script: |
       restoreSources="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"
@@ -41,6 +47,11 @@ steps:
       restoreSources+="%3Bhttps://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json"
 
       branchName=$(echo "$(Build.SourceBranch)" | sed 's/refs\/heads\///g')
+
+      identifierArgs=()
+      if [[ -n "${{ parameters.identifier }}" ]]; then
+        identifierArgs=(--identifier "${{ parameters.identifier }}")
+      fi
 
       ${{ parameters.dotnetPath }}/dotnet run \
         --project eng/tools/CreateBaselineUpdatePR/ \
@@ -51,7 +62,8 @@ steps:
         "${{ parameters.updatedFilesDirectory }}" \
         "$(Build.BuildId)" \
         --title "${{ parameters.pullRequestTitle }}" \
-        --branch "$branchName"
+        --branch "$branchName" \
+        "${identifierArgs[@]}"
     displayName: Publish Test Results PR
     workingDirectory: $(Build.SourcesDirectory)
     condition: succeededOrFailed()

--- a/eng/tools/CreateBaselineUpdatePR/PRCreator.cs
+++ b/eng/tools/CreateBaselineUpdatePR/PRCreator.cs
@@ -16,6 +16,7 @@ public partial class PRCreator
 {
     private readonly GitClient _gitClient;
     private readonly Pipelines _pipeline;
+    private readonly string _identifier;
     private const string BuildLink = "https://dev.azure.com/dnceng/internal/_build/results?buildId=";
     private const string DefaultLicenseBaselineContent = "{\n  \"files\": []\n}";
     private const string UpdatedFilePrefix = "updated";
@@ -25,10 +26,11 @@ public partial class PRCreator
     // branch as a genuine failure.
     private const int BranchCreationVerificationAttempts = 5;
     private static readonly TimeSpan BranchCreationVerificationDelay = TimeSpan.FromSeconds(2);
-    public PRCreator(GitClient gitClient, Pipelines pipeline)
+    public PRCreator(GitClient gitClient, Pipelines pipeline, string? identifier = null)
     {
         _gitClient = gitClient;
         _pipeline = pipeline;
+        _identifier = string.IsNullOrWhiteSpace(identifier) ? string.Empty : identifier.Trim();
     }
 
     [GeneratedRegex("-+")]
@@ -534,8 +536,21 @@ public partial class PRCreator
     private string BuildHeadBranchName(string targetBranch)
     {
         string sanitized = SanitizeForBranchName(targetBranch);
-        string hash = ShortHash($"{_pipeline}|{targetBranch}");
-        return $"pr-baseline-{_pipeline.ToString().ToLowerInvariant()}-{sanitized}-{hash}";
+
+        // When no identifier is supplied, preserve the exact historical branch name and hash
+        // input so open PRs from single-job pipelines (sdk, license) are undisturbed.
+        if (_identifier.Length == 0)
+        {
+            string hashNoIdentifier = ShortHash($"{_pipeline}|{targetBranch}");
+            return $"pr-baseline-{_pipeline.ToString().ToLowerInvariant()}-{sanitized}-{hashNoIdentifier}";
+        }
+
+        // With an identifier, fold it into both the readable branch name and the hash so that
+        // multiple jobs of the same pipeline targeting the same branch (e.g. the reproducibility
+        // pipeline's SourceBuilt vs Msft jobs) resolve to distinct branches and therefore distinct PRs.
+        string sanitizedIdentifier = SanitizeForBranchName(_identifier);
+        string hash = ShortHash($"{_pipeline}|{_identifier}|{targetBranch}");
+        return $"pr-baseline-{_pipeline.ToString().ToLowerInvariant()}-{sanitizedIdentifier}-{sanitized}-{hash}";
     }
 
     private static string SanitizeForBranchName(string s)

--- a/eng/tools/CreateBaselineUpdatePR/Program.cs
+++ b/eng/tools/CreateBaselineUpdatePR/Program.cs
@@ -58,6 +58,15 @@ public class Program
         DefaultValueFactory = _ => Environment.GetEnvironmentVariable("GIT_TOKEN")
     };
 
+    public static readonly Option<string?> Identifier = new("--identifier", "-i")
+    {
+        Description = "An optional discriminator folded into the generated head branch name so that " +
+            "multiple jobs of the same pipeline targeting the same branch produce distinct PRs " +
+            "(e.g. the reproducibility pipeline's SourceBuilt vs Msft jobs).",
+        Arity = ArgumentArity.ZeroOrOne,
+        DefaultValueFactory = _ => null
+    };
+
     public static readonly Option<LogLevel> Level = new("--log-level", "-l")
     {
         Description = "The log level to run the tool in.",
@@ -99,7 +108,8 @@ public class Program
             BuildId,
             Title,
             Branch,
-            Token
+            Token,
+            Identifier
         };
     }
 
@@ -120,7 +130,7 @@ public class Program
                 }
                 GitClient client = GitClient.Create(repoUri, token);
 
-                var creator = new PRCreator(client, pipeline);
+                var creator = new PRCreator(client, pipeline, result.GetValue(Identifier));
 
                 await creator.ExecuteAsync(
                     result.GetValue(OriginalFilesDirectory)!,


### PR DESCRIPTION
The reproducibility `Compare` stage runs two PR-publishing jobs (`SourceBuilt` and `Msft`). Both invoked `CreateBaselineUpdatePR` with the same target branch, so it produced an identical head branch and the jobs collided on one PR instead of two.

Add an optional `--identifier` discriminator that is folded into the generated head branch name so each job gets a distinct branch and PR. When no identifier is supplied the branch name is unchanged, so the sdk and license pipelines' existing PRs are unaffected.