### PR TITLE
Enable useBinskimResponseFile for stable package unpacking

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -72,6 +72,7 @@ extends:
       networkIsolationPolicy: Permissive, CFSClean, CFSClean2
     featureFlags:
       binskimScanAllExtensions: true
+      useBinskimResponseFile: true
       incrementalSDLBinaryAnalysis: true
       autoEnablePREfastWithNewRuleset: false
       autoEnableRoslynWithNewRuleset: false


### PR DESCRIPTION
Re-adds the `useBinskimResponseFile: true` feature flag to the official pipeline.

## Background

This flag enables the BinSkim incremental binary analysis optimization: when archive/package expansion is enabled, BinSkim scans the **extracted inner files** of the expanded archives instead of scanning the whole content by default. Without it, BinSkim is not scanning inside packages.

The flag was prototyped on a throwaway `binskim-test` branch (commit 3fce3beaf2d, Apr 2026) but was never merged to `main`, so the optimization has been absent from the official build.

## Change

Adds `useBinskimResponseFile: true` under `featureFlags` in `eng/pipelines/official.yml`.
