### PR TITLE
[release/11.0.1xx-preview7] Use internal pool for full VMR builds

### DIFF
--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -264,7 +264,7 @@ variables:
       value: windows.vs2026.amd64.open
 - ${{ else }}:
   - name: defaultPoolName
-    value: $(DncEngInternalBuildPool)
+    value: NetCore1ESPool-Internal
   - name: shortStackPoolName
     value: $(DncEngInternalBuildPool)
   - name: poolImage_Linux


### PR DESCRIPTION
Backports the preview 6 workaround from #7364.

Full Windows VMR builds need the normal internal pool because the servicing pool's current SKU has insufficient disk and is slower. Keep `shortStackPoolName` on `$(DncEngInternalBuildPool)` because short-stack builds do not need the extra disk.

Long-term servicing-pool strategy: [dnceng/internal#11887](https://dev.azure.com/dnceng/internal/_workitems/edit/11887)