### PR TITLE
Use global.json-matched SDK for VMR license scan (1xx)

### DIFF
--- a/eng/pipelines/templates/stages/vmr-license-scan.yml
+++ b/eng/pipelines/templates/stages/vmr-license-scan.yml
@@ -122,8 +122,19 @@ stages:
         artifactName: $(Agent.JobName)_BuildLogs_Attempt$(System.JobAttempt)
     steps:
 
+    # The shared source-build test container ships the latest .NET 10 SDK, which does not
+    # satisfy this branch's global.json (different feature band), so the container's system
+    # 'dotnet' cannot run the tests. Install the global.json-matched SDK and use it instead.
+    # Tracking: dotnet/source-build#5623
+    - script: |
+        source ./eng/common/tools.sh
+        InitializeDotNetCli true
+        echo "##vso[task.setvariable variable=DotNetPath]$_InitializeDotNetCli"
+      displayName: Install .NET SDK
+      workingDirectory: $(Build.SourcesDirectory)
+
     - script: >
-        dotnet test
+        $(DotNetPath)/dotnet test
         $(Build.SourcesDirectory)/test/Microsoft.DotNet.SourceBuild.Tests/Microsoft.DotNet.SourceBuild.Tests.csproj
         --filter "FullyQualifiedName=Microsoft.DotNet.SourceBuild.Tests.LicenseScanTests.ScanForLicenses"
         --logger:'trx;LogFileName=$(Agent.JobName)_LicenseScan.trx'


### PR DESCRIPTION
## What
The VMR license scan job launched dotnet test with the source-build test container's **system** .NET SDK (currently 10.0.302). On the servicing branches whose global.json pins a different feature band (this branch pins 10.0.1xx), SDK resolution fails with *"A compatible .NET SDK was not found"* (exit 155) and the scan never runs.

## Fix
Install the global.json-matched SDK via eng/common/tools.sh (InitializeDotNetCli) and invoke that `dotnet` for the scan — the same pattern the sibling `Publish_Test_Results_PR` job already uses. `/p:SkipPrepareSdkArchive=true` is kept because the license scan only reads source and does not need the source-built SDK archive.

## Testing
Once merged, the next scheduled/triggered run of the source-build license scan pipeline on this branch should launch successfully instead of failing to find an SDK.

Tracking: dotnet/source-build#5623
