### PR TITLE
Fix linux-bionic CI build breaks

### DIFF
--- a/src/runtime/eng/RuntimeIdentifier.props
+++ b/src/runtime/eng/RuntimeIdentifier.props
@@ -20,10 +20,6 @@
     <PortableOS Condition="'$(PortableOS)' == 'linux' and '$(__PortableTargetOS)' == 'linux-musl'">linux-musl</PortableOS>
     <PortableOS Condition="'$(PortableOS)' == 'linux' and '$(__PortableTargetOS)' == 'linux-bionic'">linux-bionic</PortableOS>
 
-    <!-- On Windows, we can build for Windows and Mobile.
-         For other TargetOSes, create a "win" build, built from TargetOS sources and "win" pre-built packages. -->
-    <PortableOS Condition="'$(HostOS)' == 'win' and '$(TargetsMobile)' != 'true'">win</PortableOS>
-
     <PortableTargetRid Condition="'$(PortableTargetRid)' == ''">$(PortableOS)-$(TargetArchitecture)</PortableTargetRid>
   </PropertyGroup>
 

--- a/src/runtime/eng/Subsets.props
+++ b/src/runtime/eng/Subsets.props
@@ -377,7 +377,9 @@
     The cross tools are used as part of the build process with the downloaded build tools, so we need to build them for the host architecture and build them as unsanitized binaries.
     -->
   <PropertyGroup>
-    <_BuildAnyCrossArch Condition="('$(CrossBuild)' == 'true' or '$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(HostOS)' != '$(TargetOS)' or '$(EnableNativeSanitizers)' != '')">true</_BuildAnyCrossArch>
+    <!-- linux-bionic reports TargetOS as 'linux', so the HostOS/TargetOS check below never fires for it.
+         It always targets the bionic libc via the NDK though, so host tools must be built separately. -->
+    <_BuildAnyCrossArch Condition="('$(CrossBuild)' == 'true' or '$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(HostOS)' != '$(TargetOS)' or '$(TargetsLinuxBionic)' == 'true' or '$(EnableNativeSanitizers)' != '')">true</_BuildAnyCrossArch>
     <_BuildCrossComponents Condition="$(_subset.Contains('+clr.crossarchtools+'))">true</_BuildCrossComponents>
     <_BuildCrossComponents Condition="'$(ClrRuntimeBuildSubsets)' != '' and ('$(PrimaryRuntimeFlavor)' == 'CoreCLR' or '$(TargetsMobile)' == 'true')">true</_BuildCrossComponents>
     <_CrossBitwidthBuild Condition="'$(BuildArchitecture)' == 'x64' and ('$(TargetArchitecture)' == 'x86' or '$(TargetArchitecture)' == 'arm')">true</_CrossBitwidthBuild>
@@ -703,7 +705,7 @@
             <_BuildCoreCLRRuntimePack Condition="'$(RuntimeFlavor)' == 'CoreCLR' and '$(CoreCLRSupported)' == 'true'">true</_BuildCoreCLRRuntimePack>
             <_BuildMonoRuntimePack Condition="'$(RuntimeFlavor)' == 'Mono' and '$(MonoSupported)' == 'true'">true</_BuildMonoRuntimePack>
             <_BuildHostPack Condition="'$(RuntimeFlavor)' == '$(PrimaryRuntimeFlavor)' and '$(TargetsMobile)' != 'true'">true</_BuildHostPack>
-            <_BuildCdacPack Condition="'$(_CDacToolsBuilt)' == 'true' and '$(RuntimeFlavor)' == 'CoreCLR' and '$(TargetsMobile)' != 'true' and ('$(TargetOS)' == 'windows' or '$(TargetOS)' == 'osx' or '$(TargetOS)' == 'linux')">true</_BuildCdacPack>
+            <_BuildCdacPack Condition="'$(_CDacToolsBuilt)' == 'true' and '$(RuntimeFlavor)' == 'CoreCLR' and '$(TargetsMobile)' != 'true' and '$(TargetsLinuxBionic)' != 'true' and ('$(TargetOS)' == 'windows' or '$(TargetOS)' == 'osx' or '$(TargetOS)' == 'linux')">true</_BuildCdacPack>
             <_BuildBundle Condition="'$(RuntimeFlavor)' == '$(PrimaryRuntimeFlavor)' and '$(TargetsMobile)' != 'true'">true</_BuildBundle>
           </PropertyGroup>
 

--- a/src/runtime/src/coreclr/.nuget/coreclr-packages.proj
+++ b/src/runtime/src/coreclr/.nuget/coreclr-packages.proj
@@ -7,7 +7,7 @@
     <ProjectReference Include="Microsoft.NETCore.TestHost\Microsoft.NETCore.TestHost.proj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetsMobile)' != 'true' ">
+  <ItemGroup Condition=" '$(TargetsMobile)' != 'true' and '$(TargetsLinuxBionic)' != 'true' ">
     <ProjectReference Include="Microsoft.NETCore.ILAsm\Microsoft.NETCore.ILAsm.proj" />
     <ProjectReference Include="Microsoft.NETCore.ILDAsm\Microsoft.NETCore.ILDAsm.proj" />
   </ItemGroup>

--- a/src/runtime/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/ILCompiler.ReadyToRun.Tests.csproj
+++ b/src/runtime/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/ILCompiler.ReadyToRun.Tests.csproj
@@ -48,7 +48,7 @@
        Hooks into ResolveProjectReferences so it fires for `dotnet build` (and CI's `build.sh -test`,
        which builds before testing). `dotnet build /t:test` alone won't trigger it. -->
   <PropertyGroup>
-    <_BuildJitsCrossArch Condition="'$(CrossBuild)' == 'true' or '$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(HostOS)' != '$(TargetOS)' or '$(EnableNativeSanitizers)' != ''">true</_BuildJitsCrossArch>
+    <_BuildJitsCrossArch Condition="'$(CrossBuild)' == 'true' or '$(BuildArchitecture)' != '$(TargetArchitecture)' or '$(HostOS)' != '$(TargetOS)' or '$(TargetsLinuxBionic)' == 'true' or '$(EnableNativeSanitizers)' != ''">true</_BuildJitsCrossArch>
     <_BuildJitsProperties>ClrAllJitsSubset=true;ClrWasmJitSubset=true;Configuration=$(CoreCLRConfiguration)</_BuildJitsProperties>
     <_BuildJitsProperties Condition="!$([MSBuild]::IsOsPlatform(Windows))">$(_BuildJitsProperties);Ninja=true</_BuildJitsProperties>
     <_BuildJitsProperties Condition="'$(_BuildJitsCrossArch)' == 'true'">$(_BuildJitsProperties);HostArchitecture=$(BuildArchitecture);HostCrossOS=$(HostOS);CrossBuild=false;BuildSubdirectory=$(BuildArchitecture);CMakeArgs=$(CMakeArgs) -DCLR_CROSS_COMPONENTS_BUILD=1;PgoInstrument=false;NoPgoOptimize=true</_BuildJitsProperties>

--- a/src/runtime/src/coreclr/tools/aot/crossgen2/crossgen2.csproj
+++ b/src/runtime/src/coreclr/tools/aot/crossgen2/crossgen2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <CrossHostArch Condition="'$(CrossBuild)' == 'true' or '$(TargetArchitecture)' != '$(BuildArchitecture)' or '$(HostOS)' != '$(TargetOS)' or '$(EnableNativeSanitizers)' != ''">$(BuildArchitecture)</CrossHostArch>
+    <CrossHostArch Condition="'$(CrossBuild)' == 'true' or '$(TargetArchitecture)' != '$(BuildArchitecture)' or '$(HostOS)' != '$(TargetOS)' or '$(TargetsLinuxBionic)' == 'true' or '$(EnableNativeSanitizers)' != ''">$(BuildArchitecture)</CrossHostArch>
     <OutputPath>$(RuntimeBinDir)/crossgen2</OutputPath>
   </PropertyGroup>
   <Import Project="crossgen2.props" />


### PR DESCRIPTION
The `LinuxBionic_Shortstack_x64` and `LinuxBionic_Shortstack_arm64` legs have been failing since source update #7872 flowed in dotnet/runtime#131115 ("Enable CoreCLR for linux-bionic platforms").

Regression window: build [1524524](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1524524&view=results) (green) → [1526335](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1526335&view=results) (red).

## Root cause

dotnet/runtime#131115 enabled CoreCLR for linux-bionic by copying the Android configuration. But linux-bionic reports `TargetOS` as `linux` (not `linux-bionic`) and `TargetsMobile` as `false`, so every Android-shaped guard silently let it through. The repo convention is to spell bionic out alongside mobile — `$(TargetsMobile) != true and $(TargetsLinuxBionic) != true`, as at `Subsets.props` lines 32, 49, 54, 733, 740 and 748 — and that pairing was only partly applied.

### x64: `jitinterface_x64` fails to load

`_BuildAnyCrossArch` never fired for bionic: `CrossBuild` is false, `BuildArchitecture` equals `TargetArchitecture`, and `HostOS` equals `TargetOS` (both `linux`). Android escapes this only because its `TargetOS` really is `android`.

With no cross-components build, `CrossHostArch` stayed empty and `AotCompilerCommon.props` copied the **NDK-built** `libjitinterface_x64.so` into the crossgen2 output. The glibc-host crossgen2 then failed to `dlopen` it — note `liblog.so`, an Android-only library:

```
System.DllNotFoundException: Unable to load shared library jitinterface_x64 or one of its dependencies.
  liblog.so: cannot open shared object file: No such file or directory
```

linux-bionic is always cross-targeted via the NDK regardless of what `HostOS`/`TargetOS` report, so the check is keyed on `TargetsLinuxBionic`. The same expression is duplicated in `crossgen2.csproj` and `ILCompiler.ReadyToRun.Tests.csproj`, so those are updated too.

The fix is safe because the cross-components build passes `-hostos $(HostOS)` = `linux`, and `build-commons.sh` gates the NDK toolchain on that argument — so it correctly skips the NDK and produces glibc host binaries.

### arm64: ilasm/ildasm packaging

The NDK toolchain sets `CMAKE_SYSTEM_NAME=Android`, so CMake sees `CLR_CMAKE_TARGET_ANDROID` and skips `CLR_CMAKE_BUILD_TOOLS`. `ilasm`/`ildasm` are therefore never produced, but `coreclr-packages.proj` gated them only on `TargetsMobile`:

```
File not found: .../linux.arm64.Release/ilasm
```

`_SdkToolsSupportedOS` already treats bionic like mobile for exactly this reason, so this mirrors it. (x64 would have hit this too once the crossgen2 fix landed.)

### `_BuildCdacPack` hardening

`_BuildCdacPack` passes all four terms for bionic while `compile-native.proj` disables `SupportsNativeAotComponents` for it — the same "pack requested, artifact never built" shape as the ilasm bug. Latent today only because bionics default subsets omit `tools`; Android is blocked by two independent terms, bionic by none. Verified with `/p:Subset=clr+tools+packs`: bionic `_BuildCdacPack=true`, Android empty.

## Other commits

**Enable CoreCLR for linux-bionic arm.** The bionic line picked up an `arm` exclusion that Android had already dropped two months earlier (re-enabled 2026-05-21; blocking issue dotnet/runtime#111665 closed 2026-07-20). That issue was "fseeko/ftello not supported on arm32 and x86 below API level 24", and `build-commons.sh` pins `ANDROID_API_LEVEL` to 24, so it never applied here. This is the one commit that changes a currently-green leg — `LinuxBionic_Shortstack_arm` will build full CoreCLR arm32 for the first time. It is isolated to one line and can be dropped independently if that leg goes red.

**Remove dead HostOS check.** `RuntimeIdentifier.props` overrode `PortableOS` when `HostOS` is `win`, but `OSArch.props` has only ever set `HostOS` to `windows` — including at the commit that introduced the check in February 2025 — so it never fired. Removed rather than corrected, since making it fire would change `TargetRid` from `linux-x64` to `win-x64` for Windows-host cross-target builds. No behavior change.

## Validation

Verified by MSBuild property/item evaluation, since a real linux-bionic build needs a Linux host plus the Android NDK:

| config | `_BuildAnyCrossArch` before → after | `TargetRid` |
| --- | --- | --- |
| bionic-x64 | `""` → `true` | `linux-bionic-x64` |
| bionic-arm64 | `true` → `true` | `linux-bionic-arm64` |
| bionic-arm | `true` → `true` | `linux-bionic-arm` |
| linux-x64 | `""` → `""` | `linux-x64` |
| android-arm64 | unchanged | `android-arm64` |

ILAsm/ILDAsm and cdac now drop out for bionic only; Android and plain Linux are unaffected. CI is the real test.

These changes belong in dotnet/runtime and are made here to unblock CI; they should be backflowed.

<sub>This PR was prepared with GitHub Copilot CLI.</sub>