### PR TITLE
Capitalize Git when not written as code

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,11 +186,11 @@ You can also utilize [GitHub Codespaces](https://github.com/features/codespaces)
 
 ### Building from released sources
 
-You can also build from sources (and not from a context of a git repository), such as the ones you can acquire from a [dotnet/dotnet release](https://github.com/dotnet/dotnet/releases).
+You can also build from sources (and not from a context of a Git repository), such as the ones you can acquire from a [dotnet/dotnet release](https://github.com/dotnet/dotnet/releases).
 In this case, you need to provide additional information which includes the original repository and commit hash the code was built from so that the SDK can provide a better debugging experience (think the `Step into..` functionality).
 Usually, this means the [dotnet/dotnet repository](https://github.com/dotnet/dotnet) together with the commit the release tag is connected to.
 
-In practice, this means that when calling the main build script, you need to provide additional arguments when building outside of a context of a git repository.  
+In practice, this means that when calling the main build script, you need to provide additional arguments when building outside of a context of a Git repository.  
 Alternatively, you can also provide a manifest file where this information can be read from. This file (`release.json`) can be found attached with the [dotnet/dotnet release](https://github.com/dotnet/dotnet/releases).
 
 ### Manually synchronizing code with the VMR


### PR DESCRIPTION
Git styles itself with a capital G unless it's a command