### PR TITLE
Add Microsoft.NETCore.App.Runtime.browser-wasm to MSI pack generation list

### DIFF
--- a/eng/pipelines/templates/stages/vmr-verticals.yml
+++ b/eng/pipelines/templates/stages/vmr-verticals.yml
@@ -729,6 +729,7 @@ stages:
           - ${{ if not(parameters.excludeRuntimeDependentJobs) }}:
             - Browser_Shortstack_wasm
             - Browser_Multithreaded_Shortstack_wasm
+            - Browser_CoreCLR_Shortstack
             - Wasi_Shortstack_wasm
             - Android_Shortstack_arm64
             - Android_Shortstack_arm

--- a/src/sdk/src/Workloads/VSInsertion/workloads.csproj
+++ b/src/sdk/src/Workloads/VSInsertion/workloads.csproj
@@ -90,6 +90,7 @@
     <RuntimeWorkloadPacksToDownload Include="Microsoft.NETCore.App.Runtime.Mono.tvossimulator-arm64" />
     <RuntimeWorkloadPacksToDownload Include="Microsoft.NETCore.App.Runtime.Mono.tvossimulator-x64" />
     <RuntimeWorkloadPacksToDownload Include="Microsoft.NETCore.App.Runtime.Mono.browser-wasm" />
+    <RuntimeWorkloadPacksToDownload Include="Microsoft.NETCore.App.Runtime.browser-wasm" />
     <RuntimeWorkloadPacksToDownload Include="Microsoft.NETCore.App.Runtime.Mono.multithread.browser-wasm" />
     <RuntimeWorkloadPacksToDownload Include="Microsoft.NETCore.App.Runtime.Mono.wasi-wasm" />
     <!-- Windows runtime packages don't need MSI wrappers - they're included in the SDK, not installed as workloads -->


### PR DESCRIPTION
## Summary

The runtime team added a new workload pack (\Microsoft.NETCore.App.Runtime.browser-wasm\) to the wasm-tools workload manifest but the corresponding entry was not added to the \RuntimeWorkloadPacksToDownload\ item group in \workloads.csproj\. This caused the MSI nupkg wrappers (\.Msi.x64\, \.Msi.x86\, \.Msi.arm64\) to not be generated, breaking workload installation on Windows.

## Root Cause

The NuGet pack itself exists on the feed (\Microsoft.NETCore.App.Runtime.browser-wasm/11.0.0-preview.7.26378.106\), but the MSI wrapper nupkgs were never generated because the pack was missing from the explicit list in \src/sdk/src/Workloads/VSInsertion/workloads.csproj\.

## Fix

Added \Microsoft.NETCore.App.Runtime.browser-wasm\ to the \RuntimeWorkloadPacksToDownload\ item group, alongside the existing \Microsoft.NETCore.App.Runtime.Mono.browser-wasm\ entry.

Fixes https://github.com/dotnet/sdk/issues/55491