### PR TITLE
Use eng/common/dotnet.sh for VMR license scan instead of manual SDK install

### DIFF
--- a/eng/pipelines/templates/stages/vmr-license-scan.yml
+++ b/eng/pipelines/templates/stages/vmr-license-scan.yml
@@ -122,19 +122,8 @@ stages:
         artifactName: $(Agent.JobName)_BuildLogs_Attempt$(System.JobAttempt)
     steps:
 
-    # The shared source-build test container ships the latest .NET 10 SDK, which does not
-    # satisfy this branch's global.json (different feature band), so the container's system
-    # 'dotnet' cannot run the tests. Install the global.json-matched SDK and use it instead.
-    # Tracking: dotnet/source-build#5623
-    - script: |
-        source ./eng/common/tools.sh
-        InitializeDotNetCli true
-        echo "##vso[task.setvariable variable=DotNetPath]$_InitializeDotNetCli"
-      displayName: Install .NET SDK
-      workingDirectory: $(Build.SourcesDirectory)
-
     - script: >
-        $(DotNetPath)/dotnet test
+        ./eng/common/dotnet.sh test
         $(Build.SourcesDirectory)/test/Microsoft.DotNet.SourceBuild.Tests/Microsoft.DotNet.SourceBuild.Tests.csproj
         --filter "FullyQualifiedName=Microsoft.DotNet.SourceBuild.Tests.LicenseScanTests.ScanForLicenses"
         --logger:'trx;LogFileName=$(Agent.JobName)_LicenseScan.trx'


### PR DESCRIPTION
Follow-up to #8012.

#8012 fixed the VMR license scan `exit 155` failure (the shared source-build test container ships a newer .NET 10 SDK than this branch's `global.json` pins, so the container's system `dotnet` couldn't run the tests) by installing the global.json-matched SDK via `eng/common/tools.sh` and invoking it through `$(DotNetPath)/dotnet`.

Per @ViktorHofer's review feedback (https://github.com/dotnet/dotnet/pull/8012#discussion_r3677787507), `eng/common/dotnet.sh` already acquires the correct SDK (it sources `tools.sh`, runs `InitializeDotNetCli true`, then invokes the acquired `dotnet`), so this replaces the manual install step with a direct `./eng/common/dotnet.sh test` invocation. The `Run Tests` step already runs with `workingDirectory: $(Build.SourcesDirectory)`, so the relative path resolves.

Related to dotnet/source-build#5623
