### PR TITLE
Update allowed-sb-binaries.txt to remove MicroBuild

### DIFF
--- a/eng/allowed-sb-binaries.txt
+++ b/eng/allowed-sb-binaries.txt
@@ -9,7 +9,6 @@ artifacts/
 .git/
 .packages/
 prereqs/packages/
-MicroBuild/ # This is introduced in real and test signed CI builds. Remove with https://github.com/dotnet/arcade/issues/15731
 
 **/*.bmp
 **/*.doc


### PR DESCRIPTION
https://github.com/dotnet/arcade/pull/16307 moved MicroBuild installation into a temp directory, so we should be able to remove `MicroBuild/` from allowed binaries list.