### PR TITLE
[release/10.0.1xx] Backport PAT-less internal feed auth

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -490,7 +490,6 @@ jobs:
         targetType: 'inline'
         script: |
           $sourcesPath = "$(sourcesPath)"
-          $token = $env:Token
           
           Get-ChildItem -Path "$sourcesPath/src" -Directory | ForEach-Object {
             $repoDir = $_.FullName
@@ -500,11 +499,12 @@ jobs:
             $nugetConfig = if ($nugetConfigFile) { $nugetConfigFile.FullName } else { Join-Path $repoDir "NuGet.config" }
             
             Write-Host "Setting up internal NuGet feeds for $($_.Name)"
-            & $setupScript $nugetConfig $token
+            & $setupScript $nugetConfig
             Write-Host ""
           }
-      env:
-        Token: $(dn-bot-dnceng-artifact-feeds-rw)
+
+    # Necessary for PAT-less authentication
+    - task: NuGetAuthenticate@1
 
   # When building internal, authenticate to internal feeds that may be in use
   # We do not need these for source-only builds
@@ -635,7 +635,10 @@ jobs:
           if [[ '${{ parameters.runOnline }}' == 'True' ]]; then
             customBuildArgs="$customBuildArgs --online"
           else
-            customPreBuildArgs="$customPreBuildArgs sudo -E unshare -n"
+            # Preserve HOME across the sudo boundary so the Azure Artifacts credential
+            # provider provisioned by NuGetAuthenticate can locate the credentials it
+            # cached for internal-feed restore. See https://github.com/dotnet/source-build/issues/5612
+            customPreBuildArgs="$customPreBuildArgs sudo -E --preserve-env=HOME unshare -n"
           fi
 
           if [[ '${{ parameters.enablePoison }}' == 'True' ]]; then
@@ -761,7 +764,10 @@ jobs:
 
           customPreBuildArgs=""
           if [[ '${{ parameters.runOnline }}' == 'False' ]]; then
-            customPreBuildArgs="sudo -E"
+            # Preserve HOME across the sudo boundary so the Azure Artifacts credential
+            # provider provisioned by NuGetAuthenticate can locate the credentials it
+            # cached for internal-feed restore. See https://github.com/dotnet/source-build/issues/5612
+            customPreBuildArgs="sudo -E --preserve-env=HOME"
             export MICROBUILDOUTPUTFOLDEROVERRIDE
           fi
 


### PR DESCRIPTION
Backport https://github.com/dotnet/dotnet/pull/7697 to release/10.0.1xx

Migrate from embedded-PAT NuGet auth to PAT-less credential-provider auth:

- Remove the embedded dn-bot-dnceng-artifact-feeds-rw PAT from the Setup Internal Feeds step in vmr-build.yml.
- Add an ungated NuGetAuthenticate@1 task so the Azure Artifacts credential provider is provisioned for all internal legs, including source-only.
- Preserve HOME across the sudo boundary (sudo -E --preserve-env=HOME) in the offline build and sign steps so the credential provider can locate the credentials it cached for internal-feed restore. See https://github.com/dotnet/source-build/issues/5612
- vmr-validate-installers.yml needs no change on release/10.0.1xx: it already uses NuGetAuthenticate@1 and has no embedded-PAT NuGet setup block.