### PR TITLE
Fix MSB4006 circular dependency in source-only publish pass 2

### DIFF
--- a/eng/PublishSourceBuild.props
+++ b/eng/PublishSourceBuild.props
@@ -163,9 +163,11 @@
           DestinationFolder="$(ArtifactsAssetsDir)"
           SkipUnchangedFiles="true" />
 
+    <!-- Run a second publish pass. This target also runs during that pass, so the recursion must be
+         guarded by IsPublishPass2 to avoid re-entering the same project configuration (MSB4006). -->
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="Execute"
-             Condition="'$(DotNetSourceOnlyPublishArtifacts)' == 'true'"
+             Condition="'$(DotNetSourceOnlyPublishArtifacts)' == 'true' and '$(IsPublishPass2)' != 'true'"
              Properties="@(_PublishProps);IsPublishPass2=true;AssetManifestFileName=$(SYSTEM_PHASENAME).xml" />
   </Target>
 


### PR DESCRIPTION
Fixes #8275

## Problem

All six `SB_*_Offline_MsftSdk` legs in the **VMR Source-Only Build** stage fail with an identical error ([build 3046380](https://dev.azure.com/dnceng/internal/_build/results?buildId=3046380)):

```
eng/PublishSourceBuild.props(166,5): error MSB4006: There is a circular dependency in the
target dependency graph involving target "CreatePrivateSourceBuiltArtifactsArchive".
[.packages/BootstrapPackages/microsoft.dotnet.arcade.sdk/11.0.0-beta.26381.103/toolset/Publish.proj]
```

| Failing leg | Failing step |
|---|---|
| SB_Ubuntu2404_Offline_MsftSdk_x64 | Build (ubuntuContainer) |
| SB_Ubuntu2404Arm64_Offline_MsftSdk_arm64 | Build (ubuntuArmContainer) |
| SB_CentOSStream10_Offline_MsftSdk_x64 | Build (centOSStreamContainer) |
| SB_AlmaLinux8_Offline_MsftSdk_x64 | Build (almaLinuxContainer) |
| SB_Fedora43_Offline_MsftSdk_x64 | Build (fedoraContainer) |
| SB_Alpine323_Offline_MsftSdk_x64 | Build (alpineContainer) |

## Root cause

`CreatePrivateSourceBuiltArtifactsArchive` runs `AfterTargets="Execute"` and ends by re-invoking its own project (`Publish.proj`) with `Targets="Execute"` to perform a second publish pass. The recursive call was guarded only by `DotNetSourceOnlyPublishArtifacts`, not by `IsPublishPass2`. So during pass 2 the target ran again and issued the same MSBuild request for the same project configuration with the same global properties, re-entering a configuration whose `Execute` was still in flight.

The scope matches exactly: only `*_Offline_MsftSdk` legs get `/p:DotNetSourceOnlyPublishArtifacts=true` (`eng/pipelines/templates/stages/source-build-and-validate.yml`). Online / `PreviousSourceBuiltSdk` / `CurrentSourceBuiltSdk` legs passed.

This is a latent bug that older MSBuild tolerated by silently returning a cached result. It surfaced with the toolset bump in ad791f31c2e (".NET 11.0.100-preview.7.26381.103 August 2026 Updates"), which moved the bootstrap Arcade SDK `11.0.0-beta.26359.118` to `11.0.0-beta.26381.103`. Regression window is a2c79539 (all SB legs green, build 3045766) to e1bc8c31.

## Fix

Guard the recursion with `IsPublishPass2` so pass 2 does not spawn a third pass. The target still executes during pass 2 to repackage the tarball with the leg-named asset manifest (`SB_<leg>.xml`), preserving existing behavior.

## Validation

Reproduced the target structure (`AfterTargets="Execute"` plus self-invocation) in a minimal project:

| Scenario | Before | After |
|---|---|---|
| `DotNetSourceOnlyPublishArtifacts=true` | pass 1, pass 2, then re-entrant pass 2 request | pass 1, pass 2, stops |
| flag unset (Online / `*SourceBuiltSdk` legs) | 1 pass | 1 pass (unchanged) |

## Note for reviewers

The target originally carried its own `Condition="'$(IsPublishPass2)' != 'true'"` (added in #1355). It was dropped, apparently incidentally, in 5d686aaded1 (#1983, "Include shared component packages in SB artifacts"), which only intended to refactor `DependsOnTargets`.

Restoring that target-level guard is the alternative fix and would additionally skip the redundant second tarball repackage (~30s per leg). I chose the narrower fix because the last-known-good build (3045766) did package twice, so guarding only the recursion preserves that behavior exactly. Happy to switch to the target-level guard if that redundant work is not intentional.