### PR TITLE
Fix newline stripping in reproducibility exclusions baseline tool

### DIFF
--- a/eng/tools/CreateBaselineUpdatePR/PRCreator.cs
+++ b/eng/tools/CreateBaselineUpdatePR/PRCreator.cs
@@ -170,7 +170,7 @@ public partial class PRCreator
                     // collapses to content.Replace("\n", ""), stripping every newline and mangling
                     // the file into a single line. Blank lines are formatting, not exclusions, so
                     // there is never a reason to remove them here.
-                    if (line.Length == 0)
+                    if (string.IsNullOrWhiteSpace(line))
                     {
                         continue;
                     }

--- a/eng/tools/CreateBaselineUpdatePR/PRCreator.cs
+++ b/eng/tools/CreateBaselineUpdatePR/PRCreator.cs
@@ -165,6 +165,16 @@ public partial class PRCreator
 
                 foreach (var line in originalContent)
                 {
+                    // Skip blank lines. Splitting on "\n" yields a trailing empty element for a
+                    // file ending in a newline; running the removal below for that empty line
+                    // collapses to content.Replace("\n", ""), stripping every newline and mangling
+                    // the file into a single line. Blank lines are formatting, not exclusions, so
+                    // there is never a reason to remove them here.
+                    if (line.Length == 0)
+                    {
+                        continue;
+                    }
+
                     if (!parsedFile.Contains(line))
                     {
                         // If the newline character is not present, the line is at the end of the file


### PR DESCRIPTION
The `CreateBaselineUpdatePR` tool's `UpdateExclusionFile` union path split the original exclusions file on `\n` and, for any line not present in the updated exclusions, removed it via substring replacement. For a file ending in a newline, `Split("\n")` produces a trailing empty element. That empty line is never in the updated set, so the removal collapsed to `content.Replace("\n", "")`, stripping every newline and mangling the whole file into a single line.

This only manifested when the updated exclusions file contained no blank line (e.g. `SourceBuiltReproducibilityExclusions.txt`), because an interior blank line would otherwise put an empty string into the parsed set and mask the bug.

Skip blank lines in the removal loop. Blank lines are formatting, not exclusions, so there is never a reason to remove them here.

Example of what this fix avoids: https://github.com/dotnet/dotnet/pull/7925