### PR TITLE
[release/10.0.4xx] Backport PAT-less internal feed auth

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -470,7 +470,7 @@ jobs:
             $nugetConfig = if ($nugetConfigFile) { $nugetConfigFile.FullName } else { Join-Path $repoDir "NuGet.config" }
             
             Write-Host "Setting up internal NuGet feeds for $description"
-            & $setupScript $nugetConfig $env:Token
+            & $setupScript $nugetConfig
             Write-Host ""
           }
           
@@ -481,8 +481,9 @@ jobs:
           Get-ChildItem -Path "$(sourcesPath)/src" -Directory | ForEach-Object {
             Setup-NuGetFeeds $_.FullName $_.Name
           }
-      env:
-        Token: $(dn-bot-dnceng-artifact-feeds-rw)
+
+    # Necessary for PAT-less authentication
+    - task: NuGetAuthenticate@1
 
   # When building internal, authenticate to internal feeds that may be in use
   # We do not need these for source-only builds
@@ -734,7 +735,10 @@ jobs:
           extraBuildProperties="$(baseProperties) /p:ArtifactsStagingDir=$(Build.ArtifactStagingDirectory) $(targetProperties) ${{ parameters.extraProperties }}"
 
           if [[ '${{ parameters.runOnline }}' == 'False' ]]; then
-            customPreBuildArgs="$customPreBuildArgs sudo -E"
+            # Preserve HOME across the sudo boundary so the Azure Artifacts credential
+            # provider provisioned by NuGetAuthenticate can locate the credentials it
+            # cached for internal-feed restore. See https://github.com/dotnet/source-build/issues/5612
+            customPreBuildArgs="$customPreBuildArgs sudo -E --preserve-env=HOME"
           fi
 
           if [[ '${{ parameters.buildSourceOnly }}' == 'True' ]]; then
@@ -773,7 +777,10 @@ jobs:
 
           customPreBuildArgs=""
           if [[ '${{ parameters.runOnline }}' == 'False' ]]; then
-            customPreBuildArgs="sudo -E"
+            # Preserve HOME across the sudo boundary so the Azure Artifacts credential
+            # provider provisioned by NuGetAuthenticate can locate the credentials it
+            # cached for internal-feed restore. See https://github.com/dotnet/source-build/issues/5612
+            customPreBuildArgs="sudo -E --preserve-env=HOME"
             export MICROBUILDOUTPUTFOLDEROVERRIDE
           fi
 

--- a/eng/pipelines/templates/steps/vmr-validate-installers.yml
+++ b/eng/pipelines/templates/steps/vmr-validate-installers.yml
@@ -46,9 +46,7 @@ steps:
         $setupScript = "$(Build.SourcesDirectory)/src/scenario-tests/eng/common/SetupNugetSources.ps1"
         $nugetConfigFile = Get-ChildItem -Path "$(Build.SourcesDirectory)/src/scenario-tests" -Filter "nuget.config" -File | Select-Object -First 1
         $nugetConfig = if ($nugetConfigFile) { $nugetConfigFile.FullName } else { "$(Build.SourcesDirectory)/src/scenario-tests/NuGet.config" }
-        & $setupScript $nugetConfig $env:Token
-    env:
-      Token: $(dn-bot-dnceng-artifact-feeds-rw)
+        & $setupScript $nugetConfig
 
 - ${{ if eq(parameters.OS, 'Linux') }}:
   - script: |


### PR DESCRIPTION
Migrate release/10.0.4xx from embedded-PAT NuGet auth to PAT-less credential-provider auth, backporting #7686 and #7688 while avoiding the offline sudo/HOME failure tracked by dotnet/source-build#5612.

- #7686: Remove the embedded dn-bot-dnceng-artifact-feeds-rw PAT from the Setup Internal Feeds steps in vmr-build.yml and vmr-validate-installers.yml.
- #7688: Add an ungated NuGetAuthenticate@1 task so the Azure Artifacts credential provider is provisioned for all internal legs, including source-only.
- dotnet/source-build#5612: Preserve HOME across the sudo boundary (sudo -E --preserve-env=HOME) in the offline Run Tests and Sign steps so the credential provider can locate the credentials it cached for internal-feed restore.

Test pipeline run: https://dev.azure.com/dnceng/internal/_build/results?buildId=3021586&view=logs&j=4673cdac-d537-599c-169d-a7f9ca3ff2e1&t=95768061-289f-5a1b-59f3-0482bad17354