### PR TITLE
[release/11.0.1xx-preview7] Backport PAT-less internal feed auth

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -962,7 +962,10 @@ jobs:
 
           customPreBuildArgs=""
           if [[ '${{ parameters.runOnline }}' == 'False' ]]; then
-            customPreBuildArgs="sudo -E"
+            # Preserve HOME across the sudo boundary so the Azure Artifacts credential
+            # provider provisioned by NuGetAuthenticate can locate the credentials it
+            # cached for internal-feed restore. See https://github.com/dotnet/source-build/issues/5612
+            customPreBuildArgs="sudo -E --preserve-env=HOME"
             export MICROBUILDOUTPUTFOLDEROVERRIDE
           fi
 

--- a/eng/sign-source-built-artifacts.proj
+++ b/eng/sign-source-built-artifacts.proj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.Build.Traversal">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCurrent)</TargetFramework>
+    <TargetFramework>$(BundledNETCoreAppTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,11 +9,9 @@
   </ItemGroup>
 
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.SignSourceBuiltArtifacts" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
-
   <Target Name="SignSourceBuiltArtifacts"
-      DependsOnTargets="GetSignableSourceBuiltAssets"
-      BeforeTargets="Build">
-
+          DependsOnTargets="GetSignableSourceBuiltAssets"
+          AfterTargets="Build">
     <SignSourceBuiltArtifacts
       DotNetEngDirectory="$(RepositoryEngineeringDir)"
       SignableSourceBuiltAssets="@(SignableSourceBuiltAsset)"
@@ -23,9 +21,8 @@
   </Target>
 
   <Target Name="GetSignableSourceBuiltAssets"
-    DependsOnTargets="ResolveProjectReferences"
-    BeforeTargets="Build">
-
+          DependsOnTargets="ResolveProjectReferences"
+          AfterTargets="Build">
     <!-- We always publish when building the VMR, so we need to define these properties to ensure that we're pulling the source-build artifacts from the correct locations -->
     <!-- Keep in line with the properties defined in $(RepositoryEngineeringDir)Publishing.props -->
     <PropertyGroup>

--- a/eng/sign-source-built-artifacts.proj
+++ b/eng/sign-source-built-artifacts.proj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.Build.NoTargets">
+<Project Sdk="Microsoft.Build.Traversal">
 
   <PropertyGroup>
-    <TargetFramework>$(BundledNETCoreAppTargetFramework)</TargetFramework>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,9 +9,11 @@
   </ItemGroup>
 
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.SignSourceBuiltArtifacts" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
+
   <Target Name="SignSourceBuiltArtifacts"
-          DependsOnTargets="GetSignableSourceBuiltAssets"
-          AfterTargets="Build">
+      DependsOnTargets="GetSignableSourceBuiltAssets"
+      BeforeTargets="Build">
+
     <SignSourceBuiltArtifacts
       DotNetEngDirectory="$(RepositoryEngineeringDir)"
       SignableSourceBuiltAssets="@(SignableSourceBuiltAsset)"
@@ -21,8 +23,9 @@
   </Target>
 
   <Target Name="GetSignableSourceBuiltAssets"
-          DependsOnTargets="ResolveProjectReferences"
-          AfterTargets="Build">
+    DependsOnTargets="ResolveProjectReferences"
+    BeforeTargets="Build">
+
     <!-- We always publish when building the VMR, so we need to define these properties to ensure that we're pulling the source-build artifacts from the correct locations -->
     <!-- Keep in line with the properties defined in $(RepositoryEngineeringDir)Publishing.props -->
     <PropertyGroup>


### PR DESCRIPTION
Backport of https://github.com/dotnet/dotnet/pull/7737.

Migrate to PAT-less internal-feed authentication:

- Provision the Azure Artifacts credential provider with `NuGetAuthenticate@1` for internal source-build legs.
- Preserve `HOME` across offline `sudo` boundaries so the credential provider can locate its cached internal-feed credentials during build, test, and source-built artifact signing.

The release-11 branch already contains the setup, build, and test portions through equivalent merged changes. This backport supplies the remaining source-built artifact-signing change.