### PR TITLE
Add catalog signing for unsigned apphost template files

### DIFF
--- a/src/runtime/eng/Signing.props
+++ b/src/runtime/eng/Signing.props
@@ -31,6 +31,8 @@
   <ItemGroup>
     <!-- apphost and comhost template files are not signed, by design. -->
     <FileSignInfo Include="apphost.exe;singlefilehost.exe;comhost.dll" CertificateName="None" />
+    <!-- Sign the catalog file that provides integrity verification for the unsigned apphost templates. -->
+    <FileSignInfo Include="apphost-templates.cat" CertificateName="MicrosoftDotNet500" />
 
     <!--
       The DAC and the DBI must go through special signing provisioning using a system separate

--- a/src/runtime/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Host.sfxproj
+++ b/src/runtime/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Host.sfxproj
@@ -88,4 +88,38 @@
     <HeatOutputFileElementToStabilize Include="native\singlefilehost.exe" ReplacementId="staticapphosttemplateapphostexe" />
     <HeatOutputFileElementToStabilize Include="native\comhost.dll" ReplacementId="comhosttemplatecomhostdll" />
   </ItemGroup>
+
+  <!--
+    Generate a catalog (.cat) file covering the unsigned apphost template files. These templates
+    are intentionally unsigned because the .NET SDK modifies them at build time via
+    HostWriter.CreateAppHost(); the signed catalog provides integrity verification for Visual
+    Studio signing compliance without breaking the SDK workflow.
+    See https://github.com/dotnet/runtime/issues/3694 -->
+  <Target Name="GenerateAppHostTemplateCatalog"
+          BeforeTargets="GetFilesToPackage"
+          Condition="'$(TargetOS)' == 'windows'">
+    <PropertyGroup>
+      <_AppHostCatalogOutputPath>$(IntermediateOutputPath)apphost-templates.cat</_AppHostCatalogOutputPath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_AppHostTemplateFile Include="$(DotNetHostBinDir)apphost.exe" Condition="Exists('$(DotNetHostBinDir)apphost.exe')" />
+      <_AppHostTemplateFile Include="$(DotNetHostBinDir)singlefilehost.exe" Condition="Exists('$(DotNetHostBinDir)singlefilehost.exe')" />
+      <_AppHostTemplateFile Include="$(DotNetHostBinDir)comhost.dll" Condition="Exists('$(DotNetHostBinDir)comhost.dll')" />
+    </ItemGroup>
+
+    <!-- Remove a stale catalog from a previous build so a pack without templates can't ship one. -->
+    <Delete Condition="'@(_AppHostTemplateFile)' == '' and Exists('$(_AppHostCatalogOutputPath)')"
+            Files="$(_AppHostCatalogOutputPath)" />
+
+    <GenerateFileCatalog Condition="'@(_AppHostTemplateFile)' != ''"
+                         Files="@(_AppHostTemplateFile)"
+                         OutputPath="$(_AppHostCatalogOutputPath)" />
+
+    <ItemGroup Condition="'@(_AppHostTemplateFile)' != '' and Exists('$(_AppHostCatalogOutputPath)')">
+      <FilesToPackage Include="$(_AppHostCatalogOutputPath)"
+                      TargetPath="data/apphost-templates.cat" />
+    </ItemGroup>
+    <Message Condition="'@(_AppHostTemplateFile)' != '' and Exists('$(_AppHostCatalogOutputPath)')" Importance="High" Text="Generated apphost template catalog file: $(_AppHostCatalogOutputPath)" />
+  </Target>
 </Project>


### PR DESCRIPTION
Generate apphost-templates.cat covering the unsigned apphost/singlefilehost/comhost templates using the cross-platform GenerateFileCatalog task, and sign it so VS signing compliance is satisfied without modifying the templates.

Follows approach from https://github.com/dotnet/dotnet/pull/7759