### PR TITLE
Handle nullable NuGet package authors in Template Engine

### DIFF
--- a/src/sdk/src/Cli/Microsoft.TemplateEngine.Cli/NuGet/NugetApiManager.cs
+++ b/src/sdk/src/Cli/Microsoft.TemplateEngine.Cli/NuGet/NugetApiManager.cs
@@ -117,7 +117,7 @@ namespace Microsoft.TemplateEngine.Cli.NuGet
         {
             public NugetPackageMetadata(PackageSource packageSource, IPackageSearchMetadata metadata, IPackageSearchMetadata? extraMetadata = null)
             {
-                Authors = metadata.Authors;
+                Authors = metadata.Authors ?? string.Empty;
                 Identity = metadata.Identity;
                 Description = metadata.Description;
                 ProjectUrl = metadata.ProjectUrl;


### PR DESCRIPTION
Unblocks https://github.com/dotnet/dotnet/pull/8070.

NuGet.Client PR https://github.com/NuGet/NuGet.Client/pull/7596 changed `IPackageSearchMetadata.Authors` from `string` to `string?`. The Template Engine metadata model intentionally keeps `Authors` non-nullable, so the NuGet source flow now produces `CS8601` when assigning the nullable value.

Normalize missing authors to `string.Empty`, matching the handling already used by NuGet.Client and preserving the existing non-null invariant for Template Engine consumers.

A similar codeflow branch fix was used in https://github.com/dotnet/dotnet/pull/7849.