### PR TITLE
Restore dotnet-aot to same-arch Linux SDK builds

### DIFF
--- a/src/sdk/src/Layout/Directory.Build.props
+++ b/src/sdk/src/Layout/Directory.Build.props
@@ -46,9 +46,10 @@
          a prerequisite for both native and cross-arch publishing. -->
     <_DotnetAotIsSameOSBuild Condition="'$(TargetOS)' == '$(HostOS)'">true</_DotnetAotIsSameOSBuild>
 
-    <!-- Native: same OS and same architecture as the build host (and not an explicit cross-build).
-         linux-musl is excluded because its NativeAOT toolchain is not wired up here. -->
-    <_DotnetAotIsNativeBuild Condition="'$(_DotnetAotIsSameOSBuild)' == 'true' and '$(TargetArchitecture)' == '$(BuildArchitecture)' and '$(CrossBuild)' != 'true' and '$(OSName)' != 'linux-musl'">true</_DotnetAotIsNativeBuild>
+    <!-- Native: same OS and same architecture as the build host. CrossBuild may still be true when
+         the build uses a same-architecture rootfs. linux-musl is excluded because its NativeAOT
+         toolchain is not wired up here. -->
+    <_DotnetAotIsNativeBuild Condition="'$(_DotnetAotIsSameOSBuild)' == 'true' and '$(TargetArchitecture)' == '$(BuildArchitecture)' and '$(OSName)' != 'linux-musl'">true</_DotnetAotIsNativeBuild>
 
     <!-- Cross: same OS but a different architecture from the build host. On Windows/macOS the cross
          toolchain (MSVC arm64 linker / clang) is multi-target, so an architecture mismatch alone is


### PR DESCRIPTION
## Summary

- classify same-OS, same-architecture SDK layout builds as native even when `CrossBuild=true`
- preserve the existing cross-architecture, cross-OS, linux-musl, Mono, unsupported-OS, and `NativeAotSupported` safeguards
- allow the normal VMR `Linux_x64` build, which uses a same-architecture rootfs, to include and publish `libdotnet-aot.so`

Fixes #7981

## Root cause

The `Linux_x64` VMR job targets Linux x64 from a Linux x64 host, but its same-architecture rootfs causes `CrossBuild=true` to flow into SDK layout.

The layout gate classified a build as native only when the architectures matched **and** `CrossBuild` was not true. It classified a build as cross only when the architectures differed. The VMR job therefore matched neither branch, leaving `_ShouldPublishDotnetAot=false`.

`TargetArchitecture == BuildArchitecture` is the native-versus-cross-architecture signal. `CrossBuild` can independently indicate that a rootfs/toolchain is in use, including for the same architecture.

## MSBuild evaluation proof

Evaluated `src/sdk/src/Layout/redist/redist.csproj` with `dotnet msbuild`, querying:

```text
-getProperty:_DotnetAotIsNativeBuild,_DotnetAotIsCrossBuild,_ShouldPublishDotnetAot
```

The exact regression configuration now produces:

```text
TargetOS=linux
HostOS=linux
TargetArchitecture=x64
BuildArchitecture=x64
TargetRid=linux-x64
OSName=linux
CrossBuild=true
NativeAotSupported=true
DotNetBuildUseMonoRuntime=false

_DotnetAotIsNativeBuild=true
_DotnetAotIsCrossBuild=
_ShouldPublishDotnetAot=true
```

The surrounding decision matrix produced:

| Configuration | Native | Cross | Publish |
| --- | --- | --- | --- |
| Linux x64 → x64, `CrossBuild=false` | `true` | empty | `true` |
| Linux x64 → x64, `CrossBuild=true` | `true` | empty | `true` |
| Linux x64 → arm64, `CrossBuild=true` | empty | `true` | `true` |
| Linux x64 → arm64, `CrossBuild=false` | empty | empty | `false` |
| Cross-OS | empty | empty | `false` |
| linux-musl | empty | empty | `false` |
| `NativeAotSupported=false` | `true` | empty | `false` |
| Mono runtime | `true` | empty | `false` |
| Unsupported target OS | `true` | empty | `false` |

Also queried the evaluated `ProjectReference` items. For the VMR regression configuration:

```text
_ShouldPublishDotnetAot=true
dotnet-aot project references=1
```

For Linux x64 → arm64 without `CrossBuild=true`:

```text
_ShouldPublishDotnetAot=false
dotnet-aot project references=0
```

This confirms the corrected shared gate both enables `PublishDotnetAot` and includes `dotnet-aot.csproj` in the restore/build graph for the affected VMR configuration, while preserving the Linux cross-architecture toolchain guard.