### PR TITLE
Bound test process cleanup waits

### DIFF
--- a/test/TestUtilities/ExecuteHelper.cs
+++ b/test/TestUtilities/ExecuteHelper.cs
@@ -11,6 +11,8 @@ namespace TestUtilities;
 
 public static class ExecuteHelper
 {
+    private const int KillGraceMilliseconds = 30_000;
+
     public static (Process Process, string StdOut, string StdErr) ExecuteProcess(
         string fileName,
         string args,
@@ -76,7 +78,11 @@ public static class ExecuteHelper
         {
             outputHelper.WriteLine($"Process did not exit. Killing {fileName} {args} after waiting {millisecondTimeout} milliseconds.");
             process.Kill(true);
-            process.WaitForExit();
+            if (!process.WaitForExit(KillGraceMilliseconds))
+            {
+                throw new InvalidOperationException(
+                    $"Process tree did not exit within {KillGraceMilliseconds} milliseconds after it was killed.");
+            }
         }
 
         string output;


### PR DESCRIPTION
Source-only validation can hang until the pipeline task timeout when a killed child process retains redirected output handles and the parameterless `WaitForExit()` waits indefinitely for EOF.

Bound the post-kill wait to 30 seconds and fail explicitly if the process tree still does not exit. This preserves normal cleanup behavior while converting the pathological hang into an actionable test failure.

Related to https://github.com/dotnet/scenario-tests/pull/354