### PR TITLE
Reenable DeterministicTimestamp in build

### DIFF
--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -156,8 +156,6 @@
     <CommonArgs>$(CommonArgs) /p:SourceBuiltAssetManifestsDir=$(RepoAssetManifestsDir)</CommonArgs>
 
     <CommonArgs>$(CommonArgs) /p:RepositoryName=$(RepositoryName)</CommonArgs>
-    <!-- Temporarily disable deterministic timestamps https://github.com/dotnet/dotnet/issues/7331 -->
-    <CommonArgs>$(CommonArgs) /p:DeterministicTimestamp=false</CommonArgs>
 
     <!-- Pass the repository URL in globally so that we redirect sourcelink package information to the VMR repo. -->
     <DotNetRepositoryUrl>https://github.com/dotnet/dotnet</DotNetRepositoryUrl>

--- a/src/arcade/src/Microsoft.DotNet.Arcade.Validation.Tests/TestRepoBuilder.cs
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Validation.Tests/TestRepoBuilder.cs
@@ -529,17 +529,6 @@ namespace HelloWorld
 
             allArgs.AddRange(args);
 
-            // Workaround: a NuGet change (https://github.com/NuGet/NuGet.Client/pull/7020) flowed in via Arcade
-            // incorrectly holds file locks when deterministic timestamps are enabled, causing pack/sign tests to
-            // fail on Windows during cleanup with "The process cannot access the file ... because it is being used
-            // by another process." Disable deterministic timestamps until the underlying issue is resolved.
-            // This only manifests on Windows, so scope the workaround there to avoid changing behavior elsewhere.
-            // Tracking issue: https://github.com/dotnet/arcade/issues/17065
-            if (isWindows)
-            {
-                allArgs.Add("/p:DeterministicTimestamp=false");
-            }
-
             // Invokes eng/common/build.ps1 with provided options
             return async () =>
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/dotnet/issues/7331