### PR TITLE
Use toolchain macros for sccsid attr

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Version.targets
@@ -134,7 +134,7 @@
       -->
       <_NativeVersionFileContents>
 <![CDATA[
-#if defined(__GNUC__) && !defined(__clang__) && defined(TARGET_SUNOS) && defined(TARGET_AMD64)
+#if defined(__GNUC__) && !defined(__clang__) && defined(__sun) && defined(__x86_64__)
 char sccsid[] __attribute__((used, weak)) = "$(_SccsIdString)";
 __asm__(".pushsection .init_array; .reloc ., R_X86_64_NONE, sccsid; .popsection");
 #else

--- a/src/deployment-tools/eng/native/build-commons.sh
+++ b/src/deployment-tools/eng/native/build-commons.sh
@@ -122,7 +122,7 @@ build_native()
         else
             # Generate the dummy version.c and runtime_version.h, but only if they didn't exist to make sure we don't trigger unnecessary rebuild
             __versionSourceContent=$(cat <<'EOF'
-#if defined(__GNUC__) && !defined(__clang__) && defined(TARGET_SUNOS) && defined(TARGET_AMD64)
+#if defined(__GNUC__) && !defined(__clang__) && defined(__sun) && defined(__x86_64__)
 char sccsid[] __attribute__((used, weak)) = "@(#)No version information produced";
 __asm__(".pushsection .init_array; .reloc ., R_X86_64_NONE, sccsid; .popsection");
 #else

--- a/src/diagnostics/eng/native/version/_version.c
+++ b/src/diagnostics/eng/native/version/_version.c
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if defined(__GNUC__) && !defined(__clang__) && defined(TARGET_SUNOS) && defined(TARGET_AMD64)
+#if defined(__GNUC__) && !defined(__clang__) && defined(__sun) && defined(__x86_64__)
 char sccsid[] __attribute__((used, weak)) = "@(#)No version information produced";
 __asm__(".pushsection .init_array; .reloc ., R_X86_64_NONE, sccsid; .popsection");
 #else

--- a/src/runtime/eng/native/version/_version.c
+++ b/src/runtime/eng/native/version/_version.c
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if defined(__GNUC__) && !defined(__clang__) && defined(TARGET_SUNOS) && defined(TARGET_AMD64)
+#if defined(__GNUC__) && !defined(__clang__) && defined(__sun) && defined(__x86_64__)
 char sccsid[] __attribute__((used, weak)) = "@(#)No version information produced";
 __asm__(".pushsection .init_array; .reloc ., R_X86_64_NONE, sccsid; .popsection");
 #else

--- a/src/runtime/src/mono/CMakeLists.txt
+++ b/src/runtime/src/mono/CMakeLists.txt
@@ -865,7 +865,7 @@ if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
 else()
   if(NOT EXISTS "${VERSION_FILE_PATH}")
     file(WRITE "${VERSION_FILE_PATH}"
-      "#if defined(__GNUC__) && !defined(__clang__) && defined(TARGET_SUNOS) && defined(TARGET_AMD64)\n"
+      "#if defined(__GNUC__) && !defined(__clang__) && defined(__sun) && defined(__x86_64__)\n"
       "char sccsid[] __attribute__((used, weak)) = \"@(#)Version 42.42.42.42424 @Commit: AAA\";\n"
       "__asm__(\".pushsection .init_array; .reloc ., R_X86_64_NONE, sccsid; .popsection\");\n"
       "#else\n"


### PR DESCRIPTION
JIT build has a mode where it sets `IGNORE_DEFAULT_TARGET_ARCH` and `IGNORE_DEFAULT_TARGET_OS` to prevent defining `TARGET_` macros and building those components on illumos was failing. Therefore, PR switches to toolchain macros.