### PR TITLE
Fix VMR sync: update aspire AzDO name

### DIFF
--- a/src/source-manifest.json
+++ b/src/source-manifest.json
@@ -9,7 +9,7 @@
     {
       "packageVersion": "8.0.0-preview.1.23557.2",
       "path": "aspire",
-      "remoteUri": "https://dev.azure.com/dnceng/internal/_git/dotnet-aspire",
+      "remoteUri": "https://dev.azure.com/dnceng/internal/_git/microsoft-aspire",
       "commitSha": "48e42f59d64d84b404e904996a9ed61f2a17a569"
     },
     {


### PR DESCRIPTION
The changes in https://github.com/dotnet/dotnet/pull/7627 were incomplete. Also requires updating the AzDO repo name.