### PR TITLE
Use globs for --DirectoryExclusionList argument in additionalComponentDetectorArgs

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -122,7 +122,7 @@ extends:
         # (--DirectoryExclusionList, which takes semicolon-separated glob patterns).
         #
         # Note: Keep these in sync with componentgovernance.ignoreDirectories above.
-        additionalComponentDetectorArgs: '--DirectoryExclusionList artifacts/bin/Microsoft.DotNet.SourceBuild.Tests;artifacts/obj/toolset/Publish/artifacts-layout;src/arcade/src/Microsoft.DotNet.SignTool.Tests/Resources;src/sdk/test/TestAssets/TestPackages;src/wpf/.tools'
+        additionalComponentDetectorArgs: '--DirectoryExclusionList **/artifacts/bin/Microsoft.DotNet.SourceBuild.Tests/**;**/artifacts/obj/toolset/Publish/artifacts-layout/**;**/src/arcade/src/Microsoft.DotNet.SignTool.Tests/Resources/**;**/src/sdk/test/TestAssets/TestPackages/**;**/src/wpf/.tools/**'
       autobaseline:
         isMainPipeline: true
 


### PR DESCRIPTION
The `--DirectoryExclusionList` needs glob-style paths, the older `--IgnoreDirectories` took plain path names. Fixes warnings from "Generate SBoM Manifest" task.

Follow-up to https://github.com/dotnet/dotnet/pull/7552