### PR TITLE
[release/10.0.1xx] Fix nuget audit failures for msbuild dependencies

### DIFF
--- a/src/msbuild/eng/Packages.props
+++ b/src/msbuild/eng/Packages.props
@@ -42,6 +42,7 @@
     <PackageVersion Include="xunit.console" Version="$(XUnitVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.OpenTelemetry.Collector" Version="$(MicrosoftVisualStudioOpenTelemetryVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.OpenTelemetry.ClientExtensions" Version="$(MicrosoftVisualStudioOpenTelemetryVersion)" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="$(OpenTelemetryApiVersion)" />
 
     <!-- Microsoft.VisualStudio.SolutionPersistence is maintained in eng/dependabot/Packages.props -->
   </ItemGroup>

--- a/src/msbuild/eng/Version.Details.props
+++ b/src/msbuild/eng/Version.Details.props
@@ -18,7 +18,7 @@ This file should be imported by eng/Versions.props
     <SystemResourcesExtensionsPackageVersion>9.0.0</SystemResourcesExtensionsPackageVersion>
     <SystemSecurityCryptographyPkcsPackageVersion>9.0.6</SystemSecurityCryptographyPkcsPackageVersion>
     <SystemSecurityCryptographyProtectedDataPackageVersion>9.0.6</SystemSecurityCryptographyProtectedDataPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>9.0.0</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>9.0.15</SystemSecurityCryptographyXmlPackageVersion>
     <SystemTextEncodingCodePagesPackageVersion>9.0.0</SystemTextEncodingCodePagesPackageVersion>
     <SystemTextJsonPackageVersion>9.0.0</SystemTextJsonPackageVersion>
     <SystemThreadingChannelsPackageVersion>9.0.0</SystemThreadingChannelsPackageVersion>

--- a/src/msbuild/eng/Version.Details.props
+++ b/src/msbuild/eng/Version.Details.props
@@ -11,12 +11,12 @@ This file should be imported by eng/Versions.props
     <SystemConfigurationConfigurationManagerPackageVersion>9.0.0</SystemConfigurationConfigurationManagerPackageVersion>
     <SystemDiagnosticsDiagnosticSourcePackageVersion>9.0.0</SystemDiagnosticsDiagnosticSourcePackageVersion>
     <SystemDiagnosticsEventLogPackageVersion>9.0.0</SystemDiagnosticsEventLogPackageVersion>
-    <SystemFormatsAsn1PackageVersion>9.0.6</SystemFormatsAsn1PackageVersion>
+    <SystemFormatsAsn1PackageVersion>9.0.15</SystemFormatsAsn1PackageVersion>
     <SystemFormatsNrbfPackageVersion>9.0.0</SystemFormatsNrbfPackageVersion>
     <SystemReflectionMetadataPackageVersion>9.0.0</SystemReflectionMetadataPackageVersion>
     <SystemReflectionMetadataLoadContextPackageVersion>9.0.0</SystemReflectionMetadataLoadContextPackageVersion>
     <SystemResourcesExtensionsPackageVersion>9.0.0</SystemResourcesExtensionsPackageVersion>
-    <SystemSecurityCryptographyPkcsPackageVersion>9.0.6</SystemSecurityCryptographyPkcsPackageVersion>
+    <SystemSecurityCryptographyPkcsPackageVersion>9.0.15</SystemSecurityCryptographyPkcsPackageVersion>
     <SystemSecurityCryptographyProtectedDataPackageVersion>9.0.6</SystemSecurityCryptographyProtectedDataPackageVersion>
     <SystemSecurityCryptographyXmlPackageVersion>9.0.15</SystemSecurityCryptographyXmlPackageVersion>
     <SystemTextEncodingCodePagesPackageVersion>9.0.0</SystemTextEncodingCodePagesPackageVersion>

--- a/src/msbuild/eng/Version.Details.props
+++ b/src/msbuild/eng/Version.Details.props
@@ -9,7 +9,7 @@ This file should be imported by eng/Versions.props
     <SystemCodeDomPackageVersion>9.0.0</SystemCodeDomPackageVersion>
     <SystemCollectionsImmutablePackageVersion>9.0.0</SystemCollectionsImmutablePackageVersion>
     <SystemConfigurationConfigurationManagerPackageVersion>9.0.0</SystemConfigurationConfigurationManagerPackageVersion>
-    <SystemDiagnosticsDiagnosticSourcePackageVersion>9.0.0</SystemDiagnosticsDiagnosticSourcePackageVersion>
+    <SystemDiagnosticsDiagnosticSourcePackageVersion>10.0.0</SystemDiagnosticsDiagnosticSourcePackageVersion>
     <SystemDiagnosticsEventLogPackageVersion>9.0.0</SystemDiagnosticsEventLogPackageVersion>
     <SystemFormatsAsn1PackageVersion>9.0.15</SystemFormatsAsn1PackageVersion>
     <SystemFormatsNrbfPackageVersion>9.0.0</SystemFormatsNrbfPackageVersion>

--- a/src/msbuild/eng/Version.Details.xml
+++ b/src/msbuild/eng/Version.Details.xml
@@ -75,7 +75,7 @@
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Security.Cryptography.Xml" Version="9.0.0">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="9.0.15">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>

--- a/src/msbuild/eng/Version.Details.xml
+++ b/src/msbuild/eng/Version.Details.xml
@@ -21,7 +21,7 @@
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="9.0.0">
+    <Dependency Name="System.Diagnostics.DiagnosticSource" Version="10.0.0">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>

--- a/src/msbuild/eng/Version.Details.xml
+++ b/src/msbuild/eng/Version.Details.xml
@@ -33,7 +33,7 @@
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Formats.Asn1" Version="9.0.6">
+    <Dependency Name="System.Formats.Asn1" Version="9.0.15">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>
@@ -69,7 +69,7 @@
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Security.Cryptography.Pkcs" Version="9.0.6">
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="9.0.15">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>

--- a/src/msbuild/eng/Versions.props
+++ b/src/msbuild/eng/Versions.props
@@ -55,6 +55,9 @@
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftVisualStudioOpenTelemetryVersion>0.2.104-beta</MicrosoftVisualStudioOpenTelemetryVersion>
+    <!-- Pinned above the version brought in transitively by the Microsoft.VisualStudio.OpenTelemetry.*
+         packages to pick up the fix for GHSA-g94r-2vxg-569j (CVE-2026-40894). -->
+    <OpenTelemetryApiVersion>1.15.3</OpenTelemetryApiVersion>
     <!-- Microsoft.VisualStudio.SolutionPersistence is maintained in eng/dependabot/Packages.props -->
   </PropertyGroup>
   <!-- Toolset Dependencies -->

--- a/src/msbuild/eng/Versions.props
+++ b/src/msbuild/eng/Versions.props
@@ -45,8 +45,8 @@
         However, we can update, binding-redirect to, and distribute the newest version (that matches the VS-referenced versions) in order to get the benefits of updating.
         See uses of $(UseFrozenMaintenancePackageVersions) for details.
     -->
-    <SystemMemoryVersion>4.6.0</SystemMemoryVersion>
-    <SystemRuntimeCompilerServicesUnsafeVersion>6.1.0</SystemRuntimeCompilerServicesUnsafeVersion>
+    <SystemMemoryVersion>4.6.3</SystemMemoryVersion>
+    <SystemRuntimeCompilerServicesUnsafeVersion>6.1.2</SystemRuntimeCompilerServicesUnsafeVersion>
     <SystemThreadingTasksExtensionsVersion>4.6.0</SystemThreadingTasksExtensionsVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/msbuild/src/Directory.Build.targets
+++ b/src/msbuild/src/Directory.Build.targets
@@ -142,11 +142,17 @@
     <UseFrozenMaintenancePackageVersions Condition="'$(UseFrozenMaintenancePackageVersions)' == '' AND '$(IsUnitTestProject)' != 'true' AND $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net472')) AND '$(OutputType)' != 'exe'">true</UseFrozenMaintenancePackageVersions>
 
     <FrozenMicrosoftIORedistVersion>6.0.1</FrozenMicrosoftIORedistVersion>
-    <FrozenSystemMemoryVersion>4.5.5</FrozenSystemMemoryVersion>
-    <FrozenSystemRuntimeCompilerServicesUnsafeVersion>6.0.0</FrozenSystemRuntimeCompilerServicesUnsafeVersion>
+    <!-- System.Memory is bumped to 4.6.3 (assembly 4.0.5.0) so that net472 assemblies referencing
+         OpenTelemetry.Api 1.15.3 (which hard-binds System.Memory 4.0.5.0) resolve without an MSB3277
+         conflict. Its companions (System.Buffers, System.Numerics.Vectors,
+         System.Runtime.CompilerServices.Unsafe) are bumped to the versions System.Memory 4.6.3 declares
+         as dependencies so the frozen reference closure stays self-consistent. These assembly versions
+         already match the binding redirects distributed in app.config/app.amd64.config. -->
+    <FrozenSystemMemoryVersion>4.6.3</FrozenSystemMemoryVersion>
+    <FrozenSystemRuntimeCompilerServicesUnsafeVersion>6.1.2</FrozenSystemRuntimeCompilerServicesUnsafeVersion>
     <FrozenSystemThreadingTasksExtensionsVersion>4.5.4</FrozenSystemThreadingTasksExtensionsVersion>
-    <FrozenSystemBuffersVersion>4.5.1</FrozenSystemBuffersVersion>
-    <FrozenSystemNumericsVectorsVersion>4.5.0</FrozenSystemNumericsVectorsVersion>
+    <FrozenSystemBuffersVersion>4.6.1</FrozenSystemBuffersVersion>
+    <FrozenSystemNumericsVectorsVersion>4.6.1</FrozenSystemNumericsVectorsVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UseFrozenMaintenancePackageVersions)' == 'true'">
@@ -168,16 +174,16 @@
       <Reference Include="$(NuGetPackageRoot)microsoft.io.redist\$(FrozenMicrosoftIORedistVersion)\lib\net472\Microsoft.IO.Redist.dll" />
 
       <Reference Remove="@(Reference)" Condition="'%(Reference.NuGetPackageId)' == 'System.Buffers' and $([MSBuild]::VersionGreaterThan(%(Reference.NuGetPackageVersion), '$(FrozenSystemBuffersVersion)'))" />
-      <Reference Include="$(NuGetPackageRoot)system.buffers\$(FrozenSystemBuffersVersion)\lib\net461\System.Buffers.dll" />
+      <Reference Include="$(NuGetPackageRoot)system.buffers\$(FrozenSystemBuffersVersion)\lib\net462\System.Buffers.dll" />
 
       <Reference Remove="@(Reference)" Condition="'%(Reference.NuGetPackageId)' == 'System.Memory' and $([MSBuild]::VersionGreaterThan(%(Reference.NuGetPackageVersion), '$(FrozenSystemMemoryVersion)'))" />
-      <Reference Include="$(NuGetPackageRoot)system.memory\$(FrozenSystemMemoryVersion)\lib\net461\System.Memory.dll" />
+      <Reference Include="$(NuGetPackageRoot)system.memory\$(FrozenSystemMemoryVersion)\lib\net462\System.Memory.dll" />
 
       <Reference Remove="@(Reference)" Condition="'%(Reference.NuGetPackageId)' == 'System.Numerics.Vectors' and $([MSBuild]::VersionGreaterThan(%(Reference.NuGetPackageVersion), '$(FrozenSystemNumericsVectorsVersion)'))" />
-      <Reference Include="$(NuGetPackageRoot)system.numerics.vectors\$(FrozenSystemNumericsVectorsVersion)\lib\net46\System.Numerics.Vectors.dll" />
+      <Reference Include="$(NuGetPackageRoot)system.numerics.vectors\$(FrozenSystemNumericsVectorsVersion)\lib\net462\System.Numerics.Vectors.dll" />
 
       <Reference Remove="@(Reference)" Condition="'%(Reference.NuGetPackageId)' == 'System.Runtime.CompilerServices.Unsafe' and $([MSBuild]::VersionGreaterThan(%(Reference.NuGetPackageVersion), '$(FrozenSystemRuntimeCompilerServicesUnsafeVersion)'))" />
-      <Reference Include="$(NuGetPackageRoot)system.runtime.compilerservices.unsafe\$(FrozenSystemRuntimeCompilerServicesUnsafeVersion)\lib\net461\System.Runtime.CompilerServices.Unsafe.dll" />
+      <Reference Include="$(NuGetPackageRoot)system.runtime.compilerservices.unsafe\$(FrozenSystemRuntimeCompilerServicesUnsafeVersion)\lib\net462\System.Runtime.CompilerServices.Unsafe.dll" />
 
       <Reference Remove="@(Reference)" Condition="'%(Reference.NuGetPackageId)' == 'System.Threading.Tasks.Extensions' and $([MSBuild]::VersionGreaterThan(%(Reference.NuGetPackageVersion), '$(FrozenSystemThreadingTasksExtensionsVersion)'))" />
       <Reference Include="$(NuGetPackageRoot)system.threading.tasks.extensions\$(FrozenSystemThreadingTasksExtensionsVersion)\lib\net461\System.Threading.Tasks.Extensions.dll" />

--- a/src/msbuild/src/Framework/Microsoft.Build.Framework.csproj
+++ b/src/msbuild/src/Framework/Microsoft.Build.Framework.csproj
@@ -27,6 +27,9 @@
     <!-- Telemetry in Framework-->
     <PackageReference Include="Microsoft.VisualStudio.OpenTelemetry.Collector" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.OpenTelemetry.ClientExtensions" PrivateAssets="all" />
+    <!-- Pin the transitive OpenTelemetry.Api above the vulnerable version brought in by the packages above
+         (GHSA-g94r-2vxg-569j / CVE-2026-40894). -->
+    <PackageReference Include="OpenTelemetry.Api" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- Framework and standard don't have these. -->

--- a/src/msbuild/src/MSBuild/app.amd64.config
+++ b/src/msbuild/src/MSBuild/app.amd64.config
@@ -94,8 +94,8 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.0.4.0" newVersion="4.0.4.0" />
-          <codeBase version="4.0.4.0" href="..\System.Buffers.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+          <codeBase version="4.0.5.0" href="..\System.Buffers.dll"/>
         </dependentAssembly>
 
         <!-- Pull plugins that reference SCI up to our version in case they depended on our copy of the older version -->
@@ -190,13 +190,13 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
-          <codeBase version="4.0.2.0" href="..\System.Memory.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+          <codeBase version="4.0.5.0" href="..\System.Memory.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.1.5.0" newVersion="4.1.5.0" />
-          <codeBase version="4.1.5.0" href="..\System.Numerics.Vectors.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
+          <codeBase version="4.1.6.0" href="..\System.Numerics.Vectors.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -215,8 +215,8 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-6.0.1.0" newVersion="6.0.1.0" />
-          <codeBase version="6.0.1.0" href="..\System.Runtime.CompilerServices.Unsafe.dll"/>
+          <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
+          <codeBase version="6.0.3.0" href="..\System.Runtime.CompilerServices.Unsafe.dll"/>
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/src/msbuild/src/MSBuild/app.amd64.config
+++ b/src/msbuild/src/MSBuild/app.amd64.config
@@ -106,8 +106,8 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
-          <codeBase version="9.0.0.0" href="..\System.Diagnostics.DiagnosticSource.dll" />
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+          <codeBase version="10.0.0.0" href="..\System.Diagnostics.DiagnosticSource.dll" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Formats.Nrbf" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/src/msbuild/src/MSBuild/app.config
+++ b/src/msbuild/src/MSBuild/app.config
@@ -74,7 +74,7 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+          <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/src/msbuild/src/MSBuild/app.config
+++ b/src/msbuild/src/MSBuild/app.config
@@ -57,7 +57,7 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.0.4.0" newVersion="4.0.4.0" />
+          <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
         </dependentAssembly>
         <!-- Pull plugins that reference SCI up to our version in case they depended on our copy of the older version -->
         <dependentAssembly>
@@ -78,11 +78,11 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+          <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-4.1.5.0" newVersion="4.1.5.0" />
+          <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -98,7 +98,7 @@
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-          <bindingRedirect oldVersion="0.0.0.0-6.0.1.0" newVersion="6.0.1.0" />
+          <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
         </dependentAssembly>
         <dependentAssembly>
           <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />


### PR DESCRIPTION
Resolves the NuGet audit (NU1902/NU1903) failures in the `dotnet-unified-build` (build 3022982).

**Changes (all under `src/msbuild`):**
- Bump `System.Security.Cryptography.Xml` 9.0.0 → 9.0.15 (fixes GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf; high).
- Pin transitive `OpenTelemetry.Api` to 1.15.3 (fixes GHSA-g94r-2vxg-569j / CVE-2026-40894; moderate). The `Microsoft.VisualStudio.OpenTelemetry.*` packages still reference the vulnerable 1.9.0 even at their latest version (1.0.2), so a direct pin is required.

The `SQLitePCLRaw` advisory (GHSA-2m69-gcr7-jv3q) is intentionally **not** addressed here — its only fix is a major 2.x → 3.x jump and will be handled separately if necessary.

Validation official build (dnceng/internal `dotnet-unified-build`): https://dev.azure.com/dnceng/internal/_build/results?buildId=3023440
