### PR TITLE
Get NativeAOT SDK tool symbols indexed to symweb

### DIFF
--- a/src/aspnetcore/src/Tools/NativeAot/AspNetCoreTools.NativeAot.props
+++ b/src/aspnetcore/src/Tools/NativeAot/AspNetCoreTools.NativeAot.props
@@ -5,7 +5,8 @@
     <StackTraceSupport>false</StackTraceSupport>
     <EventSourceSupport>false</EventSourceSupport>
     <MetricsSupport>false</MetricsSupport>
-    <CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
+    <!-- Symbols are excluded from the SDK layout (not the package) by src/sdk; see DeleteSymbolsFromPublishDir. -->
+    <CopyOutputSymbolsToPublishDirectory>true</CopyOutputSymbolsToPublishDirectory>
     <DebuggerSupport>false</DebuggerSupport>
     <AutoreleasePoolSupport>false</AutoreleasePoolSupport>
     <Http3Support>false</Http3Support>

--- a/src/sdk/src/Layout/redist/targets/GenerateLayout.targets
+++ b/src/sdk/src/Layout/redist/targets/GenerateLayout.targets
@@ -620,9 +620,15 @@
     <ItemGroup>
       <PdbsToDelete Include="$(OutputPath)/**/*.pdb" />
       <PdbsToDelete Include="$(OutputPath)/**/*.ni.*.map" />
+      <!-- Native AOT debug symbols (e.g. aspnetcoretools) on non-Windows. -->
+      <PdbsToDelete Include="$(OutputPath)/**/*.dbg" />
     </ItemGroup>
 
     <Delete Files="@(PdbsToDelete)" />
+
+    <!-- dSYM bundles are directories; MSBuild item globs don't match them, so use find. -->
+    <Exec Command="find '$(OutputPath)' -type d -name '*.dSYM' -prune -exec rm -rf -- {} +"
+          Condition="'$(OSName)' == 'osx'" />
   </Target>
 
   <Target Name="RetargetTools">


### PR DESCRIPTION
aspnetcoretools (dotnet-dev-certs, dotnet-user-jwts, dotnet-user-secrets) sets `CopyOutputSymbolsToPublishDirectory=false` to avoid inflating the SDK size. This also prevents its debug symbols from ever reaching symweb, since symbol upload operates on package contents (independent of the SDK's installed layout).

This flips the flag so symbols flow into the package, and extends the SDK's existing `DeleteSymbolsFromPublishDir` target (which already strips `*.pdb` from the assembled layout) to also strip the non-Windows Native AOT debug formats (`.dbg`, `.dSYM`), so the redistributed SDK size is unaffected.