### PR TITLE
Update WiX toolset to v6

### DIFF
--- a/src/arcade/Directory.Packages.props
+++ b/src/arcade/Directory.Packages.props
@@ -11,7 +11,7 @@
     <!-- Keep Microsoft.Data.Services.Client package version in sync with Microsoft.Data.OData -->
     <MicrosoftDataServicesClientVersion>5.8.4</MicrosoftDataServicesClientVersion>
     <MicrosoftSignedWixVersion>3.14.1-9323.2545153</MicrosoftSignedWixVersion>
-    <MicrosoftWixToolsetSdkVersion>6.0.3-dotnet.4</MicrosoftWixToolsetSdkVersion>
+    <MicrosoftWixToolsetSdkVersion>6.0.3-dotnet.6</MicrosoftWixToolsetSdkVersion>
     <!-- Overwrite XUnitVersion/XUnitAnalyzersVersion/XUnitRunnerConsoleVersion/XUnitRunnerVisualStudioVersion that comes from the Arcade SDK to be in sync as Arcade doesn't use a live Arcade SDK.
          Keep in sync with DefaultVersions.props. -->
     <XUnitVersion>2.9.3</XUnitVersion>

--- a/src/arcade/Directory.Packages.props
+++ b/src/arcade/Directory.Packages.props
@@ -11,7 +11,7 @@
     <!-- Keep Microsoft.Data.Services.Client package version in sync with Microsoft.Data.OData -->
     <MicrosoftDataServicesClientVersion>5.8.4</MicrosoftDataServicesClientVersion>
     <MicrosoftSignedWixVersion>3.14.1-9323.2545153</MicrosoftSignedWixVersion>
-    <MicrosoftWixToolsetSdkVersion>5.0.2-dotnet.3009129</MicrosoftWixToolsetSdkVersion>
+    <MicrosoftWixToolsetSdkVersion>6.0.3-dotnet.4</MicrosoftWixToolsetSdkVersion>
     <!-- Overwrite XUnitVersion/XUnitAnalyzersVersion/XUnitRunnerConsoleVersion/XUnitRunnerVisualStudioVersion that comes from the Arcade SDK to be in sync as Arcade doesn't use a live Arcade SDK.
          Keep in sync with DefaultVersions.props. -->
     <XUnitVersion>2.9.3</XUnitVersion>

--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -99,7 +99,7 @@
     <MicrosoftManifestToolCrossPlatformVersion Condition="'$(MicrosoftManifestToolCrossPlatformVersion)' == ''">2.1.3</MicrosoftManifestToolCrossPlatformVersion>
     <MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion Condition="'$(MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion)' == ''">1.1.286</MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion>
     <MicrosoftSignedWixVersion Condition="'$(MicrosoftSignedWixVersion)' == ''">3.14.1-9323.2545153</MicrosoftSignedWixVersion>
-    <MicrosoftWixToolsetSdkVersion Condition="'$(MicrosoftWixToolsetSdkVersion)' == ''">5.0.2-dotnet.3009129</MicrosoftWixToolsetSdkVersion>
+    <MicrosoftWixToolsetSdkVersion Condition="'$(MicrosoftWixToolsetSdkVersion)' == ''">6.0.3-dotnet.4</MicrosoftWixToolsetSdkVersion>
   </PropertyGroup>
 
   <!-- RestoreSources overrides - defines DotNetRestoreSources variable if available -->

--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/DefaultVersions.props
@@ -99,7 +99,7 @@
     <MicrosoftManifestToolCrossPlatformVersion Condition="'$(MicrosoftManifestToolCrossPlatformVersion)' == ''">2.1.3</MicrosoftManifestToolCrossPlatformVersion>
     <MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion Condition="'$(MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion)' == ''">1.1.286</MicrosoftVisualStudioEngMicroBuildPluginsSwixBuildVersion>
     <MicrosoftSignedWixVersion Condition="'$(MicrosoftSignedWixVersion)' == ''">3.14.1-9323.2545153</MicrosoftSignedWixVersion>
-    <MicrosoftWixToolsetSdkVersion Condition="'$(MicrosoftWixToolsetSdkVersion)' == ''">6.0.3-dotnet.4</MicrosoftWixToolsetSdkVersion>
+    <MicrosoftWixToolsetSdkVersion Condition="'$(MicrosoftWixToolsetSdkVersion)' == ''">6.0.3-dotnet.6</MicrosoftWixToolsetSdkVersion>
   </PropertyGroup>
 
   <!-- RestoreSources overrides - defines DotNetRestoreSources variable if available -->

--- a/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/bundle/bundle.wxs
+++ b/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/bundle/bundle.wxs
@@ -33,7 +33,7 @@
     -->
     <?ifdef RelatedDotNetBundleIds?>
       <?foreach relatedId in $(var.RelatedDotNetBundleIds)?>
-        <RelatedBundle Action="upgrade" Id="$(var.relatedId)"/>
+        <RelatedBundle Action="upgrade" Code="$(var.relatedId)"/>
       <?endforeach?>
     <?endif?>
 

--- a/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/wix.targets
+++ b/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/wix.targets
@@ -53,7 +53,7 @@
 
     <PropertyGroup>
       <WixExeDir>$(PkgMicrosoft_Wix)\tools\net6.0\any\</WixExeDir>
-      <WixExtensionsDir>wixext5</WixExtensionsDir>
+      <WixExtensionsDir>wixext6</WixExtensionsDir>
       <WixUIExtensionDir>$(PkgMicrosoft_WixToolset_UI_wixext)\$(WixExtensionsDir)\</WixUIExtensionDir>
       <WixDependencyExtensionDir>$(PkgMicrosoft_WixToolset_Dependency_wixext)\$(WixExtensionsDir)\</WixDependencyExtensionDir>
       <WixUtilExtensionDir>$(PkgMicrosoft_WixToolset_Util_wixext)\$(WixExtensionsDir)\</WixUtilExtensionDir>
@@ -298,7 +298,7 @@
       SuppressRootDirectory="true"
       DirectoryRefId="%(DirectoryToHarvest.DirectoryRef)"
       OutputFile="%(DirectoryToHarvest.WixSourceFile)"
-      AdditionalOptions="$(AdditionalHeatArgs)" />
+      AdditionalOptions="$(AdditionalHeatArgs) -sw5149" />
 
     <!--
       Currently FileElementToStabilize assumes a single DirectoryToHarvest. If there were multiple,

--- a/src/aspnetcore/global.json
+++ b/src/aspnetcore/global.json
@@ -32,6 +32,6 @@
     "Microsoft.DotNet.SharedFramework.Sdk": "10.0.0-beta.26358.108",
     "Microsoft.Build.NoTargets": "3.7.0",
     "Microsoft.Build.Traversal": "3.4.0",
-    "Microsoft.WixToolset.Sdk": "5.0.2-dotnet.3009129"
+    "Microsoft.WixToolset.Sdk": "6.0.3-dotnet.4"
   }
 }

--- a/src/aspnetcore/global.json
+++ b/src/aspnetcore/global.json
@@ -32,6 +32,6 @@
     "Microsoft.DotNet.SharedFramework.Sdk": "10.0.0-beta.26358.108",
     "Microsoft.Build.NoTargets": "3.7.0",
     "Microsoft.Build.Traversal": "3.4.0",
-    "Microsoft.WixToolset.Sdk": "6.0.3-dotnet.4"
+    "Microsoft.WixToolset.Sdk": "6.0.3-dotnet.6"
   }
 }

--- a/src/aspnetcore/src/Installers/Windows/AspNetCoreModule-Setup/ANCMIISExpressV2/ancm_iis_expressv2.wxs
+++ b/src/aspnetcore/src/Installers/Windows/AspNetCoreModule-Setup/ANCMIISExpressV2/ancm_iis_expressv2.wxs
@@ -502,7 +502,7 @@
 
     <Fragment>
         <Feature Id="FT_DepProvider_$(ProductNameShort)" AllowAdvertise="no" Description="Used for Ref Counting" Display="hidden" InstallDefault="local" Level="1" Title="RefCounting" TypicalDefault="install" AllowAbsent="no">
-            <Component Id="C_DepProvider_$(ProductNameShort)" Directory="TARGETDIR" Bitness="always32" Guid="$(DepProviderGuid)">
+            <Component Id="C_DepProvider_$(ProductNameShort)" Directory="TARGETDIR" Bitness="always32" Guid="*">
                 <Provides Key="$(ANCMDepProviderKey)" dep:Check="yes" />
             </Component>
         </Feature>

--- a/src/aspnetcore/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
+++ b/src/aspnetcore/src/Installers/Windows/AspNetCoreModule-Setup/ANCMV2/aspnetcoremodulev2.wxs
@@ -291,7 +291,7 @@
             <ComponentRef Id="C_DepProvider_$(ProductNameShort)" />
         </Feature>
 
-        <Component Id="C_DepProvider_$(ProductNameShort)" Directory="TARGETDIR" Bitness="always32" Guid="$(DepProviderGuid)">
+        <Component Id="C_DepProvider_$(ProductNameShort)" Directory="TARGETDIR" Bitness="always32" Guid="*">
             <Provides Key="$(ANCMDepProviderKey)" dep:Check="yes" />
         </Component>
     </Fragment>

--- a/src/aspnetcore/src/Installers/Windows/Wix.targets
+++ b/src/aspnetcore/src/Installers/Windows/Wix.targets
@@ -86,16 +86,6 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="_GenerateANCMGuids" Condition="'$(ANCMDepProviderKey)' != ''" BeforeTargets="CoreCompile">
-    <GenerateGuid NamespaceGuid="$(ANCMNamespaceGuid)" Values="$(ANCMDepProviderKey)">
-      <Output TaskParameter="Guid" PropertyName="DepProviderGuid" />
-    </GenerateGuid>
-
-    <PropertyGroup>
-      <DefineConstants>$(DefineConstants);DepProviderGuid=$(DepProviderGuid)</DefineConstants>
-    </PropertyGroup>
-  </Target>
-
   <Target Name="_CheckPackageFileNameIsSet" BeforeTargets="PrepareForBuild">
     <Error Text="Missing required property: PackageFileName" Condition="'$(PackageFileName)' == ''" />
   </Target>

--- a/src/runtime/eng/Versions.props
+++ b/src/runtime/eng/Versions.props
@@ -177,11 +177,11 @@
     <MicrosoftSymbolStoreVersion>1.0.406601</MicrosoftSymbolStoreVersion>
     <!-- sdk version, for testing workloads -->
     <!-- WiX 5+ dependencies for MSI generation -->
-    <MicrosoftWixVersion>5.0.2-dotnet.3009129</MicrosoftWixVersion>
-    <MicrosoftWixToolsetUIWixextVersion>5.0.2-dotnet.3009129</MicrosoftWixToolsetUIWixextVersion>
-    <MicrosoftWixToolsetDependencyWixextVersion>5.0.2-dotnet.3009129</MicrosoftWixToolsetDependencyWixextVersion>
-    <MicrosoftWixToolsetUtilWixextVersion>5.0.2-dotnet.3009129</MicrosoftWixToolsetUtilWixextVersion>
-    <MicrosoftWixToolsetBalWixextVersion>5.0.2-dotnet.3009129</MicrosoftWixToolsetBalWixextVersion>
-    <MicrosoftWixToolsetHeatVersion>5.0.2-dotnet.3009129</MicrosoftWixToolsetHeatVersion>
+    <MicrosoftWixVersion>6.0.3-dotnet.4</MicrosoftWixVersion>
+    <MicrosoftWixToolsetUIWixextVersion>6.0.3-dotnet.4</MicrosoftWixToolsetUIWixextVersion>
+    <MicrosoftWixToolsetDependencyWixextVersion>6.0.3-dotnet.4</MicrosoftWixToolsetDependencyWixextVersion>
+    <MicrosoftWixToolsetUtilWixextVersion>6.0.3-dotnet.4</MicrosoftWixToolsetUtilWixextVersion>
+    <MicrosoftWixToolsetBalWixextVersion>6.0.3-dotnet.4</MicrosoftWixToolsetBalWixextVersion>
+    <MicrosoftWixToolsetHeatVersion>6.0.3-dotnet.4</MicrosoftWixToolsetHeatVersion>
   </PropertyGroup>
 </Project>

--- a/src/runtime/eng/Versions.props
+++ b/src/runtime/eng/Versions.props
@@ -177,11 +177,11 @@
     <MicrosoftSymbolStoreVersion>1.0.406601</MicrosoftSymbolStoreVersion>
     <!-- sdk version, for testing workloads -->
     <!-- WiX 5+ dependencies for MSI generation -->
-    <MicrosoftWixVersion>6.0.3-dotnet.4</MicrosoftWixVersion>
-    <MicrosoftWixToolsetUIWixextVersion>6.0.3-dotnet.4</MicrosoftWixToolsetUIWixextVersion>
-    <MicrosoftWixToolsetDependencyWixextVersion>6.0.3-dotnet.4</MicrosoftWixToolsetDependencyWixextVersion>
-    <MicrosoftWixToolsetUtilWixextVersion>6.0.3-dotnet.4</MicrosoftWixToolsetUtilWixextVersion>
-    <MicrosoftWixToolsetBalWixextVersion>6.0.3-dotnet.4</MicrosoftWixToolsetBalWixextVersion>
-    <MicrosoftWixToolsetHeatVersion>6.0.3-dotnet.4</MicrosoftWixToolsetHeatVersion>
+    <MicrosoftWixVersion>6.0.3-dotnet.6</MicrosoftWixVersion>
+    <MicrosoftWixToolsetUIWixextVersion>6.0.3-dotnet.6</MicrosoftWixToolsetUIWixextVersion>
+    <MicrosoftWixToolsetDependencyWixextVersion>6.0.3-dotnet.6</MicrosoftWixToolsetDependencyWixextVersion>
+    <MicrosoftWixToolsetUtilWixextVersion>6.0.3-dotnet.6</MicrosoftWixToolsetUtilWixextVersion>
+    <MicrosoftWixToolsetBalWixextVersion>6.0.3-dotnet.6</MicrosoftWixToolsetBalWixextVersion>
+    <MicrosoftWixToolsetHeatVersion>6.0.3-dotnet.6</MicrosoftWixToolsetHeatVersion>
   </PropertyGroup>
 </Project>

--- a/src/sdk/global.json
+++ b/src/sdk/global.json
@@ -25,6 +25,6 @@
     "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.26356.112",
     "Microsoft.Build.NoTargets": "3.7.0",
     "Microsoft.Build.Traversal": "3.4.0",
-    "Microsoft.WixToolset.Sdk": "6.0.3-dotnet.4"
+    "Microsoft.WixToolset.Sdk": "6.0.3-dotnet.6"
   }
 }

--- a/src/sdk/global.json
+++ b/src/sdk/global.json
@@ -25,6 +25,6 @@
     "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.26356.112",
     "Microsoft.Build.NoTargets": "3.7.0",
     "Microsoft.Build.Traversal": "3.4.0",
-    "Microsoft.WixToolset.Sdk": "5.0.2-dotnet.2811440"
+    "Microsoft.WixToolset.Sdk": "6.0.3-dotnet.4"
   }
 }

--- a/src/sdk/src/Layout/pkg/windows/Directory.Build.props
+++ b/src/sdk/src/Layout/pkg/windows/Directory.Build.props
@@ -11,6 +11,7 @@
     <InstallerPlatform Condition="'$(InstallerPlatform)' == ''">$(TargetArchitecture)</InstallerPlatform>
     <Platform>$(InstallerPlatform)</Platform>
     <PlatformName>$(InstallerPlatform)</PlatformName>
+    <HarvestDirectorySuppressSpecificWarnings>5149</HarvestDirectorySuppressSpecificWarnings>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.wixproj'">

--- a/src/windowsdesktop/eng/Versions.props
+++ b/src/windowsdesktop/eng/Versions.props
@@ -34,8 +34,8 @@
     <SystemSecurityPrincipalWindowsVersion>5.0.0</SystemSecurityPrincipalWindowsVersion>
     <!-- wcf -->
     <SystemServiceModelVersion>8.1.2</SystemServiceModelVersion>
-  <!-- WiX -->
-  <MicrosoftWixToolsetSdkVersion>5.0.2-dotnet.3009129</MicrosoftWixToolsetSdkVersion>
+    <!-- WiX -->
+    <MicrosoftWixToolsetSdkVersion>6.0.3-dotnet.4</MicrosoftWixToolsetSdkVersion>
     
     <!-- Transport package version for VS insertion packages is defined in Version.Details.props -->
   </PropertyGroup>

--- a/src/windowsdesktop/eng/Versions.props
+++ b/src/windowsdesktop/eng/Versions.props
@@ -35,7 +35,7 @@
     <!-- wcf -->
     <SystemServiceModelVersion>8.1.2</SystemServiceModelVersion>
     <!-- WiX -->
-    <MicrosoftWixToolsetSdkVersion>6.0.3-dotnet.4</MicrosoftWixToolsetSdkVersion>
+    <MicrosoftWixToolsetSdkVersion>6.0.3-dotnet.6</MicrosoftWixToolsetSdkVersion>
     
     <!-- Transport package version for VS insertion packages is defined in Version.Details.props -->
   </PropertyGroup>

--- a/src/windowsdesktop/global.json
+++ b/src/windowsdesktop/global.json
@@ -23,6 +23,6 @@
     "Microsoft.Build.NoTargets": "3.7.0",
     "Microsoft.Build.Traversal": "3.4.0",
     "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25509.106",
-    "Microsoft.WixToolset.Sdk": "6.0.3-dotnet.4"
+    "Microsoft.WixToolset.Sdk": "6.0.3-dotnet.6"
   }
 }

--- a/src/windowsdesktop/global.json
+++ b/src/windowsdesktop/global.json
@@ -23,6 +23,6 @@
     "Microsoft.Build.NoTargets": "3.7.0",
     "Microsoft.Build.Traversal": "3.4.0",
     "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25509.106",
-    "Microsoft.WixToolset.Sdk": "5.0.2-dotnet.3009129"
+    "Microsoft.WixToolset.Sdk": "6.0.3-dotnet.4"
   }
 }

--- a/src/windowsdesktop/src/windowsdesktop/src/bundle/bundle.wxs
+++ b/src/windowsdesktop/src/windowsdesktop/src/bundle/bundle.wxs
@@ -10,18 +10,18 @@
   <!-- This enables preview -> RC -> GA -> servicing upgrade path -->
 
   <!-- Primary upgrade relationship using current deterministic upgrade code (for GA and all servicing) -->
-  <RelatedBundle Id="$(UpgradeCode)" Action="Upgrade" />
+  <RelatedBundle Code="$(UpgradeCode)" Action="Upgrade" />
 
   <!-- Secondary: Upgrade bundles that shipped with legacy UpgradeCode (Preview 2 through RC2) -->
   <!-- Architecture-specific legacy codes used before deterministic generation -->
   <?if $(TargetArchitecture)=x64?>
-  <RelatedBundle Id="{55414577-5A99-7937-6951-9CCC4BE8857E}" Action="Upgrade" />
+  <RelatedBundle Code="{55414577-5A99-7937-6951-9CCC4BE8857E}" Action="Upgrade" />
   <?endif?>
   <?if $(TargetArchitecture)=x86?>
-  <RelatedBundle Id="{4FEAFCE2-50E6-6CFB-797A-D44EBBE7AC5D}" Action="Upgrade" />
+  <RelatedBundle Code="{4FEAFCE2-50E6-6CFB-797A-D44EBBE7AC5D}" Action="Upgrade" />
   <?endif?>
   <?if $(TargetArchitecture)=arm64?>
-  <RelatedBundle Id="{BCE1CB35-52F6-5801-38F9-1E2D6E0FB355}" Action="Upgrade" />
+  <RelatedBundle Code="{BCE1CB35-52F6-5801-38F9-1E2D6E0FB355}" Action="Upgrade" />
   <?endif?>
 
     <bal:Condition Message="#(loc.InstallPathx64x86)" Condition="WixBundleInstalled OR (NOT DOTNETHOME_X64 ~= DOTNETHOME_X86) OR DOTNETHOMESIMILARITYCHECKOVERRIDE" />


### PR DESCRIPTION
Address bundle registration regression by updating the WiX toolset from v5 to v6. 
