### PR TITLE
Stop running VMR license scan on the 2xx band

### DIFF
--- a/eng/pipelines/vmr-license-scan.yml
+++ b/eng/pipelines/vmr-license-scan.yml
@@ -19,6 +19,12 @@ schedules:
     - release/*.0.4xx*
     - internal/release/*.0.?xx*
     - internal/release/*.0.???
+    exclude:
+    # License scan is disabled for the 2xx band: the shared source-build test container
+    # ships a newer .NET 10 SDK than the 2xx branch global.json pins, so the test cannot
+    # run there. Tracking: dotnet/source-build#5623
+    - internal/release/*.0.2xx*
+    - internal/release/*.0.2??
 
 pr: none
 
@@ -34,6 +40,10 @@ trigger:
     - release/*.0.4xx*
     - internal/release/*.0.?xx*
     - internal/release/*.0.???
+    exclude:
+    # See note above — license scan is disabled for the 2xx band. Tracking: dotnet/source-build#5623
+    - internal/release/*.0.2xx*
+    - internal/release/*.0.2??
   paths:
     include:
     - test/Microsoft.DotNet.SourceBuild.Tests/LicenseScanTests.cs


### PR DESCRIPTION
## What
Stop running the VMR license scan on the **2xx** band. The scan uses the shared source-build test container's system .NET SDK, which is now a newer .NET 10 SDK than the 2xx branch `global.json` pins, so the test cannot run there. (The companion fix for the 1xx band installs the matched SDK: nagilson/license-scan-1xx-bootstrap-sdk.)

## Fix
Add `exclude:` entries for `internal/release/*.0.2xx*` and `internal/release/*.0.2??` to both the `schedules` and `trigger` branch filters. This must live on `main` because Azure DevOps reads scheduled triggers from the pipeline's default branch.

Tracking: dotnet/source-build#5623
