### PR TITLE
Produce binlogs for CreateBaselineUpdatePR and BuildComparer tools

### DIFF
--- a/eng/pipelines/templates/stages/vmr-license-scan.yml
+++ b/eng/pipelines/templates/stages/vmr-license-scan.yml
@@ -184,6 +184,13 @@ stages:
     - template: /eng/pipelines/templates/variables/pipelines.yml@self
       # GH access token for SB bot - BotAccount-dotnet-sb-bot-pat
     - group: Dotnet-SourceBuild-Secrets
+    templateContext:
+      outputs:
+      - output: pipelineArtifact
+        displayName: 'Publish BuildLogs'
+        condition: succeededOrFailed()
+        targetPath: '$(Build.StagingDirectory)/BuildLogs'
+        artifactName: $(Agent.JobName)_BuildLogs_Attempt$(System.JobAttempt)
     steps:
     - script: |
         source ./eng/common/tools.sh
@@ -203,6 +210,9 @@ stages:
     - script: |
         find $(Pipeline.Workspace)/Artifacts -type f -exec mv {} $(Pipeline.Workspace)/Artifacts \;
       displayName: Move Artifacts to root
+
+    - script: mkdir -p $(Build.StagingDirectory)/BuildLogs
+      displayName: Create BuildLogs staging directory
 
     - template: /eng/pipelines/templates/steps/create-baseline-update-pr.yml@self
       parameters:

--- a/eng/pipelines/templates/steps/run-baseline-update-pr-tool.yml
+++ b/eng/pipelines/templates/steps/run-baseline-update-pr-tool.yml
@@ -55,6 +55,7 @@ steps:
 
       ${{ parameters.dotnetPath }}/dotnet run \
         --project eng/tools/CreateBaselineUpdatePR/ \
+        -bl:"$(Build.StagingDirectory)/BuildLogs/CreateBaselineUpdatePR.${{ parameters.pipeline }}.binlog" \
         --property:RestoreSources="$restoreSources" \
         "${{ parameters.pipeline }}" \
         "${{ parameters.repoUrl }}" \
@@ -69,3 +70,4 @@ steps:
     condition: succeededOrFailed()
     env:
       GIT_TOKEN: ${{ parameters.token }}
+

--- a/eng/pipelines/templates/steps/vmr-compare.yml
+++ b/eng/pipelines/templates/steps/vmr-compare.yml
@@ -235,6 +235,7 @@ steps:
   displayName: Set additional command arguments
 
 - script: $(InstallDarc.dotnetPath) run --project $(Build.SourcesDirectory)/eng/tools/BuildComparer/BuildComparer.csproj
+    -bl:"$(Build.SourcesDirectory)/artifacts/AssetBaselines/BuildComparer.${{ parameters.command }}.binlog"
     ${{ parameters.command }}
     -vmrAssetBasePath "$(Build.ArtifactStagingDirectory)/vmr-assets"
     -msftAssetBasePath "$(Build.ArtifactStagingDirectory)/base-assets"


### PR DESCRIPTION
Updates AzDO pipelines to produce binlogs for CreateBaselineUpdatePR and BuildComparer tools and store them in pipeline artifacts.

Fixes: #4359