### PR TITLE
[release/10.0.1xx] Don't restore runtime tools in CI

### DIFF
--- a/src/runtime/eng/Tools.props
+++ b/src/runtime/eng/Tools.props
@@ -1,5 +1,9 @@
 <Project>
-
+  <PropertyGroup>
+    <!-- Unset the repo tool manifest property in CI as we don't use repo tools there anyway -->
+    <_RepoToolManifest Condition="'$(ContinuousIntegrationBuild)' == 'true'" />
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Packaging" Version="$(MicrosoftDotNetBuildTasksPackagingVersion)" />
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" />


### PR DESCRIPTION
tool restoration is currently flaky. disabling it since it's not getting used anyway