### PR TITLE
Perform inner repo clean-up asynchronously

### DIFF
--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -836,16 +836,22 @@
       depend on this one don't wait for it. The artifacts dir is isolated to this repo and nothing
       else reads from it, and the deletion is best effort, so nothing needs to observe the result.
 
-      Redirecting all three standard streams is required, not cosmetic: Exec waits on the pipes it
-      hands out, so a detached process that inherits them keeps Exec blocked for the full delete.
+      Exec waits until the pipes it hands out are closed, not just until the process it started
+      exits, so the child must not end up holding a copy of them.
+
+      On Windows "start /B" is not enough: cmd passes the spawned process an inheritable copy of
+      those pipes, so Exec stays blocked for the whole delete even though start itself returns
+      immediately. Redirecting the streams doesn't change that. Start-Process goes through
+      ShellExecute, which doesn't inherit handles, so Exec is released right away.
+
+      On Unix redirecting to /dev/null is required, not cosmetic: without it the backgrounded
+      process inherits Exec's pipes and Exec blocks for the full delete.
     -->
     <PropertyGroup>
-      <RepoCleanLogFile>$(ArtifactsLogRepoDir)CleanupRepo.log</RepoCleanLogFile>
-      <RepoCleanCommand Condition="'$(BuildOS)' == 'windows'">start "" /B cmd /c rmdir "$(RepoArtifactsDir.TrimEnd('\'))" /s /q &gt; "$(RepoCleanLogFile)" 2&gt;&amp;1</RepoCleanCommand>
-      <RepoCleanCommand Condition="'$(BuildOS)' != 'windows'">nohup rm -rf "$(RepoArtifactsDir)" &gt; "$(RepoCleanLogFile)" 2&gt;&amp;1 &lt;/dev/null &amp;</RepoCleanCommand>
+      <RepoCleanCommand Condition="'$(BuildOS)' == 'windows'">powershell -NoProfile -Command "Start-Process cmd -ArgumentList '/c','rmdir /s /q \&quot;$(RepoArtifactsDir.TrimEnd('\'))\&quot;' -WindowStyle Hidden"</RepoCleanCommand>
+      <RepoCleanCommand Condition="'$(BuildOS)' != 'windows'">nohup rm -rf "$(RepoArtifactsDir)" &gt; /dev/null 2&gt;&amp;1 &lt;/dev/null &amp;</RepoCleanCommand>
     </PropertyGroup>
 
-    <MakeDir Directories="$(ArtifactsLogRepoDir)" />
     <Exec Command="$(RepoCleanCommand)" IgnoreExitCode="true" IgnoreStandardErrorWarningFormat="true" />
   </Target>
 

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -7,10 +7,6 @@
 
     <DiskUsageCommand Condition="'$(BuildOS)' == 'windows'">powershell -NoProfile "Get-PSDrive -PSProvider FileSystem -Name (Get-Item "$(RepoRoot.TrimEnd('\'))").PSDrive.Name"</DiskUsageCommand>
     <DiskUsageCommand Condition="'$(BuildOS)' != 'windows'">df -h $(RepoRoot)</DiskUsageCommand>
-    <BuildServerShutdownTimeoutInMilliseconds Condition="'$(BuildServerShutdownTimeoutInMilliseconds)' == ''">300000</BuildServerShutdownTimeoutInMilliseconds>
-    <BuildServerShutdownTimeoutInSeconds Condition="'$(BuildServerShutdownTimeoutInSeconds)' == ''">$([MSBuild]::Divide($(BuildServerShutdownTimeoutInMilliseconds), 1000))</BuildServerShutdownTimeoutInSeconds>
-    <BuildServerShutdownCommand Condition="'$(BuildOS)' == 'windows'">powershell -NoProfile -Command &quot;$p = Start-Process -FilePath '$(DotNetTool)' -ArgumentList '-d','build-server','shutdown','--vbcscompiler' -NoNewWindow -PassThru; if (-not $p.WaitForExit($(BuildServerShutdownTimeoutInMilliseconds))) { Write-Warning 'Build server shutdown timed out; terminating process.'; $p.Kill($true); exit 124 }; exit $p.ExitCode&quot;</BuildServerShutdownCommand>
-    <BuildServerShutdownCommand Condition="'$(BuildOS)' != 'windows'">&quot;$(DotNetTool)&quot; -d build-server shutdown --vbcscompiler &amp; _build_server_shutdown_pid=$!; (sleep $(BuildServerShutdownTimeoutInSeconds); kill $_build_server_shutdown_pid 2&gt;/dev/null) &amp; _build_server_shutdown_watchdog_pid=$!; wait $_build_server_shutdown_pid; _build_server_shutdown_exit_code=$?; kill $_build_server_shutdown_watchdog_pid 2&gt;/dev/null; exit $_build_server_shutdown_exit_code</BuildServerShutdownCommand>
 
     <!-- Force use of dotnet msbuild (ignoring global.json contents) unless ForceDotNetMSBuildEngine is explicitly set in the repo project. -->
     <CommonArgs Condition="'$(BuildOS)' == 'windows' and '$(ForceDotNetMSBuildEngine)' != 'false'">$(CommonArgs) $(FlagParameterPrefix)msbuildEngine dotnet</CommonArgs>
@@ -828,48 +824,29 @@
   </Target>
 
   <Target Name="CleanupRepo"
-          Inputs="$(MSBuildProjectFullPath)"
-          Outputs="$(BaseIntermediateOutputPath)CleanupRepo.complete"
           DependsOnTargets="BackupProjectAssetsJsonFiles"
           Condition="'$(IsUtilityProject)' != 'true' and
                      '$(CleanWhileBuilding)' == 'true' and
                      Exists('$(RepoArtifactsDir)')">
-    <!--
-      Some repositories (WinForms) use source generators that open files manually and keep file handles open on the compiler server (CsWin32).
-      These source generators are written incorrectly (a source generator should never do IO itself),
-      but the required features to read in binary files as input to a source generator don't exist.
-      To work around these source generators, shut down the compiler server so we can delete the obj directories.
-      Don't fail the build when shutdown returns a failure.
-
-      Don't run when source building to prevent the build from hanging indefinitely - https://github.com/dotnet/source-build/issues/4796
-    -->
-    <!-- Use an external timeout wrapper so timeout failures are absorbed by IgnoreExitCode instead of logged as MSBuild task errors. -->
-    <Exec Command="$(BuildServerShutdownCommand)"
-          Condition="'$(DotNetBuildSourceOnly)' != 'true'"
-          EnvironmentVariables="NUGET_PACKAGES=$(RepoArtifactsPackageCache)"
-          ContinueOnError="WarnAndContinue"
-          IgnoreStandardErrorWarningFormat="true"
-          IgnoreExitCode="true" />
-
     <Message Text="DirSize After Building $(RepositoryName)" Importance="High" />
     <Exec Command="$(DiskUsageCommand)" />
 
-    <!-- Cleanup the entire repo artifacts dir. Ignore failures as this is best effort.
-         Don't use Removedir as ContinueOnError on it doesn't work when using warnaserror/TreatWarningsAsErrors. -->
+    <!--
+      Delete the entire repo artifacts dir in a detached background process so that repos which
+      depend on this one don't wait for it. The artifacts dir is isolated to this repo and nothing
+      else reads from it, and the deletion is best effort, so nothing needs to observe the result.
+
+      Redirecting all three standard streams is required, not cosmetic: Exec waits on the pipes it
+      hands out, so a detached process that inherits them keeps Exec blocked for the full delete.
+    -->
     <PropertyGroup>
-      <RepoCleanCommand Condition="'$(BuildOS)' == 'windows'">rmdir "$(RepoArtifactsDir.TrimEnd('\'))" /s /q</RepoCleanCommand>
-      <RepoCleanCommand Condition="'$(BuildOS)' != 'windows'">rm -rf "$(RepoArtifactsDir)"</RepoCleanCommand>
+      <RepoCleanLogFile>$(ArtifactsLogRepoDir)CleanupRepo.log</RepoCleanLogFile>
+      <RepoCleanCommand Condition="'$(BuildOS)' == 'windows'">start "" /B cmd /c rmdir "$(RepoArtifactsDir.TrimEnd('\'))" /s /q &gt; "$(RepoCleanLogFile)" 2&gt;&amp;1</RepoCleanCommand>
+      <RepoCleanCommand Condition="'$(BuildOS)' != 'windows'">nohup rm -rf "$(RepoArtifactsDir)" &gt; "$(RepoCleanLogFile)" 2&gt;&amp;1 &lt;/dev/null &amp;</RepoCleanCommand>
     </PropertyGroup>
 
+    <MakeDir Directories="$(ArtifactsLogRepoDir)" />
     <Exec Command="$(RepoCleanCommand)" IgnoreExitCode="true" IgnoreStandardErrorWarningFormat="true" />
-
-    <Message Text="DirSize After CleanupRepo $(RepositoryName)" Importance="High" />
-    <Exec Command="$(DiskUsageCommand)" />
-
-    <MakeDir Directories="$(BaseIntermediateOutputPath)" />
-    <Touch Files="$(BaseIntermediateOutputPath)CleanupRepo.complete" AlwaysCreate="true">
-      <Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
-    </Touch>
   </Target>
 
   <PropertyGroup>


### PR DESCRIPTION
Fixes #8167.

`CleanupRepo` deleted the repo's artifacts dir synchronously as part of the repo wrapper project's build, so every dependent repo waited for that deletion before it could start building. The artifacts dir is isolated to the repo that produced it and nothing else reads from it, so there's no reason for the P2P protocol to wait on it.

It's now spawned as a detached background process.

### Why detaching is subtle

`Exec` doesn't just wait on the process it launches, it waits until the **stdout/stderr pipes it handed out are closed**. Any child that ends up holding a copy of those pipes keeps `Exec` blocked for the full deletion.

On Windows `start /B` doesn't achieve this: `cmd` gives the spawned process an inheritable copy of those pipes, so `Exec` waits for the whole delete even though `start` itself returns in ~30 ms. Redirecting the streams doesn't change that. `Start-Process` goes through `ShellExecute`, which doesn't inherit handles, so `Exec` is released immediately.

On Unix `nohup ... &` does detach, but only if the streams are redirected — `</dev/null` and `>/dev/null` are load-bearing rather than cosmetic.

Measured by timing a complete MSBuild invocation against an 8s command:

| | Windows | Unix |
| --- | --- | --- |
| synchronous | 9488 ms | 8257 ms |
| `start /B`, redirected to a file | 9587 ms | – |
| `start /B`, redirected to `NUL` | 9565 ms | – |
| backgrounded, no redirection | – | 8203 ms |
| backgrounded, redirected to `/dev/null` | – | **126 ms** |
| `Start-Process -WindowStyle Hidden` | **2006 ms** | – |

The Windows figure is dominated by `powershell` start-up. Each case was also checked against a real directory to confirm the deletion actually ran to completion rather than being silently dropped.

### No clean-up log

Nothing consumes the output and the deletion is best effort, so both platforms redirect to the null device and no `CleanupRepo.log` is produced or published. On Unix such a log would always be empty regardless: POSIX unlinks directory entries even when handles are open, so `rm -rf` doesn't fail on locked files.

### Also removed

| Removed | Why |
| --- | --- |
| The build server shutdown | Only needed back when a failed clean operation failed the build. Also makes the source-build hang workaround for dotnet/source-build#4796 unnecessary, and drops the two `BuildServerShutdownTimeout*` properties, which had no other consumers. |
| `Inputs`/`Outputs`/`MakeDir`/`Touch` | The target's existing `Exists('$(RepoArtifactsDir)')` condition already expresses whether cleanup is needed, and more truthfully than a stamp written before the detached deletion completes. Nothing else read `CleanupRepo.complete`. |
| `DirSize After CleanupRepo` | With the deletion running in the background this races the other repos and no longer measures anything. `DirSize Before Building` and `DirSize After Building` are unchanged and still go to the console. |

### Behaviour changes worth knowing

- **Deletion failures are no longer observable.** Since the build server is no longer shut down first, a held file handle on Windows makes `rmdir` skip that file and its whole parent chain, so some space silently isn't reclaimed. The build still succeeds and nothing reports it.
- **Cancelling the build doesn't cancel the deletion.** The detached process has no console attachment, and POSIX has `&` ignore `SIGINT` in non-interactive shells, so the deletion runs to completion either way. This is benign — the space still gets freed and the artifacts are garbage after a cancel — but restarting a build immediately after cancelling can race an in-flight deletion. `CleanWhileBuilding` is opt-in (`--clean-while-building`) and predominantly used in CI, where cancellation kills the agent anyway.
- **There is no backpressure.** Several repos can now be deleting concurrently, so peak disk usage is slightly higher than before. The deletion still *starts* at the same point, it just no longer blocks dependents, so space is reclaimed while subsequent repos build rather than before they start.

### Validation

- `dotnet msbuild repo-projects\roslyn.proj -getProperty:RepoArtifactsDir` evaluates cleanly.
- No remaining references to `BuildServerShutdown*` or `CleanupRepo.complete` outside `src/`.
- Verified on both platforms that `Exec` returns immediately, that the deletion completes afterwards, and that the detached process outlives its parent shell.
- Verified the spawn creates no new console window (`conhost` and windowed-process counts unchanged) and no `Terminate batch job (Y/N)?` prompt — the detached command is `cmd /c rmdir`, an internal command rather than a batch file.
- Verified the Windows command against a path containing spaces.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.


