### PR TITLE
Remove WPF C4995 suppression

### DIFF
--- a/src/wpf/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
+++ b/src/wpf/eng/WpfArcadeSdk/tools/Wpf.Cpp.props
@@ -96,8 +96,6 @@
     <ManagedCxxSuppressions>$(ManagedCxxSuppressions);4945</ManagedCxxSuppressions>
     <!-- Type marked as obsolete. -->
     <ManagedCxxSuppressions>$(ManagedCxxSuppressions);4947</ManagedCxxSuppressions>
-    <!-- Type marked as #pragma deprecated. -->
-    <ManagedCxxSuppressions>$(ManagedCxxSuppressions);4995</ManagedCxxSuppressions>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary

Remove the global WPF managed C++ suppression for warning C4995. This prevents /wd4995 from being applied to DirectWriteForwarder and resolves the BinSkim BA2007 result tracked by #8042.

## Validation

Built DirectWriteForwarder in Release for x86, x64, and arm64 with zero warnings and zero errors.

Fixes #8042