### PR TITLE
Don't build CoreCLR runtime pack for wasi in DotNetBuildAllRuntimePacks

### DIFF
--- a/src/runtime/eng/Subsets.props
+++ b/src/runtime/eng/Subsets.props
@@ -702,7 +702,7 @@
           </PropertyGroup>
 
           <PropertyGroup Condition="'$(DotNetBuildAllRuntimePacks)' == 'true' and '$(DotNetBuildSourceOnly)' != 'true'">
-            <_BuildCoreCLRRuntimePack Condition="'$(CoreCLRSupported)' == 'true' and '$(TargetsBrowser)' != 'true'">true</_BuildCoreCLRRuntimePack>
+            <_BuildCoreCLRRuntimePack Condition="'$(CoreCLRSupported)' == 'true' and '$(TargetsWasm)' != 'true'">true</_BuildCoreCLRRuntimePack>
             <_BuildMonoRuntimePack Condition="'$(MonoSupported)' == 'true'">true</_BuildMonoRuntimePack>
           </PropertyGroup>
 


### PR DESCRIPTION
## Problem

The VMR `dotnet-unified-build` **wasi-wasm** leg fails when building all runtime packs (`DotNetBuildAllRuntimePacks=true`). The inner runtime build errors with:

```
src/runtime/eng/liveBuilds.targets(80,5): error : The CoreCLR artifacts path does not exist
'.../src/runtime/artifacts/bin/coreclr/wasi.wasm.Release/'. The 'clr' subset must be built
before building this project.
[.../Microsoft.NETCore.App.Runtime.CoreCLR.sfxproj]
```

The wasi-wasm leg only builds the **Mono** subset, but the runtime-pack selection tried to build the **CoreCLR** runtime pack as well.

## Root cause

`CoreCLRSupported` is now `true` for wasi (`src/runtime/eng/Subsets.props`), but the `DotNetBuildAllRuntimePacks` selection for the CoreCLR runtime pack only excluded `TargetsBrowser`, not wasi:

```xml
<_BuildCoreCLRRuntimePack Condition="'$(CoreCLRSupported)' == 'true' and '$(TargetsBrowser)' != 'true'">true</_BuildCoreCLRRuntimePack>
```

So browser was correctly skipped, but wasi slipped through and attempted to build a CoreCLR runtime pack with no `clr` artifacts present.

## Fix

Exclude `TargetsWasm` (true for both browser and wasi, since both use the `wasm` architecture) instead of just `TargetsBrowser`, making wasi symmetric with browser:

```xml
<_BuildCoreCLRRuntimePack Condition="'$(CoreCLRSupported)' == 'true' and '$(TargetsWasm)' != 'true'">true</_BuildCoreCLRRuntimePack>
```

The wasi-wasm leg now builds only the Mono runtime pack (which already succeeds) and no longer attempts the CoreCLR pack.

## Does this block building CoreCLR for wasi in the runtime repo?

**No.** This is important because CoreCLR-on-wasi is under active development in `dotnet/runtime` and must keep building there.

`_BuildCoreCLRRuntimePack` only gates the **runtime pack packaging** project (`Microsoft.NETCore.App.Runtime.CoreCLR.sfxproj`). It does **not** gate building the actual CoreCLR VM / native runtime (the `clr` subset), which is selected independently.

The change is also scoped to a single `PropertyGroup` that only applies when `DotNetBuildAllRuntimePacks=true`. The default path used for explicit CoreCLR builds is untouched:

```xml
<!-- Default path — used by explicit /p:RuntimeFlavor=CoreCLR builds, NOT changed -->
<_BuildCoreCLRRuntimePack Condition="'$(RuntimeFlavor)' == 'CoreCLR' and '$(CoreCLRSupported)' == 'true'">true</_BuildCoreCLRRuntimePack>
```

Impact matrix:

| Scenario | Path | Affected? |
| --- | --- | --- |
| Building the CoreCLR VM / `clr` subset for wasi (e.g. `-s clr /p:RuntimeFlavor=CoreCLR`) | `clr` subset (separate) | No |
| CoreCLR wasi runtime pack via explicit `/p:RuntimeFlavor=CoreCLR` | default `PropertyGroup` | No |
| CoreCLR wasi runtime pack in `DotNetBuildAllRuntimePacks=true` mode | this `PropertyGroup` | Yes — now skipped (same as browser) |

So ongoing CoreCLR-on-wasi development, which builds with an explicit `/p:RuntimeFlavor=CoreCLR`, is unaffected. Only the VMR "build every runtime pack" mode changes, which is exactly the failing scenario and currently builds only the Mono subset for wasi.

**Future follow-up:** once the wasi leg actually builds the `clr` subset and we want the VMR/all-packs build to ship a `Microsoft.NETCore.App.Runtime.CoreCLR.wasi-wasm` pack, this `TargetsWasm != 'true'` exclusion should be relaxed (e.g. gate it on whether `clr` was built for wasm) — mirroring the same decision browser will eventually face.

## Notes

This edits a mirrored `src/runtime/**` file. The equivalent change should also land in `dotnet/runtime` so it isn't overwritten by the next codeflow.

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.
