### PR TITLE
Alternative: suppress NuGet audit advisories for OpenTelemetry + System.Security.Cryptography.Xml (compile-time-only)

### DIFF
--- a/src/msbuild/Directory.Build.props
+++ b/src/msbuild/Directory.Build.props
@@ -69,6 +69,25 @@ ates https://learn.microsoft.com/en-gb/dotnet/fundamentals/syslib-diagnostics/sy
     <NoWarn Condition="'$(DotNetBuild)' == 'true'">$(NoWarn);NU5104;</NoWarn>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!--
+        Suppress exactly these NuGet audit advisories as an alternative to
+        dotnet/dotnet PR #7766 (OpenTelemetry upgrade) and PR #7821 (dropping net472).
+
+        OpenTelemetry.Api GHSA-g94r-2vxg-569j is present through the net472
+        Visual Studio telemetry references Microsoft.VisualStudio.OpenTelemetry.Collector
+        and Microsoft.VisualStudio.OpenTelemetry.ClientExtensions, which are marked
+        PrivateAssets=all. System.Security.Cryptography.Xml GHSA-37gx-xxp4-5rgx and
+        GHSA-w3x6-4m5h-cxqf are present through compile-time signing helpers. These
+        compile-time-only dependency paths are not representative of the packages
+        actually deployed or shipped by the product, so suppressing the audit
+        advisories is preferred here over upgrading the dependency graph.
+    -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-g94r-2vxg-569j" />
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-37gx-xxp4-5rgx" />
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-w3x6-4m5h-cxqf" />
+  </ItemGroup>
+
   <!-- Configuration MSBuild for portable (xcopy-install) toolsets: works on WinNT and linux/mac via Mono, isolates from machine environment:
     uses only tools installed with it, ignores Registry and GAC and Visual Studio installations to provide the same build experience on all machines -->
   <PropertyGroup Condition="'$(Configuration)' == 'MachineIndependent'">


### PR DESCRIPTION
## Summary

This is a third alternative for the MSBuild NuGet audit failures. Instead of upgrading the dependency graph like #7766 or dropping net472 like #7821, this PR adds scoped NuGetAuditSuppress items under src\msbuild for exactly the affected advisories.

Suppressed advisories:
- OpenTelemetry.Api: GHSA-g94r-2vxg-569j (CVE-2026-40894) -> https://github.com/advisories/GHSA-g94r-2vxg-569j
- System.Security.Cryptography.Xml: GHSA-37gx-xxp4-5rgx -> https://github.com/advisories/GHSA-37gx-xxp4-5rgx
- System.Security.Cryptography.Xml: GHSA-w3x6-4m5h-cxqf -> https://github.com/advisories/GHSA-w3x6-4m5h-cxqf

## Rationale

These are compile-time-only dependency paths, not representative of the packages actually deployed or shipped by the product:

- OpenTelemetry.Api comes transitively through the net472 Visual Studio telemetry references Microsoft.VisualStudio.OpenTelemetry.Collector and Microsoft.VisualStudio.OpenTelemetry.ClientExtensions, which are referenced with PrivateAssets=all.
- System.Security.Cryptography.Xml is used through compile-time signing helpers and is also private to the build dependency path.

Because the audit hits are not representative of the shipped package surface, suppressing the specific advisories is appropriate here and keeps this alternative smaller than an OpenTelemetry upgrade cascade (#7766) or removing the net472 target (#7821).

cc @rainersigwald
