### PR TITLE
Add -mt and -nodereuse switches to build scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -274,6 +274,8 @@ while [[ $# > 0 ]]; do
       ;;
     -msbuildmultithreaded|-mt)
       msbuild_multi_threaded=$2
+      # Flow the explicit choice down to the individual repo builds as well.
+      properties+=( "/p:DotNetBuildMT=$2" )
       shift
       ;;
     -preparemachine)

--- a/build.sh
+++ b/build.sh
@@ -114,7 +114,7 @@ build_check=false
 ci=''
 exclude_ci_binary_log=''
 node_reuse=''
-# Empty means "not specified"; tools.sh defaults it to on for local builds and off on CI.
+# Empty means "not specified"; tools.sh leaves it off unless it's explicitly requested.
 msbuild_multi_threaded=''
 prepare_machine=''
 warn_as_error=''

--- a/build.sh
+++ b/build.sh
@@ -54,6 +54,7 @@ usage()
   echo "  --clean-while-building          Cleans each repo after building (reduces disk space usage, short: -cwb)"
   echo "  --excludeCIBinarylog            Don't output binary log (short: -nobl)"
   echo "  --nodeReuse <value>             Sets nodereuse msbuild parameter ('true' or 'false')"
+  echo "  --msbuildMultiThreaded <value>  Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('true' or 'false') (short: --mt)"
   echo "  --prepareMachine                Prepare machine for CI run, clean up processes after build"
   echo "  --projects <value>              Project or solution file to build"
   echo "  --use-mono-runtime              Output uses the mono runtime"
@@ -113,6 +114,8 @@ build_check=false
 ci=''
 exclude_ci_binary_log=''
 node_reuse=''
+# Empty means "not specified"; tools.sh defaults it to on for local builds and off on CI.
+msbuild_multi_threaded=''
 prepare_machine=''
 warn_as_error=''
 targetOS=''
@@ -267,6 +270,10 @@ while [[ $# > 0 ]]; do
       ;;
     -nodereuse)
       node_reuse=$2
+      shift
+      ;;
+    -msbuildmultithreaded|-mt)
+      msbuild_multi_threaded=$2
       shift
       ;;
     -preparemachine)

--- a/build.sh
+++ b/build.sh
@@ -300,15 +300,19 @@ if [[ "$ci" == true ]]; then
   fi
 fi
 
-# tools.sh fills in the default below, so remember whether -mt was passed explicitly.
+# tools.sh fills in the defaults below, so remember whether these were passed explicitly.
 msbuild_multi_threaded_explicit=$msbuild_multi_threaded
+node_reuse_explicit=$node_reuse
 
 source "$scriptroot/eng/common/tools.sh"
 source "$scriptroot/eng/source-build-toolset-init.sh"
 
-# Flow an explicit -mt choice down to the individual repo builds as well.
+# Flow the explicit choices down to the individual repo builds as well.
 if [[ -n "$msbuild_multi_threaded_explicit" ]]; then
   properties+=( "/p:DotNetBuildMT=$msbuild_multi_threaded" )
+fi
+if [[ -n "$node_reuse_explicit" ]]; then
+  properties+=( "/p:DotNetBuildNodeReuse=$node_reuse" )
 fi
 
 # Default properties

--- a/build.sh
+++ b/build.sh
@@ -274,8 +274,6 @@ while [[ $# > 0 ]]; do
       ;;
     -msbuildmultithreaded|-mt)
       msbuild_multi_threaded=$2
-      # Flow the explicit choice down to the individual repo builds as well.
-      properties+=( "/p:DotNetBuildMT=$2" )
       shift
       ;;
     -preparemachine)
@@ -302,8 +300,16 @@ if [[ "$ci" == true ]]; then
   fi
 fi
 
+# tools.sh fills in the default below, so remember whether -mt was passed explicitly.
+msbuild_multi_threaded_explicit=$msbuild_multi_threaded
+
 source "$scriptroot/eng/common/tools.sh"
 source "$scriptroot/eng/source-build-toolset-init.sh"
+
+# Flow an explicit -mt choice down to the individual repo builds as well.
+if [[ -n "$msbuild_multi_threaded_explicit" ]]; then
+  properties+=( "/p:DotNetBuildMT=$msbuild_multi_threaded" )
+fi
 
 # Default properties
 properties+=( "/p:RepoRoot=$repo_root" )

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -100,8 +100,9 @@ if ($buildRepoTests) { $arguments += "/p:DotNetBuildTests=true" }
 if ($cleanWhileBuilding) { $arguments += "/p:CleanWhileBuilding=true" }
 if ($branding) { $arguments += "/p:RepoDotNetFinalVersionKind=$branding" }
 if ($officialBuildId) { $arguments += "/p:OfficialBuildId=$officialBuildId" }
-# Flow the explicit choice down to the individual repo builds as well.
+# Flow the explicit choices down to the individual repo builds as well.
 if ($PSBoundParameters.ContainsKey('msbuildMultiThreaded')) { $arguments += "/p:DotNetBuildMT=$msbuildMultiThreaded" }
+if ($PSBoundParameters.ContainsKey('nodeReuse')) { $arguments += "/p:DotNetBuildNodeReuse=$nodeReuse" }
 
 function Build {
   $toolsetBuildProj = InitializeToolset
@@ -131,7 +132,10 @@ try {
     if (-not $excludeCIBinarylog) {
       $binaryLog = $true
     }
-    $nodeReuse = $false
+    # Node reuse isn't used on CI unless it was explicitly requested via -nodeReuse.
+    if (-not $PSBoundParameters.ContainsKey('nodeReuse')) {
+      $nodeReuse = $false
+    }
     # MSBuild's multi-threaded mode isn't run on CI unless it was explicitly requested via -msbuildMultiThreaded.
     if (-not $PSBoundParameters.ContainsKey('msbuildMultiThreaded')) {
       $msbuildMultiThreaded = $false

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -25,6 +25,7 @@ Param(
   [switch][Alias('cwb')]$cleanWhileBuilding,
   [switch][Alias('nobl')]$excludeCIBinarylog,
   [bool]$nodeReuse,
+  [bool][Alias('mt')]$msbuildMultiThreaded = $true,
   [switch]$prepareMachine,
   [string]$projects,
   [bool] $warnAsError = $true,
@@ -62,6 +63,7 @@ function Get-Usage() {
   Write-Host "  -cleanWhileBuilding         Cleans each repo after building (reduces disk space usage, short: -cwb)"
   Write-Host "  -excludeCIBinarylog         Don't output binary log (short: -nobl)"
   Write-Host "  -nodeReuse <value>          Sets nodereuse msbuild parameter ('true' or 'false')"
+  Write-Host "  -msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('true' or 'false') (short: -mt)"
   Write-Host "  -prepareMachine             Prepare machine for CI run, clean up processes after build"
   Write-Host "  -projects <value>           Project or solution file to build"
   Write-Host "  -warnAsError <value>        Sets warnaserror msbuild parameter ('true' or 'false')"
@@ -128,6 +130,10 @@ try {
       $binaryLog = $true
     }
     $nodeReuse = $false
+    # MSBuild's multi-threaded mode isn't run on CI unless it was explicitly requested via -msbuildMultiThreaded.
+    if (-not $PSBoundParameters.ContainsKey('msbuildMultiThreaded')) {
+      $msbuildMultiThreaded = $false
+    }
   }
 
   Build

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -63,7 +63,7 @@ function Get-Usage() {
   Write-Host "  -cleanWhileBuilding         Cleans each repo after building (reduces disk space usage, short: -cwb)"
   Write-Host "  -excludeCIBinarylog         Don't output binary log (short: -nobl)"
   Write-Host "  -nodeReuse <value>          Sets nodereuse msbuild parameter ('true' or 'false')"
-  Write-Host "  -msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('true' or 'false') (short: -mt)"
+  Write-Host "  -msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('1' or '0') (short: -mt)"
   Write-Host "  -prepareMachine             Prepare machine for CI run, clean up processes after build"
   Write-Host "  -projects <value>           Project or solution file to build"
   Write-Host "  -warnAsError <value>        Sets warnaserror msbuild parameter ('true' or 'false')"
@@ -100,6 +100,8 @@ if ($buildRepoTests) { $arguments += "/p:DotNetBuildTests=true" }
 if ($cleanWhileBuilding) { $arguments += "/p:CleanWhileBuilding=true" }
 if ($branding) { $arguments += "/p:RepoDotNetFinalVersionKind=$branding" }
 if ($officialBuildId) { $arguments += "/p:OfficialBuildId=$officialBuildId" }
+# Flow the explicit choice down to the individual repo builds as well.
+if ($PSBoundParameters.ContainsKey('msbuildMultiThreaded')) { $arguments += "/p:DotNetBuildMT=$msbuildMultiThreaded" }
 
 function Build {
   $toolsetBuildProj = InitializeToolset

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -25,7 +25,7 @@ Param(
   [switch][Alias('cwb')]$cleanWhileBuilding,
   [switch][Alias('nobl')]$excludeCIBinarylog,
   [bool]$nodeReuse,
-  [bool][Alias('mt')]$msbuildMultiThreaded = $true,
+  [bool][Alias('mt')]$msbuildMultiThreaded = $false,
   [switch]$prepareMachine,
   [string]$projects,
   [bool] $warnAsError = $true,
@@ -135,10 +135,6 @@ try {
     # Node reuse isn't used on CI unless it was explicitly requested via -nodeReuse.
     if (-not $PSBoundParameters.ContainsKey('nodeReuse')) {
       $nodeReuse = $false
-    }
-    # MSBuild's multi-threaded mode isn't run on CI unless it was explicitly requested via -msbuildMultiThreaded.
-    if (-not $PSBoundParameters.ContainsKey('msbuildMultiThreaded')) {
-      $msbuildMultiThreaded = $false
     }
   }
 

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -79,7 +79,7 @@ function Print-Usage() {
   Write-Host "  -excludePrereleaseVS    Set to exclude build engines in prerelease versions of Visual Studio"
   Write-Host "  -nativeToolsOnMachine   Sets the native tools on machine environment variable (indicating that the script should use native tools on machine)"
   Write-Host "  -nodeReuse <value>      Sets nodereuse msbuild parameter ('true' or 'false')"
-  Write-Host "  -msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('true' or 'false') (short: -mt)"
+  Write-Host "  -msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('1' or '0') (short: -mt)"
   Write-Host "  -buildCheck             Sets /check msbuild parameter"
   Write-Host "  -fromVMR                Set when building from within the VMR"
   Write-Host ""

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -8,6 +8,7 @@ Param(
   [bool] $warnAsError = $true,
   [string] $warnNotAsError = '',
   [bool] $nodeReuse = $true,
+  [bool][Alias('mt')]$msbuildMultiThreaded = $true,
   [switch] $buildCheck = $false,
   [switch][Alias('r')]$restore,
   [switch] $deployDeps,
@@ -78,6 +79,7 @@ function Print-Usage() {
   Write-Host "  -excludePrereleaseVS    Set to exclude build engines in prerelease versions of Visual Studio"
   Write-Host "  -nativeToolsOnMachine   Sets the native tools on machine environment variable (indicating that the script should use native tools on machine)"
   Write-Host "  -nodeReuse <value>      Sets nodereuse msbuild parameter ('true' or 'false')"
+  Write-Host "  -msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('true' or 'false') (short: -mt)"
   Write-Host "  -buildCheck             Sets /check msbuild parameter"
   Write-Host "  -fromVMR                Set when building from within the VMR"
   Write-Host ""
@@ -177,6 +179,10 @@ try {
     # Internal testing only; this env var will be replaced with a switch (https://github.com/dotnet/arcade/issues/17013) and must not be depended on.
     if ($env:MSBUILD_NODEREUSE_ENABLED -ne "1") {
       $nodeReuse = $false
+    }
+    # MSBuild's multi-threaded mode isn't run on CI unless it was explicitly requested via -msbuildMultiThreaded.
+    if (-not $PSBoundParameters.ContainsKey('msbuildMultiThreaded')) {
+      $msbuildMultiThreaded = $false
     }
   }
 

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -8,7 +8,7 @@ Param(
   [bool] $warnAsError = $true,
   [string] $warnNotAsError = '',
   [bool] $nodeReuse = $true,
-  [bool][Alias('mt')]$msbuildMultiThreaded = $true,
+  [bool][Alias('mt')]$msbuildMultiThreaded = $false,
   [switch] $buildCheck = $false,
   [switch][Alias('r')]$restore,
   [switch] $deployDeps,
@@ -178,10 +178,6 @@ try {
     # Node reuse isn't used on CI unless it was explicitly requested via -nodeReuse.
     if (-not $PSBoundParameters.ContainsKey('nodeReuse')) {
       $nodeReuse = $false
-    }
-    # MSBuild's multi-threaded mode isn't run on CI unless it was explicitly requested via -msbuildMultiThreaded.
-    if (-not $PSBoundParameters.ContainsKey('msbuildMultiThreaded')) {
-      $msbuildMultiThreaded = $false
     }
   }
 

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -175,9 +175,8 @@ try {
     if (-not $excludeCIBinarylog) {
       $binaryLog = $true
     }
-    # Disable node reuse on CI unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
-    # Internal testing only; this env var will be replaced with a switch (https://github.com/dotnet/arcade/issues/17013) and must not be depended on.
-    if ($env:MSBUILD_NODEREUSE_ENABLED -ne "1") {
+    # Node reuse isn't used on CI unless it was explicitly requested via -nodeReuse.
+    if (-not $PSBoundParameters.ContainsKey('nodeReuse')) {
       $nodeReuse = $false
     }
     # MSBuild's multi-threaded mode isn't run on CI unless it was explicitly requested via -msbuildMultiThreaded.

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -42,6 +42,7 @@ usage()
   echo "  --excludeCIBinarylog     Don't output binary log (short: -nobl)"
   echo "  --prepareMachine         Prepare machine for CI run, clean up processes after build"
   echo "  --nodeReuse <value>      Sets nodereuse msbuild parameter ('true' or 'false')"
+  echo "  --msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('true' or 'false') (short: --mt)"
   echo "  --warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
   echo "  --warnNotAsError <value> Sets a semi-colon delimited list of warning codes that should not be treated as errors"
   echo "  --buildCheck <value>     Sets /check msbuild parameter"
@@ -82,6 +83,8 @@ clean=false
 warn_as_error=true
 warn_not_as_error=''
 node_reuse=true
+# Empty means "not specified"; tools.sh defaults it to on for local builds and off on CI.
+msbuild_multi_threaded=''
 build_check=false
 binary_log=false
 binary_log_name=''
@@ -187,6 +190,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     -nodereuse)
       node_reuse=$2
+      shift
+      ;;
+    -msbuildmultithreaded|-mt)
+      msbuild_multi_threaded=$2
       shift
       ;;
     -buildcheck)

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -82,8 +82,8 @@ clean=false
 
 warn_as_error=true
 warn_not_as_error=''
-node_reuse=true
-# Empty means "not specified"; tools.sh defaults it to on for local builds and off on CI.
+# Empty means "not specified"; tools.sh defaults these to on for local builds and off on CI.
+node_reuse=''
 msbuild_multi_threaded=''
 build_check=false
 binary_log=false
@@ -220,11 +220,6 @@ if [[ -z "$configuration" ]]; then
 fi
 
 if [[ "$ci" == true ]]; then
-  # Disable node reuse on CI unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
-  # Internal testing only; this env var will be replaced with a switch (https://github.com/dotnet/arcade/issues/17013) and must not be depended on.
-  if [[ "${MSBUILD_NODEREUSE_ENABLED:-}" != "1" ]]; then
-    node_reuse=false
-  fi
   if [[ "$exclude_ci_binary_log" == false ]]; then
     binary_log=true
   fi

--- a/eng/common/msbuild.ps1
+++ b/eng/common/msbuild.ps1
@@ -3,6 +3,7 @@ Param(
   [string] $verbosity = 'minimal',
   [bool] $warnAsError = $true,
   [bool] $nodeReuse = $true,
+  [bool][Alias('mt')]$msbuildMultiThreaded = $true,
   [switch] $ci,
   [switch] $prepareMachine,
   [switch] $excludePrereleaseVS,
@@ -13,12 +14,14 @@ Param(
 . $PSScriptRoot\tools.ps1
 
 try {
-  if ($ci) {
-    # Disable node reuse on CI unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
-    # Internal testing only; this env var will be replaced with a switch (https://github.com/dotnet/arcade/issues/17013) and must not be depended on.
-    if ($env:MSBUILD_NODEREUSE_ENABLED -ne "1") {
-      $nodeReuse = $false
-    }
+  # Node reuse isn't used on CI unless it was explicitly requested via -nodeReuse.
+  if ($ci -and -not $PSBoundParameters.ContainsKey('nodeReuse')) {
+    $nodeReuse = $false
+  }
+
+  # MSBuild's multi-threaded mode isn't run on CI unless it was explicitly requested via -msbuildMultiThreaded.
+  if ($ci -and -not $PSBoundParameters.ContainsKey('msbuildMultiThreaded')) {
+    $msbuildMultiThreaded = $false
   }
 
   MSBuild @extraArgs

--- a/eng/common/msbuild.ps1
+++ b/eng/common/msbuild.ps1
@@ -3,7 +3,7 @@ Param(
   [string] $verbosity = 'minimal',
   [bool] $warnAsError = $true,
   [bool] $nodeReuse = $true,
-  [bool][Alias('mt')]$msbuildMultiThreaded = $true,
+  [bool][Alias('mt')]$msbuildMultiThreaded = $false,
   [switch] $ci,
   [switch] $prepareMachine,
   [switch] $excludePrereleaseVS,
@@ -17,11 +17,6 @@ try {
   # Node reuse isn't used on CI unless it was explicitly requested via -nodeReuse.
   if ($ci -and -not $PSBoundParameters.ContainsKey('nodeReuse')) {
     $nodeReuse = $false
-  }
-
-  # MSBuild's multi-threaded mode isn't run on CI unless it was explicitly requested via -msbuildMultiThreaded.
-  if ($ci -and -not $PSBoundParameters.ContainsKey('msbuildMultiThreaded')) {
-    $msbuildMultiThreaded = $false
   }
 
   MSBuild @extraArgs

--- a/eng/common/msbuild.sh
+++ b/eng/common/msbuild.sh
@@ -14,7 +14,9 @@ scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
 verbosity='minimal'
 warn_as_error=true
-node_reuse=true
+# Empty means "not specified"; tools.sh defaults these to on for local builds and off on CI.
+node_reuse=''
+msbuild_multi_threaded=''
 prepare_machine=false
 extra_args=''
 
@@ -33,6 +35,10 @@ while (($# > 0)); do
       node_reuse=$2
       shift 2
       ;;
+    --msbuildmultithreaded|--mt)
+      msbuild_multi_threaded=$2
+      shift 2
+      ;;
     --ci)
       ci=true
       shift 1
@@ -49,14 +55,6 @@ while (($# > 0)); do
 done
 
 . "$scriptroot/tools.sh"
-
-if [[ "$ci" == true ]]; then
-  # Disable node reuse on CI unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
-  # Internal testing only; this env var will be replaced with a switch (https://github.com/dotnet/arcade/issues/17013) and must not be depended on.
-  if [[ "${MSBUILD_NODEREUSE_ENABLED:-}" != "1" ]]; then
-    node_reuse=false
-  fi
-fi
 
 MSBuild $extra_args
 ExitWithExitCode 0

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -25,8 +25,9 @@
 # Set to true to reuse msbuild nodes. Recommended to not reuse on CI.
 [bool]$nodeReuse = if (Test-Path variable:nodeReuse) { $nodeReuse } else { !$ci }
 
-# Set to true to build with MSBuild's multi-threaded mode (-mt). Enabled by default for local builds and not run on CI.
-[bool]$msbuildMultiThreaded = if (Test-Path variable:msbuildMultiThreaded) { $msbuildMultiThreaded } else { !$ci }
+# Set to true to build with MSBuild's multi-threaded mode (-mt). Opt-in for now, so off unless it was
+# explicitly requested. It's intended to become the default for local builds once it has proven out.
+[bool]$msbuildMultiThreaded = if (Test-Path variable:msbuildMultiThreaded) { $msbuildMultiThreaded } else { $false }
 
 # Configures warning treatment in msbuild.
 [bool]$warnAsError = if (Test-Path variable:warnAsError) { $warnAsError } else { $true }

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -25,6 +25,9 @@
 # Set to true to reuse msbuild nodes. Recommended to not reuse on CI.
 [bool]$nodeReuse = if (Test-Path variable:nodeReuse) { $nodeReuse } else { !$ci }
 
+# Set to true to build with MSBuild's multi-threaded mode (-mt). Enabled by default for local builds and not run on CI.
+[bool]$msbuildMultiThreaded = if (Test-Path variable:msbuildMultiThreaded) { $msbuildMultiThreaded } else { !$ci }
+
 # Configures warning treatment in msbuild.
 [bool]$warnAsError = if (Test-Path variable:warnAsError) { $warnAsError } else { $true }
 
@@ -754,8 +757,8 @@ function MSBuild() {
 
   $cmdArgs = "$($buildTool.Command) /m /nologo /clp:Summary /v:$verbosity /nr:$nodeReuse /p:ContinuousIntegrationBuild=$ci"
 
-  # Add -mt flag for MSBuild multithreaded mode if enabled via environment variable
-  if ($env:MSBUILD_MT_ENABLED -eq "1") {
+  # Build with MSBuild's multi-threaded mode.
+  if ($msbuildMultiThreaded) {
     $cmdArgs += ' -mt'
   }
 

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -744,13 +744,6 @@ function MSBuild() {
       Write-PipelineTelemetryError -Category 'Build' -Message 'Binary log must be enabled in CI build, or explicitly opted-out from with the -excludeCIBinarylog switch.'
       ExitWithExitCode 1
     }
-
-    # Node reuse must be disabled in CI builds unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
-    # Internal testing only; this env var will be replaced with a switch (https://github.com/dotnet/arcade/issues/17013) and must not be depended on.
-    if ($nodeReuse -and $env:MSBUILD_NODEREUSE_ENABLED -ne "1") {
-      Write-PipelineTelemetryError -Category 'Build' -Message 'Node reuse must be disabled in CI build.'
-      ExitWithExitCode 1
-    }
   }
 
   $buildTool = InitializeBuildTool

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -50,13 +50,10 @@ else
   node_reuse=${node_reuse:-true}
 fi
 
-# Set to true to build with MSBuild's multi-threaded mode (-mt). Enabled by default for local builds and not run on CI.
+# Set to true to build with MSBuild's multi-threaded mode (-mt). Opt-in for now, so off unless it was
+# explicitly requested. It's intended to become the default for local builds once it has proven out.
 msbuild_multi_threaded=$(NormalizeBoolArg "${msbuild_multi_threaded:-}")
-if [[ "$ci" == true ]]; then
-  msbuild_multi_threaded=${msbuild_multi_threaded:-false}
-else
-  msbuild_multi_threaded=${msbuild_multi_threaded:-true}
-fi
+msbuild_multi_threaded=${msbuild_multi_threaded:-false}
 
 # Configures warning treatment in msbuild.
 warn_as_error=$(NormalizeBoolArg "${warn_as_error:-}")

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -516,13 +516,6 @@ function MSBuild {
       Write-PipelineTelemetryError -category 'Build'  "Binary log must be enabled in CI build, or explicitly opted-out from with the -noBinaryLog switch."
       ExitWithExitCode 1
     fi
-
-    # Node reuse must be disabled in CI builds unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
-    # Internal testing only; this env var will be replaced with a switch (https://github.com/dotnet/arcade/issues/17013) and must not be depended on.
-    if [[ "$node_reuse" == true && "${MSBUILD_NODEREUSE_ENABLED:-}" != "1" ]]; then
-      Write-PipelineTelemetryError -category 'Build'  "Node reuse must be disabled in CI build."
-      ExitWithExitCode 1
-    fi
   fi
 
   InitializeBuildTool

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+# Normalizes the value of a boolean build argument. Accepts 1/0 in addition to true/false so that
+# the same value works with the PowerShell scripts, whose [bool] parameters only bind 1/0.
+function NormalizeBoolArg {
+  case "${1:-}" in
+    1) echo true ;;
+    0) echo false ;;
+    *) echo "${1:-}" ;;
+  esac
+}
+
 # Initialize variables if they aren't already defined.
 
 # CI mode - set to true on CI server for PR validation build or official build.
@@ -33,6 +43,7 @@ restore=${restore:-true}
 verbosity=${verbosity:-'minimal'}
 
 # Set to true to reuse msbuild nodes. Recommended to not reuse on CI.
+node_reuse=$(NormalizeBoolArg "${node_reuse:-}")
 if [[ "$ci" == true ]]; then
   node_reuse=${node_reuse:-false}
 else
@@ -40,6 +51,7 @@ else
 fi
 
 # Set to true to build with MSBuild's multi-threaded mode (-mt). Enabled by default for local builds and not run on CI.
+msbuild_multi_threaded=$(NormalizeBoolArg "${msbuild_multi_threaded:-}")
 if [[ "$ci" == true ]]; then
   msbuild_multi_threaded=${msbuild_multi_threaded:-false}
 else
@@ -47,6 +59,7 @@ else
 fi
 
 # Configures warning treatment in msbuild.
+warn_as_error=$(NormalizeBoolArg "${warn_as_error:-}")
 warn_as_error=${warn_as_error:-true}
 
 # Specifies semi-colon delimited list of warning codes that should not be treated as errors.

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -39,6 +39,13 @@ else
   node_reuse=${node_reuse:-true}
 fi
 
+# Set to true to build with MSBuild's multi-threaded mode (-mt). Enabled by default for local builds and not run on CI.
+if [[ "$ci" == true ]]; then
+  msbuild_multi_threaded=${msbuild_multi_threaded:-false}
+else
+  msbuild_multi_threaded=${msbuild_multi_threaded:-true}
+fi
+
 # Configures warning treatment in msbuild.
 warn_as_error=${warn_as_error:-true}
 
@@ -534,9 +541,9 @@ function MSBuild {
     }
   }
 
-  # Add -mt flag for MSBuild multithreaded mode if enabled via environment variable
+  # Build with MSBuild's multi-threaded mode.
   local mt_switch=""
-  if [[ "${MSBUILD_MT_ENABLED:-}" == "1" ]]; then
+  if [[ "$msbuild_multi_threaded" == true ]]; then
     mt_switch="-mt"
   fi
 

--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -72,10 +72,12 @@
   <PropertyGroup Condition="'$(BuildOS)' == 'windows'">
     <FlagParameterPrefix>-</FlagParameterPrefix>
     <ArcadeFalseBoolBuildArg>0</ArcadeFalseBoolBuildArg>
+    <ArcadeTrueBoolBuildArg>1</ArcadeTrueBoolBuildArg>
   </PropertyGroup>
   <PropertyGroup Condition="'$(BuildOS)' != 'windows'">
     <FlagParameterPrefix>--</FlagParameterPrefix>
     <ArcadeFalseBoolBuildArg>false</ArcadeFalseBoolBuildArg>
+    <ArcadeTrueBoolBuildArg>true</ArcadeTrueBoolBuildArg>
   </PropertyGroup>
 
   <!-- Add 100 to the revision number to avoid clashing with the existing msft official builds. -->
@@ -117,7 +119,8 @@
 
     <!-- MSBuild's multi-threaded mode is on by default for local builds and isn't run on CI.
          Set DotNetBuildMT to explicitly opt in or out for all repo builds. -->
-    <CommonArgs Condition="'$(DotNetBuildMT)' != ''">$(CommonArgs) $(FlagParameterPrefix)mt $(DotNetBuildMT)</CommonArgs>
+    <CommonArgs Condition="'$(DotNetBuildMT)' == 'true'">$(CommonArgs) $(FlagParameterPrefix)mt $(ArcadeTrueBoolBuildArg)</CommonArgs>
+    <CommonArgs Condition="'$(DotNetBuildMT)' == 'false'">$(CommonArgs) $(FlagParameterPrefix)mt $(ArcadeFalseBoolBuildArg)</CommonArgs>
 
     <!-- Pass down configuration properties -->
     <CommonArgs>$(CommonArgs) $(FlagParameterPrefix)configuration $(Configuration)</CommonArgs>

--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -114,11 +114,14 @@
     <CommonArgs Condition="'$(ContinuousIntegrationBuild)' == 'true'">$(CommonArgs) $(FlagParameterPrefix)ci</CommonArgs>
 
     <!-- MSBuild's multi-threaded mode is on by default for local builds and isn't run on CI.
-         Set DotNetBuildMT to explicitly opt in or out for all repo builds.
-         1/0 is used instead of true/false because PowerShell's [bool] parameters only bind 1/0;
-         the shell scripts normalize 1/0 to true/false, so it's the one form that works everywhere. -->
+         Set DotNetBuildMT to explicitly opt in or out for all repo builds. -->
     <CommonArgs Condition="'$(DotNetBuildMT)' == 'true'">$(CommonArgs) $(FlagParameterPrefix)mt 1</CommonArgs>
     <CommonArgs Condition="'$(DotNetBuildMT)' == 'false'">$(CommonArgs) $(FlagParameterPrefix)mt 0</CommonArgs>
+
+    <!-- MSBuild node reuse is on by default for local builds and isn't used on CI.
+         Set DotNetBuildNodeReuse to explicitly opt in or out for all repo builds. -->
+    <CommonArgs Condition="'$(DotNetBuildNodeReuse)' == 'true'">$(CommonArgs) $(FlagParameterPrefix)nodeReuse 1</CommonArgs>
+    <CommonArgs Condition="'$(DotNetBuildNodeReuse)' == 'false'">$(CommonArgs) $(FlagParameterPrefix)nodeReuse 0</CommonArgs>
 
     <!-- Pass down configuration properties -->
     <CommonArgs>$(CommonArgs) $(FlagParameterPrefix)configuration $(Configuration)</CommonArgs>
@@ -217,15 +220,6 @@
 
     <!-- If MSBuild exits early, make sure debug output like 'MSBuild_*.failure.txt' ends up in a place we can see it. -->
     <EnvironmentVariables Include="MSBUILDDEBUGPATH=$(ArtifactsLogRepoDir)" />
-  </ItemGroup>
-
-  <!-- NOTE: This is for internal testing only; real CI should not have node reuse.
-       Follow-up to replace this env var with a proper switch: https://github.com/dotnet/arcade/issues/17013
-       Enable MSBuild node reuse when DotNetBuildNodeReuse is set and the repository hasn't opted out.
-       By default CI builds force nodeReuse=false; opting in keeps the worker MSBuild nodes alive
-       between invocations. A repository can opt out by setting <UseNodeReuse>false</UseNodeReuse>. -->
-  <ItemGroup Condition="'$(DotNetBuildNodeReuse)' == 'true' and '$(UseNodeReuse)' != 'false'">
-    <EnvironmentVariables Include="MSBUILD_NODEREUSE_ENABLED=1" />
   </ItemGroup>
 
   <ItemGroup  Condition="'$(DotNetBuildSourceOnly)' == 'true'">

--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -115,6 +115,10 @@
 
     <CommonArgs Condition="'$(ContinuousIntegrationBuild)' == 'true'">$(CommonArgs) $(FlagParameterPrefix)ci</CommonArgs>
 
+    <!-- MSBuild's multi-threaded mode is on by default for local builds and isn't run on CI.
+         Set DotNetBuildMT to explicitly opt in or out for all repo builds. -->
+    <CommonArgs Condition="'$(DotNetBuildMT)' != ''">$(CommonArgs) $(FlagParameterPrefix)mt $(DotNetBuildMT)</CommonArgs>
+
     <!-- Pass down configuration properties -->
     <CommonArgs>$(CommonArgs) $(FlagParameterPrefix)configuration $(Configuration)</CommonArgs>
     <CommonArgs>$(CommonArgs) $(FlagParameterPrefix)verbosity $(LogVerbosity)</CommonArgs>
@@ -212,11 +216,6 @@
 
     <!-- If MSBuild exits early, make sure debug output like 'MSBuild_*.failure.txt' ends up in a place we can see it. -->
     <EnvironmentVariables Include="MSBUILDDEBUGPATH=$(ArtifactsLogRepoDir)" />
-  </ItemGroup>
-
-  <!-- Enable MSBuild -mt mode when DotNetBuildMT is true -->
-  <ItemGroup Condition="'$(DotNetBuildMT)' == 'true'">
-    <EnvironmentVariables Include="MSBUILD_MT_ENABLED=1" />
   </ItemGroup>
 
   <!-- NOTE: This is for internal testing only; real CI should not have node reuse.

--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -113,7 +113,7 @@
 
     <CommonArgs Condition="'$(ContinuousIntegrationBuild)' == 'true'">$(CommonArgs) $(FlagParameterPrefix)ci</CommonArgs>
 
-    <!-- MSBuild's multi-threaded mode is on by default for local builds and isn't run on CI.
+    <!-- MSBuild's multi-threaded mode is opt-in for now, so it's off unless it's explicitly requested.
          Set DotNetBuildMT to explicitly opt in or out for all repo builds. -->
     <CommonArgs Condition="'$(DotNetBuildMT)' == 'true'">$(CommonArgs) $(FlagParameterPrefix)mt 1</CommonArgs>
     <CommonArgs Condition="'$(DotNetBuildMT)' == 'false'">$(CommonArgs) $(FlagParameterPrefix)mt 0</CommonArgs>

--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -75,13 +75,6 @@
   <PropertyGroup Condition="'$(BuildOS)' != 'windows'">
     <FlagParameterPrefix>--</FlagParameterPrefix>
   </PropertyGroup>
-  <PropertyGroup>
-    <!-- Value to pass to an Arcade build script parameter that takes a boolean. PowerShell's [bool]
-         parameters only bind 1/0 (not the strings 'true'/'false') and the shell scripts normalize
-         1/0 to true/false, so 1/0 is the one form that works on every platform. -->
-    <ArcadeFalseBoolBuildArg>0</ArcadeFalseBoolBuildArg>
-    <ArcadeTrueBoolBuildArg>1</ArcadeTrueBoolBuildArg>
-  </PropertyGroup>
 
   <!-- Add 100 to the revision number to avoid clashing with the existing msft official builds. -->
   <PropertyGroup Condition="'$(OfficialBuildId)' != ''">
@@ -121,9 +114,11 @@
     <CommonArgs Condition="'$(ContinuousIntegrationBuild)' == 'true'">$(CommonArgs) $(FlagParameterPrefix)ci</CommonArgs>
 
     <!-- MSBuild's multi-threaded mode is on by default for local builds and isn't run on CI.
-         Set DotNetBuildMT to explicitly opt in or out for all repo builds. -->
-    <CommonArgs Condition="'$(DotNetBuildMT)' == 'true'">$(CommonArgs) $(FlagParameterPrefix)mt $(ArcadeTrueBoolBuildArg)</CommonArgs>
-    <CommonArgs Condition="'$(DotNetBuildMT)' == 'false'">$(CommonArgs) $(FlagParameterPrefix)mt $(ArcadeFalseBoolBuildArg)</CommonArgs>
+         Set DotNetBuildMT to explicitly opt in or out for all repo builds.
+         1/0 is used instead of true/false because PowerShell's [bool] parameters only bind 1/0;
+         the shell scripts normalize 1/0 to true/false, so it's the one form that works everywhere. -->
+    <CommonArgs Condition="'$(DotNetBuildMT)' == 'true'">$(CommonArgs) $(FlagParameterPrefix)mt 1</CommonArgs>
+    <CommonArgs Condition="'$(DotNetBuildMT)' == 'false'">$(CommonArgs) $(FlagParameterPrefix)mt 0</CommonArgs>
 
     <!-- Pass down configuration properties -->
     <CommonArgs>$(CommonArgs) $(FlagParameterPrefix)configuration $(Configuration)</CommonArgs>

--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -71,13 +71,16 @@
 
   <PropertyGroup Condition="'$(BuildOS)' == 'windows'">
     <FlagParameterPrefix>-</FlagParameterPrefix>
-    <ArcadeFalseBoolBuildArg>0</ArcadeFalseBoolBuildArg>
-    <ArcadeTrueBoolBuildArg>1</ArcadeTrueBoolBuildArg>
   </PropertyGroup>
   <PropertyGroup Condition="'$(BuildOS)' != 'windows'">
     <FlagParameterPrefix>--</FlagParameterPrefix>
-    <ArcadeFalseBoolBuildArg>false</ArcadeFalseBoolBuildArg>
-    <ArcadeTrueBoolBuildArg>true</ArcadeTrueBoolBuildArg>
+  </PropertyGroup>
+  <PropertyGroup>
+    <!-- Value to pass to an Arcade build script parameter that takes a boolean. PowerShell's [bool]
+         parameters only bind 1/0 (not the strings 'true'/'false') and the shell scripts normalize
+         1/0 to true/false, so 1/0 is the one form that works on every platform. -->
+    <ArcadeFalseBoolBuildArg>0</ArcadeFalseBoolBuildArg>
+    <ArcadeTrueBoolBuildArg>1</ArcadeTrueBoolBuildArg>
   </PropertyGroup>
 
   <!-- Add 100 to the revision number to avoid clashing with the existing msft official builds. -->

--- a/src/arcade/eng/common/build.ps1
+++ b/src/arcade/eng/common/build.ps1
@@ -177,9 +177,8 @@ try {
     if (-not $excludeCIBinarylog) {
       $binaryLog = $true
     }
-    # Disable node reuse on CI unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
-    # Internal testing only; this env var will be replaced with a switch (https://github.com/dotnet/arcade/issues/17013) and must not be depended on.
-    if ($env:MSBUILD_NODEREUSE_ENABLED -ne "1") {
+    # Node reuse isn't used on CI unless it was explicitly requested via -nodeReuse.
+    if (-not $PSBoundParameters.ContainsKey('nodeReuse')) {
       $nodeReuse = $false
     }
     # MSBuild's multi-threaded mode isn't run on CI unless it was explicitly requested via -msbuildMultiThreaded.

--- a/src/arcade/eng/common/build.ps1
+++ b/src/arcade/eng/common/build.ps1
@@ -8,7 +8,7 @@ Param(
   [bool] $warnAsError = $true,
   [string] $warnNotAsError = '',
   [bool] $nodeReuse = $true,
-  [bool][Alias('mt')]$msbuildMultiThreaded = $true,
+  [bool][Alias('mt')]$msbuildMultiThreaded = $false,
   [switch] $buildCheck = $false,
   [switch][Alias('r')]$restore,
   [switch] $deployDeps,
@@ -180,10 +180,6 @@ try {
     # Node reuse isn't used on CI unless it was explicitly requested via -nodeReuse.
     if (-not $PSBoundParameters.ContainsKey('nodeReuse')) {
       $nodeReuse = $false
-    }
-    # MSBuild's multi-threaded mode isn't run on CI unless it was explicitly requested via -msbuildMultiThreaded.
-    if (-not $PSBoundParameters.ContainsKey('msbuildMultiThreaded')) {
-      $msbuildMultiThreaded = $false
     }
   }
 

--- a/src/arcade/eng/common/build.ps1
+++ b/src/arcade/eng/common/build.ps1
@@ -80,7 +80,7 @@ function Print-Usage() {
   Write-Host "  -excludePrereleaseVS    Set to exclude build engines in prerelease versions of Visual Studio"
   Write-Host "  -nativeToolsOnMachine   Sets the native tools on machine environment variable (indicating that the script should use native tools on machine)"
   Write-Host "  -nodeReuse <value>      Sets nodereuse msbuild parameter ('true' or 'false')"
-  Write-Host "  -msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('true' or 'false') (short: -mt)"
+  Write-Host "  -msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('1' or '0') (short: -mt)"
   Write-Host "  -buildCheck             Sets /check msbuild parameter"
   Write-Host "  -fromVMR                Set when building from within the VMR"
   Write-Host "  -disablePipelineSetResult Set to disable masking the actual exit code in the pipeline when the build fails"

--- a/src/arcade/eng/common/build.ps1
+++ b/src/arcade/eng/common/build.ps1
@@ -8,6 +8,7 @@ Param(
   [bool] $warnAsError = $true,
   [string] $warnNotAsError = '',
   [bool] $nodeReuse = $true,
+  [bool][Alias('mt')]$msbuildMultiThreaded = $true,
   [switch] $buildCheck = $false,
   [switch][Alias('r')]$restore,
   [switch] $deployDeps,
@@ -79,6 +80,7 @@ function Print-Usage() {
   Write-Host "  -excludePrereleaseVS    Set to exclude build engines in prerelease versions of Visual Studio"
   Write-Host "  -nativeToolsOnMachine   Sets the native tools on machine environment variable (indicating that the script should use native tools on machine)"
   Write-Host "  -nodeReuse <value>      Sets nodereuse msbuild parameter ('true' or 'false')"
+  Write-Host "  -msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('true' or 'false') (short: -mt)"
   Write-Host "  -buildCheck             Sets /check msbuild parameter"
   Write-Host "  -fromVMR                Set when building from within the VMR"
   Write-Host "  -disablePipelineSetResult Set to disable masking the actual exit code in the pipeline when the build fails"
@@ -179,6 +181,10 @@ try {
     # Internal testing only; this env var will be replaced with a switch (https://github.com/dotnet/arcade/issues/17013) and must not be depended on.
     if ($env:MSBUILD_NODEREUSE_ENABLED -ne "1") {
       $nodeReuse = $false
+    }
+    # MSBuild's multi-threaded mode isn't run on CI unless it was explicitly requested via -msbuildMultiThreaded.
+    if (-not $PSBoundParameters.ContainsKey('msbuildMultiThreaded')) {
+      $msbuildMultiThreaded = $false
     }
   }
 

--- a/src/arcade/eng/common/build.sh
+++ b/src/arcade/eng/common/build.sh
@@ -85,8 +85,8 @@ clean=false
 
 warn_as_error=true
 warn_not_as_error=''
-node_reuse=true
-# Empty means "not specified"; tools.sh defaults it to on for local builds and off on CI.
+# Empty means "not specified"; tools.sh defaults these to on for local builds and off on CI.
+node_reuse=''
 msbuild_multi_threaded=''
 build_check=false
 binary_log=false
@@ -231,11 +231,6 @@ fi
 
 if [[ "$ci" == true ]]; then
   pipelines_log=true
-  # Disable node reuse on CI unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
-  # Internal testing only; this env var will be replaced with a switch (https://github.com/dotnet/arcade/issues/17013) and must not be depended on.
-  if [[ "${MSBUILD_NODEREUSE_ENABLED:-}" != "1" ]]; then
-    node_reuse=false
-  fi
   if [[ "$exclude_ci_binary_log" == false ]]; then
     binary_log=true
   fi

--- a/src/arcade/eng/common/build.sh
+++ b/src/arcade/eng/common/build.sh
@@ -43,6 +43,7 @@ usage()
   echo "  --pipelinesLog           Promote msbuild errors/warnings to Azure Pipelines timeline issues; defaults to on in CI (short: -pl)"
   echo "  --prepareMachine         Prepare machine for CI run, clean up processes after build"
   echo "  --nodeReuse <value>      Sets nodereuse msbuild parameter ('true' or 'false')"
+  echo "  --msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('true' or 'false') (short: --mt)"
   echo "  --warnAsError <value>    Sets warnaserror msbuild parameter ('true' or 'false')"
   echo "  --warnNotAsError <value> Sets a semi-colon delimited list of warning codes that should not be treated as errors"
   echo "  --buildCheck <value>     Sets /check msbuild parameter"
@@ -85,6 +86,8 @@ clean=false
 warn_as_error=true
 warn_not_as_error=''
 node_reuse=true
+# Empty means "not specified"; tools.sh defaults it to on for local builds and off on CI.
+msbuild_multi_threaded=''
 build_check=false
 binary_log=false
 binary_log_name=''
@@ -197,6 +200,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     -nodereuse)
       node_reuse=$2
+      shift
+      ;;
+    -msbuildmultithreaded|-mt)
+      msbuild_multi_threaded=$2
       shift
       ;;
     -buildcheck)

--- a/src/arcade/eng/common/msbuild.ps1
+++ b/src/arcade/eng/common/msbuild.ps1
@@ -3,6 +3,7 @@ Param(
   [string] $verbosity = 'minimal',
   [bool] $warnAsError = $true,
   [bool] $nodeReuse = $true,
+  [bool][Alias('mt')]$msbuildMultiThreaded = $true,
   [switch] $ci,
   [switch] $prepareMachine,
   [switch] $excludePrereleaseVS,
@@ -13,12 +14,14 @@ Param(
 . $PSScriptRoot\tools.ps1
 
 try {
-  if ($ci) {
-    # Disable node reuse on CI unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
-    # Internal testing only; this env var will be replaced with a switch (https://github.com/dotnet/arcade/issues/17013) and must not be depended on.
-    if ($env:MSBUILD_NODEREUSE_ENABLED -ne "1") {
-      $nodeReuse = $false
-    }
+  # Node reuse isn't used on CI unless it was explicitly requested via -nodeReuse.
+  if ($ci -and -not $PSBoundParameters.ContainsKey('nodeReuse')) {
+    $nodeReuse = $false
+  }
+
+  # MSBuild's multi-threaded mode isn't run on CI unless it was explicitly requested via -msbuildMultiThreaded.
+  if ($ci -and -not $PSBoundParameters.ContainsKey('msbuildMultiThreaded')) {
+    $msbuildMultiThreaded = $false
   }
 
   MSBuild @extraArgs

--- a/src/arcade/eng/common/msbuild.ps1
+++ b/src/arcade/eng/common/msbuild.ps1
@@ -3,7 +3,7 @@ Param(
   [string] $verbosity = 'minimal',
   [bool] $warnAsError = $true,
   [bool] $nodeReuse = $true,
-  [bool][Alias('mt')]$msbuildMultiThreaded = $true,
+  [bool][Alias('mt')]$msbuildMultiThreaded = $false,
   [switch] $ci,
   [switch] $prepareMachine,
   [switch] $excludePrereleaseVS,
@@ -17,11 +17,6 @@ try {
   # Node reuse isn't used on CI unless it was explicitly requested via -nodeReuse.
   if ($ci -and -not $PSBoundParameters.ContainsKey('nodeReuse')) {
     $nodeReuse = $false
-  }
-
-  # MSBuild's multi-threaded mode isn't run on CI unless it was explicitly requested via -msbuildMultiThreaded.
-  if ($ci -and -not $PSBoundParameters.ContainsKey('msbuildMultiThreaded')) {
-    $msbuildMultiThreaded = $false
   }
 
   MSBuild @extraArgs

--- a/src/arcade/eng/common/msbuild.sh
+++ b/src/arcade/eng/common/msbuild.sh
@@ -14,7 +14,9 @@ scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
 verbosity='minimal'
 warn_as_error=true
-node_reuse=true
+# Empty means "not specified"; tools.sh defaults these to on for local builds and off on CI.
+node_reuse=''
+msbuild_multi_threaded=''
 prepare_machine=false
 extra_args=''
 
@@ -33,6 +35,10 @@ while (($# > 0)); do
       node_reuse=$2
       shift 2
       ;;
+    --msbuildmultithreaded|--mt)
+      msbuild_multi_threaded=$2
+      shift 2
+      ;;
     --ci)
       ci=true
       shift 1
@@ -49,14 +55,6 @@ while (($# > 0)); do
 done
 
 . "$scriptroot/tools.sh"
-
-if [[ "$ci" == true ]]; then
-  # Disable node reuse on CI unless explicitly opted in via MSBUILD_NODEREUSE_ENABLED.
-  # Internal testing only; this env var will be replaced with a switch (https://github.com/dotnet/arcade/issues/17013) and must not be depended on.
-  if [[ "${MSBUILD_NODEREUSE_ENABLED:-}" != "1" ]]; then
-    node_reuse=false
-  fi
-fi
 
 MSBuild $extra_args
 ExitWithExitCode 0

--- a/src/arcade/eng/common/tools.ps1
+++ b/src/arcade/eng/common/tools.ps1
@@ -31,6 +31,9 @@
 # Set to true to reuse msbuild nodes. Recommended to not reuse on CI.
 [bool]$nodeReuse = if (Test-Path variable:nodeReuse) { $nodeReuse } else { !$ci }
 
+# Set to true to build with MSBuild's multi-threaded mode (-mt). Enabled by default for local builds and not run on CI.
+[bool]$msbuildMultiThreaded = if (Test-Path variable:msbuildMultiThreaded) { $msbuildMultiThreaded } else { !$ci }
+
 # Configures warning treatment in msbuild.
 [bool]$warnAsError = if (Test-Path variable:warnAsError) { $warnAsError } else { $true }
 
@@ -808,8 +811,8 @@ function MSBuild() {
 
   $cmdArgs = "$($buildTool.Command) /m /nologo /clp:Summary /v:$verbosity /nr:$nodeReuse /p:ContinuousIntegrationBuild=$ci"
 
-  # Add -mt flag for MSBuild multithreaded mode if enabled via environment variable
-  if ($env:MSBUILD_MT_ENABLED -eq "1") {
+  # Build with MSBuild's multi-threaded mode.
+  if ($msbuildMultiThreaded) {
     $cmdArgs += ' -mt'
   }
 

--- a/src/arcade/eng/common/tools.ps1
+++ b/src/arcade/eng/common/tools.ps1
@@ -31,8 +31,9 @@
 # Set to true to reuse msbuild nodes. Recommended to not reuse on CI.
 [bool]$nodeReuse = if (Test-Path variable:nodeReuse) { $nodeReuse } else { !$ci }
 
-# Set to true to build with MSBuild's multi-threaded mode (-mt). Enabled by default for local builds and not run on CI.
-[bool]$msbuildMultiThreaded = if (Test-Path variable:msbuildMultiThreaded) { $msbuildMultiThreaded } else { !$ci }
+# Set to true to build with MSBuild's multi-threaded mode (-mt). Opt-in for now, so off unless it was
+# explicitly requested. It's intended to become the default for local builds once it has proven out.
+[bool]$msbuildMultiThreaded = if (Test-Path variable:msbuildMultiThreaded) { $msbuildMultiThreaded } else { $false }
 
 # Configures warning treatment in msbuild.
 [bool]$warnAsError = if (Test-Path variable:warnAsError) { $warnAsError } else { $true }

--- a/src/arcade/eng/common/tools.sh
+++ b/src/arcade/eng/common/tools.sh
@@ -60,13 +60,10 @@ else
   node_reuse=${node_reuse:-true}
 fi
 
-# Set to true to build with MSBuild's multi-threaded mode (-mt). Enabled by default for local builds and not run on CI.
+# Set to true to build with MSBuild's multi-threaded mode (-mt). Opt-in for now, so off unless it was
+# explicitly requested. It's intended to become the default for local builds once it has proven out.
 msbuild_multi_threaded=$(NormalizeBoolArg "${msbuild_multi_threaded:-}")
-if [[ "$ci" == true ]]; then
-  msbuild_multi_threaded=${msbuild_multi_threaded:-false}
-else
-  msbuild_multi_threaded=${msbuild_multi_threaded:-true}
-fi
+msbuild_multi_threaded=${msbuild_multi_threaded:-false}
 
 # Configures warning treatment in msbuild.
 warn_as_error=$(NormalizeBoolArg "${warn_as_error:-}")

--- a/src/arcade/eng/common/tools.sh
+++ b/src/arcade/eng/common/tools.sh
@@ -49,6 +49,13 @@ else
   node_reuse=${node_reuse:-true}
 fi
 
+# Set to true to build with MSBuild's multi-threaded mode (-mt). Enabled by default for local builds and not run on CI.
+if [[ "$ci" == true ]]; then
+  msbuild_multi_threaded=${msbuild_multi_threaded:-false}
+else
+  msbuild_multi_threaded=${msbuild_multi_threaded:-true}
+fi
+
 # Configures warning treatment in msbuild.
 warn_as_error=${warn_as_error:-true}
 
@@ -587,9 +594,9 @@ function MSBuild {
     }
   }
 
-  # Add -mt flag for MSBuild multithreaded mode if enabled via environment variable
+  # Build with MSBuild's multi-threaded mode.
   local mt_switch=""
-  if [[ "${MSBUILD_MT_ENABLED:-}" == "1" ]]; then
+  if [[ "$msbuild_multi_threaded" == true ]]; then
     mt_switch="-mt"
   fi
 

--- a/src/arcade/eng/common/tools.sh
+++ b/src/arcade/eng/common/tools.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+# Normalizes the value of a boolean build argument. Accepts 1/0 in addition to true/false so that
+# the same value works with the PowerShell scripts, whose [bool] parameters only bind 1/0.
+function NormalizeBoolArg {
+  case "${1:-}" in
+    1) echo true ;;
+    0) echo false ;;
+    *) echo "${1:-}" ;;
+  esac
+}
+
 # Initialize variables if they aren't already defined.
 
 # CI mode - set to true on CI server for PR validation build or official build.
@@ -43,6 +53,7 @@ restore=${restore:-true}
 verbosity=${verbosity:-'minimal'}
 
 # Set to true to reuse msbuild nodes. Recommended to not reuse on CI.
+node_reuse=$(NormalizeBoolArg "${node_reuse:-}")
 if [[ "$ci" == true ]]; then
   node_reuse=${node_reuse:-false}
 else
@@ -50,6 +61,7 @@ else
 fi
 
 # Set to true to build with MSBuild's multi-threaded mode (-mt). Enabled by default for local builds and not run on CI.
+msbuild_multi_threaded=$(NormalizeBoolArg "${msbuild_multi_threaded:-}")
 if [[ "$ci" == true ]]; then
   msbuild_multi_threaded=${msbuild_multi_threaded:-false}
 else
@@ -57,6 +69,7 @@ else
 fi
 
 # Configures warning treatment in msbuild.
+warn_as_error=$(NormalizeBoolArg "${warn_as_error:-}")
 warn_as_error=${warn_as_error:-true}
 
 # Specifies semi-colon delimited list of warning codes that should not be treated as errors.

--- a/src/aspnetcore/eng/build.ps1
+++ b/src/aspnetcore/eng/build.ps1
@@ -103,6 +103,10 @@ Set when building from within the VMR.
 Sets MSBuild's multi-threaded mode, i.e. the -mt switch (short: -mt). Defaults to on for local builds and is not
 run on CI unless explicitly requested.
 
+.PARAMETER NodeReuse
+Sets the nodereuse msbuild parameter. Node reuse is disabled by default in this repository as a workaround for
+issues with custom task assemblies; passing this parameter explicitly overrides that.
+
 .EXAMPLE
 Building both native and managed projects.
 
@@ -210,6 +214,9 @@ param(
     # Passed through to tools.ps1 MSBuild function
     [Alias('mt')]
     [bool]$msbuildMultiThreaded = $true,
+
+    # Passed through to tools.ps1 MSBuild function
+    [bool]$nodeReuse = $false,
 
     # Capture the rest
     [Parameter(ValueFromRemainingArguments = $true)]
@@ -351,9 +358,12 @@ $restore = $RunRestore
 
 # Though VS Code may indicate $nodeReuse is unused, tools.ps1 uses them.
 
-# Disable node reuse - Workaround perpetual issues in node reuse and custom task assemblies
-$nodeReuse = $false
-$env:MSBUILDDISABLENODEREUSE=1
+# Disable node reuse - Workaround perpetual issues in node reuse and custom task assemblies.
+# An explicitly passed -nodeReuse value wins.
+if (-not $PSBoundParameters.ContainsKey('nodeReuse')) {
+    $nodeReuse = $false
+    $env:MSBUILDDISABLENODEREUSE=1
+}
 
 # MSBuild's multi-threaded mode isn't run on CI unless it was explicitly requested via -msbuildMultiThreaded.
 if ($CI -and -not $PSBoundParameters.ContainsKey('msbuildMultiThreaded')) {

--- a/src/aspnetcore/eng/build.ps1
+++ b/src/aspnetcore/eng/build.ps1
@@ -100,8 +100,8 @@ Build the repository in product mode (short: -pb).
 Set when building from within the VMR.
 
 .PARAMETER MSBuildMultiThreaded
-Sets MSBuild's multi-threaded mode, i.e. the -mt switch (short: -mt). Defaults to on for local builds and is not
-run on CI unless explicitly requested.
+Sets MSBuild's multi-threaded mode, i.e. the -mt switch (short: -mt). Opt-in for now, so off unless it is
+explicitly requested.
 
 .PARAMETER NodeReuse
 Sets the nodereuse msbuild parameter. Node reuse is disabled by default in this repository as a workaround for
@@ -213,7 +213,7 @@ param(
 
     # Passed through to tools.ps1 MSBuild function
     [Alias('mt')]
-    [bool]$msbuildMultiThreaded = $true,
+    [bool]$msbuildMultiThreaded = $false,
 
     # Passed through to tools.ps1 MSBuild function
     [bool]$nodeReuse = $false,
@@ -363,11 +363,6 @@ $restore = $RunRestore
 if (-not $PSBoundParameters.ContainsKey('nodeReuse')) {
     $nodeReuse = $false
     $env:MSBUILDDISABLENODEREUSE=1
-}
-
-# MSBuild's multi-threaded mode isn't run on CI unless it was explicitly requested via -msbuildMultiThreaded.
-if ($CI -and -not $PSBoundParameters.ContainsKey('msbuildMultiThreaded')) {
-    $msbuildMultiThreaded = $false
 }
 
 # Ensure passing neither -bl nor -nobl on CI avoids errors in tools.ps1. This is needed because both parameters are

--- a/src/aspnetcore/eng/build.ps1
+++ b/src/aspnetcore/eng/build.ps1
@@ -99,6 +99,10 @@ Build the repository in product mode (short: -pb).
 .PARAMETER fromVMR
 Set when building from within the VMR.
 
+.PARAMETER MSBuildMultiThreaded
+Sets MSBuild's multi-threaded mode, i.e. the -mt switch (short: -mt). Defaults to on for local builds and is not
+run on CI unless explicitly requested.
+
 .EXAMPLE
 Building both native and managed projects.
 
@@ -202,6 +206,10 @@ param(
 
     # Passed through to tools.ps1 MSBuild function
     [string]$warnNotAsError = '',
+
+    # Passed through to tools.ps1 MSBuild function
+    [Alias('mt')]
+    [bool]$msbuildMultiThreaded = $true,
 
     # Capture the rest
     [Parameter(ValueFromRemainingArguments = $true)]
@@ -346,6 +354,11 @@ $restore = $RunRestore
 # Disable node reuse - Workaround perpetual issues in node reuse and custom task assemblies
 $nodeReuse = $false
 $env:MSBUILDDISABLENODEREUSE=1
+
+# MSBuild's multi-threaded mode isn't run on CI unless it was explicitly requested via -msbuildMultiThreaded.
+if ($CI -and -not $PSBoundParameters.ContainsKey('msbuildMultiThreaded')) {
+    $msbuildMultiThreaded = $false
+}
 
 # Ensure passing neither -bl nor -nobl on CI avoids errors in tools.ps1. This is needed because both parameters are
 # $false by default i.e. they always exist. (We currently avoid binary logs but that is made visible in the YAML.)

--- a/src/aspnetcore/eng/build.sh
+++ b/src/aspnetcore/eng/build.sh
@@ -87,6 +87,7 @@ Options:
     --warnAsError                     Sets warnaserror msbuild parameter: 'true' or 'false'
     --warnNotAsError                  Sets a semi-colon delimited list of warning codes that should not be treated as errors
     --msbuildMultiThreaded|--mt       Sets MSBuild's multi-threaded mode, i.e. the -mt switch: 'true' or 'false'
+    --nodeReuse                       Sets nodereuse msbuild parameter: 'true' or 'false'
 
     --runtime-source-feed             Additional feed that can be used when downloading .NET runtimes and SDKs
     --runtime-source-feed-key         Key for feed that can be used when downloading .NET runtimes and SDKs
@@ -273,6 +274,11 @@ while [[ $# -gt 0 ]]; do
             [ -z "${1:-}" ] && __error "Missing value for parameter --msbuildMultiThreaded" && __usage
             msbuild_multi_threaded="${1:-}"
             ;;
+        -nodereuse)
+            shift
+            [ -z "${1:-}" ] && __error "Missing value for parameter --nodeReuse" && __usage
+            node_reuse="${1:-}"
+            ;;
         *)
             msbuild_args[${#msbuild_args[*]}]="$1"
             ;;
@@ -370,9 +376,12 @@ fi
 # Initialize global variables need to be set before the import of Arcade is imported
 restore=$run_restore
 
-# Disable node reuse - Workaround perpetual issues in node reuse and custom task assemblies
-nodeReuse=false
-export MSBUILDDISABLENODEREUSE=1
+# Disable node reuse - Workaround perpetual issues in node reuse and custom task assemblies.
+# An explicitly passed --nodeReuse value wins.
+if [[ -z "${node_reuse:-}" ]]; then
+    node_reuse=false
+    export MSBUILDDISABLENODEREUSE=1
+fi
 
 # Ensure passing neither --bl nor --nobl on CI avoids errors in tools.sh. This is needed because we set both variables
 # to false by default i.e. they always exist. (We currently avoid binary logs but that is made visible in the YAML.)

--- a/src/aspnetcore/eng/build.sh
+++ b/src/aspnetcore/eng/build.sh
@@ -37,6 +37,8 @@ product_build=''
 from_vmr=''
 warn_as_error=true
 warn_not_as_error=''
+# Empty means "not specified"; tools.sh defaults it to on for local builds and off on CI.
+msbuild_multi_threaded=''
 from_vmr=''
 
 source "$DIR/common/native/init-os-and-arch.sh"
@@ -84,6 +86,7 @@ Options:
     --verbosity|-v                    MSBuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]
     --warnAsError                     Sets warnaserror msbuild parameter: 'true' or 'false'
     --warnNotAsError                  Sets a semi-colon delimited list of warning codes that should not be treated as errors
+    --msbuildMultiThreaded|--mt       Sets MSBuild's multi-threaded mode, i.e. the -mt switch: 'true' or 'false'
 
     --runtime-source-feed             Additional feed that can be used when downloading .NET runtimes and SDKs
     --runtime-source-feed-key         Key for feed that can be used when downloading .NET runtimes and SDKs
@@ -264,6 +267,11 @@ while [[ $# -gt 0 ]]; do
             shift
             [ -z "${1:-}" ] && __error "Missing value for parameter --warnNotAsError" && __usage
             warn_not_as_error="${1:-}"
+            ;;
+        -msbuildmultithreaded|-mt)
+            shift
+            [ -z "${1:-}" ] && __error "Missing value for parameter --msbuildMultiThreaded" && __usage
+            msbuild_multi_threaded="${1:-}"
             ;;
         *)
             msbuild_args[${#msbuild_args[*]}]="$1"

--- a/src/aspnetcore/eng/build.sh
+++ b/src/aspnetcore/eng/build.sh
@@ -37,7 +37,7 @@ product_build=''
 from_vmr=''
 warn_as_error=true
 warn_not_as_error=''
-# Empty means "not specified"; tools.sh defaults it to on for local builds and off on CI.
+# Empty means "not specified"; tools.sh leaves it off unless it's explicitly requested.
 msbuild_multi_threaded=''
 from_vmr=''
 

--- a/src/fsharp/eng/Build.ps1
+++ b/src/fsharp/eng/Build.ps1
@@ -45,7 +45,7 @@ param (
     [switch]$procdump,
     [switch]$deployExtensions,
     [switch]$prepareMachine,
-    [bool][Alias('mt')]$msbuildMultiThreaded = $true,
+    [bool][Alias('mt')]$msbuildMultiThreaded = $false,
     [bool]$nodeReuse = $false,
     [switch]$useGlobalNuGetCache = $true,
     [switch]$dontUseGlobalNuGetCache = $false,
@@ -81,11 +81,6 @@ param (
 Set-StrictMode -version 2.0
 $ErrorActionPreference = "Stop"
 
-# MSBuild's multi-threaded mode isn't run on CI unless it was explicitly requested via -msbuildMultiThreaded.
-# tools.ps1 reads $msbuildMultiThreaded, so this has to be settled before Arcade is imported.
-if ($ci -and -not $PSBoundParameters.ContainsKey('msbuildMultiThreaded')) {
-    $msbuildMultiThreaded = $false
-}
 $BuildCategory = ""
 $BuildMessage = ""
 

--- a/src/fsharp/eng/Build.ps1
+++ b/src/fsharp/eng/Build.ps1
@@ -45,6 +45,7 @@ param (
     [switch]$procdump,
     [switch]$deployExtensions,
     [switch]$prepareMachine,
+    [bool][Alias('mt')]$msbuildMultiThreaded = $true,
     [switch]$useGlobalNuGetCache = $true,
     [switch]$dontUseGlobalNuGetCache = $false,
     [switch]$warnAsError = $true,
@@ -78,6 +79,12 @@ param (
 
 Set-StrictMode -version 2.0
 $ErrorActionPreference = "Stop"
+
+# MSBuild's multi-threaded mode isn't run on CI unless it was explicitly requested via -msbuildMultiThreaded.
+# tools.ps1 reads $msbuildMultiThreaded, so this has to be settled before Arcade is imported.
+if ($ci -and -not $PSBoundParameters.ContainsKey('msbuildMultiThreaded')) {
+    $msbuildMultiThreaded = $false
+}
 $BuildCategory = ""
 $BuildMessage = ""
 
@@ -140,6 +147,7 @@ function Print-Usage() {
     Write-Host "  -msbuildEngine <value>        Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
     Write-Host "  -procdump                     Monitor test runs with procdump"
     Write-Host "  -prepareMachine               Prepare machine for CI run, clean up processes after build"
+    Write-Host "  -msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('true' or 'false') (short: -mt)"
     Write-Host "  -dontUseGlobalNuGetCache      Do not use the global NuGet cache"
     Write-Host "  -noVisualStudio               Only build fsc and fsi as .NET Core applications. No Visual Studio required. '-configuration', '-verbosity', '-norestore', '-rebuild' are supported."
     Write-Host "  -productBuild                 Build the repository in product-build mode."

--- a/src/fsharp/eng/Build.ps1
+++ b/src/fsharp/eng/Build.ps1
@@ -147,7 +147,7 @@ function Print-Usage() {
     Write-Host "  -msbuildEngine <value>        Msbuild engine to use to run build ('dotnet', 'vs', or unspecified)."
     Write-Host "  -procdump                     Monitor test runs with procdump"
     Write-Host "  -prepareMachine               Prepare machine for CI run, clean up processes after build"
-    Write-Host "  -msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('true' or 'false') (short: -mt)"
+    Write-Host "  -msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('1' or '0') (short: -mt)"
     Write-Host "  -dontUseGlobalNuGetCache      Do not use the global NuGet cache"
     Write-Host "  -noVisualStudio               Only build fsc and fsi as .NET Core applications. No Visual Studio required. '-configuration', '-verbosity', '-norestore', '-rebuild' are supported."
     Write-Host "  -productBuild                 Build the repository in product-build mode."

--- a/src/fsharp/eng/Build.ps1
+++ b/src/fsharp/eng/Build.ps1
@@ -46,6 +46,7 @@ param (
     [switch]$deployExtensions,
     [switch]$prepareMachine,
     [bool][Alias('mt')]$msbuildMultiThreaded = $true,
+    [bool]$nodeReuse = $false,
     [switch]$useGlobalNuGetCache = $true,
     [switch]$dontUseGlobalNuGetCache = $false,
     [switch]$warnAsError = $true,
@@ -148,6 +149,7 @@ function Print-Usage() {
     Write-Host "  -procdump                     Monitor test runs with procdump"
     Write-Host "  -prepareMachine               Prepare machine for CI run, clean up processes after build"
     Write-Host "  -msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('1' or '0') (short: -mt)"
+    Write-Host "  -nodeReuse <value>            Sets nodereuse msbuild parameter ('1' or '0')"
     Write-Host "  -dontUseGlobalNuGetCache      Do not use the global NuGet cache"
     Write-Host "  -noVisualStudio               Only build fsc and fsi as .NET Core applications. No Visual Studio required. '-configuration', '-verbosity', '-norestore', '-rebuild' are supported."
     Write-Host "  -productBuild                 Build the repository in product-build mode."
@@ -172,8 +174,6 @@ function Process-Arguments() {
     if ($dontUseGlobalNugetCache -or $ci) {
         $script:useGlobalNugetCache = $False
     }
-
-    $script:nodeReuse = $False;
 
     if ($testAll) {
         $script:testDesktop = $True

--- a/src/fsharp/eng/build.sh
+++ b/src/fsharp/eng/build.sh
@@ -34,6 +34,7 @@ usage()
   echo "  --skipAnalyzers                Do not run analyzers during build operations"
   echo "  --skipBuild                    Do not run the build"
   echo "  --prepareMachine               Prepare machine for CI run, clean up processes after build"
+  echo "  --msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('true' or 'false') (short: --mt)"
   echo "  --sourceBuild                  Build the repository in source-only mode."
   echo "  --productBuild                 Build the repository in product-build mode."
   echo "  --fromVMR                      Set when building from within the VMR"
@@ -75,6 +76,8 @@ ci=false
 skip_analyzers=false
 skip_build=false
 prepare_machine=false
+# Empty means "not specified"; tools.sh defaults it to on for local builds and off on CI.
+msbuild_multi_threaded=''
 source_build=false
 product_build=false
 from_vmr=false
@@ -166,6 +169,10 @@ while [[ $# > 0 ]]; do
       ;;
     --preparemachine)
       prepare_machine=true
+      ;;
+    --msbuildmultithreaded|--mt)
+      msbuild_multi_threaded=$2
+      shift
       ;;
     --docker)
       docker=true

--- a/src/fsharp/eng/build.sh
+++ b/src/fsharp/eng/build.sh
@@ -77,7 +77,7 @@ ci=false
 skip_analyzers=false
 skip_build=false
 prepare_machine=false
-# Empty means "not specified"; tools.sh defaults it to on for local builds and off on CI.
+# Empty means "not specified"; tools.sh leaves it off unless it's explicitly requested.
 msbuild_multi_threaded=''
 source_build=false
 product_build=false

--- a/src/fsharp/eng/build.sh
+++ b/src/fsharp/eng/build.sh
@@ -35,6 +35,7 @@ usage()
   echo "  --skipBuild                    Do not run the build"
   echo "  --prepareMachine               Prepare machine for CI run, clean up processes after build"
   echo "  --msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('true' or 'false') (short: --mt)"
+  echo "  --nodeReuse <value>            Sets nodereuse msbuild parameter ('true' or 'false')"
   echo "  --sourceBuild                  Build the repository in source-only mode."
   echo "  --productBuild                 Build the repository in product-build mode."
   echo "  --fromVMR                      Set when building from within the VMR"
@@ -172,6 +173,10 @@ while [[ $# > 0 ]]; do
       ;;
     --msbuildmultithreaded|--mt)
       msbuild_multi_threaded=$2
+      shift
+      ;;
+    --nodereuse)
+      node_reuse=$2
       shift
       ;;
     --docker)

--- a/src/msbuild/azure-pipelines/vmr-sb-validation.yml
+++ b/src/msbuild/azure-pipelines/vmr-sb-validation.yml
@@ -19,9 +19,9 @@ schedules:
 
 parameters:
 - name: extraPropertiesStage2
-  displayName: 'Extra MSBuild properties for stage 2 (e.g., /p:DotNetBuildMT=true)'
+  displayName: 'Extra flags passed to the stage2 build (e.g., -mt 1)'
   type: string
-  default: '/p:DotNetBuildMT=true'
+  default: '-mt 1'
 
 variables:
 - template: /eng/common/templates/variables/pool-providers.yml@self

--- a/src/msbuild/eng/build.ps1
+++ b/src/msbuild/eng/build.ps1
@@ -15,6 +15,21 @@ Param(
 $pwshPath = (Get-Process -Id $PID).Path
 $buildScript = Join-Path $PSScriptRoot 'common\build.ps1'
 
+# The stage builds run out-of-proc so that stage 2 doesn't inherit stage 1's state variables, but
+# they are invoked through `pwsh -Command` rather than `pwsh -File`. `-File` passes every argument
+# as a literal string, which typed parameters such as `[bool] $nodeReuse` and `[bool] $msbuildMultiThreaded`
+# can't bind to. `-Command` re-parses the arguments as PowerShell, so `-mt 1` arrives as an integer.
+# Quote anything that isn't a simple token so it survives that re-parse intact
+# (e.g. '-warnnotaserror NU1901;NU1902;NU1903', where ';' would otherwise separate statements).
+function Get-BuildCommand([string[]] $arguments) {
+  $quoted = $arguments | ForEach-Object {
+    if ($_ -match '^[\w\-/\\.:=+]+$') { $_ } else { "'" + ($_ -replace "'", "''") + "'" }
+  }
+  # Default to a failure exit code so that an error which prevents the script from running at all
+  # (e.g. a parameter binding failure) isn't reported as success by the trailing `exit`.
+  "`$global:LASTEXITCODE = 1`n& '$($buildScript -replace "'", "''")' $($quoted -join ' ')`nexit `$LASTEXITCODE"
+}
+
 # Arguments common to the stage1 and stage2 builds, including any caller-supplied $properties.
 $commonBuildArgs = @('-configuration', $configuration) + $properties
 
@@ -59,11 +74,12 @@ if ($test -and -not $stage2) {
 }
 
 # Log the stage 1 build command so that it's clear which arguments flow to it.
+$stage1Command = Get-BuildCommand $buildArgs
 if ($stage2) {
-  Write-Host "Stage 1 build: & `"$buildScript`" $buildArgs"
+  Write-Host "Stage 1 build: $stage1Command"
 }
 
-& $pwshPath -NoLogo -NoProfile -ExecutionPolicy ByPass -File "$buildScript" @buildArgs
+& $pwshPath -NoLogo -NoProfile -ExecutionPolicy ByPass -Command $stage1Command
 
 if (-not $stage2) {
   exit $LASTEXITCODE
@@ -166,8 +182,9 @@ if ($test) {
 
 $stage2BuildArgs += $stage2Args
 
-Write-Host "Stage 2 build: & `"$buildScript`" $stage2BuildArgs"
+$stage2Command = Get-BuildCommand $stage2BuildArgs
+Write-Host "Stage 2 build: $stage2Command"
 # Needs to run out-of-proc to not inherit the stage 1 build's state variables.
-& $pwshPath -NoLogo -NoProfile -ExecutionPolicy ByPass -File "$buildScript" @stage2BuildArgs
+& $pwshPath -NoLogo -NoProfile -ExecutionPolicy ByPass -Command $stage2Command
 
 exit $LASTEXITCODE

--- a/src/nuget-client/eng/dotnet-build/build.ps1
+++ b/src/nuget-client/eng/dotnet-build/build.ps1
@@ -10,7 +10,7 @@ param (
   [switch][Alias('pb')]$productBuild,
   [switch]$fromVMR,
   [bool]$nodeReuse = $true,
-  [bool][Alias('mt')]$msbuildMultiThreaded = $true,
+  [bool][Alias('mt')]$msbuildMultiThreaded = $false,
   [bool]$warnAsError = $true,
   [string]$warnNotAsError = '',
   [Parameter(ValueFromRemainingArguments = $true)][string[]]$properties
@@ -38,10 +38,6 @@ try {
     # Node reuse isn't used on CI unless it was explicitly requested via -nodeReuse.
     if (-not $PSBoundParameters.ContainsKey('nodeReuse')) {
       $nodeReuse = $false
-    }
-    # MSBuild's multi-threaded mode isn't run on CI unless it was explicitly requested via -msbuildMultiThreaded.
-    if (-not $PSBoundParameters.ContainsKey('msbuildMultiThreaded')) {
-      $msbuildMultiThreaded = $false
     }
   }
 

--- a/src/nuget-client/eng/dotnet-build/build.ps1
+++ b/src/nuget-client/eng/dotnet-build/build.ps1
@@ -10,6 +10,7 @@ param (
   [switch][Alias('pb')]$productBuild,
   [switch]$fromVMR,
   [bool]$nodeReuse = $true,
+  [bool][Alias('mt')]$msbuildMultiThreaded = $true,
   [bool]$warnAsError = $true,
   [string]$warnNotAsError = '',
   [Parameter(ValueFromRemainingArguments = $true)][string[]]$properties
@@ -35,6 +36,10 @@ try {
       $binaryLog = $true
     }
     $nodeReuse = $false
+    # MSBuild's multi-threaded mode isn't run on CI unless it was explicitly requested via -msbuildMultiThreaded.
+    if (-not $PSBoundParameters.ContainsKey('msbuildMultiThreaded')) {
+      $msbuildMultiThreaded = $false
+    }
   }
 
   Build

--- a/src/nuget-client/eng/dotnet-build/build.ps1
+++ b/src/nuget-client/eng/dotnet-build/build.ps1
@@ -35,7 +35,10 @@ try {
     if (-not $excludeCIBinarylog) {
       $binaryLog = $true
     }
-    $nodeReuse = $false
+    # Node reuse isn't used on CI unless it was explicitly requested via -nodeReuse.
+    if (-not $PSBoundParameters.ContainsKey('nodeReuse')) {
+      $nodeReuse = $false
+    }
     # MSBuild's multi-threaded mode isn't run on CI unless it was explicitly requested via -msbuildMultiThreaded.
     if (-not $PSBoundParameters.ContainsKey('msbuildMultiThreaded')) {
       $msbuildMultiThreaded = $false

--- a/src/nuget-client/eng/dotnet-build/build.sh
+++ b/src/nuget-client/eng/dotnet-build/build.sh
@@ -140,6 +140,11 @@ if [[ "$binary_log" == true ]]; then
   bl="/bl:\"${repo_root}artifacts/log/${configuration}/Build.binlog\""
 fi
 
+# Accept 1/0 in addition to true/false for boolean arguments (see eng/common/tools.sh).
+for v in node_reuse warn_as_error msbuild_multi_threaded; do
+  case "${!v}" in 1) printf -v "$v" true ;; 0) printf -v "$v" false ;; esac
+done
+
 if [[ "$ci" == true ]]; then
   node_reuse=false
 fi

--- a/src/nuget-client/eng/dotnet-build/build.sh
+++ b/src/nuget-client/eng/dotnet-build/build.sh
@@ -15,6 +15,8 @@ product_build=false
 from_vmr=false
 ci=false
 node_reuse=true
+# Empty means "not specified"; defaults to on for local builds and off on CI (see below).
+msbuild_multi_threaded=''
 binary_log=false
 warn_as_error=true
 warn_not_as_error=''
@@ -61,6 +63,10 @@ while [[ $# > 0 ]]; do
       ;;
     --nodereuse)
       node_reuse=$2
+      shift
+      ;;
+    --msbuildmultithreaded|--mt)
+      msbuild_multi_threaded=$2
       shift
       ;;
     --warnaserror)
@@ -138,6 +144,13 @@ if [[ "$ci" == true ]]; then
   node_reuse=false
 fi
 
+# MSBuild's multi-threaded mode is on by default for local builds and isn't run on CI unless it was
+# explicitly requested via --msbuildMultiThreaded.
+mt_switch=""
+if [[ "$msbuild_multi_threaded" == true || (-z "$msbuild_multi_threaded" && "$ci" != true) ]]; then
+  mt_switch="-mt"
+fi
+
 warnaserror_switch=""
 if [[ "$warn_as_error" == true ]]; then
   warnaserror_switch="/warnaserror"
@@ -148,4 +161,4 @@ if [[ -n "$warn_not_as_error" && "$warn_as_error" == true ]]; then
   warnnotaserror_switch="/warnnotaserror:$warn_not_as_error /p:AdditionalWarningsNotAsErrors=${warn_not_as_error//;/%3B}"
 fi
 
-"$DOTNET" msbuild /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse /p:ContinuousIntegrationBuild=$ci $bl $warnaserror_switch $warnnotaserror_switch ${dotnetArguments[@]+"${dotnetArguments[@]}"} ${args[@]+"${args[@]}"}
+"$DOTNET" msbuild /m /nologo /clp:Summary /v:$verbosity /nr:$node_reuse $mt_switch /p:ContinuousIntegrationBuild=$ci $bl $warnaserror_switch $warnnotaserror_switch ${dotnetArguments[@]+"${dotnetArguments[@]}"} ${args[@]+"${args[@]}"}

--- a/src/nuget-client/eng/dotnet-build/build.sh
+++ b/src/nuget-client/eng/dotnet-build/build.sh
@@ -14,8 +14,8 @@ source_build=false
 product_build=false
 from_vmr=false
 ci=false
-node_reuse=true
-# Empty means "not specified"; defaults to on for local builds and off on CI (see below).
+# Empty means "not specified"; these default to on for local builds and off on CI (see below).
+node_reuse=''
 msbuild_multi_threaded=''
 binary_log=false
 warn_as_error=true
@@ -146,7 +146,9 @@ for v in node_reuse warn_as_error msbuild_multi_threaded; do
 done
 
 if [[ "$ci" == true ]]; then
-  node_reuse=false
+  node_reuse=${node_reuse:-false}
+else
+  node_reuse=${node_reuse:-true}
 fi
 
 # MSBuild's multi-threaded mode is on by default for local builds and isn't run on CI unless it was

--- a/src/nuget-client/eng/dotnet-build/build.sh
+++ b/src/nuget-client/eng/dotnet-build/build.sh
@@ -151,10 +151,10 @@ else
   node_reuse=${node_reuse:-true}
 fi
 
-# MSBuild's multi-threaded mode is on by default for local builds and isn't run on CI unless it was
-# explicitly requested via --msbuildMultiThreaded.
+# MSBuild's multi-threaded mode is opt-in for now, so it's off unless it was explicitly requested
+# via --msbuildMultiThreaded.
 mt_switch=""
-if [[ "$msbuild_multi_threaded" == true || (-z "$msbuild_multi_threaded" && "$ci" != true) ]]; then
+if [[ "$msbuild_multi_threaded" == true ]]; then
   mt_switch="-mt"
 fi
 

--- a/src/roslyn/eng/build.ps1
+++ b/src/roslyn/eng/build.ps1
@@ -125,7 +125,7 @@ function Print-Usage() {
   Write-Host "  -runAnalyzers             Run analyzers during build operations (short: -a)"
   Write-Host "  -skipDocumentation        Skip generation of XML documentation files"
   Write-Host "  -prepareMachine           Prepare machine for CI run, clean up processes after build"
-  Write-Host "  -msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('true' or 'false') (short: -mt)"
+  Write-Host "  -msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('1' or '0') (short: -mt)"
   Write-Host "  -useGlobalNuGetCache      Use global NuGet cache."
   Write-Host "  -warnAsError              Treat all warnings as errors"
   Write-Host "  -warnNotAsError <codes>   Suppress specific warnings from being treated as errors (semi-colon delimited)"

--- a/src/roslyn/eng/build.ps1
+++ b/src/roslyn/eng/build.ps1
@@ -41,6 +41,7 @@ param (
   [switch]$skipDocumentation = $false,
   [switch][Alias('d')]$deployExtensions,
   [switch]$prepareMachine,
+  [bool][Alias('mt')]$msbuildMultiThreaded = $true,
   [switch]$useGlobalNuGetCache = $true,
   [switch]$warnAsError = $false,
   [string]$warnNotAsError = "",
@@ -78,6 +79,12 @@ param (
 
 Set-StrictMode -version 2.0
 $ErrorActionPreference = "Stop"
+
+# MSBuild's multi-threaded mode isn't run on CI unless it was explicitly requested via -msbuildMultiThreaded.
+# tools.ps1 reads $msbuildMultiThreaded, so this has to be settled before Arcade is imported.
+if ($ci -and -not $PSBoundParameters.ContainsKey('msbuildMultiThreaded')) {
+  $msbuildMultiThreaded = $false
+}
 
 function Print-Usage() {
   Write-Host "Common settings:"
@@ -118,6 +125,7 @@ function Print-Usage() {
   Write-Host "  -runAnalyzers             Run analyzers during build operations (short: -a)"
   Write-Host "  -skipDocumentation        Skip generation of XML documentation files"
   Write-Host "  -prepareMachine           Prepare machine for CI run, clean up processes after build"
+  Write-Host "  -msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('true' or 'false') (short: -mt)"
   Write-Host "  -useGlobalNuGetCache      Use global NuGet cache."
   Write-Host "  -warnAsError              Treat all warnings as errors"
   Write-Host "  -warnNotAsError <codes>   Suppress specific warnings from being treated as errors (semi-colon delimited)"

--- a/src/roslyn/eng/build.ps1
+++ b/src/roslyn/eng/build.ps1
@@ -41,7 +41,7 @@ param (
   [switch]$skipDocumentation = $false,
   [switch][Alias('d')]$deployExtensions,
   [switch]$prepareMachine,
-  [bool][Alias('mt')]$msbuildMultiThreaded = $true,
+  [bool][Alias('mt')]$msbuildMultiThreaded = $false,
   [bool]$nodeReuse = $true,
   [switch]$useGlobalNuGetCache = $true,
   [switch]$warnAsError = $false,
@@ -80,12 +80,6 @@ param (
 
 Set-StrictMode -version 2.0
 $ErrorActionPreference = "Stop"
-
-# MSBuild's multi-threaded mode isn't run on CI unless it was explicitly requested via -msbuildMultiThreaded.
-# tools.ps1 reads $msbuildMultiThreaded, so this has to be settled before Arcade is imported.
-if ($ci -and -not $PSBoundParameters.ContainsKey('msbuildMultiThreaded')) {
-  $msbuildMultiThreaded = $false
-}
 
 # Node reuse isn't used on CI unless it was explicitly requested via -nodeReuse.
 # tools.ps1 reads $nodeReuse, so this has to be settled before Arcade is imported.

--- a/src/roslyn/eng/build.ps1
+++ b/src/roslyn/eng/build.ps1
@@ -42,6 +42,7 @@ param (
   [switch][Alias('d')]$deployExtensions,
   [switch]$prepareMachine,
   [bool][Alias('mt')]$msbuildMultiThreaded = $true,
+  [bool]$nodeReuse = $true,
   [switch]$useGlobalNuGetCache = $true,
   [switch]$warnAsError = $false,
   [string]$warnNotAsError = "",
@@ -86,6 +87,12 @@ if ($ci -and -not $PSBoundParameters.ContainsKey('msbuildMultiThreaded')) {
   $msbuildMultiThreaded = $false
 }
 
+# Node reuse isn't used on CI unless it was explicitly requested via -nodeReuse.
+# tools.ps1 reads $nodeReuse, so this has to be settled before Arcade is imported.
+if ($ci -and -not $PSBoundParameters.ContainsKey('nodeReuse')) {
+  $nodeReuse = $false
+}
+
 function Print-Usage() {
   Write-Host "Common settings:"
   Write-Host "  -configuration <value>    Build configuration: 'Debug' or 'Release' (short: -c)"
@@ -126,6 +133,7 @@ function Print-Usage() {
   Write-Host "  -skipDocumentation        Skip generation of XML documentation files"
   Write-Host "  -prepareMachine           Prepare machine for CI run, clean up processes after build"
   Write-Host "  -msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('1' or '0') (short: -mt)"
+  Write-Host "  -nodeReuse <value>        Sets nodereuse msbuild parameter ('1' or '0')"
   Write-Host "  -useGlobalNuGetCache      Use global NuGet cache."
   Write-Host "  -warnAsError              Treat all warnings as errors"
   Write-Host "  -warnNotAsError <codes>   Suppress specific warnings from being treated as errors (semi-colon delimited)"

--- a/src/roslyn/eng/build.sh
+++ b/src/roslyn/eng/build.sh
@@ -37,6 +37,7 @@ usage()
   echo "  --runAnalyzers             Run analyzers during build operations"
   echo "  --skipDocumentation        Skip generation of XML documentation files"
   echo "  --prepareMachine           Prepare machine for CI run, clean up processes after build"
+  echo "  --msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('true' or 'false') (short: --mt)"
   echo "  --warnAsError              Treat all warnings as errors"
   echo "  --warnNotAsError <codes>   Suppress specific warnings from being treated as errors (semi-colon delimited)"
   echo "  --sourceBuild              Build the repository in source-only mode"
@@ -82,6 +83,8 @@ bootstrap=false
 run_analyzers=false
 skip_documentation=false
 prepare_machine=false
+# Empty means "not specified"; tools.sh defaults it to on for local builds and off on CI.
+msbuild_multi_threaded=''
 warn_as_error=false
 warn_not_as_error=""
 properties=()
@@ -180,6 +183,11 @@ while [[ $# > 0 ]]; do
       ;;
     --preparemachine)
       prepare_machine=true
+      ;;
+    --msbuildmultithreaded|--mt)
+      msbuild_multi_threaded=$2
+      args="$args $1"
+      shift
       ;;
     --warnaserror)
       warn_as_error=true

--- a/src/roslyn/eng/build.sh
+++ b/src/roslyn/eng/build.sh
@@ -38,6 +38,7 @@ usage()
   echo "  --skipDocumentation        Skip generation of XML documentation files"
   echo "  --prepareMachine           Prepare machine for CI run, clean up processes after build"
   echo "  --msbuildMultiThreaded <value> Sets MSBuild's multi-threaded mode, i.e. the -mt switch ('true' or 'false') (short: --mt)"
+  echo "  --nodeReuse <value>        Sets nodereuse msbuild parameter ('true' or 'false')"
   echo "  --warnAsError              Treat all warnings as errors"
   echo "  --warnNotAsError <codes>   Suppress specific warnings from being treated as errors (semi-colon delimited)"
   echo "  --sourceBuild              Build the repository in source-only mode"
@@ -186,6 +187,11 @@ while [[ $# > 0 ]]; do
       ;;
     --msbuildmultithreaded|--mt)
       msbuild_multi_threaded=$2
+      args="$args $1"
+      shift
+      ;;
+    --nodereuse)
+      node_reuse=$2
       args="$args $1"
       shift
       ;;

--- a/src/roslyn/eng/build.sh
+++ b/src/roslyn/eng/build.sh
@@ -84,7 +84,7 @@ bootstrap=false
 run_analyzers=false
 skip_documentation=false
 prepare_machine=false
-# Empty means "not specified"; tools.sh defaults it to on for local builds and off on CI.
+# Empty means "not specified"; tools.sh leaves it off unless it's explicitly requested.
 msbuild_multi_threaded=''
 warn_as_error=false
 warn_not_as_error=""


### PR DESCRIPTION
Implements https://github.com/dotnet/arcade/issues/17242.

MSBuild's experimental multi-threaded mode was previously gated behind an internal `MSBUILD_MT_ENABLED` environment variable. This promotes it to a first-class build script switch.

**The switch defaults to off for now**, on CI and locally, so this is a no-op for existing builds. Enabling it by default for local builds is deliberately deferred until the mode has proven out; that will be a one-line change per `tools.ps1`/`tools.sh`.

### Resolution semantics

Identical across the PowerShell and shell variants:

1. An explicitly specified `-mt` / `--mt` value always wins, on CI and locally.
2. Otherwise it's off.

`tools.ps1` / `tools.sh` own the default resolution and emit `-mt`; the build scripts just expose the switch.

`-mt` takes a value, consistent with the existing `-nodeReuse` and `-warnAsError` parameters:

```console
.\build.cmd -mt 1     # local build with multi-threading
./build.sh --mt 1     # same on Unix
```

### Changes

| Area | Change |
| --- | --- |
| `eng/common` and `src/arcade/eng/common` | `tools.ps1`/`tools.sh` resolve `$msbuildMultiThreaded` / `msbuild_multi_threaded` and emit `-mt`; `build.ps1`/`build.sh` expose `-mt <value>` (long form `-msbuildMultiThreaded`) |
| `build.sh` and `eng/build.ps1` | The VMR's own entry points don't go through `eng/common/build.*`, so they expose the switch directly. An explicit value is also flowed down as `/p:DotNetBuildMT=<value>`, so a single `-mt 0` covers the orchestrator *and* every repo build. |
| `fsharp`, `roslyn`, `aspnetcore`, `nuget-client` | These repos don't use `eng/common/build.*`, so their own build scripts gained `-mt` and `-nodeReuse`. `nuget-client`'s `eng/dotnet-build/build.sh` invokes `msbuild` directly and therefore resolves the defaults itself. |
| `repo-projects/Directory.Build.props` | Replaced the `MSBUILD_MT_ENABLED=1` environment variable with the new switch. `DotNetBuildMT` now passes `-mt <value>`, so it can be used to opt *out* as well as in. |

All other repos pick the change up automatically — the `UpdateEngCommonFiles` target copies the VMR's `eng/common` over every `src/<repo>/eng/common` before that repo builds.

### Repos with custom build scripts

`fsharp`, `roslyn`, `aspnetcore` and `nuget-client` don't call `eng/common/build.*` directly, so both switches had to be added to their own scripts. `fsharp` and `roslyn` reject unknown arguments outright, and `aspnetcore`, `fsharp` and `nuget-client` hard-disabled node reuse, so an explicitly passed value was silently dropped. Each script now declares the parameter and only applies its own default when the caller didn't specify one.

`msbuild` and `runtime` do forward unrecognized arguments to `eng/common/build.*`, but only `runtime` did so in a way that preserves argument types. `msbuild`'s wrapper re-invoked Arcade with `pwsh -File`, which passes every argument as a literal string, and a PowerShell `[bool]` parameter can never bind from a string:

```
Cannot process argument transformation on parameter 'msbuildMultiThreaded'.
Cannot convert value "System.String" to type "System.Boolean".
```

It now uses `pwsh -Command`, which re-parses the arguments as PowerShell so `-mt 1` arrives as an integer — the same thing `runtime`'s wrapper achieves with `Invoke-Expression`, and what `msbuild`'s own `build.cmd` already does when it calls this script. The build still runs out-of-proc so that stage 2 doesn't inherit stage 1's state variables.

> Two behaviours `-File` provided for free had to be restored: arguments that aren't simple tokens are single-quoted so they survive the re-parse (`-warnnotaserror NU1901;NU1902;NU1903`, paths containing spaces), while bare tokens such as `1` stay unquoted so they keep their type; and because `-Command` doesn't propagate a script's `exit N`, the generated command ends with `exit $LASTEXITCODE`, pre-seeded to `1` so a failure that prevents the script from running at all isn't reported as success.

Hard-disabling node reuse is worth fixing at the source, since it also defeats MSBuild Server. Filed dotnet/aspnetcore#68251 and dotnet/fsharp#20217; the changes here are a stop-gap.

### `-nodeReuse` gets the same treatment

Also implements https://github.com/dotnet/arcade/issues/17013.

Node reuse was gated the same way, behind an internal `MSBUILD_NODEREUSE_ENABLED` environment variable, with the added twist that `tools.ps1` / `tools.sh` hard-failed any CI build that had node reuse enabled. `-nodeReuse` already existed as a parameter, it just couldn't be turned *on* for a CI build.

It now works the same way as `-mt` in that an explicitly passed value wins, on CI and locally. Unlike `-mt` its default is unchanged: `!ci`, i.e. on for local builds and off on CI. The `MSBUILD_NODEREUSE_ENABLED` environment variable and the CI hard error are gone, and `eng/build.ps1` / `build.sh` flow an explicit value down as `/p:DotNetBuildNodeReuse`, which `repo-projects/Directory.Build.props` turns into `-nodeReuse 1|0` for every repo build.

`msbuild.ps1` / `msbuild.sh` gained the `-mt` switch as well, so the two smaller entry points behave like `build.ps1` / `build.sh`.

> Removing the CI hard error is a deliberate relaxation: node reuse stays off on CI by default, but it can now be opted into.

### Drive-by: `1`/`0` is now accepted by the shell scripts

PowerShell's `[bool]` parameters only bind `$true`/`$false`/`1`/`0` — passing the *string* `true` or `false` throws a `ParameterBindingArgumentTransformationException`. The shell scripts, on the other hand, only understood `true`/`false`. That meant a caller driving both (like `repo-projects/Directory.Build.props`) had to pick a different value per OS.

`tools.sh` now normalizes `1`/`0` to `true`/`false` for the boolean build arguments — `-nodeReuse`, `-warnAsError` and `-msbuildMultiThreaded` — so `1`/`0` is the one form that works everywhere. Normalization happens on the variable rather than at the comparison, so values forwarded straight to MSBuild (`/nr:$node_reuse`, `/p:TreatWarningsAsErrors=$warn_as_error`) stay valid. Empty still means "not specified".

This is why the per-OS `ArcadeTrueBoolBuildArg` / `ArcadeFalseBoolBuildArg` properties could be removed.

> Note that this slightly changes existing behaviour: `--nodereuse 1` previously meant *off*.

### Validation

- All modified `.ps1` files parse cleanly; all modified `.sh` files pass `bash -n`.
- Sandboxed harnesses with a stubbed build tool captured the real command line produced by `tools.sh`, `eng/common/build.sh` and `eng/common/build.ps1`. `-mt` is suppressed by default both locally and on CI, and emitted for `-mt 1` in either case.
- Verified the full `-mt` matrix against the real `eng/common/build.ps1` parameter block and the real `tools.ps1` / `tools.sh` resolution lines: unset locally, unset on CI, `-mt 1`, `-mt 0`, `-ci -mt 1`, `-ci -mt 0` and the long-form `-msbuildMultiThreaded` all resolve identically on both platforms.
- `dotnet msbuild -getProperty:CommonArgs` on a repo project confirms no `-mt` by default, `-mt 1` with `DotNetBuildMT=true`, and `-mt 0` with `DotNetBuildMT=false`.
- `-mt` resolves to a `Boolean` parameter with the `mt` alias on all six PowerShell entry points, and `--mt 0` is accepted by the `roslyn`/`fsharp` shell scripts (which reject unknown arguments).
- Verified `1`/`0`, `true`/`false` and the unset case all resolve identically through `tools.sh`, and that `--mt 1` propagates as `/p:DotNetBuildMT=true`.
- Verified `dotnet msbuild -mt` is accepted by the MSBuild version in this repo (18.9).
- The same harnesses confirm the `-nodeReuse` matrix on both platforms: off by default on CI, on by default locally, `-ci -nodeReuse 1` yields `/nr:true`, and `-nodeReuse 1|0` propagates as `/p:DotNetBuildNodeReuse`. `dotnet msbuild -getProperty:CommonArgs` confirms `-nodeReuse 1|0` is only emitted when `DotNetBuildNodeReuse` is set.
- `MSBUILD_MT_ENABLED` and `MSBUILD_NODEREUSE_ENABLED` no longer appear anywhere in the repository.
- `msbuild`'s wrapper was replayed against the real Arcade parameter block with the exact command line that failed in CI: `-mt 1 -nodeReuse 1` now bind as booleans, `-mt 0` yields `False`, every `/p:` and `/clp:` argument survives (including one containing spaces) along with `NU1901;NU1902;NU1903`, exit codes propagate through both process hops, and a genuine parameter binding failure exits non-zero.

### Note

`-mt` requires MSBuild 18+. Repos built with `-msbuildEngine vs` (for example `aspnetcore` on Windows) fail with `MSB1001` on a VS 17.x install if `-mt` is passed. This isn't hit while the switch defaults to off, but it needs resolving before the default is flipped.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.
