### PR TITLE
Fix internal feeds auth: Remove Token env variable from NuGet feeds setup

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -584,7 +584,7 @@ jobs:
             $nugetConfig = if ($nugetConfigFile) { $nugetConfigFile.FullName } else { Join-Path $repoDir "NuGet.config" }
             
             Write-Host "Setting up internal NuGet feeds for $description"
-            & $setupScript $nugetConfig $env:Token
+            & $setupScript $nugetConfig
             Write-Host ""
           }
           
@@ -595,8 +595,6 @@ jobs:
           Get-ChildItem -Path "$(sourcesPath)/src" -Directory | ForEach-Object {
             Setup-NuGetFeeds $_.FullName $_.Name
           }
-      env:
-        Token: $(dn-bot-dnceng-artifact-feeds-rw)
 
   # When building internal, authenticate to internal feeds that may be in use
   # We do not need these for source-only builds

--- a/eng/pipelines/templates/steps/vmr-validate-installers.yml
+++ b/eng/pipelines/templates/steps/vmr-validate-installers.yml
@@ -46,9 +46,7 @@ steps:
         $setupScript = "$(Build.SourcesDirectory)/src/scenario-tests/eng/common/SetupNugetSources.ps1"
         $nugetConfigFile = Get-ChildItem -Path "$(Build.SourcesDirectory)/src/scenario-tests" -Filter "nuget.config" -File | Select-Object -First 1
         $nugetConfig = if ($nugetConfigFile) { $nugetConfigFile.FullName } else { "$(Build.SourcesDirectory)/src/scenario-tests/NuGet.config" }
-        & $setupScript $nugetConfig $env:Token
-    env:
-      Token: $(dn-bot-dnceng-artifact-feeds-rw)
+        & $setupScript $nugetConfig
 
 - ${{ if eq(parameters.OS, 'Linux') }}:
   - script: |


### PR DESCRIPTION
Removed Token environment variable from NuGet feeds setup.

Unblocks official builds. Reacts to https://github.com/dotnet/arcade/pull/17079