### PR TITLE
Fix NuGet Audit errors and build issues

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -65,11 +65,11 @@
     <!-- roslyn dependencies -->
     <MicrosoftCodeAnalysisVersion>4.4.0</MicrosoftCodeAnalysisVersion>
     <!-- runtime dependencies -->
-    <MicrosoftExtensionsFileSystemGlobbingVersion>10.0.8</MicrosoftExtensionsFileSystemGlobbingVersion>
-    <MicrosoftExtensionsLoggingConsoleVersion>10.0.8</MicrosoftExtensionsLoggingConsoleVersion>
-    <MicrosoftExtensionsLoggingVersion>10.0.8</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftExtensionsHostingVersion>10.0.8</MicrosoftExtensionsHostingVersion>
-    <SystemSecurityCryptographyXmlVersion>10.0.8</SystemSecurityCryptographyXmlVersion>
+    <MicrosoftExtensionsFileSystemGlobbingVersion>10.0.10</MicrosoftExtensionsFileSystemGlobbingVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>10.0.10</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsLoggingVersion>10.0.10</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsHostingVersion>10.0.10</MicrosoftExtensionsHostingVersion>
+    <SystemSecurityCryptographyXmlVersion>10.0.10</SystemSecurityCryptographyXmlVersion>
     <!-- sdk dependencies -->
     <MicrosoftDotNetApiCompatTaskVersion>10.0.100</MicrosoftDotNetApiCompatTaskVersion>
   </PropertyGroup>

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -767,7 +767,8 @@ function MSBuild() {
   }
 
   if ($warnAsError -and $warnNotAsError) {
-    $cmdArgs += " /warnnotaserror:$warnNotAsError /p:AdditionalWarningsNotAsErrors=$warnNotAsError"
+    $escapedWarnNotAsError = $warnNotAsError -replace ';', '%3B'
+    $cmdArgs += " /warnnotaserror:$warnNotAsError /p:AdditionalWarningsNotAsErrors=$escapedWarnNotAsError"
   }
 
   foreach ($arg in $args) {

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -542,7 +542,7 @@ function MSBuild {
 
   local warnnotaserror_switch=""
   if [[ -n "$warn_not_as_error" && "$warn_as_error" == true ]]; then
-    warnnotaserror_switch="/warnnotaserror:$warn_not_as_error /p:AdditionalWarningsNotAsErrors=$warn_not_as_error"
+    warnnotaserror_switch="/warnnotaserror:$warn_not_as_error /p:AdditionalWarningsNotAsErrors=${warn_not_as_error//;/%3B}"
   fi
 
   RunBuildTool "$_InitializeBuildToolCommand" /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch $mt_switch $warnnotaserror_switch /p:TreatWarningsAsErrors=$warn_as_error /p:ContinuousIntegrationBuild=$ci "$@"

--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -74,10 +74,12 @@
   <PropertyGroup Condition="'$(BuildOS)' == 'windows'">
     <FlagParameterPrefix>-</FlagParameterPrefix>
     <ArcadeFalseBoolBuildArg>0</ArcadeFalseBoolBuildArg>
+    <FlagParameterSemicolon>`;</FlagParameterSemicolon>
   </PropertyGroup>
   <PropertyGroup Condition="'$(BuildOS)' != 'windows'">
     <FlagParameterPrefix>--</FlagParameterPrefix>
     <ArcadeFalseBoolBuildArg>false</ArcadeFalseBoolBuildArg>
+    <FlagParameterSemicolon>\;</FlagParameterSemicolon>
   </PropertyGroup>
 
   <!-- Add 100 to the revision number to avoid clashing with the existing msft official builds. -->

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -55,10 +55,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- MinimalConsoleLogOutput determines if the repository build should be logged to a separate file or directly to the console.
-         Enable it by default as with prallel repository builds the log becomes non-readable. -->
     <RepoConsoleLogFile>$(ArtifactsLogRepoDir)$(RepositoryName).log</RepoConsoleLogFile>
-    <MinimalConsoleLogOutput Condition="'$(MinimalConsoleLogOutput)' == ''">$(BuildInParallel)</MinimalConsoleLogOutput>
   </PropertyGroup>
 
   <!-- Exclude shared repositories from the build, unless shared component building is explicitly enabled. -->
@@ -612,7 +609,7 @@
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Building $(RepositoryName)" />
     <Message Importance="High" Text="Running command:" />
     <Message Importance="High" Text="  $(BuildCommand)" />
-    <Message Importance="High" Text="  Log: $(RepoConsoleLogFile)" Condition="'$(MinimalConsoleLogOutput)' == 'true'" />
+    <Message Importance="High" Text="  Log: $(RepoConsoleLogFile)" />
     <Message Importance="High" Text="  With Environment Variables:"/>
     <Message Importance="High" Text="    %(EnvironmentVariables.Identity)" />
     <Message Importance="High" Text="    %(BuildEnvironmentVariable.Identity)" Condition="'@(BuildEnvironmentVariable)' != ''" />
@@ -623,7 +620,9 @@
 
     <PropertyGroup>
       <FullCommand>$(BuildCommand)</FullCommand>
-      <FullCommand Condition="'$(MinimalConsoleLogOutput)' == 'true'">$(FullCommand) &gt; $(RepoConsoleLogFile) 2&gt;&amp;1</FullCommand>
+      <FullCommand Condition="'$(BuildOS)' == 'windows'">powershell -NoProfile -Command "&amp; { cmd /c '$(BuildCommand)' 2&gt;&amp;1 | Tee-Object -FilePath '$(RepoConsoleLogFile)'%3B exit %24LASTEXITCODE }"</FullCommand>
+      <FullCommand Condition="'$(BuildOS)' != 'windows'">rcf=%24(mktemp); { $(BuildCommand); printf %s "%24?" &gt;"%24rcf"; } 2&gt;&amp;1 | tee "$(RepoConsoleLogFile)"; rc=%24(cat "%24rcf"); rm -f "%24rcf"; exit "%24rc"</FullCommand> <!-- POSIX compliant -->
+      <RepoStandardOutputImportance Condition="'$(RepoStandardOutputImportance)' == ''">low</RepoStandardOutputImportance> <!-- low, normal, high -->
     </PropertyGroup>
 
     <MakeDir Directories="$([System.IO.Path]::GetDirectoryName('$(RepoConsoleLogFile)'));
@@ -639,7 +638,8 @@
           WorkingDirectory="$(ProjectDirectory)"
           EnvironmentVariables="@(EnvironmentVariables);@(BuildEnvironmentVariable)"
           IgnoreStandardErrorWarningFormat="true"
-          YieldDuringToolExecution="true">
+          YieldDuringToolExecution="true"
+          StandardOutputImportance="$(RepoStandardOutputImportance)">
       <Output TaskParameter="ExitCode" PropertyName="RepoBuildExitCode" />
     </Exec>
 
@@ -653,8 +653,8 @@
     <OnError ExecuteTargets="MoveDotNetBuildLogs;LogRepoBuildError" />
   </Target>
 
-  <!-- Propagate errors to the output when using the minimal console log feature. -->
-  <Target Name="LogRepoBuildError" Condition="'$(MinimalConsoleLogOutput)' == 'true'">
+  <!-- Propagate errors to the output by printing the repository build log. -->
+  <Target Name="LogRepoBuildError">
     <Message Importance="High" Text="$([System.IO.File]::ReadAllText('$(RepoConsoleLogFile)'))" Condition="Exists('$(RepoConsoleLogFile)')" />
     <Message Importance="High" Text="'$(RepositoryName)' failed during build." />
     <Message Importance="High" Text="See '$(RepoConsoleLogFile)' for more information." Condition="Exists('$(RepoConsoleLogFile)')" />
@@ -706,7 +706,7 @@
       <LogManifestNotFoundError Condition="('$(DotNetBuildPass)' == '' or '$(DotNetBuildPass)' == '1') and '@(RepoAssetManifest)' == ''">true</LogManifestNotFoundError>
     </PropertyGroup>
 
-    <Message Importance="High" Text="$([System.IO.File]::ReadAllText('$(RepoConsoleLogFile)'))" Condition="'$(LogManifestNotFoundError)' == 'true' and '$(MinimalConsoleLogOutput)' == 'true' and Exists('$(RepoConsoleLogFile)')" />
+    <Message Importance="High" Text="$([System.IO.File]::ReadAllText('$(RepoConsoleLogFile)'))" Condition="'$(LogManifestNotFoundError)' == 'true' and Exists('$(RepoConsoleLogFile)')" />
     <Error Text="No repository asset manifest files found at '$(RepoAssetManifestsDir)*.xml'. This often means the build failed but did not log an error." Condition="'$(LogManifestNotFoundError)' == 'true'" />
 
     <GetKnownArtifactsFromAssetManifests AssetManifests="@(RepoAssetManifest)">

--- a/src/arcade/Directory.Build.props
+++ b/src/arcade/Directory.Build.props
@@ -15,8 +15,6 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <RepositoryUrl>https://github.com/dotnet/arcade</RepositoryUrl>
-    <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
-    <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/arcade/NuGet.config
+++ b/src/arcade/NuGet.config
@@ -63,4 +63,8 @@
   <disabledPackageSources>
     <clear />
   </disabledPackageSources>
+  <auditSources>
+    <clear />
+    <add key="nuget.org" value="https://data.nuget.org/v3/index.json" />
+  </auditSources>
 </configuration>

--- a/src/arcade/eng/Version.Details.props
+++ b/src/arcade/eng/Version.Details.props
@@ -28,18 +28,18 @@ This file should be imported by eng/Versions.props
     <MicrosoftCodeAnalysisCSharpPackageVersion>4.8.0</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftNetCompilersToolsetPackageVersion>4.8.0</MicrosoftNetCompilersToolsetPackageVersion>
     <!-- dotnet-runtime dependencies -->
-    <MicrosoftExtensionsDependencyInjectionPackageVersion>10.0.9</MicrosoftExtensionsDependencyInjectionPackageVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>10.0.9</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
-    <MicrosoftExtensionsDependencyModelPackageVersion>10.0.9</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>10.0.9</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
-    <MicrosoftExtensionsFileSystemGlobbingPackageVersion>10.0.9</MicrosoftExtensionsFileSystemGlobbingPackageVersion>
-    <MicrosoftExtensionsHttpPackageVersion>10.0.9</MicrosoftExtensionsHttpPackageVersion>
-    <MicrosoftExtensionsLoggingAbstractionsPackageVersion>10.0.9</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
-    <MicrosoftExtensionsLoggingConsolePackageVersion>10.0.9</MicrosoftExtensionsLoggingConsolePackageVersion>
-    <SystemCompositionPackageVersion>10.0.9</SystemCompositionPackageVersion>
-    <SystemIOPackagingPackageVersion>10.0.9</SystemIOPackagingPackageVersion>
-    <SystemSecurityCryptographyPkcsPackageVersion>10.0.9</SystemSecurityCryptographyPkcsPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>10.0.9</SystemSecurityCryptographyXmlPackageVersion>
+    <MicrosoftExtensionsDependencyInjectionPackageVersion>10.0.10</MicrosoftExtensionsDependencyInjectionPackageVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>10.0.10</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
+    <MicrosoftExtensionsDependencyModelPackageVersion>10.0.10</MicrosoftExtensionsDependencyModelPackageVersion>
+    <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>10.0.10</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
+    <MicrosoftExtensionsFileSystemGlobbingPackageVersion>10.0.10</MicrosoftExtensionsFileSystemGlobbingPackageVersion>
+    <MicrosoftExtensionsHttpPackageVersion>10.0.10</MicrosoftExtensionsHttpPackageVersion>
+    <MicrosoftExtensionsLoggingAbstractionsPackageVersion>10.0.10</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
+    <MicrosoftExtensionsLoggingConsolePackageVersion>10.0.10</MicrosoftExtensionsLoggingConsolePackageVersion>
+    <SystemCompositionPackageVersion>10.0.10</SystemCompositionPackageVersion>
+    <SystemIOPackagingPackageVersion>10.0.10</SystemIOPackagingPackageVersion>
+    <SystemSecurityCryptographyPkcsPackageVersion>10.0.10</SystemSecurityCryptographyPkcsPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>10.0.10</SystemSecurityCryptographyXmlPackageVersion>
     <!-- dotnet-sdk dependencies -->
     <MicrosoftNETSdkWorkloadManifestReaderPackageVersion>9.0.100-preview.6.24328.19</MicrosoftNETSdkWorkloadManifestReaderPackageVersion>
     <!-- dotnet-symreader-converter dependencies -->

--- a/src/arcade/eng/Version.Details.xml
+++ b/src/arcade/eng/Version.Details.xml
@@ -54,43 +54,43 @@
     </Dependency>
     <!-- Necessary for source-build. The dependency is loaded in during built-time
          by consumers of NuGetRepack.Tasks, so we cannot use a ref pack for it -->
-    <Dependency Name="System.IO.Packaging" Version="10.0.9">
+    <Dependency Name="System.IO.Packaging" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>dc5fd7a8dce8309e4add8fd4bd5d8718f221b15a</Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the dependency
          to flow in and eliminates related prebuilts. -->
-    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>dc5fd7a8dce8309e4add8fd4bd5d8718f221b15a</Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the dependency
          to flow in and eliminates related prebuilts. -->
-    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.9">
+    <Dependency Name="Microsoft.Extensions.DependencyInjection" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>dc5fd7a8dce8309e4add8fd4bd5d8718f221b15a</Sha>
     </Dependency>
     <!-- Necessary for source-build. The dependency is loaded in during built-time
          by consumers of SharedFramework.Sdk (such as runtime), so we cannot use a ref pack for it -->
-    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="10.0.9">
+    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>dc5fd7a8dce8309e4add8fd4bd5d8718f221b15a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Http" Version="10.0.9">
+    <Dependency Name="Microsoft.Extensions.Http" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>dc5fd7a8dce8309e4add8fd4bd5d8718f221b15a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.9">
+    <Dependency Name="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>dc5fd7a8dce8309e4add8fd4bd5d8718f221b15a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.9">
+    <Dependency Name="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>dc5fd7a8dce8309e4add8fd4bd5d8718f221b15a</Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the dependency
          to flow in and eliminates related prebuilts. -->
-    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.9">
+    <Dependency Name="Microsoft.Extensions.Logging.Console" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>dc5fd7a8dce8309e4add8fd4bd5d8718f221b15a</Sha>
     </Dependency>
@@ -106,11 +106,11 @@
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>c7b5e07cfed85e88c162dc1c916efaff03742e6e</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Pkcs" Version="10.0.9">
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>dc5fd7a8dce8309e4add8fd4bd5d8718f221b15a</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="10.0.9">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>dc5fd7a8dce8309e4add8fd4bd5d8718f221b15a</Sha>
     </Dependency>
@@ -166,11 +166,11 @@
       <Uri>https://github.com/nuget/nuget.client</Uri>
       <Sha>779eff1e73420573dd39dbbe54896ff8f08955e1</Sha>
     </Dependency>
-    <Dependency Name="System.Composition" Version="10.0.9">
+    <Dependency Name="System.Composition" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>dc5fd7a8dce8309e4add8fd4bd5d8718f221b15a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9">
+    <Dependency Name="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>dc5fd7a8dce8309e4add8fd4bd5d8718f221b15a</Sha>
     </Dependency>

--- a/src/arcade/eng/common/tools.ps1
+++ b/src/arcade/eng/common/tools.ps1
@@ -821,7 +821,8 @@ function MSBuild() {
   }
 
   if ($warnAsError -and $warnNotAsError) {
-    $cmdArgs += " /warnnotaserror:$warnNotAsError /p:AdditionalWarningsNotAsErrors=$warnNotAsError"
+    $escapedWarnNotAsError = $warnNotAsError -replace ';', '%3B'
+    $cmdArgs += " /warnnotaserror:$warnNotAsError /p:AdditionalWarningsNotAsErrors=$escapedWarnNotAsError"
   }
 
   foreach ($arg in $args) {

--- a/src/arcade/eng/common/tools.sh
+++ b/src/arcade/eng/common/tools.sh
@@ -595,7 +595,7 @@ function MSBuild {
 
   local warnnotaserror_switch=""
   if [[ -n "$warn_not_as_error" && "$warn_as_error" == true ]]; then
-    warnnotaserror_switch="/warnnotaserror:$warn_not_as_error /p:AdditionalWarningsNotAsErrors=$warn_not_as_error"
+    warnnotaserror_switch="/warnnotaserror:$warn_not_as_error /p:AdditionalWarningsNotAsErrors=${warn_not_as_error//;/%3B}"
   fi
 
   RunBuildTool "$_InitializeBuildToolCommand" /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $warnaserror_switch $mt_switch $warnnotaserror_switch ${logger_switch[@]+"${logger_switch[@]}"} /p:TreatWarningsAsErrors=$warn_as_error /p:ContinuousIntegrationBuild=$ci "$@"

--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/ProjectDefaults.props
@@ -20,9 +20,6 @@
     <PackageIcon>Icon.png</PackageIcon>
     <PackageIconFullPath>$(MSBuildThisFileDirectory)Assets\DotNetPackageIcon.png</PackageIconFullPath>
 
-    <!-- Append build script specified warnings not as errors. -->
-    <WarningsNotAsErrors Condition="'$(AdditionalWarningsNotAsErrors)' != ''">$(WarningsNotAsErrors);$(AdditionalWarningsNotAsErrors)</WarningsNotAsErrors>
- 
     <!-- Turn on package pruning by default. -->
     <RestoreEnablePackagePruning>true</RestoreEnablePackagePruning>
 

--- a/src/cecil/global.json
+++ b/src/cecil/global.json
@@ -1,4 +1,8 @@
 {
+  "sdk": {
+    "version": "11.0.100-preview.4.26210.111",
+    "allowPrerelease": true
+  },
   "tools": {
     "dotnet": "11.0.100-preview.4.26210.111"
   },

--- a/src/deployment-tools/Directory.Build.props
+++ b/src/deployment-tools/Directory.Build.props
@@ -88,9 +88,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <CodeAnalysisRuleset>$(RepositoryEngineeringDir)CodeAnalysis.ruleset</CodeAnalysisRuleset>
-
-    <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
-    <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/deployment-tools/Directory.Packages.props
+++ b/src/deployment-tools/Directory.Packages.props
@@ -28,9 +28,4 @@
     <PackageVersion Update="System.Text.Json" Version="$(SystemTextJsonVersion)" Condition="'$(SystemTextJsonVersion)' != ''" />
   </ItemGroup>
 
-  <!-- Suppress System.Text.Json/8.0.4 advisory as desktop msbuild doesn't yet provide binding redirects for the non-vulnerable version (8.0.5). -->
-  <ItemGroup>
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-8g4q-xg66-9fp4" />
-  </ItemGroup>
-
 </Project>

--- a/src/fsharp/eng/Version.Details.props
+++ b/src/fsharp/eng/Version.Details.props
@@ -32,7 +32,7 @@ This file should be imported by eng/Versions.props
     <SystemCompositionPackageVersion>10.0.2</SystemCompositionPackageVersion>
     <SystemDiagnosticsDiagnosticSourcePackageVersion>10.0.2</SystemDiagnosticsDiagnosticSourcePackageVersion>
     <SystemReflectionMetadataPackageVersion>10.0.2</SystemReflectionMetadataPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>10.0.8</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>10.0.10</SystemSecurityCryptographyXmlPackageVersion>
   </PropertyGroup>
   <!--Property group for alternate package version names-->
   <PropertyGroup>

--- a/src/fsharp/eng/Version.Details.xml
+++ b/src/fsharp/eng/Version.Details.xml
@@ -74,7 +74,7 @@
       <Sha>
       </Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="10.0.8">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha />
     </Dependency>

--- a/src/fsharp/src/FSharp.Build/FSharp.Build.fsproj
+++ b/src/fsharp/src/FSharp.Build/FSharp.Build.fsproj
@@ -89,7 +89,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" PrivateAssets="all" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" PrivateAssets="all" /> <!-- Update transitive vulnerable package -->
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafeVersion)" />
   </ItemGroup>

--- a/src/fsharp/src/fsc/fsc.targets
+++ b/src/fsharp/src/fsc/fsc.targets
@@ -56,6 +56,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" PrivateAssets="all" /> <!-- Update transitive vulnerable package -->
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">

--- a/src/fsharp/src/fsi/fsi.targets
+++ b/src/fsharp/src/fsi/fsi.targets
@@ -68,6 +68,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" PrivateAssets="all" /> <!-- Update transitive vulnerable package -->
   </ItemGroup>
 
 </Project>

--- a/src/fsharp/tests/FSharp.Build.UnitTests/FSharp.Build.UnitTests.fsproj
+++ b/src/fsharp/tests/FSharp.Build.UnitTests/FSharp.Build.UnitTests.fsproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" PrivateAssets="all" /> <!-- Update transitive vulnerable package -->
   </ItemGroup>
 
 </Project>

--- a/src/msbuild/eng/Version.Details.props
+++ b/src/msbuild/eng/Version.Details.props
@@ -16,14 +16,14 @@ This file should be imported by eng/Versions.props
     <SystemConfigurationConfigurationManagerPackageVersion>10.0.9</SystemConfigurationConfigurationManagerPackageVersion>
     <SystemDiagnosticsDiagnosticSourcePackageVersion>10.0.9</SystemDiagnosticsDiagnosticSourcePackageVersion>
     <SystemDiagnosticsEventLogPackageVersion>10.0.9</SystemDiagnosticsEventLogPackageVersion>
-    <SystemFormatsAsn1PackageVersion>10.0.9</SystemFormatsAsn1PackageVersion>
+    <SystemFormatsAsn1PackageVersion>10.0.10</SystemFormatsAsn1PackageVersion>
     <SystemFormatsNrbfPackageVersion>10.0.9</SystemFormatsNrbfPackageVersion>
     <SystemReflectionMetadataPackageVersion>10.0.9</SystemReflectionMetadataPackageVersion>
     <SystemReflectionMetadataLoadContextPackageVersion>10.0.9</SystemReflectionMetadataLoadContextPackageVersion>
     <SystemResourcesExtensionsPackageVersion>10.0.9</SystemResourcesExtensionsPackageVersion>
-    <SystemSecurityCryptographyPkcsPackageVersion>10.0.9</SystemSecurityCryptographyPkcsPackageVersion>
+    <SystemSecurityCryptographyPkcsPackageVersion>10.0.10</SystemSecurityCryptographyPkcsPackageVersion>
     <SystemSecurityCryptographyProtectedDataPackageVersion>10.0.9</SystemSecurityCryptographyProtectedDataPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>10.0.9</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>10.0.10</SystemSecurityCryptographyXmlPackageVersion>
     <SystemTextEncodingCodePagesPackageVersion>10.0.9</SystemTextEncodingCodePagesPackageVersion>
     <SystemTextJsonPackageVersion>10.0.9</SystemTextJsonPackageVersion>
     <SystemThreadingChannelsPackageVersion>10.0.9</SystemThreadingChannelsPackageVersion>

--- a/src/msbuild/eng/Version.Details.xml
+++ b/src/msbuild/eng/Version.Details.xml
@@ -33,7 +33,7 @@
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Formats.Asn1" Version="10.0.9">
+    <Dependency Name="System.Formats.Asn1" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>
@@ -69,13 +69,13 @@
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Security.Cryptography.Pkcs" Version="10.0.9">
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="System.Security.Cryptography.Xml" Version="10.0.9">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>
       </Sha>

--- a/src/msbuild/global.json
+++ b/src/msbuild/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
+    "version": "11.0.100-preview.7.26360.111",
     "allowPrerelease": true,
     "paths": [
       "$host$"

--- a/src/nuget-client/Directory.Packages.props
+++ b/src/nuget-client/Directory.Packages.props
@@ -29,7 +29,7 @@
     <SystemMemoryPackageVersion Condition="'$(SystemMemoryPackageVersion)' == ''">4.6.3</SystemMemoryPackageVersion>
     <SystemSecurityCryptographyPkcsVersion Condition="'$(SystemSecurityCryptographyPkcsVersion)' == ''">8.0.1</SystemSecurityCryptographyPkcsVersion>
     <SystemSecurityCryptographyProtectedDataVersion Condition="'$(SystemSecurityCryptographyProtectedDataVersion)' == ''">8.0.0</SystemSecurityCryptographyProtectedDataVersion>
-    <SystemSecurityCryptographyXmlPackageVersion Condition="'$(SystemSecurityCryptographyXmlPackageVersion)' == ''">10.0.8</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion Condition="'$(SystemSecurityCryptographyXmlPackageVersion)' == ''">10.0.10</SystemSecurityCryptographyXmlPackageVersion>
     <MicrosoftDotNetXliffTasksVersion Condition="'$(MicrosoftDotNetXliffTasksVersion)' == ''">10.0.0-beta.25260.104</MicrosoftDotNetXliffTasksVersion>
   </PropertyGroup>
 

--- a/src/nuget-client/eng/Version.Details.props
+++ b/src/nuget-client/eng/Version.Details.props
@@ -20,7 +20,7 @@ This file should be imported by eng/Versions.props
     <SystemFormatsAsn1PackageVersion>8.0.1</SystemFormatsAsn1PackageVersion>
     <SystemSecurityCryptographyPkcsPackageVersion>6.0.4</SystemSecurityCryptographyPkcsPackageVersion>
     <SystemSecurityCryptographyProtectedDataPackageVersion>9.0.6</SystemSecurityCryptographyProtectedDataPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>8.0.3</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>10.0.10</SystemSecurityCryptographyXmlPackageVersion>
     <!-- dotnet-xdt dependencies -->
     <MicrosoftWebXdtPackageVersion>3.2.0</MicrosoftWebXdtPackageVersion>
   </PropertyGroup>

--- a/src/nuget-client/eng/Version.Details.xml
+++ b/src/nuget-client/eng/Version.Details.xml
@@ -46,7 +46,7 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>2aade6beb02ea367fd97c4070a4198802fe61c03</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="8.0.3">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="10.0.10">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>ace9703c57db8596ccc3e3efdc7e65b6975c0b2d</Sha>
     </Dependency>

--- a/src/nuget-client/eng/dotnet-build/build.ps1
+++ b/src/nuget-client/eng/dotnet-build/build.ps1
@@ -10,6 +10,7 @@ param (
   [switch][Alias('pb')]$productBuild,
   [switch]$fromVMR,
   [bool]$nodeReuse = $true,
+  [bool]$warnAsError = $true,
   [string]$warnNotAsError = '',
   [Parameter(ValueFromRemainingArguments = $true)][string[]]$properties
 )

--- a/src/nuget-client/eng/dotnet-build/build.sh
+++ b/src/nuget-client/eng/dotnet-build/build.sh
@@ -63,7 +63,7 @@ while [[ $# > 0 ]]; do
       node_reuse=$2
       shift
       ;;
-    -warnaserror)
+    --warnaserror)
       warn_as_error=$2
       shift
       ;;

--- a/src/nuget-client/eng/dotnet-build/build.sh
+++ b/src/nuget-client/eng/dotnet-build/build.sh
@@ -16,6 +16,7 @@ from_vmr=false
 ci=false
 node_reuse=true
 binary_log=false
+warn_as_error=true
 warn_not_as_error=''
 
 # resolve $SOURCE until the file is no longer a symlink
@@ -60,6 +61,10 @@ while [[ $# > 0 ]]; do
       ;;
     --nodereuse)
       node_reuse=$2
+      shift
+      ;;
+    -warnaserror)
+      warn_as_error=$2
       shift
       ;;
     --warnnotaserror)
@@ -133,12 +138,14 @@ if [[ "$ci" == true ]]; then
   node_reuse=false
 fi
 
-warnnotaserror_switch=""
-if [[ -n "$warn_not_as_error" ]]; then
-  # Only passing /p:AdditionalWarningsNotAsErrors here because this script does not pass /warnaserror to MSBuild.
-  # /warnNotAsError requires /warnaserror to be present, otherwise MSBuild will error.
-  # If /warnaserror is ever added to the command below, also add /warnnotaserror:$warn_not_as_error here.
-  warnnotaserror_switch="/p:AdditionalWarningsNotAsErrors=$warn_not_as_error"
+warnaserror_switch=""
+if [[ "$warn_as_error" == true ]]; then
+  warnaserror_switch="/warnaserror"
 fi
 
-"$DOTNET" msbuild /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse /p:ContinuousIntegrationBuild=$ci $bl $warnnotaserror_switch ${dotnetArguments[@]+"${dotnetArguments[@]}"} ${args[@]+"${args[@]}"}
+warnnotaserror_switch=""
+if [[ -n "$warn_not_as_error" && "$warn_as_error" == true ]]; then
+  warnnotaserror_switch="/warnnotaserror:$warn_not_as_error /p:AdditionalWarningsNotAsErrors=${warn_not_as_error//;/%3B}"
+fi
+
+"$DOTNET" msbuild /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse /p:ContinuousIntegrationBuild=$ci $bl $warnaserror_switch $warnnotaserror_switch ${dotnetArguments[@]+"${dotnetArguments[@]}"} ${args[@]+"${args[@]}"}

--- a/src/nuget-client/global.json
+++ b/src/nuget-client/global.json
@@ -1,4 +1,8 @@
 {
+  "sdk": {
+    "version": "11.0.100-preview.5.26302.115",
+    "allowPrerelease": true
+  },
   "tools": {
     "dotnet": "11.0.100-preview.5.26302.115",
     "pinned": true

--- a/src/runtime/Directory.Build.props
+++ b/src/runtime/Directory.Build.props
@@ -212,10 +212,6 @@
     <MSBuildEnableWorkloadResolver>false</MSBuildEnableWorkloadResolver>
     <!-- Turn off producing Windows PDBs from our portable PDBs. No one uses them and they slow down publishing. -->
     <PublishWindowsPdb>false</PublishWindowsPdb>
-    <!-- Disable source link when building locally. -->
-    <DisableSourceLink Condition="'$(DisableSourceLink)' == '' and
-                                  '$(ContinuousIntegrationBuild)' != 'true' and
-                                  '$(OfficialBuildId)' == ''">true</DisableSourceLink>
     <!-- Runtime doesn't support Arcade-driven target framework filtering. -->
     <NoTargetFrameworkFiltering>true</NoTargetFrameworkFiltering>
 

--- a/src/runtime/Directory.Build.props
+++ b/src/runtime/Directory.Build.props
@@ -292,8 +292,6 @@
     <!-- Enables Strict mode for Roslyn compiler -->
     <Features>strict;nullablePublicOnly</Features>
     <TreatWarningsAsErrors Condition="'$(TreatWarningsAsErrors)' == ''">true</TreatWarningsAsErrors>
-    <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
-    <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true' OR '$(NuGetAuditWarnNotError)' == 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
     <!-- Warnings to always disable -->
     <NoWarn>$(NoWarn);CS8500;CS8969</NoWarn>
     <!-- Suppress "CS1591 - Missing XML comment for publicly visible type or member" compiler errors for private assemblies. -->

--- a/src/scenario-tests/global.json
+++ b/src/scenario-tests/global.json
@@ -1,4 +1,9 @@
 {
+  "sdk": {
+    "version": "11.0.100-preview.5.26302.115",
+    "allowPrerelease": true,
+    "rollForward": "latestFeature"
+  },
   "tools": {
     "dotnet": "11.0.100-preview.5.26302.115",
     "runtimes": {

--- a/src/scenario-tests/src/Directory.Build.props
+++ b/src/scenario-tests/src/Directory.Build.props
@@ -7,9 +7,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <LangVersion>latest</LangVersion>
-
-    <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
-    <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <!-- Common properties for the test projects -->

--- a/src/scenario-tests/src/Directory.Build.targets
+++ b/src/scenario-tests/src/Directory.Build.targets
@@ -33,6 +33,11 @@
     <!-- Clean the test root to avoid dirty content from a previous run -->
     <RemoveDir Directories="$(TestRoot)" />
 
+    <!-- Isolate test environment by creating an empty global.json so that the repo root one is never considered. -->
+    <WriteLinesToFile File="$(TestRoot)global.json"
+      Lines="{}"
+      Overwrite="true" />
+
     <Exec Command='"$(TestDotNetTool)" exec $(TestFxVersionCLI)"$(TargetPath)" $(TestArgs)'
           EnvironmentVariables="@(TestEnvironmentVariable)" />
   </Target>

--- a/src/sdk/Directory.Build.props
+++ b/src/sdk/Directory.Build.props
@@ -96,22 +96,10 @@
 
     <!-- https://github.com/dotnet/source-build/issues/4115. -->
     <PublishWindowsPdb>false</PublishWindowsPdb>
-
-    <!-- Enable NuGet Audit to check for security vulnerabilities -->
-    <NuGetAudit>true</NuGetAudit>
-    <NuGetAuditLevel>low</NuGetAuditLevel>
-    <NuGetAuditMode>all</NuGetAuditMode>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
     <GenerateProgramFile>false</GenerateProgramFile>
-  </PropertyGroup>
-
-  <!-- Disable NuGet audit in official builds. MSBuild does not correctly handle
-       WarningsNotAsErrors for NuGet warnings (https://github.com/dotnet/msbuild/issues/10801),
-       so audit findings become errors via TreatWarningsAsErrors. -->
-  <PropertyGroup Condition="'$(OfficialBuild)' == 'true'">
-    <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/sdk/global.json
+++ b/src/sdk/global.json
@@ -1,5 +1,8 @@
 {
   "sdk": {
+    "version": "11.0.100-preview.5.26302.115",
+    "allowPrerelease": true,
+    "rollForward": "latestFeature",
     "paths": [
       ".dotnet",
       "$host$"

--- a/src/source-build-assets/Directory.Build.props
+++ b/src/source-build-assets/Directory.Build.props
@@ -37,9 +37,6 @@
 
     <LogVerbosity Condition="'$(LogVerbosity)' == ''">minimal</LogVerbosity>
 
-    <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
-    <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-
     <!-- Don't use Arcade's ExcludeFrom* or TFM filtering build infra -->
     <DisableArcadeExcludeFromBuildSupport>true</DisableArcadeExcludeFromBuildSupport>
     <NoTargetFrameworkFiltering>true</NoTargetFrameworkFiltering>

--- a/src/sourcelink/src/Directory.Build.props
+++ b/src/sourcelink/src/Directory.Build.props
@@ -10,9 +10,6 @@
     <PublishWindowsPdb>false</PublishWindowsPdb>
     
     <IncludeSymbols Condition="'$(DebugType)' != 'embedded' and '$(UsingMicrosoftNoTargetsSdk)' != 'true'">true</IncludeSymbols>
-
-    <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
-    <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/symreader/src/Directory.Build.props
+++ b/src/symreader/src/Directory.Build.props
@@ -10,9 +10,6 @@
 
     <!-- Any code that allows overflows intentionally should be explicitly in an unchecked region. -->
     <CheckForOverflowUnderflow Condition="'$(Configuration)' == 'Debug'">true</CheckForOverflowUnderflow>
-
-    <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
-    <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/windowsdesktop/Directory.Build.props
+++ b/src/windowsdesktop/Directory.Build.props
@@ -32,9 +32,6 @@
     <TargetArchitecture Condition="'$(TargetArchitecture)' == '' AND '$(Platform)' != '' AND '$(Platform)' != 'AnyCPU'">$(Platform)</TargetArchitecture>
     <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
 
-    <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
-    <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-
     <!-- Builds are portable by default -->
     <PortableBuild Condition="'$(PortableBuild)' != 'false'">true</PortableBuild>
   </PropertyGroup>

--- a/src/winforms/eng/Analyzer.props
+++ b/src/winforms/eng/Analyzer.props
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <IsAnalyzerProject Condition="'$(IsAnalyzerProject)' == ''">false</IsAnalyzerProject>
 
-    <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
-    <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-
     <!-- Suppress NU1507 (Package source mapping is not compatible with VMR backflow operations) -->
     <NoWarn>$(NoWarn);NU1507</NoWarn>
 

--- a/src/winforms/src/BuildAssist/BuildAssist.msbuildproj
+++ b/src/winforms/src/BuildAssist/BuildAssist.msbuildproj
@@ -3,6 +3,11 @@
   This project is an adapter to use the Framework version of msbuild from dotnet build.
 -->
 <Project Sdk="Microsoft.Build.NoTargets/3.6.0">
+
+  <PropertyGroup>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="vswhere" Version="$(VsWherePackageVersion)" IsImplicitlyDefined="true" GeneratePathProperty="true" />
   </ItemGroup>
@@ -26,7 +31,6 @@
   </Target>
 
   <Target Name="FindFrameworkMsbuild">
-
     <Error
       Text="Pkgvswhere is not set."
       Condition="'$(Pkgvswhere)' == ''" />
@@ -56,6 +60,6 @@
     <Error
       Text="Could not find MSBuild path. '%24%28_MSBuildCurrentPath%29' == '$(_MSBuildCurrentPath)'"
       Condition="!Exists('$(_MSBuildCurrentPath)')" />
-
   </Target>
+
 </Project>

--- a/src/wpf/eng/WpfArcadeSdk/tools/CodeAnalysis.props
+++ b/src/wpf/eng/WpfArcadeSdk/tools/CodeAnalysis.props
@@ -1,9 +1,6 @@
 <Project>
 
   <PropertyGroup>
-    <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
-    <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
-
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 
     <!--

--- a/src/xdt/Directory.Build.props
+++ b/src/xdt/Directory.Build.props
@@ -21,8 +21,6 @@
     <RepositoryUrl>https://github.com/dotnet/xdt</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
-    <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/test/Microsoft.DotNet.SourceBuild.Tests/DotNetHelper.cs
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/DotNetHelper.cs
@@ -94,7 +94,7 @@ internal partial class DotNetHelper
             DotNetPath,
             args,
             OutputHelper,
-            configureCallback: (process) => configureProcess(process, workingDirectory),
+            configureCallback: (process) => configureProcess(process, workingDirectory ?? ProjectsDirectory),
             millisecondTimeout: millisecondTimeout);
 
         if (expectedExitCode != null)
@@ -102,7 +102,7 @@ internal partial class DotNetHelper
             ExecuteHelper.ValidateExitCode(executeResult, (int)expectedExitCode);
         }
 
-        void configureProcess(Process process, string? workingDirectory)
+        void configureProcess(Process process, string workingDirectory)
         {
             ConfigureProcess(process, workingDirectory);
 
@@ -110,12 +110,9 @@ internal partial class DotNetHelper
         }
     }
 
-    public static void ConfigureProcess(Process process, string? workingDirectory)
+    public static void ConfigureProcess(Process process, string workingDirectory)
     {
-        if (workingDirectory != null)
-        {
-            process.StartInfo.WorkingDirectory = workingDirectory;
-        }
+        process.StartInfo.WorkingDirectory = workingDirectory;
 
         process.StartInfo.EnvironmentVariables["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
         process.StartInfo.EnvironmentVariables["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "1";

--- a/test/Microsoft.DotNet.SourceBuild.Tests/DotNetHelper.cs
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/DotNetHelper.cs
@@ -55,6 +55,9 @@ internal partial class DotNetHelper
             {
                 Directory.CreateDirectory(ProjectsDirectory);
                 InitNugetConfig();
+
+                // Isolate test environment by creating an empty global.json so that the repo root one is never considered.
+                File.WriteAllText(Path.Combine(ProjectsDirectory, "global.json"), "{}");
             }
 
             if (!Directory.Exists(PackagesDirectory))

--- a/test/Microsoft.DotNet.SourceBuild.Tests/OmniSharpTests.cs
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/OmniSharpTests.cs
@@ -21,7 +21,7 @@ public class OmniSharpTests : SdkTests
     // Update version as new releases become available: https://github.com/OmniSharp/omnisharp-roslyn/releases
     private const string OmniSharpReleaseVersion = "1.39.15";
 
-    private string OmniSharpDirectory { get; } = Path.Combine(Directory.GetCurrentDirectory(), nameof(OmniSharpTests));
+    private string OmniSharpDirectory { get; } = Path.Combine(DotNetHelper.ProjectsDirectory, nameof(OmniSharpTests));
 
     public static bool IncludeOmniSharpTests => Config.TargetArchitecture != "ppc64le" && Config.TargetArchitecture != "s390x";
 

--- a/test/Microsoft.DotNet.SourceBuild.Tests/SourcelinkTests.cs
+++ b/test/Microsoft.DotNet.SourceBuild.Tests/SourcelinkTests.cs
@@ -128,7 +128,7 @@ public class SourcelinkTests : SdkTests
                     logOutput: false,
                     excludeInfo: true, // Exclude info messages, as there can be 1,000+ processes
                     millisecondTimeout: 60000,
-                    configureCallback: (process) => DotNetHelper.ConfigureProcess(process, null));
+                    configureCallback: (process) => DotNetHelper.ConfigureProcess(process, DotNetHelper.ProjectsDirectory));
                 elapsed = DateTime.UtcNow - startTime;
                 exitCode = executeResult.Process?.ExitCode ?? -1;
 


### PR DESCRIPTION
Unblocks dev/PR builds that have NuGet Audit enabled
Forward port https://github.com/dotnet/dotnet/pull/7885, https://github.com/dotnet/dotnet/pull/7875, https://github.com/dotnet/dotnet/pull/7873 and https://github.com/dotnet/dotnet/pull/7906

Summary:

- Define an sdk::version entry in all global.json so that the host picks the correct SDK version (the one determined by the VMR root). Otherwise the build fails when a matching SDK is installed globally.
- Add missing auditSources feed in arcade
- Prepare infra to emit warnings in the VMR by updating the Exec Task with metadata
- Fix warnNotAsError inputs when passing semicolon separated entries in (tools.sh & tools.ps1) in both the bootstrap and arcade live files.
- Update vulnerable packages in fsharp, nuget-client, sourcelink and msbuild
- Fix winforms not building inside the VMR when .NET Framework 4.8.1 reference assemblies aren't globally installed by marking the test utility project appropriately so that it doesn't get built by default.