### PR TITLE
Add catalog signing for fsharp VSIX XML content files

### DIFF
--- a/src/fsharp/eng/Signing.props
+++ b/src/fsharp/eng/Signing.props
@@ -3,6 +3,8 @@
   <ItemGroup>
     <FileSignInfo Include="Nerdbank.Streams.dll" CertificateName="None" />
     <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="None" />
+    <!-- Sign the catalog covering non-PE content files (XML docs/templates) in the VisualFSharp VSIXes. -->
+    <FileSignInfo Include="FSharpVsixTemplateContent.cat" CertificateName="Microsoft400" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/fsharp/eng/Version.Details.props
+++ b/src/fsharp/eng/Version.Details.props
@@ -7,6 +7,7 @@ This file should be imported by eng/Versions.props
   <PropertyGroup>
     <!-- dotnet-arcade dependencies -->
     <MicrosoftDotNetArcadeSdkPackageVersion>10.0.0-beta.26324.4</MicrosoftDotNetArcadeSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksFileCatalogPackageVersion>10.0.0-beta.26324.4</MicrosoftDotNetBuildTasksFileCatalogPackageVersion>
     <!-- dotnet-msbuild dependencies -->
     <MicrosoftBuildPackageVersion>18.10.0-preview-26357-08</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>18.10.0-preview-26357-08</MicrosoftBuildFrameworkPackageVersion>
@@ -38,6 +39,7 @@ This file should be imported by eng/Versions.props
   <PropertyGroup>
     <!-- dotnet-arcade dependencies -->
     <MicrosoftDotNetArcadeSdkVersion>$(MicrosoftDotNetArcadeSdkPackageVersion)</MicrosoftDotNetArcadeSdkVersion>
+    <MicrosoftDotNetBuildTasksFileCatalogVersion>$(MicrosoftDotNetBuildTasksFileCatalogPackageVersion)</MicrosoftDotNetBuildTasksFileCatalogVersion>
     <!-- dotnet-msbuild dependencies -->
     <MicrosoftBuildVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildVersion>
     <MicrosoftBuildFrameworkVersion>$(MicrosoftBuildFrameworkPackageVersion)</MicrosoftBuildFrameworkVersion>

--- a/src/fsharp/eng/Version.Details.xml
+++ b/src/fsharp/eng/Version.Details.xml
@@ -84,6 +84,10 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>1373629deb1e04f3e8e66fb68bb48ae36479c5ef</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.FileCatalog" Version="10.0.0-beta.26324.4">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>1373629deb1e04f3e8e66fb68bb48ae36479c5ef</Sha>
+    </Dependency>
     <Dependency Name="optimization.windows_nt-x64.MIBC.Runtime" Version="1.0.0-prerelease.26318.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>
       <Sha>06d09f3116a8ce9eed58e97ab167a3d1f4e1f151</Sha>

--- a/src/fsharp/vsintegration/Vsix/VisualFSharpFull/VisualFSharp.Core.targets
+++ b/src/fsharp/vsintegration/Vsix/VisualFSharpFull/VisualFSharp.Core.targets
@@ -262,6 +262,48 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" PrivateAssets="all" ExcludeAssets="runtime;contentFiles;build;analyzers;native" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+
+    <!-- Provides the GenerateFileCatalog task used by the GenerateContentCatalog target below. -->
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.FileCatalog" Version="$(MicrosoftDotNetBuildTasksFileCatalogVersion)" />
   </ItemGroup>
+
+  <!--
+    Generate a single catalog (.cat) file covering the non-PE content files (XML docs/templates)
+    that ship loose in the VSIX and include it in the VSIX itself, so the VS signing scan does not
+    flag those files as unsigned. This runs for every VSIX that imports these shared targets
+    (VisualFSharpFull and VisualFSharpDebug), producing one catalog per VSIX.
+
+    It hooks BeforeTargets="GenerateFileManifest" so the catalog is added to @(VSIXSourceItem)
+    before the VSIX file manifest is generated, ensuring the .cat lands inside the .vsix container.
+    GenerateFileCatalog is cross-platform (no makecat.exe / Windows SDK dependency). -->
+  <Target Name="GenerateContentCatalog"
+          BeforeTargets="GenerateFileManifest"
+          Condition="'$(CreateVsixContainer)' == 'true'">
+    <ItemGroup>
+      <!-- Loose non-PE content that can't be Authenticode-signed directly, chiefly the XML
+           doc files shipped next to the assemblies (e.g. FSharp.Core.xml). VS item/project
+           templates are packaged as .zip by TemplateProjectOutputGroup, so their .vstemplate
+           and .xml payloads are inside the .zip and never appear here. -->
+      <_CatalogContentFile Include="@(VSIXSourceItem)" Condition="'%(Extension)' == '.xml'" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_ContentCatalogPath>$(IntermediateOutputPath)FSharpVsixTemplateContent.cat</_ContentCatalogPath>
+    </PropertyGroup>
+
+    <!-- Run unconditionally: with no input files the task deletes any stale catalog from a
+         previous build, so an out-of-date .cat is never packaged. -->
+    <GenerateFileCatalog Files="@(_CatalogContentFile)"
+                         OutputPath="$(_ContentCatalogPath)" />
+
+    <!-- Include the generated catalog at the root of the VSIX. -->
+    <ItemGroup Condition="Exists('$(_ContentCatalogPath)')">
+      <VSIXSourceItem Include="$(_ContentCatalogPath)">
+        <VSIXSubPath></VSIXSubPath>
+      </VSIXSourceItem>
+    </ItemGroup>
+
+    <Message Condition="Exists('$(_ContentCatalogPath)')" Importance="High" Text="Generated content catalog: $(_ContentCatalogPath)" />
+  </Target>
 
 </Project>


### PR DESCRIPTION
Generate FSharpVsixTemplateContent.cat covering the non-PE XML content files in the VisualFSharp VSIXes using the cross-platform GenerateFileCatalog task, include it inside each VSIX, and sign it so the VS signing scan no longer flags those files as unsigned.

Follows approach from https://github.com/dotnet/dotnet/pull/7759