### PR TITLE
Alternative: drop net472 from Microsoft.Build.Framework to avoid vulnerable OpenTelemetry.*

### DIFF
--- a/src/msbuild/eng/Version.Details.props
+++ b/src/msbuild/eng/Version.Details.props
@@ -11,14 +11,14 @@ This file should be imported by eng/Versions.props
     <SystemConfigurationConfigurationManagerPackageVersion>9.0.0</SystemConfigurationConfigurationManagerPackageVersion>
     <SystemDiagnosticsDiagnosticSourcePackageVersion>9.0.0</SystemDiagnosticsDiagnosticSourcePackageVersion>
     <SystemDiagnosticsEventLogPackageVersion>9.0.0</SystemDiagnosticsEventLogPackageVersion>
-    <SystemFormatsAsn1PackageVersion>9.0.6</SystemFormatsAsn1PackageVersion>
+    <SystemFormatsAsn1PackageVersion>9.0.15</SystemFormatsAsn1PackageVersion>
     <SystemFormatsNrbfPackageVersion>9.0.0</SystemFormatsNrbfPackageVersion>
     <SystemReflectionMetadataPackageVersion>9.0.0</SystemReflectionMetadataPackageVersion>
     <SystemReflectionMetadataLoadContextPackageVersion>9.0.0</SystemReflectionMetadataLoadContextPackageVersion>
     <SystemResourcesExtensionsPackageVersion>9.0.0</SystemResourcesExtensionsPackageVersion>
-    <SystemSecurityCryptographyPkcsPackageVersion>9.0.6</SystemSecurityCryptographyPkcsPackageVersion>
+    <SystemSecurityCryptographyPkcsPackageVersion>9.0.15</SystemSecurityCryptographyPkcsPackageVersion>
     <SystemSecurityCryptographyProtectedDataPackageVersion>9.0.6</SystemSecurityCryptographyProtectedDataPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>9.0.0</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>9.0.15</SystemSecurityCryptographyXmlPackageVersion>
     <SystemTextEncodingCodePagesPackageVersion>9.0.0</SystemTextEncodingCodePagesPackageVersion>
     <SystemTextJsonPackageVersion>9.0.0</SystemTextJsonPackageVersion>
     <SystemThreadingChannelsPackageVersion>9.0.0</SystemThreadingChannelsPackageVersion>

--- a/src/msbuild/eng/Version.Details.xml
+++ b/src/msbuild/eng/Version.Details.xml
@@ -33,7 +33,7 @@
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Formats.Asn1" Version="9.0.6">
+    <Dependency Name="System.Formats.Asn1" Version="9.0.15">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>
@@ -69,13 +69,13 @@
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Security.Cryptography.Pkcs" Version="9.0.6">
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="9.0.15">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Security.Cryptography.Xml" Version="9.0.0">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="9.0.15">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>

--- a/src/msbuild/src/Framework/Microsoft.Build.Framework.csproj
+++ b/src/msbuild/src/Framework/Microsoft.Build.Framework.csproj
@@ -1,6 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
+    <!-- Drop net472 targeting to avoid the vulnerable OpenTelemetry.* transitive dependency
+         (GHSA-g94r-2vxg-569j / CVE-2026-40894). The Microsoft.VisualStudio.OpenTelemetry.*
+         telemetry references that pull it in live in the '.NETFramework'-only ItemGroup below,
+         so building only .NET Core + netstandard2.0 removes the NuGet audit failure without an
+         OpenTelemetry.Api upgrade. NOTE: the net472 flavor of Microsoft.Build.Framework is
+         consumed by the rest of MSBuild's net472 (Visual Studio) build; dropping it here is a
+         deliberate trade-off explored as an alternative to bumping OpenTelemetry.Api. -->
+    <TargetFrameworks>$(LatestDotNetCoreForMSBuild);netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateReferenceAssemblySource>true</GenerateReferenceAssemblySource>
     <!-- Do not create Tlbs when building in .NET product mode. The packages are not shipped to VS,


### PR DESCRIPTION
## Alternative approach: drop net472 from `Microsoft.Build.Framework`

This is an **alternative** to #7766 for resolving the NuGet audit failures (`NU1902`/`NU1903`). The novel part is how the OpenTelemetry advisory (**GHSA-g94r-2vxg-569j / CVE-2026-40894**) is handled: instead of upgrading `OpenTelemetry.Api`, drop `net472` targeting.

### OpenTelemetry advisory - the alternative approach
`OpenTelemetry.Api` is pulled in transitively by `Microsoft.VisualStudio.OpenTelemetry.Collector` / `Microsoft.VisualStudio.OpenTelemetry.ClientExtensions`, which live in the `.NETFramework`-only `ItemGroup` in `Microsoft.Build.Framework.csproj`. By targeting only `.NET Core + netstandard2.0` (dropping `net472`), the vulnerable dependency is never restored - **no `OpenTelemetry.Api` upgrade**.

This sidesteps the cascade the OTel upgrade triggers in #7766: net472 `MSB3277` assembly-version conflicts (`System.Memory` -> `System.Diagnostics.DiagnosticSource`), each needing frozen-maintenance-package bumps + binding-redirect updates.

### Remaining audit fixes (folded in, approach-independent)
Same bumps as in #7766 so this PR resolves **all** reported audit failures on its own:
- `System.Security.Cryptography.Xml` 9.0.0 -> 9.0.15 (GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf)
- `System.Formats.Asn1` 9.0.6 -> 9.0.15
- `System.Security.Cryptography.Pkcs` 9.0.6 -> 9.0.15

### Trade-off / caveat
The `net472` flavor of `Microsoft.Build.Framework` is consumed by the rest of MSBuild's `net472` (Visual Studio) build. Dropping it here will break the net472 build of the rest of MSBuild, so this is offered **for evaluation** of the approach vs. #7766, not a drop-in change.

cc @rainersigwald