### PR TITLE
[release/10.0.4xx] Reset F# mapping to build 322121 (drop obsolete branding override)

### DIFF
--- a/src/fsharp/.github/workflows/aw-auto-update.lock.yml
+++ b/src/fsharp/.github/workflows/aw-auto-update.lock.yml
@@ -1359,3 +1359,4 @@ jobs:
             /tmp/gh-aw/safe-output-items.jsonl
             /tmp/gh-aw/temporary-id-map.json
           if-no-files-found: ignore
+

--- a/src/fsharp/.github/workflows/repo-assist.lock.yml
+++ b/src/fsharp/.github/workflows/repo-assist.lock.yml
@@ -89,7 +89,7 @@ on:
     - created
     - edited
   schedule:
-  - cron: "24 */12 * * *"
+  - cron: "30 */12 * * *"
   workflow_dispatch:
     inputs:
       aw_context:

--- a/src/fsharp/azure-pipelines.yml
+++ b/src/fsharp/azure-pipelines.yml
@@ -29,11 +29,11 @@ variables:
   # The future "product" gets developed in main, so should be main in main.
   # When servicing branch gets created, this should maintain the mapping between F# servicing and VS servicing branches
   - name: FSharpReleaseBranchName
-    value: main
+    value: release/10.0.4xx
   # VS Insertion branch name (NOT the same as F# branch)
   # ( for main we insert into VS main and for all *previous* releases we insert into corresponding VS release),
   - name: VSInsertionTargetBranchName
-    value: main
+    value: rel/insiders
   - name: _TeamName
     value: FSharp
   - name: TeamName

--- a/src/fsharp/eng/Version.Details.props
+++ b/src/fsharp/eng/Version.Details.props
@@ -8,10 +8,10 @@ This file should be imported by eng/Versions.props
     <!-- dotnet-arcade dependencies -->
     <MicrosoftDotNetArcadeSdkPackageVersion>10.0.0-beta.26324.4</MicrosoftDotNetArcadeSdkPackageVersion>
     <!-- dotnet-msbuild dependencies -->
-    <MicrosoftBuildPackageVersion>18.10.0-preview-26353-05</MicrosoftBuildPackageVersion>
-    <MicrosoftBuildFrameworkPackageVersion>18.10.0-preview-26353-05</MicrosoftBuildFrameworkPackageVersion>
-    <MicrosoftBuildTasksCorePackageVersion>18.10.0-preview-26353-05</MicrosoftBuildTasksCorePackageVersion>
-    <MicrosoftBuildUtilitiesCorePackageVersion>18.10.0-preview-26353-05</MicrosoftBuildUtilitiesCorePackageVersion>
+    <MicrosoftBuildPackageVersion>18.10.0-preview-26357-08</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildFrameworkPackageVersion>18.10.0-preview-26357-08</MicrosoftBuildFrameworkPackageVersion>
+    <MicrosoftBuildTasksCorePackageVersion>18.10.0-preview-26357-08</MicrosoftBuildTasksCorePackageVersion>
+    <MicrosoftBuildUtilitiesCorePackageVersion>18.10.0-preview-26357-08</MicrosoftBuildUtilitiesCorePackageVersion>
     <!-- dotnet-optimization dependencies -->
     <optimizationlinuxarm64MIBCRuntimePackageVersion>1.0.0-prerelease.26318.1</optimizationlinuxarm64MIBCRuntimePackageVersion>
     <optimizationlinuxx64MIBCRuntimePackageVersion>1.0.0-prerelease.26318.1</optimizationlinuxx64MIBCRuntimePackageVersion>
@@ -19,14 +19,14 @@ This file should be imported by eng/Versions.props
     <optimizationwindows_ntx64MIBCRuntimePackageVersion>1.0.0-prerelease.26318.1</optimizationwindows_ntx64MIBCRuntimePackageVersion>
     <optimizationwindows_ntx86MIBCRuntimePackageVersion>1.0.0-prerelease.26318.1</optimizationwindows_ntx86MIBCRuntimePackageVersion>
     <!-- dotnet-roslyn dependencies -->
-    <MicrosoftCodeAnalysisPackageVersion>5.10.0-1.26356.6</MicrosoftCodeAnalysisPackageVersion>
-    <MicrosoftCodeAnalysisCompilersPackageVersion>5.10.0-1.26356.6</MicrosoftCodeAnalysisCompilersPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>5.10.0-1.26356.6</MicrosoftCodeAnalysisCSharpPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesPackageVersion>5.10.0-1.26356.6</MicrosoftCodeAnalysisEditorFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>5.10.0-1.26356.6</MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
-    <MicrosoftCodeAnalysisExternalAccessFSharpPackageVersion>5.10.0-1.26356.6</MicrosoftCodeAnalysisExternalAccessFSharpPackageVersion>
-    <MicrosoftCodeAnalysisFeaturesPackageVersion>5.10.0-1.26356.6</MicrosoftCodeAnalysisFeaturesPackageVersion>
-    <MicrosoftVisualStudioLanguageServicesPackageVersion>5.10.0-1.26356.6</MicrosoftVisualStudioLanguageServicesPackageVersion>
+    <MicrosoftCodeAnalysisPackageVersion>5.10.0-1.26357.6</MicrosoftCodeAnalysisPackageVersion>
+    <MicrosoftCodeAnalysisCompilersPackageVersion>5.10.0-1.26357.6</MicrosoftCodeAnalysisCompilersPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>5.10.0-1.26357.6</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesPackageVersion>5.10.0-1.26357.6</MicrosoftCodeAnalysisEditorFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>5.10.0-1.26357.6</MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
+    <MicrosoftCodeAnalysisExternalAccessFSharpPackageVersion>5.10.0-1.26357.6</MicrosoftCodeAnalysisExternalAccessFSharpPackageVersion>
+    <MicrosoftCodeAnalysisFeaturesPackageVersion>5.10.0-1.26357.6</MicrosoftCodeAnalysisFeaturesPackageVersion>
+    <MicrosoftVisualStudioLanguageServicesPackageVersion>5.10.0-1.26357.6</MicrosoftVisualStudioLanguageServicesPackageVersion>
     <!-- dotnet-runtime dependencies -->
     <SystemCollectionsImmutablePackageVersion>10.0.2</SystemCollectionsImmutablePackageVersion>
     <SystemCompositionPackageVersion>10.0.2</SystemCompositionPackageVersion>

--- a/src/fsharp/eng/Version.Details.xml
+++ b/src/fsharp/eng/Version.Details.xml
@@ -2,73 +2,83 @@
 <Dependencies>
   <Source Uri="https://github.com/dotnet/dotnet" Mapping="fsharp" Sha="1358fe9202089df7bdb79282a191c9dbbb773a06" BarId="320196" />
   <ProductDependencies>
-    <Dependency Name="Microsoft.Build" Version="18.10.0-preview-26353-05">
+    <Dependency Name="Microsoft.Build" Version="18.10.0-preview-26357-08">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>e2c0a316c8fb5b2d991eb71bdd78bc4a8e279bf8</Sha>
+      <Sha>746aeb090c9e2bcedc398751370da862014ebf7a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build.Framework" Version="18.10.0-preview-26353-05">
+    <Dependency Name="Microsoft.Build.Framework" Version="18.10.0-preview-26357-08">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>e2c0a316c8fb5b2d991eb71bdd78bc4a8e279bf8</Sha>
+      <Sha>746aeb090c9e2bcedc398751370da862014ebf7a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build.Tasks.Core" Version="18.10.0-preview-26353-05">
+    <Dependency Name="Microsoft.Build.Tasks.Core" Version="18.10.0-preview-26357-08">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>e2c0a316c8fb5b2d991eb71bdd78bc4a8e279bf8</Sha>
+      <Sha>746aeb090c9e2bcedc398751370da862014ebf7a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build.Utilities.Core" Version="18.10.0-preview-26353-05">
+    <Dependency Name="Microsoft.Build.Utilities.Core" Version="18.10.0-preview-26357-08">
       <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>e2c0a316c8fb5b2d991eb71bdd78bc4a8e279bf8</Sha>
+      <Sha>746aeb090c9e2bcedc398751370da862014ebf7a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis" Version="5.10.0-1.26356.6">
+    <Dependency Name="Microsoft.CodeAnalysis" Version="5.10.0-1.26357.6">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ed7c2f0b8555529c2abd079945dbc918f0e009df</Sha>
+      <Sha>97ee762dcf4f7135ff591ebf24b6f1dab3fe0632</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Features" Version="5.10.0-1.26356.6">
+    <Dependency Name="Microsoft.CodeAnalysis.Features" Version="5.10.0-1.26357.6">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ed7c2f0b8555529c2abd079945dbc918f0e009df</Sha>
+      <Sha>97ee762dcf4f7135ff591ebf24b6f1dab3fe0632</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures" Version="5.10.0-1.26356.6">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures" Version="5.10.0-1.26357.6">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ed7c2f0b8555529c2abd079945dbc918f0e009df</Sha>
+      <Sha>97ee762dcf4f7135ff591ebf24b6f1dab3fe0632</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="5.10.0-1.26356.6">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="5.10.0-1.26357.6">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ed7c2f0b8555529c2abd079945dbc918f0e009df</Sha>
+      <Sha>97ee762dcf4f7135ff591ebf24b6f1dab3fe0632</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.FSharp" Version="5.10.0-1.26356.6">
+    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.FSharp" Version="5.10.0-1.26357.6">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ed7c2f0b8555529c2abd079945dbc918f0e009df</Sha>
+      <Sha>97ee762dcf4f7135ff591ebf24b6f1dab3fe0632</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="5.10.0-1.26356.6">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="5.10.0-1.26357.6">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ed7c2f0b8555529c2abd079945dbc918f0e009df</Sha>
+      <Sha>97ee762dcf4f7135ff591ebf24b6f1dab3fe0632</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Compilers" Version="5.10.0-1.26356.6">
+    <Dependency Name="Microsoft.CodeAnalysis.Compilers" Version="5.10.0-1.26357.6">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ed7c2f0b8555529c2abd079945dbc918f0e009df</Sha>
+      <Sha>97ee762dcf4f7135ff591ebf24b6f1dab3fe0632</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.VisualStudio.LanguageServices" Version="5.10.0-1.26356.6">
+    <Dependency Name="Microsoft.VisualStudio.LanguageServices" Version="5.10.0-1.26357.6">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>ed7c2f0b8555529c2abd079945dbc918f0e009df</Sha>
+      <Sha>97ee762dcf4f7135ff591ebf24b6f1dab3fe0632</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.Metadata" Version="10.0.2">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha />
-    </Dependency>
-    <Dependency Name="System.Composition" Version="10.0.2">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha />
-    </Dependency>
+    <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
     <Dependency Name="System.Collections.Immutable" Version="10.0.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha />
+      <Sha>
+      </Sha>
     </Dependency>
+    <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
+    <Dependency Name="System.Composition" Version="10.0.2">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>
+      </Sha>
+    </Dependency>
+    <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
     <Dependency Name="System.Diagnostics.DiagnosticSource" Version="10.0.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha />
+      <Sha>
+      </Sha>
     </Dependency>
+    <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
+    <Dependency Name="System.Reflection.Metadata" Version="10.0.2">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>
+      </Sha>
+    </Dependency>
+    <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
     <Dependency Name="System.Security.Cryptography.Xml" Version="10.0.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha />
+      <Sha>
+      </Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/src/fsharp/eng/Versions.props
+++ b/src/fsharp/eng/Versions.props
@@ -14,26 +14,14 @@
   <PropertyGroup>
     <!-- Don't use the built in support for pre-release iteration. The nuget repack task doesn't support
          the iteration format at the moment. https://github.com/dotnet/arcade/issues/15919 -->
-    <FSharpPreReleaseIteration>7</FSharpPreReleaseIteration>
-    <PreReleaseVersionLabel>preview$(FSharpPreReleaseIteration)</PreReleaseVersionLabel>
-    <!-- F# Version components -->
-    <FSMajorVersion>11</FSMajorVersion>
-    <FSMinorVersion>0</FSMinorVersion>
-    <FSBuildVersion>101</FSBuildVersion>
-    <FSRevisionVersion>0</FSRevisionVersion>
-    <!-- -->
-
-
-    <!-- BEGIN - SPECIFIC OVERRIDES for 10.0.4xx. Those are overrides instead of updates to reduce risk of git conflicts in codeflow -->
     <FSharpPreReleaseIteration></FSharpPreReleaseIteration>
     <PreReleaseVersionLabel>servicing$(FSharpPreReleaseIteration)</PreReleaseVersionLabel>
+    <!-- F# Version components -->
     <FSMajorVersion>10</FSMajorVersion>
     <FSMinorVersion>0</FSMinorVersion>
     <FSBuildVersion>400</FSBuildVersion>
-    <FSRevisionVersion>0</FSRevisionVersion>    
-    <!-- END - SPECIFIC OVERRIDES for 10.0.4xx -->
-
-
+    <FSRevisionVersion>0</FSRevisionVersion>
+    <!-- -->
     <!-- F# Language version -->
     <FSLanguageVersion>$(FSMajorVersion).$(FSMinorVersion)</FSLanguageVersion>
     <!-- -->
@@ -50,7 +38,7 @@
     <!-- -->
     <!-- FSharp.Compiler.Service version -->
     <FCSMajorVersion>43</FCSMajorVersion>
-    <FCSMinorVersion>11</FCSMinorVersion>
+    <FCSMinorVersion>12</FCSMinorVersion>
     <FCSBuildVersion>$(FSBuildVersion)</FCSBuildVersion>
     <FCSRevisionVersion>$(FSRevisionVersion)</FCSRevisionVersion>
     <FSharpCompilerServicePackageVersion>$(FCSMajorVersion).$(FCSMinorVersion).$(FCSBuildVersion)</FSharpCompilerServicePackageVersion>

--- a/src/fsharp/global.json
+++ b/src/fsharp/global.json
@@ -8,21 +8,21 @@
     ],
     "errorMessage": "The .NET SDK could not be found, please run ./eng/common/dotnet.sh."
   },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  },
   "tools": {
     "dotnet": "10.0.301",
     "vs": {
-      "version": "17.14",
+      "version": "18.0",
       "components": [
         "Microsoft.VisualStudio.Component.FSharp"
       ]
     },
-    "xcopy-msbuild": "17.14.16"
+    "xcopy-msbuild": "18.0.0"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.26324.4",
     "Microsoft.DotNet.Helix.Sdk": "8.0.0-beta.23255.2"
-  },
-  "test": {
-    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/src/source-manifest.json
+++ b/src/source-manifest.json
@@ -13,10 +13,10 @@
       "commitSha": "73f1fdca8d9fb191297a7e687790b804f4e78ef5"
     },
     {
-      "barId": 321793,
+      "barId": 322121,
       "path": "fsharp",
       "remoteUri": "https://github.com/dotnet/fsharp",
-      "commitSha": "527a6c3c19827f0801197b76e9e5480e9e7562ab"
+      "commitSha": "85903b5f57bd64d0cf0af7316c1e368de12f8234"
     },
     {
       "barId": 322353,


### PR DESCRIPTION
Resets the `fsharp` mapping to build 322121 (`85903b5`) — the first F# build carrying the `release/10.0.4xx` servicing branding (F# 10.0.400, FCS 43.12.400).

Drops the now-obsolete inline version override and advances the mapping, unblocking the forward-flow codeflow that was stuck on it. This branch has no backflow, so the mapping reset is safe.

Ref #7656.
