### PR TITLE
Remove semantic versioning v1 flag from StringTools

### DIFF
--- a/src/msbuild/src/StringTools/StringTools.csproj
+++ b/src/msbuild/src/StringTools/StringTools.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>$(LibraryTargetFrameworks);net35</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -12,11 +13,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <SemanticVersioningV1>true</SemanticVersioningV1>
-
     <EnablePackageValidation>true</EnablePackageValidation>
-
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 
     <AssemblyName>Microsoft.NET.StringTools</AssemblyName>
     <PackageDescription>This package contains the $(AssemblyName) assembly which implements common string-related functionality such as weak interning.</PackageDescription>
@@ -60,4 +58,5 @@
         <TfmSpecificPackageFile Include="$(TargetRefPath);@(FinalDocFile)" PackagePath="ref/$(TargetFramework)" />
       </ItemGroup>
   </Target>
+
 </Project>


### PR DESCRIPTION
Fixes the broken official build due to msbuild packages now using semver v2 but stringtools semver1 which causes an incompatibility when restoring: `18.10.0-1-26359-122` vs `18.10.0-1.26359.122`