### PR TITLE
Revert aspire rename in source-mappings

### DIFF
--- a/src/source-mappings.json
+++ b/src/source-mappings.json
@@ -62,7 +62,7 @@
         },
         {
             "name": "aspire",
-            "defaultRemote": "https://github.com/microsoft/aspire",
+            "defaultRemote": "https://github.com/dotnet/aspire",
             "exclude": [
                 "src/Aspire.Dashboard/**/*",
                 "samples/**/*"


### PR DESCRIPTION
This needs to be reset back to the original name to unblock the sync's patching logic.