### PR TITLE
Update source mappings by removing excluded path

### DIFF
--- a/src/source-mappings.json
+++ b/src/source-mappings.json
@@ -57,7 +57,6 @@
             "name": "aspnetcore",
             "defaultRemote": "https://github.com/dotnet/aspnetcore",
             "exclude": [
-                "src/submodules/MessagePack-CSharp/src/MessagePack.UnityClient/UserSettings/EditorUserSettings.asset",
                 // Non-OSS license - https://github.com/dotnet/source-build/issues/3537
                 "src/Installers/Windows/AspNetCoreModule-Setup/**/*"
             ]


### PR DESCRIPTION
Removed excluded path for UserSettings.asset from source mappings.

This exclusion was mistakenly added directly in the VMR rather than the sdk repo's branch. Need to revert it to unblock the VMR sync patching behavior in https://github.com/dotnet/sdk/pull/55281.