### PR TITLE
[DO NOT MERGE] Break vstest SCI pin to 9.0.11 to trip the coverage scenario test

### DIFF
--- a/src/vstest/eng/Version.Details.props
+++ b/src/vstest/eng/Version.Details.props
@@ -13,7 +13,7 @@ This file should be imported by eng/Versions.props
     <MicrosoftDiagnosticsNETCoreClientPackageVersion>0.2.0-preview.26360.111</MicrosoftDiagnosticsNETCoreClientPackageVersion>
     <!-- dotnet-runtime dependencies -->
     <MicrosoftExtensionsDependencyModelPackageVersion>6.0.2</MicrosoftExtensionsDependencyModelPackageVersion>
-    <SystemCollectionsImmutablePackageVersion>10.0.0</SystemCollectionsImmutablePackageVersion>
+    <SystemCollectionsImmutablePackageVersion>9.0.11</SystemCollectionsImmutablePackageVersion>
     <!-- dotnet-symreader-converter dependencies -->
     <MicrosoftDiaSymReaderConverterPackageVersion>1.1.0-beta2-19575-01</MicrosoftDiaSymReaderConverterPackageVersion>
     <MicrosoftDiaSymReaderPdb2PdbPackageVersion>1.1.0-beta2-19575-01</MicrosoftDiaSymReaderPdb2PdbPackageVersion>

--- a/src/vstest/eng/Version.Details.xml
+++ b/src/vstest/eng/Version.Details.xml
@@ -20,9 +20,9 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
     </Dependency>
-    <Dependency Name="System.Collections.Immutable" Version="10.0.0">
+    <Dependency Name="System.Collections.Immutable" Version="9.0.11">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>60629d14374c56f1cb51819049ad1fa529307f8d</Sha>
+      <Sha>7d57652f33493fa022125b7f63aad0d70c52d810</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>


### PR DESCRIPTION
Not for merge. This is a deliberate regression to check that the new `dotnet test` coverage scenarios (dotnet/scenario-tests#348) actually catch the System.Collections.Immutable binding redirect mismatch, so we know the guard works before we rely on it.

It is the reverse of #7454 (and #7192 on 4xx): vstest goes back to shipping System.Collections.Immutable 9.0.11 while the three vstest app.configs (vstest.console, datacollector, testhost.x86) still redirect every load to 10.0.0.0. That is the FileLoadException mismatch we fixed.

I expect the Windows-only `VerifyMSTestVSTestNetFrameworkWithCoverage` scenario to go red, because the net48 VSTest leg runs through vstest.console.exe where the app.config redirect applies. The MTP legs and the .NET (non-Framework) legs do not go through that redirect, so they should stay green.

Will close once we have seen the scenario fail.

Related: #7454, #7192, dotnet/scenario-tests#348