### PR TITLE
Disable CodeQL in reproducibility tests

### DIFF
--- a/eng/pipelines/unified-build-reproducibility-tests.yml
+++ b/eng/pipelines/unified-build-reproducibility-tests.yml
@@ -63,7 +63,6 @@ extends:
         compiled:
           # Compiler instrumentation changes generated source paths, invalidating byte-for-byte comparisons.
           enabled: false
-        runSourceLanguagesInSourceAnalysis: false
 
     containers:
       ${{ variables.centOSStreamContainerName }}:

--- a/eng/pipelines/unified-build-reproducibility-tests.yml
+++ b/eng/pipelines/unified-build-reproducibility-tests.yml
@@ -59,6 +59,11 @@ extends:
           name: $(DncEngInternalBuildPool)
           image: 1es-windows-2022
           os: windows
+      codeql:
+        compiled:
+          # Compiler instrumentation changes generated source paths, invalidating byte-for-byte comparisons.
+          enabled: false
+        runSourceLanguagesInSourceAnalysis: false
 
     containers:
       ${{ variables.centOSStreamContainerName }}:


### PR DESCRIPTION
CodeQL compiler instrumentation changes generated-source paths and can make otherwise equivalent unified builds produce different binaries, invalidating byte-for-byte reproducibility comparisons.

Disable compiled CodeQL instrumentation for this pipeline using the established 1ES SDL setting. Other SDL tooling remains enabled.