### PR TITLE
Build IdentityModel against Cryptography source-build reference package

### DIFF
--- a/src/source-build-assets/eng/Version.Details.props
+++ b/src/source-build-assets/eng/Version.Details.props
@@ -6,7 +6,6 @@ This file should be imported by eng/Versions.props
 <Project>
   <PropertyGroup>
     <!-- dotnet-dotnet dependencies -->
-    <MicrosoftBclCryptographyPackageVersion>10.0.12</MicrosoftBclCryptographyPackageVersion>
     <MicrosoftBuildPackageVersion>18.0.11</MicrosoftBuildPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>18.0.11</MicrosoftBuildUtilitiesCorePackageVersion>
     <MicrosoftDotNetArcadeSdkPackageVersion>10.0.0-beta.26403.103</MicrosoftDotNetArcadeSdkPackageVersion>
@@ -17,7 +16,6 @@ This file should be imported by eng/Versions.props
   <!--Property group for alternate package version names-->
   <PropertyGroup>
     <!-- dotnet-dotnet dependencies -->
-    <MicrosoftBclCryptographyVersion>$(MicrosoftBclCryptographyPackageVersion)</MicrosoftBclCryptographyVersion>
     <MicrosoftBuildVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildVersion>
     <MicrosoftBuildUtilitiesCoreVersion>$(MicrosoftBuildUtilitiesCorePackageVersion)</MicrosoftBuildUtilitiesCoreVersion>
     <MicrosoftDotNetArcadeSdkVersion>$(MicrosoftDotNetArcadeSdkPackageVersion)</MicrosoftDotNetArcadeSdkVersion>

--- a/src/source-build-assets/eng/Version.Details.xml
+++ b/src/source-build-assets/eng/Version.Details.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <Source Uri="https://github.com/dotnet/dotnet" Mapping="source-build-assets" Sha="fa946937d18098cdb873c8d1bfdaa91c49e11c8d" BarId="325432" />
-  <ProductDependencies>
-    <Dependency Name="Microsoft.Bcl.Cryptography" Version="10.0.12">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>fa946937d18098cdb873c8d1bfdaa91c49e11c8d</Sha>
-    </Dependency>
-  </ProductDependencies>
+  <ProductDependencies />
   <ToolsetDependencies>
     <Dependency Name="Microsoft.Build" Version="18.0.11">
       <Uri>https://github.com/dotnet/dotnet</Uri>

--- a/src/source-build-assets/eng/Versions.props
+++ b/src/source-build-assets/eng/Versions.props
@@ -11,6 +11,7 @@
   <!-- External package versions -->
   <PropertyGroup>
     <AzureActiveDirectoryIdentityModelExtensionsForDotNetReleaseVersion>8.19.2</AzureActiveDirectoryIdentityModelExtensionsForDotNetReleaseVersion>
+    <IdentityModelMicrosoftBclCryptographyVersion>10.0.10</IdentityModelMicrosoftBclCryptographyVersion>
     <CssParserReleaseVersionSuffix>20230414.1</CssParserReleaseVersionSuffix>
     <HumanizerReleaseVersion>2.14.1</HumanizerReleaseVersion>
     <MSBuildLocatorReleaseVersion>1.10.2</MSBuildLocatorReleaseVersion>

--- a/src/source-build-assets/src/externalPackages/projects/azure-activedirectory-identitymodel-extensions-for-dotnet.proj
+++ b/src/source-build-assets/src/externalPackages/projects/azure-activedirectory-identitymodel-extensions-for-dotnet.proj
@@ -5,10 +5,21 @@
     <CustomRepoBuild>true</CustomRepoBuild>
   </PropertyGroup>
 
-  <Target Name="AddPreviouslySourceBuiltPackageSource" AfterTargets="CreateNuGetConfig">
+  <Target Name="ConfigureMicrosoftBclCryptographyPackageSource" AfterTargets="CreateNuGetConfig">
+    <!-- Standalone builds get Microsoft.Bcl.Cryptography from the dependency-flow feed. -->
+    <Copy SourceFiles="$(RepoRoot)NuGet.config"
+          DestinationFiles="$(NuGetConfigFile)"
+          Condition="'$(PreviouslySourceBuiltNupkgCacheDir)' == ''" />
+
     <AddSourceToNuGetConfig NuGetConfigFile="$(NuGetConfigFile)"
                             SourceName="Previously source-built"
-                            SourcePath="$(PreviouslySourceBuiltNupkgCacheDir)" />
+                            SourcePath="$(PreviouslySourceBuiltNupkgCacheDir)"
+                            Condition="'$(PreviouslySourceBuiltNupkgCacheDir)' != ''" />
+
+    <AddSourceToNuGetConfig NuGetConfigFile="$(NuGetConfigFile)"
+                            SourceName="SBA"
+                            SourcePath="$(ArtifactsPackagesDir)"
+                            Condition="'$(PreviouslySourceBuiltNupkgCacheDir)' == ''" />
   </Target>
 
   <Target Name="CustomRepoBuild">

--- a/src/source-build-assets/src/externalPackages/projects/azure-activedirectory-identitymodel-extensions-for-dotnet.proj
+++ b/src/source-build-assets/src/externalPackages/projects/azure-activedirectory-identitymodel-extensions-for-dotnet.proj
@@ -5,23 +5,6 @@
     <CustomRepoBuild>true</CustomRepoBuild>
   </PropertyGroup>
 
-  <Target Name="ConfigureMicrosoftBclCryptographyPackageSource" AfterTargets="CreateNuGetConfig">
-    <!-- Standalone builds get Microsoft.Bcl.Cryptography from the dependency-flow feed. -->
-    <Copy SourceFiles="$(RepoRoot)NuGet.config"
-          DestinationFiles="$(NuGetConfigFile)"
-          Condition="'$(PreviouslySourceBuiltNupkgCacheDir)' == ''" />
-
-    <AddSourceToNuGetConfig NuGetConfigFile="$(NuGetConfigFile)"
-                            SourceName="Previously source-built"
-                            SourcePath="$(PreviouslySourceBuiltNupkgCacheDir)"
-                            Condition="'$(PreviouslySourceBuiltNupkgCacheDir)' != ''" />
-
-    <AddSourceToNuGetConfig NuGetConfigFile="$(NuGetConfigFile)"
-                            SourceName="SBA"
-                            SourcePath="$(ArtifactsPackagesDir)"
-                            Condition="'$(PreviouslySourceBuiltNupkgCacheDir)' == ''" />
-  </Target>
-
   <Target Name="CustomRepoBuild">
     <PropertyGroup>
       <SystemIdentityModelTokensJwtProject>$(ProjectDirectory)src/System.IdentityModel.Tokens.Jwt/System.IdentityModel.Tokens.Jwt.csproj</SystemIdentityModelTokensJwtProject>
@@ -34,7 +17,7 @@
       <BuildCommandArgs>$(BuildCommandArgs) /v:$(LogVerbosity)</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) $(RedirectRepoOutputToLog)</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) /p:Version=$(AzureActiveDirectoryIdentityModelExtensionsForDotNetReleaseVersion)</BuildCommandArgs>
-      <BuildCommandArgs>$(BuildCommandArgs) /p:MicrosoftBclCryptographyVersion=$(MicrosoftBclCryptographyVersion)</BuildCommandArgs>
+      <BuildCommandArgs>$(BuildCommandArgs) /p:MicrosoftBclCryptographyVersion=$(IdentityModelMicrosoftBclCryptographyVersion)</BuildCommandArgs>
       <BuildCommandArgs>$(BuildCommandArgs) /p:IsAotCompatible=false /p:IsTrimmable=false</BuildCommandArgs>
 
       <PackCommandArgs>$(BuildCommandArgs) --output $(ProjectDirectory)pack</PackCommandArgs>

--- a/src/source-build-assets/src/referencePackages/Directory.Build.targets
+++ b/src/source-build-assets/src/referencePackages/Directory.Build.targets
@@ -50,7 +50,7 @@
   <Import Project="$(CustomizationsPropsPath)" Condition="Exists('$(CustomizationsPropsPath)')" />
 
   <!-- Keep in sync with available targeting packs under src/targetPacks/ILsrc. -->
-  <ItemGroup>
+  <ItemGroup Condition="'$(UseLocalTargetingPack)' != 'false'">
     <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.NETCore.App'))">
       <TargetingPackVersion Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('%(TargetFramework)', '^net\d+\.0$'))">$([System.Text.RegularExpressions.Regex]::Match('%(TargetFramework)', '\d+').Value).0.0</TargetingPackVersion>
     </KnownFrameworkReference>
@@ -107,7 +107,9 @@
   </Target>
 
   <!-- Use local targeting packs -->
-  <Target Name="UseLocalTargetingPack" AfterTargets="ResolveFrameworkReferences">
+  <Target Name="UseLocalTargetingPack"
+          AfterTargets="ResolveFrameworkReferences"
+          Condition="'$(UseLocalTargetingPack)' != 'false'">
     <ItemGroup>
       <ResolvedTargetingPack Path="$(ArtifactsBinDir)%(ResolvedTargetingPack.NuGetPackageId).%(ResolvedTargetingPack.NuGetPackageVersion)\pack"
                              PackageDirectory="$(ArtifactsBinDir)%(ResolvedTargetingPack.NuGetPackageId).%(ResolvedTargetingPack.NuGetPackageVersion)\pack" />

--- a/src/source-build-assets/src/referencePackages/src/microsoft.bcl.cryptography/10.0.10/Microsoft.Bcl.Cryptography.10.0.10.csproj
+++ b/src/source-build-assets/src/referencePackages/src/microsoft.bcl.cryptography/10.0.10/Microsoft.Bcl.Cryptography.10.0.10.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>Microsoft.Bcl.Cryptography</PackageId>
+    <TargetFrameworks>net10.0;net8.0;net9.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <PackageVersion>10.0.10</PackageVersion>
+    <AssemblyName>Microsoft.Bcl.Cryptography</AssemblyName>
+    <StrongNameKeyId>Open</StrongNameKeyId>
+    <Description>Provides support for some cryptographic primitives for .NET Framework and .NET Standard.</Description>
+    <PackageProjectUrl>https://dot.net/</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</PackageReleaseNotes>
+    <!-- release/10.0 does not carry the net10.0 source-built targeting pack. -->
+    <UseLocalTargetingPack Condition="'$(TargetFramework)' == 'net10.0'">false</UseLocalTargetingPack>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <ProjectReference Include="../../system.formats.asn1/10.0.10/System.Formats.Asn1.10.0.10.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <ProjectReference Include="../../system.formats.asn1/10.0.10/System.Formats.Asn1.10.0.10.csproj" />
+    <ProjectReference Include="../../system.memory/4.6.3/System.Memory.4.6.3.csproj" />
+    <ProjectReference Include="../../system.runtime.compilerservices.unsafe/6.1.2/System.Runtime.CompilerServices.Unsafe.6.1.2.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <ProjectReference Include="../../system.formats.asn1/10.0.10/System.Formats.Asn1.10.0.10.csproj" />
+    <ProjectReference Include="../../system.runtime.compilerservices.unsafe/6.1.2/System.Runtime.CompilerServices.Unsafe.6.1.2.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/source-build-assets/src/referencePackages/src/microsoft.bcl.cryptography/10.0.10/lib/net10.0/Microsoft.Bcl.Cryptography.cs
+++ b/src/source-build-assets/src/referencePackages/src/microsoft.bcl.cryptography/10.0.10/lib/net10.0/Microsoft.Bcl.Cryptography.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v10.0", FrameworkDisplayName = ".NET 10.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("Microsoft.Bcl.Cryptography")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("IsAotCompatible", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides support for some cryptographic primitives for .NET Framework and .NET Standard.")]
+[assembly: System.Reflection.AssemblyFileVersion("10.0.1026.32716")]
+[assembly: System.Reflection.AssemblyInformationalVersion("10.0.10+f7d90799ce4ef09a0bb257852a57248d2a8fb8dd")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("Microsoft.Bcl.Cryptography")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/dotnet")]
+[assembly: System.Reflection.AssemblyVersionAttribute("10.0.0.10")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.AesGcm))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.AuthenticationTagMismatchException))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.CompositeMLDsa))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.CompositeMLDsaAlgorithm))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.CompositeMLDsaCng))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.MLDsa))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.MLDsaAlgorithm))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.MLDsaCng))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.MLKem))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.MLKemAlgorithm))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.MLKemCng))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.PbeEncryptionAlgorithm))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.PbeParameters))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.SlhDsa))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.SlhDsaAlgorithm))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.SlhDsaCng))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.SP800108HmacCounterKdf))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.X509Certificates.Pkcs12LoaderLimits))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.X509Certificates.Pkcs12LoadLimitExceededException))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.X509Certificates.X509CertificateLoader))]
+namespace System.Security.Cryptography.X509Certificates
+{
+    public static partial class X509CertificateKeyAccessors
+    {
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static X509Certificate2 CopyWithPrivateKey(this X509Certificate2 certificate, CompositeMLDsa privateKey) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static X509Certificate2 CopyWithPrivateKey(this X509Certificate2 certificate, MLDsa privateKey) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static X509Certificate2 CopyWithPrivateKey(this X509Certificate2 certificate, MLKem privateKey) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static X509Certificate2 CopyWithPrivateKey(this X509Certificate2 certificate, SlhDsa privateKey) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static CompositeMLDsa? GetCompositeMLDsaPrivateKey(this X509Certificate2 certificate) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static CompositeMLDsa? GetCompositeMLDsaPublicKey(this X509Certificate2 certificate) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa? GetMLDsaPrivateKey(this X509Certificate2 certificate) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa? GetMLDsaPublicKey(this X509Certificate2 certificate) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem? GetMLKemPrivateKey(this X509Certificate2 certificate) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem? GetMLKemPublicKey(this X509Certificate2 certificate) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static SlhDsa? GetSlhDsaPrivateKey(this X509Certificate2 certificate) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static SlhDsa? GetSlhDsaPublicKey(this X509Certificate2 certificate) { throw null; }
+    }
+}

--- a/src/source-build-assets/src/referencePackages/src/microsoft.bcl.cryptography/10.0.10/lib/net8.0/Microsoft.Bcl.Cryptography.cs
+++ b/src/source-build-assets/src/referencePackages/src/microsoft.bcl.cryptography/10.0.10/lib/net8.0/Microsoft.Bcl.Cryptography.cs
@@ -1,0 +1,594 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName = ".NET 8.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("Microsoft.Bcl.Cryptography")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("IsAotCompatible", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides support for some cryptographic primitives for .NET Framework and .NET Standard.")]
+[assembly: System.Reflection.AssemblyFileVersion("10.0.1026.32716")]
+[assembly: System.Reflection.AssemblyInformationalVersion("10.0.10+f7d90799ce4ef09a0bb257852a57248d2a8fb8dd")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("Microsoft.Bcl.Cryptography")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/dotnet")]
+[assembly: System.Reflection.AssemblyVersionAttribute("10.0.0.10")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.AesGcm))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.AuthenticationTagMismatchException))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.PbeEncryptionAlgorithm))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.PbeParameters))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.SP800108HmacCounterKdf))]
+namespace System.Security.Cryptography
+{
+    [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+    public abstract partial class CompositeMLDsa : IDisposable
+    {
+        protected CompositeMLDsa(CompositeMLDsaAlgorithm algorithm) { }
+        public CompositeMLDsaAlgorithm Algorithm { get { throw null; } }
+        public static bool IsSupported { get { throw null; } }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public byte[] ExportCompositeMLDsaPrivateKey() { throw null; }
+        public int ExportCompositeMLDsaPrivateKey(Span<byte> destination) { throw null; }
+        protected abstract int ExportCompositeMLDsaPrivateKeyCore(Span<byte> destination);
+        public byte[] ExportCompositeMLDsaPublicKey() { throw null; }
+        public int ExportCompositeMLDsaPublicKey(Span<byte> destination) { throw null; }
+        protected abstract int ExportCompositeMLDsaPublicKeyCore(Span<byte> destination);
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(string password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportPkcs8PrivateKey() { throw null; }
+        public string ExportPkcs8PrivateKeyPem() { throw null; }
+        public byte[] ExportSubjectPublicKeyInfo() { throw null; }
+        public string ExportSubjectPublicKeyInfoPem() { throw null; }
+        public static CompositeMLDsa GenerateKey(CompositeMLDsaAlgorithm algorithm) { throw null; }
+        public static CompositeMLDsa ImportCompositeMLDsaPrivateKey(CompositeMLDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static CompositeMLDsa ImportCompositeMLDsaPrivateKey(CompositeMLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static CompositeMLDsa ImportCompositeMLDsaPublicKey(CompositeMLDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static CompositeMLDsa ImportCompositeMLDsaPublicKey(CompositeMLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static CompositeMLDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, ReadOnlySpan<byte> source) { throw null; }
+        public static CompositeMLDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, ReadOnlySpan<byte> source) { throw null; }
+        public static CompositeMLDsa ImportEncryptedPkcs8PrivateKey(string password, byte[] source) { throw null; }
+        public static CompositeMLDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<byte> passwordBytes) { throw null; }
+        public static CompositeMLDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<char> password) { throw null; }
+        public static CompositeMLDsa ImportFromEncryptedPem(string source, byte[] passwordBytes) { throw null; }
+        public static CompositeMLDsa ImportFromEncryptedPem(string source, string password) { throw null; }
+        public static CompositeMLDsa ImportFromPem(ReadOnlySpan<char> source) { throw null; }
+        public static CompositeMLDsa ImportFromPem(string source) { throw null; }
+        public static CompositeMLDsa ImportPkcs8PrivateKey(byte[] source) { throw null; }
+        public static CompositeMLDsa ImportPkcs8PrivateKey(ReadOnlySpan<byte> source) { throw null; }
+        public static CompositeMLDsa ImportSubjectPublicKeyInfo(byte[] source) { throw null; }
+        public static CompositeMLDsa ImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source) { throw null; }
+        public static bool IsAlgorithmSupported(CompositeMLDsaAlgorithm algorithm) { throw null; }
+        public byte[] SignData(byte[] data, byte[]? context = null) { throw null; }
+        public int SignData(ReadOnlySpan<byte> data, Span<byte> destination, ReadOnlySpan<byte> context = default) { throw null; }
+        protected abstract int SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination);
+        public bool TryExportCompositeMLDsaPrivateKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportCompositeMLDsaPublicKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        protected abstract bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten);
+        public bool TryExportSubjectPublicKeyInfo(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool VerifyData(byte[] data, byte[] signature, byte[]? context = null) { throw null; }
+        public bool VerifyData(ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, ReadOnlySpan<byte> context = default) { throw null; }
+        protected abstract bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature);
+    }
+
+    [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+    public sealed partial class CompositeMLDsaAlgorithm : IEquatable<CompositeMLDsaAlgorithm>
+    {
+        internal CompositeMLDsaAlgorithm() { }
+        public int MaxSignatureSizeInBytes { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa44WithECDsaP256 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa44WithEd25519 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa44WithRSA2048Pkcs15 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa44WithRSA2048Pss { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithECDsaBrainpoolP256r1 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithECDsaP256 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithECDsaP384 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithEd25519 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithRSA3072Pkcs15 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithRSA3072Pss { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithRSA4096Pkcs15 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithRSA4096Pss { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithECDsaBrainpoolP384r1 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithECDsaP384 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithECDsaP521 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithEd448 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithRSA3072Pss { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithRSA4096Pss { get { throw null; } }
+        public string Name { get { throw null; } }
+        public override bool Equals(object? obj) { throw null; }
+        public bool Equals(CompositeMLDsaAlgorithm? other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(CompositeMLDsaAlgorithm? left, CompositeMLDsaAlgorithm? right) { throw null; }
+        public static bool operator !=(CompositeMLDsaAlgorithm? left, CompositeMLDsaAlgorithm? right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+
+    [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+    public sealed partial class CompositeMLDsaCng : CompositeMLDsa
+    {
+        [Runtime.Versioning.SupportedOSPlatform("windows")]
+        public CompositeMLDsaCng(CngKey key) : base(default!) { }
+        protected override int ExportCompositeMLDsaPrivateKeyCore(Span<byte> destination) { throw null; }
+        protected override int ExportCompositeMLDsaPublicKeyCore(Span<byte> destination) { throw null; }
+        public CngKey GetKey() { throw null; }
+        protected override int SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination) { throw null; }
+        protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten) { throw null; }
+        protected override bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature) { throw null; }
+    }
+
+    public abstract partial class MLDsa : IDisposable
+    {
+        protected MLDsa(MLDsaAlgorithm algorithm) { }
+        public MLDsaAlgorithm Algorithm { get { throw null; } }
+        public static bool IsSupported { get { throw null; } }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] ExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public string ExportEncryptedPkcs8PrivateKeyPem(string password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportMLDsaPrivateKey() { throw null; }
+        public void ExportMLDsaPrivateKey(Span<byte> destination) { }
+        protected abstract void ExportMLDsaPrivateKeyCore(Span<byte> destination);
+        public byte[] ExportMLDsaPrivateSeed() { throw null; }
+        public void ExportMLDsaPrivateSeed(Span<byte> destination) { }
+        protected abstract void ExportMLDsaPrivateSeedCore(Span<byte> destination);
+        public byte[] ExportMLDsaPublicKey() { throw null; }
+        public void ExportMLDsaPublicKey(Span<byte> destination) { }
+        protected abstract void ExportMLDsaPublicKeyCore(Span<byte> destination);
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] ExportPkcs8PrivateKey() { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public string ExportPkcs8PrivateKeyPem() { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] ExportSubjectPublicKeyInfo() { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public string ExportSubjectPublicKeyInfoPem() { throw null; }
+        public static MLDsa GenerateKey(MLDsaAlgorithm algorithm) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, ReadOnlySpan<byte> source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, ReadOnlySpan<byte> source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportEncryptedPkcs8PrivateKey(string password, byte[] source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<byte> passwordBytes) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<char> password) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportFromEncryptedPem(string source, byte[] passwordBytes) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportFromEncryptedPem(string source, string password) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportFromPem(ReadOnlySpan<char> source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportFromPem(string source) { throw null; }
+        public static MLDsa ImportMLDsaPrivateKey(MLDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLDsa ImportMLDsaPrivateKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static MLDsa ImportMLDsaPrivateSeed(MLDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLDsa ImportMLDsaPrivateSeed(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static MLDsa ImportMLDsaPublicKey(MLDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLDsa ImportMLDsaPublicKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportPkcs8PrivateKey(byte[] source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportPkcs8PrivateKey(ReadOnlySpan<byte> source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportSubjectPublicKeyInfo(byte[] source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source) { throw null; }
+        public byte[] SignData(byte[] data, byte[]? context = null) { throw null; }
+        public void SignData(ReadOnlySpan<byte> data, Span<byte> destination, ReadOnlySpan<byte> context = default) { }
+        protected abstract void SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination);
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] SignMu(byte[] externalMu) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public void SignMu(ReadOnlySpan<byte> externalMu, Span<byte> destination) { }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] SignMu(ReadOnlySpan<byte> externalMu) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        protected abstract void SignMuCore(ReadOnlySpan<byte> externalMu, Span<byte> destination);
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] SignPreHash(byte[] hash, string hashAlgorithmOid, byte[]? context = null) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public void SignPreHash(ReadOnlySpan<byte> hash, Span<byte> destination, string hashAlgorithmOid, ReadOnlySpan<byte> context = default) { }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        protected abstract void SignPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, Span<byte> destination);
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool TryExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        protected abstract bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten);
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool TryExportSubjectPublicKeyInfo(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool VerifyData(byte[] data, byte[] signature, byte[]? context = null) { throw null; }
+        public bool VerifyData(ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, ReadOnlySpan<byte> context = default) { throw null; }
+        protected abstract bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature);
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool VerifyMu(byte[] externalMu, byte[] signature) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool VerifyMu(ReadOnlySpan<byte> externalMu, ReadOnlySpan<byte> signature) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        protected abstract bool VerifyMuCore(ReadOnlySpan<byte> externalMu, ReadOnlySpan<byte> signature);
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool VerifyPreHash(byte[] hash, byte[] signature, string hashAlgorithmOid, byte[]? context = null) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool VerifyPreHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature, string hashAlgorithmOid, ReadOnlySpan<byte> context = default) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        protected abstract bool VerifyPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, ReadOnlySpan<byte> signature);
+    }
+
+    public sealed partial class MLDsaAlgorithm : IEquatable<MLDsaAlgorithm>
+    {
+        internal MLDsaAlgorithm() { }
+        public static MLDsaAlgorithm MLDsa44 { get { throw null; } }
+        public static MLDsaAlgorithm MLDsa65 { get { throw null; } }
+        public static MLDsaAlgorithm MLDsa87 { get { throw null; } }
+        public int MuSizeInBytes { get { throw null; } }
+        public string Name { get { throw null; } }
+        public int PrivateKeySizeInBytes { get { throw null; } }
+        public int PrivateSeedSizeInBytes { get { throw null; } }
+        public int PublicKeySizeInBytes { get { throw null; } }
+        public int SignatureSizeInBytes { get { throw null; } }
+        public override bool Equals(object? obj) { throw null; }
+        public bool Equals(MLDsaAlgorithm? other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(MLDsaAlgorithm? left, MLDsaAlgorithm? right) { throw null; }
+        public static bool operator !=(MLDsaAlgorithm? left, MLDsaAlgorithm? right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+
+    public sealed partial class MLDsaCng : MLDsa
+    {
+        [Runtime.Versioning.SupportedOSPlatform("windows")]
+        public MLDsaCng(CngKey key) : base(default!) { }
+        protected override void Dispose(bool disposing) { }
+        protected override void ExportMLDsaPrivateKeyCore(Span<byte> destination) { }
+        protected override void ExportMLDsaPrivateSeedCore(Span<byte> destination) { }
+        protected override void ExportMLDsaPublicKeyCore(Span<byte> destination) { }
+        public CngKey GetKey() { throw null; }
+        protected override void SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination) { }
+        protected override void SignMuCore(ReadOnlySpan<byte> mu, Span<byte> destination) { }
+        protected override void SignPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, Span<byte> destination) { }
+        protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten) { throw null; }
+        protected override bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature) { throw null; }
+        protected override bool VerifyMuCore(ReadOnlySpan<byte> mu, ReadOnlySpan<byte> signature) { throw null; }
+        protected override bool VerifyPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, ReadOnlySpan<byte> signature) { throw null; }
+    }
+
+    public abstract partial class MLKem : IDisposable
+    {
+        protected MLKem(MLKemAlgorithm algorithm) { }
+        public MLKemAlgorithm Algorithm { get { throw null; } }
+        public static bool IsSupported { get { throw null; } }
+        public byte[] Decapsulate(byte[] ciphertext) { throw null; }
+        public void Decapsulate(ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret) { }
+        protected abstract void DecapsulateCore(ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret);
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public void Encapsulate(out byte[] ciphertext, out byte[] sharedSecret) { throw null; }
+        public void Encapsulate(Span<byte> ciphertext, Span<byte> sharedSecret) { }
+        protected abstract void EncapsulateCore(Span<byte> ciphertext, Span<byte> sharedSecret);
+        public byte[] ExportDecapsulationKey() { throw null; }
+        public void ExportDecapsulationKey(Span<byte> destination) { }
+        protected abstract void ExportDecapsulationKeyCore(Span<byte> destination);
+        public byte[] ExportEncapsulationKey() { throw null; }
+        public void ExportEncapsulationKey(Span<byte> destination) { }
+        protected abstract void ExportEncapsulationKeyCore(Span<byte> destination);
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] ExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public string ExportEncryptedPkcs8PrivateKeyPem(string password, PbeParameters pbeParameters) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] ExportPkcs8PrivateKey() { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public string ExportPkcs8PrivateKeyPem() { throw null; }
+        public byte[] ExportPrivateSeed() { throw null; }
+        public void ExportPrivateSeed(Span<byte> destination) { }
+        protected abstract void ExportPrivateSeedCore(Span<byte> destination);
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] ExportSubjectPublicKeyInfo() { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public string ExportSubjectPublicKeyInfoPem() { throw null; }
+        public static MLKem GenerateKey(MLKemAlgorithm algorithm) { throw null; }
+        public static MLKem ImportDecapsulationKey(MLKemAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLKem ImportDecapsulationKey(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static MLKem ImportEncapsulationKey(MLKemAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLKem ImportEncapsulationKey(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, ReadOnlySpan<byte> source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, ReadOnlySpan<byte> source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportEncryptedPkcs8PrivateKey(string password, byte[] source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<byte> passwordBytes) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<char> password) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportFromEncryptedPem(string source, byte[] passwordBytes) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportFromEncryptedPem(string source, string password) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportFromPem(ReadOnlySpan<char> source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportFromPem(string source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportPkcs8PrivateKey(byte[] source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportPkcs8PrivateKey(ReadOnlySpan<byte> source) { throw null; }
+        public static MLKem ImportPrivateSeed(MLKemAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLKem ImportPrivateSeed(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportSubjectPublicKeyInfo(byte[] source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool TryExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        protected abstract bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten);
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool TryExportSubjectPublicKeyInfo(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public sealed partial class MLKemAlgorithm : IEquatable<MLKemAlgorithm>
+    {
+        internal MLKemAlgorithm() { }
+        public int CiphertextSizeInBytes { get { throw null; } }
+        public int DecapsulationKeySizeInBytes { get { throw null; } }
+        public int EncapsulationKeySizeInBytes { get { throw null; } }
+        public static MLKemAlgorithm MLKem1024 { get { throw null; } }
+        public static MLKemAlgorithm MLKem512 { get { throw null; } }
+        public static MLKemAlgorithm MLKem768 { get { throw null; } }
+        public string Name { get { throw null; } }
+        public int PrivateSeedSizeInBytes { get { throw null; } }
+        public int SharedSecretSizeInBytes { get { throw null; } }
+        public override bool Equals(object? obj) { throw null; }
+        public bool Equals(MLKemAlgorithm? other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(MLKemAlgorithm? left, MLKemAlgorithm? right) { throw null; }
+        public static bool operator !=(MLKemAlgorithm? left, MLKemAlgorithm? right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+
+    public sealed partial class MLKemCng : MLKem
+    {
+        [Runtime.Versioning.SupportedOSPlatform("windows")]
+        public MLKemCng(CngKey key) : base(default!) { }
+        protected override void DecapsulateCore(ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret) { }
+        protected override void Dispose(bool disposing) { }
+        protected override void EncapsulateCore(Span<byte> ciphertext, Span<byte> sharedSecret) { }
+        protected override void ExportDecapsulationKeyCore(Span<byte> destination) { }
+        protected override void ExportEncapsulationKeyCore(Span<byte> destination) { }
+        protected override void ExportPrivateSeedCore(Span<byte> destination) { }
+        public CngKey GetKey() { throw null; }
+        protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+    public abstract partial class SlhDsa : IDisposable
+    {
+        protected SlhDsa(SlhDsaAlgorithm algorithm) { }
+        public SlhDsaAlgorithm Algorithm { get { throw null; } }
+        public static bool IsSupported { get { throw null; } }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(string password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportPkcs8PrivateKey() { throw null; }
+        public string ExportPkcs8PrivateKeyPem() { throw null; }
+        public byte[] ExportSlhDsaPrivateKey() { throw null; }
+        public void ExportSlhDsaPrivateKey(Span<byte> destination) { }
+        protected abstract void ExportSlhDsaPrivateKeyCore(Span<byte> destination);
+        public byte[] ExportSlhDsaPublicKey() { throw null; }
+        public void ExportSlhDsaPublicKey(Span<byte> destination) { }
+        protected abstract void ExportSlhDsaPublicKeyCore(Span<byte> destination);
+        public byte[] ExportSubjectPublicKeyInfo() { throw null; }
+        public string ExportSubjectPublicKeyInfoPem() { throw null; }
+        public static SlhDsa GenerateKey(SlhDsaAlgorithm algorithm) { throw null; }
+        public static SlhDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, ReadOnlySpan<byte> source) { throw null; }
+        public static SlhDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, ReadOnlySpan<byte> source) { throw null; }
+        public static SlhDsa ImportEncryptedPkcs8PrivateKey(string password, byte[] source) { throw null; }
+        public static SlhDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<byte> passwordBytes) { throw null; }
+        public static SlhDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<char> password) { throw null; }
+        public static SlhDsa ImportFromEncryptedPem(string source, byte[] passwordBytes) { throw null; }
+        public static SlhDsa ImportFromEncryptedPem(string source, string password) { throw null; }
+        public static SlhDsa ImportFromPem(ReadOnlySpan<char> source) { throw null; }
+        public static SlhDsa ImportFromPem(string source) { throw null; }
+        public static SlhDsa ImportPkcs8PrivateKey(byte[] source) { throw null; }
+        public static SlhDsa ImportPkcs8PrivateKey(ReadOnlySpan<byte> source) { throw null; }
+        public static SlhDsa ImportSlhDsaPrivateKey(SlhDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static SlhDsa ImportSlhDsaPrivateKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static SlhDsa ImportSlhDsaPublicKey(SlhDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static SlhDsa ImportSlhDsaPublicKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static SlhDsa ImportSubjectPublicKeyInfo(byte[] source) { throw null; }
+        public static SlhDsa ImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source) { throw null; }
+        public byte[] SignData(byte[] data, byte[]? context = null) { throw null; }
+        public void SignData(ReadOnlySpan<byte> data, Span<byte> destination, ReadOnlySpan<byte> context = default) { }
+        protected abstract void SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination);
+        public byte[] SignPreHash(byte[] hash, string hashAlgorithmOid, byte[]? context = null) { throw null; }
+        public void SignPreHash(ReadOnlySpan<byte> hash, Span<byte> destination, string hashAlgorithmOid, ReadOnlySpan<byte> context = default) { }
+        protected abstract void SignPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, Span<byte> destination);
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        protected virtual bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportSubjectPublicKeyInfo(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool VerifyData(byte[] data, byte[] signature, byte[]? context = null) { throw null; }
+        public bool VerifyData(ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, ReadOnlySpan<byte> context = default) { throw null; }
+        protected abstract bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature);
+        public bool VerifyPreHash(byte[] hash, byte[] signature, string hashAlgorithmOid, byte[]? context = null) { throw null; }
+        public bool VerifyPreHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature, string hashAlgorithmOid, ReadOnlySpan<byte> context = default) { throw null; }
+        protected abstract bool VerifyPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, ReadOnlySpan<byte> signature);
+    }
+
+    [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+    public sealed partial class SlhDsaAlgorithm : IEquatable<SlhDsaAlgorithm>
+    {
+        internal SlhDsaAlgorithm() { }
+        public string Name { get { throw null; } }
+        public int PrivateKeySizeInBytes { get { throw null; } }
+        public int PublicKeySizeInBytes { get { throw null; } }
+        public int SignatureSizeInBytes { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_128f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_128s { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_192f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_192s { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_256f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_256s { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake128f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake128s { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake192f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake192s { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake256f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake256s { get { throw null; } }
+        public override bool Equals(object? obj) { throw null; }
+        public bool Equals(SlhDsaAlgorithm? other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(SlhDsaAlgorithm? left, SlhDsaAlgorithm? right) { throw null; }
+        public static bool operator !=(SlhDsaAlgorithm? left, SlhDsaAlgorithm? right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+
+    [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+    public sealed partial class SlhDsaCng : SlhDsa
+    {
+        [Runtime.Versioning.SupportedOSPlatform("windows")]
+        public SlhDsaCng(CngKey key) : base(default!) { }
+        protected override void ExportSlhDsaPrivateKeyCore(Span<byte> destination) { }
+        protected override void ExportSlhDsaPublicKeyCore(Span<byte> destination) { }
+        public CngKey GetKey() { throw null; }
+        protected override void SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination) { }
+        protected override void SignPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, Span<byte> destination) { }
+        protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten) { throw null; }
+        protected override bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature) { throw null; }
+        protected override bool VerifyPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, ReadOnlySpan<byte> signature) { throw null; }
+    }
+}
+
+namespace System.Security.Cryptography.X509Certificates
+{
+    public sealed partial class Pkcs12LoaderLimits
+    {
+        public Pkcs12LoaderLimits() { }
+        public Pkcs12LoaderLimits(Pkcs12LoaderLimits copyFrom) { }
+        public static Pkcs12LoaderLimits DangerousNoLimits { get { throw null; } }
+        public static Pkcs12LoaderLimits Defaults { get { throw null; } }
+        public bool IgnoreEncryptedAuthSafes { get { throw null; } set { } }
+        public bool IgnorePrivateKeys { get { throw null; } set { } }
+        public int? IndividualKdfIterationLimit { get { throw null; } set { } }
+        public bool IsReadOnly { get { throw null; } }
+        public int? MacIterationLimit { get { throw null; } set { } }
+        public int? MaxCertificates { get { throw null; } set { } }
+        public int? MaxKeys { get { throw null; } set { } }
+        public bool PreserveCertificateAlias { get { throw null; } set { } }
+        public bool PreserveKeyName { get { throw null; } set { } }
+        public bool PreserveStorageProvider { get { throw null; } set { } }
+        public bool PreserveUnknownAttributes { get { throw null; } set { } }
+        public int? TotalKdfIterationLimit { get { throw null; } set { } }
+        public void MakeReadOnly() { }
+    }
+
+    public sealed partial class Pkcs12LoadLimitExceededException : CryptographicException
+    {
+        public Pkcs12LoadLimitExceededException(string propertyName) { }
+    }
+
+    public static partial class X509CertificateKeyAccessors
+    {
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static X509Certificate2 CopyWithPrivateKey(this X509Certificate2 certificate, CompositeMLDsa privateKey) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static X509Certificate2 CopyWithPrivateKey(this X509Certificate2 certificate, MLDsa privateKey) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static X509Certificate2 CopyWithPrivateKey(this X509Certificate2 certificate, MLKem privateKey) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static X509Certificate2 CopyWithPrivateKey(this X509Certificate2 certificate, SlhDsa privateKey) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static CompositeMLDsa? GetCompositeMLDsaPrivateKey(this X509Certificate2 certificate) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static CompositeMLDsa? GetCompositeMLDsaPublicKey(this X509Certificate2 certificate) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa? GetMLDsaPrivateKey(this X509Certificate2 certificate) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa? GetMLDsaPublicKey(this X509Certificate2 certificate) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem? GetMLKemPrivateKey(this X509Certificate2 certificate) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem? GetMLKemPublicKey(this X509Certificate2 certificate) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static SlhDsa? GetSlhDsaPrivateKey(this X509Certificate2 certificate) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static SlhDsa? GetSlhDsaPublicKey(this X509Certificate2 certificate) { throw null; }
+    }
+
+    [Runtime.Versioning.UnsupportedOSPlatform("browser")]
+    public static partial class X509CertificateLoader
+    {
+        public static X509Certificate2 LoadCertificate(byte[] data) { throw null; }
+        public static X509Certificate2 LoadCertificate(ReadOnlySpan<byte> data) { throw null; }
+        public static X509Certificate2 LoadCertificateFromFile(string path) { throw null; }
+        public static X509Certificate2 LoadPkcs12(byte[] data, string? password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+        public static X509Certificate2 LoadPkcs12(ReadOnlySpan<byte> data, ReadOnlySpan<char> password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+        public static X509Certificate2Collection LoadPkcs12Collection(byte[] data, string? password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+        public static X509Certificate2Collection LoadPkcs12Collection(ReadOnlySpan<byte> data, ReadOnlySpan<char> password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+        public static X509Certificate2Collection LoadPkcs12CollectionFromFile(string path, ReadOnlySpan<char> password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+        public static X509Certificate2Collection LoadPkcs12CollectionFromFile(string path, string? password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+        public static X509Certificate2 LoadPkcs12FromFile(string path, ReadOnlySpan<char> password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+        public static X509Certificate2 LoadPkcs12FromFile(string path, string? password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+    }
+}

--- a/src/source-build-assets/src/referencePackages/src/microsoft.bcl.cryptography/10.0.10/lib/net9.0/Microsoft.Bcl.Cryptography.cs
+++ b/src/source-build-assets/src/referencePackages/src/microsoft.bcl.cryptography/10.0.10/lib/net9.0/Microsoft.Bcl.Cryptography.cs
@@ -1,0 +1,555 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v9.0", FrameworkDisplayName = ".NET 9.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("Microsoft.Bcl.Cryptography")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("IsAotCompatible", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides support for some cryptographic primitives for .NET Framework and .NET Standard.")]
+[assembly: System.Reflection.AssemblyFileVersion("10.0.1026.32716")]
+[assembly: System.Reflection.AssemblyInformationalVersion("10.0.10+f7d90799ce4ef09a0bb257852a57248d2a8fb8dd")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("Microsoft.Bcl.Cryptography")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/dotnet")]
+[assembly: System.Reflection.AssemblyVersionAttribute("10.0.0.10")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.AesGcm))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.AuthenticationTagMismatchException))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.PbeEncryptionAlgorithm))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.PbeParameters))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.SP800108HmacCounterKdf))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.X509Certificates.Pkcs12LoaderLimits))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.X509Certificates.Pkcs12LoadLimitExceededException))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.X509Certificates.X509CertificateLoader))]
+namespace System.Security.Cryptography
+{
+    [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+    public abstract partial class CompositeMLDsa : IDisposable
+    {
+        protected CompositeMLDsa(CompositeMLDsaAlgorithm algorithm) { }
+        public CompositeMLDsaAlgorithm Algorithm { get { throw null; } }
+        public static bool IsSupported { get { throw null; } }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public byte[] ExportCompositeMLDsaPrivateKey() { throw null; }
+        public int ExportCompositeMLDsaPrivateKey(Span<byte> destination) { throw null; }
+        protected abstract int ExportCompositeMLDsaPrivateKeyCore(Span<byte> destination);
+        public byte[] ExportCompositeMLDsaPublicKey() { throw null; }
+        public int ExportCompositeMLDsaPublicKey(Span<byte> destination) { throw null; }
+        protected abstract int ExportCompositeMLDsaPublicKeyCore(Span<byte> destination);
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(string password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportPkcs8PrivateKey() { throw null; }
+        public string ExportPkcs8PrivateKeyPem() { throw null; }
+        public byte[] ExportSubjectPublicKeyInfo() { throw null; }
+        public string ExportSubjectPublicKeyInfoPem() { throw null; }
+        public static CompositeMLDsa GenerateKey(CompositeMLDsaAlgorithm algorithm) { throw null; }
+        public static CompositeMLDsa ImportCompositeMLDsaPrivateKey(CompositeMLDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static CompositeMLDsa ImportCompositeMLDsaPrivateKey(CompositeMLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static CompositeMLDsa ImportCompositeMLDsaPublicKey(CompositeMLDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static CompositeMLDsa ImportCompositeMLDsaPublicKey(CompositeMLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static CompositeMLDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, ReadOnlySpan<byte> source) { throw null; }
+        public static CompositeMLDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, ReadOnlySpan<byte> source) { throw null; }
+        public static CompositeMLDsa ImportEncryptedPkcs8PrivateKey(string password, byte[] source) { throw null; }
+        public static CompositeMLDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<byte> passwordBytes) { throw null; }
+        public static CompositeMLDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<char> password) { throw null; }
+        public static CompositeMLDsa ImportFromEncryptedPem(string source, byte[] passwordBytes) { throw null; }
+        public static CompositeMLDsa ImportFromEncryptedPem(string source, string password) { throw null; }
+        public static CompositeMLDsa ImportFromPem(ReadOnlySpan<char> source) { throw null; }
+        public static CompositeMLDsa ImportFromPem(string source) { throw null; }
+        public static CompositeMLDsa ImportPkcs8PrivateKey(byte[] source) { throw null; }
+        public static CompositeMLDsa ImportPkcs8PrivateKey(ReadOnlySpan<byte> source) { throw null; }
+        public static CompositeMLDsa ImportSubjectPublicKeyInfo(byte[] source) { throw null; }
+        public static CompositeMLDsa ImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source) { throw null; }
+        public static bool IsAlgorithmSupported(CompositeMLDsaAlgorithm algorithm) { throw null; }
+        public byte[] SignData(byte[] data, byte[]? context = null) { throw null; }
+        public int SignData(ReadOnlySpan<byte> data, Span<byte> destination, ReadOnlySpan<byte> context = default) { throw null; }
+        protected abstract int SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination);
+        public bool TryExportCompositeMLDsaPrivateKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportCompositeMLDsaPublicKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        protected abstract bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten);
+        public bool TryExportSubjectPublicKeyInfo(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool VerifyData(byte[] data, byte[] signature, byte[]? context = null) { throw null; }
+        public bool VerifyData(ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, ReadOnlySpan<byte> context = default) { throw null; }
+        protected abstract bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature);
+    }
+
+    [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+    public sealed partial class CompositeMLDsaAlgorithm : IEquatable<CompositeMLDsaAlgorithm>
+    {
+        internal CompositeMLDsaAlgorithm() { }
+        public int MaxSignatureSizeInBytes { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa44WithECDsaP256 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa44WithEd25519 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa44WithRSA2048Pkcs15 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa44WithRSA2048Pss { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithECDsaBrainpoolP256r1 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithECDsaP256 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithECDsaP384 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithEd25519 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithRSA3072Pkcs15 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithRSA3072Pss { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithRSA4096Pkcs15 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithRSA4096Pss { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithECDsaBrainpoolP384r1 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithECDsaP384 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithECDsaP521 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithEd448 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithRSA3072Pss { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithRSA4096Pss { get { throw null; } }
+        public string Name { get { throw null; } }
+        public override bool Equals(object? obj) { throw null; }
+        public bool Equals(CompositeMLDsaAlgorithm? other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(CompositeMLDsaAlgorithm? left, CompositeMLDsaAlgorithm? right) { throw null; }
+        public static bool operator !=(CompositeMLDsaAlgorithm? left, CompositeMLDsaAlgorithm? right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+
+    [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+    public sealed partial class CompositeMLDsaCng : CompositeMLDsa
+    {
+        [Runtime.Versioning.SupportedOSPlatform("windows")]
+        public CompositeMLDsaCng(CngKey key) : base(default!) { }
+        protected override int ExportCompositeMLDsaPrivateKeyCore(Span<byte> destination) { throw null; }
+        protected override int ExportCompositeMLDsaPublicKeyCore(Span<byte> destination) { throw null; }
+        public CngKey GetKey() { throw null; }
+        protected override int SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination) { throw null; }
+        protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten) { throw null; }
+        protected override bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature) { throw null; }
+    }
+
+    public abstract partial class MLDsa : IDisposable
+    {
+        protected MLDsa(MLDsaAlgorithm algorithm) { }
+        public MLDsaAlgorithm Algorithm { get { throw null; } }
+        public static bool IsSupported { get { throw null; } }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] ExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public string ExportEncryptedPkcs8PrivateKeyPem(string password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportMLDsaPrivateKey() { throw null; }
+        public void ExportMLDsaPrivateKey(Span<byte> destination) { }
+        protected abstract void ExportMLDsaPrivateKeyCore(Span<byte> destination);
+        public byte[] ExportMLDsaPrivateSeed() { throw null; }
+        public void ExportMLDsaPrivateSeed(Span<byte> destination) { }
+        protected abstract void ExportMLDsaPrivateSeedCore(Span<byte> destination);
+        public byte[] ExportMLDsaPublicKey() { throw null; }
+        public void ExportMLDsaPublicKey(Span<byte> destination) { }
+        protected abstract void ExportMLDsaPublicKeyCore(Span<byte> destination);
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] ExportPkcs8PrivateKey() { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public string ExportPkcs8PrivateKeyPem() { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] ExportSubjectPublicKeyInfo() { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public string ExportSubjectPublicKeyInfoPem() { throw null; }
+        public static MLDsa GenerateKey(MLDsaAlgorithm algorithm) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, ReadOnlySpan<byte> source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, ReadOnlySpan<byte> source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportEncryptedPkcs8PrivateKey(string password, byte[] source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<byte> passwordBytes) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<char> password) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportFromEncryptedPem(string source, byte[] passwordBytes) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportFromEncryptedPem(string source, string password) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportFromPem(ReadOnlySpan<char> source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportFromPem(string source) { throw null; }
+        public static MLDsa ImportMLDsaPrivateKey(MLDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLDsa ImportMLDsaPrivateKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static MLDsa ImportMLDsaPrivateSeed(MLDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLDsa ImportMLDsaPrivateSeed(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static MLDsa ImportMLDsaPublicKey(MLDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLDsa ImportMLDsaPublicKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportPkcs8PrivateKey(byte[] source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportPkcs8PrivateKey(ReadOnlySpan<byte> source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportSubjectPublicKeyInfo(byte[] source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa ImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source) { throw null; }
+        public byte[] SignData(byte[] data, byte[]? context = null) { throw null; }
+        public void SignData(ReadOnlySpan<byte> data, Span<byte> destination, ReadOnlySpan<byte> context = default) { }
+        protected abstract void SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination);
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] SignMu(byte[] externalMu) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public void SignMu(ReadOnlySpan<byte> externalMu, Span<byte> destination) { }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] SignMu(ReadOnlySpan<byte> externalMu) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        protected abstract void SignMuCore(ReadOnlySpan<byte> externalMu, Span<byte> destination);
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] SignPreHash(byte[] hash, string hashAlgorithmOid, byte[]? context = null) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public void SignPreHash(ReadOnlySpan<byte> hash, Span<byte> destination, string hashAlgorithmOid, ReadOnlySpan<byte> context = default) { }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        protected abstract void SignPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, Span<byte> destination);
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool TryExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        protected abstract bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten);
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool TryExportSubjectPublicKeyInfo(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool VerifyData(byte[] data, byte[] signature, byte[]? context = null) { throw null; }
+        public bool VerifyData(ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, ReadOnlySpan<byte> context = default) { throw null; }
+        protected abstract bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature);
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool VerifyMu(byte[] externalMu, byte[] signature) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool VerifyMu(ReadOnlySpan<byte> externalMu, ReadOnlySpan<byte> signature) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        protected abstract bool VerifyMuCore(ReadOnlySpan<byte> externalMu, ReadOnlySpan<byte> signature);
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool VerifyPreHash(byte[] hash, byte[] signature, string hashAlgorithmOid, byte[]? context = null) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool VerifyPreHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature, string hashAlgorithmOid, ReadOnlySpan<byte> context = default) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        protected abstract bool VerifyPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, ReadOnlySpan<byte> signature);
+    }
+
+    public sealed partial class MLDsaAlgorithm : IEquatable<MLDsaAlgorithm>
+    {
+        internal MLDsaAlgorithm() { }
+        public static MLDsaAlgorithm MLDsa44 { get { throw null; } }
+        public static MLDsaAlgorithm MLDsa65 { get { throw null; } }
+        public static MLDsaAlgorithm MLDsa87 { get { throw null; } }
+        public int MuSizeInBytes { get { throw null; } }
+        public string Name { get { throw null; } }
+        public int PrivateKeySizeInBytes { get { throw null; } }
+        public int PrivateSeedSizeInBytes { get { throw null; } }
+        public int PublicKeySizeInBytes { get { throw null; } }
+        public int SignatureSizeInBytes { get { throw null; } }
+        public override bool Equals(object? obj) { throw null; }
+        public bool Equals(MLDsaAlgorithm? other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(MLDsaAlgorithm? left, MLDsaAlgorithm? right) { throw null; }
+        public static bool operator !=(MLDsaAlgorithm? left, MLDsaAlgorithm? right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+
+    public sealed partial class MLDsaCng : MLDsa
+    {
+        [Runtime.Versioning.SupportedOSPlatform("windows")]
+        public MLDsaCng(CngKey key) : base(default!) { }
+        protected override void Dispose(bool disposing) { }
+        protected override void ExportMLDsaPrivateKeyCore(Span<byte> destination) { }
+        protected override void ExportMLDsaPrivateSeedCore(Span<byte> destination) { }
+        protected override void ExportMLDsaPublicKeyCore(Span<byte> destination) { }
+        public CngKey GetKey() { throw null; }
+        protected override void SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination) { }
+        protected override void SignMuCore(ReadOnlySpan<byte> mu, Span<byte> destination) { }
+        protected override void SignPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, Span<byte> destination) { }
+        protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten) { throw null; }
+        protected override bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature) { throw null; }
+        protected override bool VerifyMuCore(ReadOnlySpan<byte> mu, ReadOnlySpan<byte> signature) { throw null; }
+        protected override bool VerifyPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, ReadOnlySpan<byte> signature) { throw null; }
+    }
+
+    public abstract partial class MLKem : IDisposable
+    {
+        protected MLKem(MLKemAlgorithm algorithm) { }
+        public MLKemAlgorithm Algorithm { get { throw null; } }
+        public static bool IsSupported { get { throw null; } }
+        public byte[] Decapsulate(byte[] ciphertext) { throw null; }
+        public void Decapsulate(ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret) { }
+        protected abstract void DecapsulateCore(ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret);
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public void Encapsulate(out byte[] ciphertext, out byte[] sharedSecret) { throw null; }
+        public void Encapsulate(Span<byte> ciphertext, Span<byte> sharedSecret) { }
+        protected abstract void EncapsulateCore(Span<byte> ciphertext, Span<byte> sharedSecret);
+        public byte[] ExportDecapsulationKey() { throw null; }
+        public void ExportDecapsulationKey(Span<byte> destination) { }
+        protected abstract void ExportDecapsulationKeyCore(Span<byte> destination);
+        public byte[] ExportEncapsulationKey() { throw null; }
+        public void ExportEncapsulationKey(Span<byte> destination) { }
+        protected abstract void ExportEncapsulationKeyCore(Span<byte> destination);
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] ExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public string ExportEncryptedPkcs8PrivateKeyPem(string password, PbeParameters pbeParameters) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] ExportPkcs8PrivateKey() { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public string ExportPkcs8PrivateKeyPem() { throw null; }
+        public byte[] ExportPrivateSeed() { throw null; }
+        public void ExportPrivateSeed(Span<byte> destination) { }
+        protected abstract void ExportPrivateSeedCore(Span<byte> destination);
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public byte[] ExportSubjectPublicKeyInfo() { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public string ExportSubjectPublicKeyInfoPem() { throw null; }
+        public static MLKem GenerateKey(MLKemAlgorithm algorithm) { throw null; }
+        public static MLKem ImportDecapsulationKey(MLKemAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLKem ImportDecapsulationKey(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static MLKem ImportEncapsulationKey(MLKemAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLKem ImportEncapsulationKey(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, ReadOnlySpan<byte> source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, ReadOnlySpan<byte> source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportEncryptedPkcs8PrivateKey(string password, byte[] source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<byte> passwordBytes) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<char> password) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportFromEncryptedPem(string source, byte[] passwordBytes) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportFromEncryptedPem(string source, string password) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportFromPem(ReadOnlySpan<char> source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportFromPem(string source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportPkcs8PrivateKey(byte[] source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportPkcs8PrivateKey(ReadOnlySpan<byte> source) { throw null; }
+        public static MLKem ImportPrivateSeed(MLKemAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLKem ImportPrivateSeed(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportSubjectPublicKeyInfo(byte[] source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem ImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool TryExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        protected abstract bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten);
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public bool TryExportSubjectPublicKeyInfo(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public sealed partial class MLKemAlgorithm : IEquatable<MLKemAlgorithm>
+    {
+        internal MLKemAlgorithm() { }
+        public int CiphertextSizeInBytes { get { throw null; } }
+        public int DecapsulationKeySizeInBytes { get { throw null; } }
+        public int EncapsulationKeySizeInBytes { get { throw null; } }
+        public static MLKemAlgorithm MLKem1024 { get { throw null; } }
+        public static MLKemAlgorithm MLKem512 { get { throw null; } }
+        public static MLKemAlgorithm MLKem768 { get { throw null; } }
+        public string Name { get { throw null; } }
+        public int PrivateSeedSizeInBytes { get { throw null; } }
+        public int SharedSecretSizeInBytes { get { throw null; } }
+        public override bool Equals(object? obj) { throw null; }
+        public bool Equals(MLKemAlgorithm? other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(MLKemAlgorithm? left, MLKemAlgorithm? right) { throw null; }
+        public static bool operator !=(MLKemAlgorithm? left, MLKemAlgorithm? right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+
+    public sealed partial class MLKemCng : MLKem
+    {
+        [Runtime.Versioning.SupportedOSPlatform("windows")]
+        public MLKemCng(CngKey key) : base(default!) { }
+        protected override void DecapsulateCore(ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret) { }
+        protected override void Dispose(bool disposing) { }
+        protected override void EncapsulateCore(Span<byte> ciphertext, Span<byte> sharedSecret) { }
+        protected override void ExportDecapsulationKeyCore(Span<byte> destination) { }
+        protected override void ExportEncapsulationKeyCore(Span<byte> destination) { }
+        protected override void ExportPrivateSeedCore(Span<byte> destination) { }
+        public CngKey GetKey() { throw null; }
+        protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+    public abstract partial class SlhDsa : IDisposable
+    {
+        protected SlhDsa(SlhDsaAlgorithm algorithm) { }
+        public SlhDsaAlgorithm Algorithm { get { throw null; } }
+        public static bool IsSupported { get { throw null; } }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(string password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportPkcs8PrivateKey() { throw null; }
+        public string ExportPkcs8PrivateKeyPem() { throw null; }
+        public byte[] ExportSlhDsaPrivateKey() { throw null; }
+        public void ExportSlhDsaPrivateKey(Span<byte> destination) { }
+        protected abstract void ExportSlhDsaPrivateKeyCore(Span<byte> destination);
+        public byte[] ExportSlhDsaPublicKey() { throw null; }
+        public void ExportSlhDsaPublicKey(Span<byte> destination) { }
+        protected abstract void ExportSlhDsaPublicKeyCore(Span<byte> destination);
+        public byte[] ExportSubjectPublicKeyInfo() { throw null; }
+        public string ExportSubjectPublicKeyInfoPem() { throw null; }
+        public static SlhDsa GenerateKey(SlhDsaAlgorithm algorithm) { throw null; }
+        public static SlhDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, ReadOnlySpan<byte> source) { throw null; }
+        public static SlhDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, ReadOnlySpan<byte> source) { throw null; }
+        public static SlhDsa ImportEncryptedPkcs8PrivateKey(string password, byte[] source) { throw null; }
+        public static SlhDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<byte> passwordBytes) { throw null; }
+        public static SlhDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<char> password) { throw null; }
+        public static SlhDsa ImportFromEncryptedPem(string source, byte[] passwordBytes) { throw null; }
+        public static SlhDsa ImportFromEncryptedPem(string source, string password) { throw null; }
+        public static SlhDsa ImportFromPem(ReadOnlySpan<char> source) { throw null; }
+        public static SlhDsa ImportFromPem(string source) { throw null; }
+        public static SlhDsa ImportPkcs8PrivateKey(byte[] source) { throw null; }
+        public static SlhDsa ImportPkcs8PrivateKey(ReadOnlySpan<byte> source) { throw null; }
+        public static SlhDsa ImportSlhDsaPrivateKey(SlhDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static SlhDsa ImportSlhDsaPrivateKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static SlhDsa ImportSlhDsaPublicKey(SlhDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static SlhDsa ImportSlhDsaPublicKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static SlhDsa ImportSubjectPublicKeyInfo(byte[] source) { throw null; }
+        public static SlhDsa ImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source) { throw null; }
+        public byte[] SignData(byte[] data, byte[]? context = null) { throw null; }
+        public void SignData(ReadOnlySpan<byte> data, Span<byte> destination, ReadOnlySpan<byte> context = default) { }
+        protected abstract void SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination);
+        public byte[] SignPreHash(byte[] hash, string hashAlgorithmOid, byte[]? context = null) { throw null; }
+        public void SignPreHash(ReadOnlySpan<byte> hash, Span<byte> destination, string hashAlgorithmOid, ReadOnlySpan<byte> context = default) { }
+        protected abstract void SignPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, Span<byte> destination);
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        protected virtual bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportSubjectPublicKeyInfo(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool VerifyData(byte[] data, byte[] signature, byte[]? context = null) { throw null; }
+        public bool VerifyData(ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, ReadOnlySpan<byte> context = default) { throw null; }
+        protected abstract bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature);
+        public bool VerifyPreHash(byte[] hash, byte[] signature, string hashAlgorithmOid, byte[]? context = null) { throw null; }
+        public bool VerifyPreHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature, string hashAlgorithmOid, ReadOnlySpan<byte> context = default) { throw null; }
+        protected abstract bool VerifyPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, ReadOnlySpan<byte> signature);
+    }
+
+    [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+    public sealed partial class SlhDsaAlgorithm : IEquatable<SlhDsaAlgorithm>
+    {
+        internal SlhDsaAlgorithm() { }
+        public string Name { get { throw null; } }
+        public int PrivateKeySizeInBytes { get { throw null; } }
+        public int PublicKeySizeInBytes { get { throw null; } }
+        public int SignatureSizeInBytes { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_128f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_128s { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_192f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_192s { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_256f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_256s { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake128f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake128s { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake192f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake192s { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake256f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake256s { get { throw null; } }
+        public override bool Equals(object? obj) { throw null; }
+        public bool Equals(SlhDsaAlgorithm? other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(SlhDsaAlgorithm? left, SlhDsaAlgorithm? right) { throw null; }
+        public static bool operator !=(SlhDsaAlgorithm? left, SlhDsaAlgorithm? right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+
+    [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+    public sealed partial class SlhDsaCng : SlhDsa
+    {
+        [Runtime.Versioning.SupportedOSPlatform("windows")]
+        public SlhDsaCng(CngKey key) : base(default!) { }
+        protected override void ExportSlhDsaPrivateKeyCore(Span<byte> destination) { }
+        protected override void ExportSlhDsaPublicKeyCore(Span<byte> destination) { }
+        public CngKey GetKey() { throw null; }
+        protected override void SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination) { }
+        protected override void SignPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, Span<byte> destination) { }
+        protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten) { throw null; }
+        protected override bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature) { throw null; }
+        protected override bool VerifyPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, ReadOnlySpan<byte> signature) { throw null; }
+    }
+}
+
+namespace System.Security.Cryptography.X509Certificates
+{
+    public static partial class X509CertificateKeyAccessors
+    {
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static X509Certificate2 CopyWithPrivateKey(this X509Certificate2 certificate, CompositeMLDsa privateKey) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static X509Certificate2 CopyWithPrivateKey(this X509Certificate2 certificate, MLDsa privateKey) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static X509Certificate2 CopyWithPrivateKey(this X509Certificate2 certificate, MLKem privateKey) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static X509Certificate2 CopyWithPrivateKey(this X509Certificate2 certificate, SlhDsa privateKey) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static CompositeMLDsa? GetCompositeMLDsaPrivateKey(this X509Certificate2 certificate) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static CompositeMLDsa? GetCompositeMLDsaPublicKey(this X509Certificate2 certificate) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa? GetMLDsaPrivateKey(this X509Certificate2 certificate) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLDsa? GetMLDsaPublicKey(this X509Certificate2 certificate) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem? GetMLKemPrivateKey(this X509Certificate2 certificate) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static MLKem? GetMLKemPublicKey(this X509Certificate2 certificate) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static SlhDsa? GetSlhDsaPrivateKey(this X509Certificate2 certificate) { throw null; }
+        [Diagnostics.CodeAnalysis.Experimental("SYSLIB5006", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        public static SlhDsa? GetSlhDsaPublicKey(this X509Certificate2 certificate) { throw null; }
+    }
+}

--- a/src/source-build-assets/src/referencePackages/src/microsoft.bcl.cryptography/10.0.10/lib/netstandard2.0/Microsoft.Bcl.Cryptography.cs
+++ b/src/source-build-assets/src/referencePackages/src/microsoft.bcl.cryptography/10.0.10/lib/netstandard2.0/Microsoft.Bcl.Cryptography.cs
@@ -1,0 +1,550 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("Microsoft.Bcl.Cryptography")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("IsAotCompatible", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides support for some cryptographic primitives for .NET Framework and .NET Standard.")]
+[assembly: System.Reflection.AssemblyFileVersion("10.0.1026.32716")]
+[assembly: System.Reflection.AssemblyInformationalVersion("10.0.10+f7d90799ce4ef09a0bb257852a57248d2a8fb8dd")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("Microsoft.Bcl.Cryptography")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/dotnet")]
+[assembly: System.Reflection.AssemblyVersionAttribute("10.0.0.10")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, Inherited = false)]
+    internal sealed partial class AllowNullAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, Inherited = false)]
+    internal sealed partial class DisallowNullAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    internal sealed partial class DoesNotReturnAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed partial class DoesNotReturnIfAttribute : Attribute
+    {
+        public DoesNotReturnIfAttribute(bool parameterValue) { }
+        public bool ParameterValue { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed partial class MaybeNullAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed partial class MaybeNullWhenAttribute : Attribute
+    {
+        public MaybeNullWhenAttribute(bool returnValue) { }
+        public bool ReturnValue { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+    internal sealed partial class MemberNotNullAttribute : Attribute
+    {
+        public MemberNotNullAttribute(string member) { }
+        public MemberNotNullAttribute(params string[] members) { }
+        public string[] Members { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+    internal sealed partial class MemberNotNullWhenAttribute : Attribute
+    {
+        public MemberNotNullWhenAttribute(bool returnValue, string member) { }
+        public MemberNotNullWhenAttribute(bool returnValue, params string[] members) { }
+        public string[] Members { get { throw null; } }
+        public bool ReturnValue { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed partial class NotNullAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+    internal sealed partial class NotNullIfNotNullAttribute : Attribute
+    {
+        public NotNullIfNotNullAttribute(string parameterName) { }
+        public string ParameterName { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed partial class NotNullWhenAttribute : Attribute
+    {
+        public NotNullWhenAttribute(bool returnValue) { }
+        public bool ReturnValue { get { throw null; } }
+    }
+}
+
+namespace System.Security.Cryptography
+{
+    public abstract partial class CompositeMLDsa : IDisposable
+    {
+        protected CompositeMLDsa(CompositeMLDsaAlgorithm algorithm) { }
+        public CompositeMLDsaAlgorithm Algorithm { get { throw null; } }
+        public static bool IsSupported { get { throw null; } }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public byte[] ExportCompositeMLDsaPrivateKey() { throw null; }
+        public int ExportCompositeMLDsaPrivateKey(Span<byte> destination) { throw null; }
+        protected abstract int ExportCompositeMLDsaPrivateKeyCore(Span<byte> destination);
+        public byte[] ExportCompositeMLDsaPublicKey() { throw null; }
+        public int ExportCompositeMLDsaPublicKey(Span<byte> destination) { throw null; }
+        protected abstract int ExportCompositeMLDsaPublicKeyCore(Span<byte> destination);
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(string password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportPkcs8PrivateKey() { throw null; }
+        public string ExportPkcs8PrivateKeyPem() { throw null; }
+        public byte[] ExportSubjectPublicKeyInfo() { throw null; }
+        public string ExportSubjectPublicKeyInfoPem() { throw null; }
+        public static CompositeMLDsa GenerateKey(CompositeMLDsaAlgorithm algorithm) { throw null; }
+        public static CompositeMLDsa ImportCompositeMLDsaPrivateKey(CompositeMLDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static CompositeMLDsa ImportCompositeMLDsaPrivateKey(CompositeMLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static CompositeMLDsa ImportCompositeMLDsaPublicKey(CompositeMLDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static CompositeMLDsa ImportCompositeMLDsaPublicKey(CompositeMLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static CompositeMLDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, ReadOnlySpan<byte> source) { throw null; }
+        public static CompositeMLDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, ReadOnlySpan<byte> source) { throw null; }
+        public static CompositeMLDsa ImportEncryptedPkcs8PrivateKey(string password, byte[] source) { throw null; }
+        public static CompositeMLDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<byte> passwordBytes) { throw null; }
+        public static CompositeMLDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<char> password) { throw null; }
+        public static CompositeMLDsa ImportFromEncryptedPem(string source, byte[] passwordBytes) { throw null; }
+        public static CompositeMLDsa ImportFromEncryptedPem(string source, string password) { throw null; }
+        public static CompositeMLDsa ImportFromPem(ReadOnlySpan<char> source) { throw null; }
+        public static CompositeMLDsa ImportFromPem(string source) { throw null; }
+        public static CompositeMLDsa ImportPkcs8PrivateKey(byte[] source) { throw null; }
+        public static CompositeMLDsa ImportPkcs8PrivateKey(ReadOnlySpan<byte> source) { throw null; }
+        public static CompositeMLDsa ImportSubjectPublicKeyInfo(byte[] source) { throw null; }
+        public static CompositeMLDsa ImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source) { throw null; }
+        public static bool IsAlgorithmSupported(CompositeMLDsaAlgorithm algorithm) { throw null; }
+        public byte[] SignData(byte[] data, byte[]? context = null) { throw null; }
+        public int SignData(ReadOnlySpan<byte> data, Span<byte> destination, ReadOnlySpan<byte> context = default) { throw null; }
+        protected abstract int SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination);
+        public bool TryExportCompositeMLDsaPrivateKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportCompositeMLDsaPublicKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        protected abstract bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten);
+        public bool TryExportSubjectPublicKeyInfo(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool VerifyData(byte[] data, byte[] signature, byte[]? context = null) { throw null; }
+        public bool VerifyData(ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, ReadOnlySpan<byte> context = default) { throw null; }
+        protected abstract bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature);
+    }
+
+    public sealed partial class CompositeMLDsaAlgorithm : IEquatable<CompositeMLDsaAlgorithm>
+    {
+        internal CompositeMLDsaAlgorithm() { }
+        public int MaxSignatureSizeInBytes { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa44WithECDsaP256 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa44WithEd25519 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa44WithRSA2048Pkcs15 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa44WithRSA2048Pss { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithECDsaBrainpoolP256r1 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithECDsaP256 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithECDsaP384 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithEd25519 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithRSA3072Pkcs15 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithRSA3072Pss { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithRSA4096Pkcs15 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithRSA4096Pss { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithECDsaBrainpoolP384r1 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithECDsaP384 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithECDsaP521 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithEd448 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithRSA3072Pss { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithRSA4096Pss { get { throw null; } }
+        public string Name { get { throw null; } }
+        public override bool Equals(object? obj) { throw null; }
+        public bool Equals(CompositeMLDsaAlgorithm? other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(CompositeMLDsaAlgorithm? left, CompositeMLDsaAlgorithm? right) { throw null; }
+        public static bool operator !=(CompositeMLDsaAlgorithm? left, CompositeMLDsaAlgorithm? right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+
+    public abstract partial class MLDsa : IDisposable
+    {
+        protected MLDsa(MLDsaAlgorithm algorithm) { }
+        public MLDsaAlgorithm Algorithm { get { throw null; } }
+        public static bool IsSupported { get { throw null; } }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(string password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportMLDsaPrivateKey() { throw null; }
+        public void ExportMLDsaPrivateKey(Span<byte> destination) { }
+        protected abstract void ExportMLDsaPrivateKeyCore(Span<byte> destination);
+        public byte[] ExportMLDsaPrivateSeed() { throw null; }
+        public void ExportMLDsaPrivateSeed(Span<byte> destination) { }
+        protected abstract void ExportMLDsaPrivateSeedCore(Span<byte> destination);
+        public byte[] ExportMLDsaPublicKey() { throw null; }
+        public void ExportMLDsaPublicKey(Span<byte> destination) { }
+        protected abstract void ExportMLDsaPublicKeyCore(Span<byte> destination);
+        public byte[] ExportPkcs8PrivateKey() { throw null; }
+        public string ExportPkcs8PrivateKeyPem() { throw null; }
+        public byte[] ExportSubjectPublicKeyInfo() { throw null; }
+        public string ExportSubjectPublicKeyInfoPem() { throw null; }
+        public static MLDsa GenerateKey(MLDsaAlgorithm algorithm) { throw null; }
+        public static MLDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, ReadOnlySpan<byte> source) { throw null; }
+        public static MLDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, ReadOnlySpan<byte> source) { throw null; }
+        public static MLDsa ImportEncryptedPkcs8PrivateKey(string password, byte[] source) { throw null; }
+        public static MLDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<byte> passwordBytes) { throw null; }
+        public static MLDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<char> password) { throw null; }
+        public static MLDsa ImportFromEncryptedPem(string source, byte[] passwordBytes) { throw null; }
+        public static MLDsa ImportFromEncryptedPem(string source, string password) { throw null; }
+        public static MLDsa ImportFromPem(ReadOnlySpan<char> source) { throw null; }
+        public static MLDsa ImportFromPem(string source) { throw null; }
+        public static MLDsa ImportMLDsaPrivateKey(MLDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLDsa ImportMLDsaPrivateKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static MLDsa ImportMLDsaPrivateSeed(MLDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLDsa ImportMLDsaPrivateSeed(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static MLDsa ImportMLDsaPublicKey(MLDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLDsa ImportMLDsaPublicKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static MLDsa ImportPkcs8PrivateKey(byte[] source) { throw null; }
+        public static MLDsa ImportPkcs8PrivateKey(ReadOnlySpan<byte> source) { throw null; }
+        public static MLDsa ImportSubjectPublicKeyInfo(byte[] source) { throw null; }
+        public static MLDsa ImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source) { throw null; }
+        public byte[] SignData(byte[] data, byte[]? context = null) { throw null; }
+        public void SignData(ReadOnlySpan<byte> data, Span<byte> destination, ReadOnlySpan<byte> context = default) { }
+        protected abstract void SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination);
+        public byte[] SignMu(byte[] externalMu) { throw null; }
+        public void SignMu(ReadOnlySpan<byte> externalMu, Span<byte> destination) { }
+        public byte[] SignMu(ReadOnlySpan<byte> externalMu) { throw null; }
+        protected abstract void SignMuCore(ReadOnlySpan<byte> externalMu, Span<byte> destination);
+        public byte[] SignPreHash(byte[] hash, string hashAlgorithmOid, byte[]? context = null) { throw null; }
+        public void SignPreHash(ReadOnlySpan<byte> hash, Span<byte> destination, string hashAlgorithmOid, ReadOnlySpan<byte> context = default) { }
+        protected abstract void SignPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, Span<byte> destination);
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        protected abstract bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten);
+        public bool TryExportSubjectPublicKeyInfo(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool VerifyData(byte[] data, byte[] signature, byte[]? context = null) { throw null; }
+        public bool VerifyData(ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, ReadOnlySpan<byte> context = default) { throw null; }
+        protected abstract bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature);
+        public bool VerifyMu(byte[] externalMu, byte[] signature) { throw null; }
+        public bool VerifyMu(ReadOnlySpan<byte> externalMu, ReadOnlySpan<byte> signature) { throw null; }
+        protected abstract bool VerifyMuCore(ReadOnlySpan<byte> externalMu, ReadOnlySpan<byte> signature);
+        public bool VerifyPreHash(byte[] hash, byte[] signature, string hashAlgorithmOid, byte[]? context = null) { throw null; }
+        public bool VerifyPreHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature, string hashAlgorithmOid, ReadOnlySpan<byte> context = default) { throw null; }
+        protected abstract bool VerifyPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, ReadOnlySpan<byte> signature);
+    }
+
+    public sealed partial class MLDsaAlgorithm : IEquatable<MLDsaAlgorithm>
+    {
+        internal MLDsaAlgorithm() { }
+        public static MLDsaAlgorithm MLDsa44 { get { throw null; } }
+        public static MLDsaAlgorithm MLDsa65 { get { throw null; } }
+        public static MLDsaAlgorithm MLDsa87 { get { throw null; } }
+        public int MuSizeInBytes { get { throw null; } }
+        public string Name { get { throw null; } }
+        public int PrivateKeySizeInBytes { get { throw null; } }
+        public int PrivateSeedSizeInBytes { get { throw null; } }
+        public int PublicKeySizeInBytes { get { throw null; } }
+        public int SignatureSizeInBytes { get { throw null; } }
+        public override bool Equals(object? obj) { throw null; }
+        public bool Equals(MLDsaAlgorithm? other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(MLDsaAlgorithm? left, MLDsaAlgorithm? right) { throw null; }
+        public static bool operator !=(MLDsaAlgorithm? left, MLDsaAlgorithm? right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+
+    public abstract partial class MLKem : IDisposable
+    {
+        protected MLKem(MLKemAlgorithm algorithm) { }
+        public MLKemAlgorithm Algorithm { get { throw null; } }
+        public static bool IsSupported { get { throw null; } }
+        public byte[] Decapsulate(byte[] ciphertext) { throw null; }
+        public void Decapsulate(ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret) { }
+        protected abstract void DecapsulateCore(ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret);
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public void Encapsulate(out byte[] ciphertext, out byte[] sharedSecret) { throw null; }
+        public void Encapsulate(Span<byte> ciphertext, Span<byte> sharedSecret) { }
+        protected abstract void EncapsulateCore(Span<byte> ciphertext, Span<byte> sharedSecret);
+        public byte[] ExportDecapsulationKey() { throw null; }
+        public void ExportDecapsulationKey(Span<byte> destination) { }
+        protected abstract void ExportDecapsulationKeyCore(Span<byte> destination);
+        public byte[] ExportEncapsulationKey() { throw null; }
+        public void ExportEncapsulationKey(Span<byte> destination) { }
+        protected abstract void ExportEncapsulationKeyCore(Span<byte> destination);
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(string password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportPkcs8PrivateKey() { throw null; }
+        public string ExportPkcs8PrivateKeyPem() { throw null; }
+        public byte[] ExportPrivateSeed() { throw null; }
+        public void ExportPrivateSeed(Span<byte> destination) { }
+        protected abstract void ExportPrivateSeedCore(Span<byte> destination);
+        public byte[] ExportSubjectPublicKeyInfo() { throw null; }
+        public string ExportSubjectPublicKeyInfoPem() { throw null; }
+        public static MLKem GenerateKey(MLKemAlgorithm algorithm) { throw null; }
+        public static MLKem ImportDecapsulationKey(MLKemAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLKem ImportDecapsulationKey(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static MLKem ImportEncapsulationKey(MLKemAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLKem ImportEncapsulationKey(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static MLKem ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, ReadOnlySpan<byte> source) { throw null; }
+        public static MLKem ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, ReadOnlySpan<byte> source) { throw null; }
+        public static MLKem ImportEncryptedPkcs8PrivateKey(string password, byte[] source) { throw null; }
+        public static MLKem ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<byte> passwordBytes) { throw null; }
+        public static MLKem ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<char> password) { throw null; }
+        public static MLKem ImportFromEncryptedPem(string source, byte[] passwordBytes) { throw null; }
+        public static MLKem ImportFromEncryptedPem(string source, string password) { throw null; }
+        public static MLKem ImportFromPem(ReadOnlySpan<char> source) { throw null; }
+        public static MLKem ImportFromPem(string source) { throw null; }
+        public static MLKem ImportPkcs8PrivateKey(byte[] source) { throw null; }
+        public static MLKem ImportPkcs8PrivateKey(ReadOnlySpan<byte> source) { throw null; }
+        public static MLKem ImportPrivateSeed(MLKemAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLKem ImportPrivateSeed(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static MLKem ImportSubjectPublicKeyInfo(byte[] source) { throw null; }
+        public static MLKem ImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        protected abstract bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten);
+        public bool TryExportSubjectPublicKeyInfo(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public sealed partial class MLKemAlgorithm : IEquatable<MLKemAlgorithm>
+    {
+        internal MLKemAlgorithm() { }
+        public int CiphertextSizeInBytes { get { throw null; } }
+        public int DecapsulationKeySizeInBytes { get { throw null; } }
+        public int EncapsulationKeySizeInBytes { get { throw null; } }
+        public static MLKemAlgorithm MLKem1024 { get { throw null; } }
+        public static MLKemAlgorithm MLKem512 { get { throw null; } }
+        public static MLKemAlgorithm MLKem768 { get { throw null; } }
+        public string Name { get { throw null; } }
+        public int PrivateSeedSizeInBytes { get { throw null; } }
+        public int SharedSecretSizeInBytes { get { throw null; } }
+        public override bool Equals(object? obj) { throw null; }
+        public bool Equals(MLKemAlgorithm? other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(MLKemAlgorithm? left, MLKemAlgorithm? right) { throw null; }
+        public static bool operator !=(MLKemAlgorithm? left, MLKemAlgorithm? right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+
+    public enum PbeEncryptionAlgorithm
+    {
+        Unknown = 0,
+        Aes128Cbc = 1,
+        Aes192Cbc = 2,
+        Aes256Cbc = 3,
+        TripleDes3KeyPkcs12 = 4
+    }
+
+    public sealed partial class PbeParameters
+    {
+        public PbeParameters(PbeEncryptionAlgorithm encryptionAlgorithm, HashAlgorithmName hashAlgorithm, int iterationCount) { }
+        public PbeEncryptionAlgorithm EncryptionAlgorithm { get { throw null; } }
+        public HashAlgorithmName HashAlgorithm { get { throw null; } }
+        public int IterationCount { get { throw null; } }
+    }
+
+    public abstract partial class SlhDsa : IDisposable
+    {
+        protected SlhDsa(SlhDsaAlgorithm algorithm) { }
+        public SlhDsaAlgorithm Algorithm { get { throw null; } }
+        public static bool IsSupported { get { throw null; } }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(string password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportPkcs8PrivateKey() { throw null; }
+        public string ExportPkcs8PrivateKeyPem() { throw null; }
+        public byte[] ExportSlhDsaPrivateKey() { throw null; }
+        public void ExportSlhDsaPrivateKey(Span<byte> destination) { }
+        protected abstract void ExportSlhDsaPrivateKeyCore(Span<byte> destination);
+        public byte[] ExportSlhDsaPublicKey() { throw null; }
+        public void ExportSlhDsaPublicKey(Span<byte> destination) { }
+        protected abstract void ExportSlhDsaPublicKeyCore(Span<byte> destination);
+        public byte[] ExportSubjectPublicKeyInfo() { throw null; }
+        public string ExportSubjectPublicKeyInfoPem() { throw null; }
+        public static SlhDsa GenerateKey(SlhDsaAlgorithm algorithm) { throw null; }
+        public static SlhDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, ReadOnlySpan<byte> source) { throw null; }
+        public static SlhDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, ReadOnlySpan<byte> source) { throw null; }
+        public static SlhDsa ImportEncryptedPkcs8PrivateKey(string password, byte[] source) { throw null; }
+        public static SlhDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<byte> passwordBytes) { throw null; }
+        public static SlhDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<char> password) { throw null; }
+        public static SlhDsa ImportFromEncryptedPem(string source, byte[] passwordBytes) { throw null; }
+        public static SlhDsa ImportFromEncryptedPem(string source, string password) { throw null; }
+        public static SlhDsa ImportFromPem(ReadOnlySpan<char> source) { throw null; }
+        public static SlhDsa ImportFromPem(string source) { throw null; }
+        public static SlhDsa ImportPkcs8PrivateKey(byte[] source) { throw null; }
+        public static SlhDsa ImportPkcs8PrivateKey(ReadOnlySpan<byte> source) { throw null; }
+        public static SlhDsa ImportSlhDsaPrivateKey(SlhDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static SlhDsa ImportSlhDsaPrivateKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static SlhDsa ImportSlhDsaPublicKey(SlhDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static SlhDsa ImportSlhDsaPublicKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static SlhDsa ImportSubjectPublicKeyInfo(byte[] source) { throw null; }
+        public static SlhDsa ImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source) { throw null; }
+        public byte[] SignData(byte[] data, byte[]? context = null) { throw null; }
+        public void SignData(ReadOnlySpan<byte> data, Span<byte> destination, ReadOnlySpan<byte> context = default) { }
+        protected abstract void SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination);
+        public byte[] SignPreHash(byte[] hash, string hashAlgorithmOid, byte[]? context = null) { throw null; }
+        public void SignPreHash(ReadOnlySpan<byte> hash, Span<byte> destination, string hashAlgorithmOid, ReadOnlySpan<byte> context = default) { }
+        protected abstract void SignPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, Span<byte> destination);
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        protected virtual bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportSubjectPublicKeyInfo(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool VerifyData(byte[] data, byte[] signature, byte[]? context = null) { throw null; }
+        public bool VerifyData(ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, ReadOnlySpan<byte> context = default) { throw null; }
+        protected abstract bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature);
+        public bool VerifyPreHash(byte[] hash, byte[] signature, string hashAlgorithmOid, byte[]? context = null) { throw null; }
+        public bool VerifyPreHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature, string hashAlgorithmOid, ReadOnlySpan<byte> context = default) { throw null; }
+        protected abstract bool VerifyPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, ReadOnlySpan<byte> signature);
+    }
+
+    public sealed partial class SlhDsaAlgorithm : IEquatable<SlhDsaAlgorithm>
+    {
+        internal SlhDsaAlgorithm() { }
+        public string Name { get { throw null; } }
+        public int PrivateKeySizeInBytes { get { throw null; } }
+        public int PublicKeySizeInBytes { get { throw null; } }
+        public int SignatureSizeInBytes { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_128f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_128s { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_192f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_192s { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_256f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_256s { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake128f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake128s { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake192f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake192s { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake256f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake256s { get { throw null; } }
+        public override bool Equals(object? obj) { throw null; }
+        public bool Equals(SlhDsaAlgorithm? other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(SlhDsaAlgorithm? left, SlhDsaAlgorithm? right) { throw null; }
+        public static bool operator !=(SlhDsaAlgorithm? left, SlhDsaAlgorithm? right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+
+    public sealed partial class SP800108HmacCounterKdf : IDisposable
+    {
+        public SP800108HmacCounterKdf(byte[] key, HashAlgorithmName hashAlgorithm) { }
+        public SP800108HmacCounterKdf(ReadOnlySpan<byte> key, HashAlgorithmName hashAlgorithm) { }
+        public static byte[] DeriveBytes(byte[] key, HashAlgorithmName hashAlgorithm, byte[] label, byte[] context, int derivedKeyLengthInBytes) { throw null; }
+        public static byte[] DeriveBytes(byte[] key, HashAlgorithmName hashAlgorithm, string label, string context, int derivedKeyLengthInBytes) { throw null; }
+        public static byte[] DeriveBytes(ReadOnlySpan<byte> key, HashAlgorithmName hashAlgorithm, ReadOnlySpan<byte> label, ReadOnlySpan<byte> context, int derivedKeyLengthInBytes) { throw null; }
+        public static void DeriveBytes(ReadOnlySpan<byte> key, HashAlgorithmName hashAlgorithm, ReadOnlySpan<byte> label, ReadOnlySpan<byte> context, Span<byte> destination) { }
+        public static byte[] DeriveBytes(ReadOnlySpan<byte> key, HashAlgorithmName hashAlgorithm, ReadOnlySpan<char> label, ReadOnlySpan<char> context, int derivedKeyLengthInBytes) { throw null; }
+        public static void DeriveBytes(ReadOnlySpan<byte> key, HashAlgorithmName hashAlgorithm, ReadOnlySpan<char> label, ReadOnlySpan<char> context, Span<byte> destination) { }
+        public byte[] DeriveKey(byte[] label, byte[] context, int derivedKeyLengthInBytes) { throw null; }
+        public byte[] DeriveKey(ReadOnlySpan<byte> label, ReadOnlySpan<byte> context, int derivedKeyLengthInBytes) { throw null; }
+        public void DeriveKey(ReadOnlySpan<byte> label, ReadOnlySpan<byte> context, Span<byte> destination) { }
+        public byte[] DeriveKey(ReadOnlySpan<char> label, ReadOnlySpan<char> context, int derivedKeyLengthInBytes) { throw null; }
+        public void DeriveKey(ReadOnlySpan<char> label, ReadOnlySpan<char> context, Span<byte> destination) { }
+        public byte[] DeriveKey(string label, string context, int derivedKeyLengthInBytes) { throw null; }
+        public void Dispose() { }
+    }
+}
+
+namespace System.Security.Cryptography.X509Certificates
+{
+    public sealed partial class Pkcs12LoaderLimits
+    {
+        public Pkcs12LoaderLimits() { }
+        public Pkcs12LoaderLimits(Pkcs12LoaderLimits copyFrom) { }
+        public static Pkcs12LoaderLimits DangerousNoLimits { get { throw null; } }
+        public static Pkcs12LoaderLimits Defaults { get { throw null; } }
+        public bool IgnoreEncryptedAuthSafes { get { throw null; } set { } }
+        public bool IgnorePrivateKeys { get { throw null; } set { } }
+        public int? IndividualKdfIterationLimit { get { throw null; } set { } }
+        public bool IsReadOnly { get { throw null; } }
+        public int? MacIterationLimit { get { throw null; } set { } }
+        public int? MaxCertificates { get { throw null; } set { } }
+        public int? MaxKeys { get { throw null; } set { } }
+        public bool PreserveCertificateAlias { get { throw null; } set { } }
+        public bool PreserveKeyName { get { throw null; } set { } }
+        public bool PreserveStorageProvider { get { throw null; } set { } }
+        public bool PreserveUnknownAttributes { get { throw null; } set { } }
+        public int? TotalKdfIterationLimit { get { throw null; } set { } }
+        public void MakeReadOnly() { }
+    }
+
+    public sealed partial class Pkcs12LoadLimitExceededException : CryptographicException
+    {
+        public Pkcs12LoadLimitExceededException(string propertyName) { }
+    }
+
+    public static partial class X509CertificateKeyAccessors
+    {
+        public static X509Certificate2 CopyWithPrivateKey(this X509Certificate2 certificate, CompositeMLDsa privateKey) { throw null; }
+        public static X509Certificate2 CopyWithPrivateKey(this X509Certificate2 certificate, MLDsa privateKey) { throw null; }
+        public static X509Certificate2 CopyWithPrivateKey(this X509Certificate2 certificate, MLKem privateKey) { throw null; }
+        public static X509Certificate2 CopyWithPrivateKey(this X509Certificate2 certificate, SlhDsa privateKey) { throw null; }
+        public static CompositeMLDsa? GetCompositeMLDsaPrivateKey(this X509Certificate2 certificate) { throw null; }
+        public static CompositeMLDsa? GetCompositeMLDsaPublicKey(this X509Certificate2 certificate) { throw null; }
+        public static MLDsa? GetMLDsaPrivateKey(this X509Certificate2 certificate) { throw null; }
+        public static MLDsa? GetMLDsaPublicKey(this X509Certificate2 certificate) { throw null; }
+        public static MLKem? GetMLKemPrivateKey(this X509Certificate2 certificate) { throw null; }
+        public static MLKem? GetMLKemPublicKey(this X509Certificate2 certificate) { throw null; }
+        public static SlhDsa? GetSlhDsaPrivateKey(this X509Certificate2 certificate) { throw null; }
+        public static SlhDsa? GetSlhDsaPublicKey(this X509Certificate2 certificate) { throw null; }
+    }
+
+    public static partial class X509CertificateLoader
+    {
+        public static X509Certificate2 LoadCertificate(byte[] data) { throw null; }
+        public static X509Certificate2 LoadCertificate(ReadOnlySpan<byte> data) { throw null; }
+        public static X509Certificate2 LoadCertificateFromFile(string path) { throw null; }
+        public static X509Certificate2 LoadPkcs12(byte[] data, string? password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+        public static X509Certificate2 LoadPkcs12(ReadOnlySpan<byte> data, ReadOnlySpan<char> password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+        public static X509Certificate2Collection LoadPkcs12Collection(byte[] data, string? password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+        public static X509Certificate2Collection LoadPkcs12Collection(ReadOnlySpan<byte> data, ReadOnlySpan<char> password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+        public static X509Certificate2Collection LoadPkcs12CollectionFromFile(string path, ReadOnlySpan<char> password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+        public static X509Certificate2Collection LoadPkcs12CollectionFromFile(string path, string? password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+        public static X509Certificate2 LoadPkcs12FromFile(string path, ReadOnlySpan<char> password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+        public static X509Certificate2 LoadPkcs12FromFile(string path, string? password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+    }
+}

--- a/src/source-build-assets/src/referencePackages/src/microsoft.bcl.cryptography/10.0.10/lib/netstandard2.1/Microsoft.Bcl.Cryptography.cs
+++ b/src/source-build-assets/src/referencePackages/src/microsoft.bcl.cryptography/10.0.10/lib/netstandard2.1/Microsoft.Bcl.Cryptography.cs
@@ -1,0 +1,482 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName = ".NET Standard 2.1")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("Microsoft.Bcl.Cryptography")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("IsAotCompatible", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides support for some cryptographic primitives for .NET Framework and .NET Standard.")]
+[assembly: System.Reflection.AssemblyFileVersion("10.0.1026.32716")]
+[assembly: System.Reflection.AssemblyInformationalVersion("10.0.10+f7d90799ce4ef09a0bb257852a57248d2a8fb8dd")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("Microsoft.Bcl.Cryptography")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/dotnet")]
+[assembly: System.Reflection.AssemblyVersionAttribute("10.0.0.10")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.PbeEncryptionAlgorithm))]
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(typeof(System.Security.Cryptography.PbeParameters))]
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+    internal sealed partial class MemberNotNullAttribute : Attribute
+    {
+        public MemberNotNullAttribute(string member) { }
+        public MemberNotNullAttribute(params string[] members) { }
+        public string[] Members { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+    internal sealed partial class MemberNotNullWhenAttribute : Attribute
+    {
+        public MemberNotNullWhenAttribute(bool returnValue, string member) { }
+        public MemberNotNullWhenAttribute(bool returnValue, params string[] members) { }
+        public string[] Members { get { throw null; } }
+        public bool ReturnValue { get { throw null; } }
+    }
+}
+
+namespace System.Security.Cryptography
+{
+    public abstract partial class CompositeMLDsa : IDisposable
+    {
+        protected CompositeMLDsa(CompositeMLDsaAlgorithm algorithm) { }
+        public CompositeMLDsaAlgorithm Algorithm { get { throw null; } }
+        public static bool IsSupported { get { throw null; } }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public byte[] ExportCompositeMLDsaPrivateKey() { throw null; }
+        public int ExportCompositeMLDsaPrivateKey(Span<byte> destination) { throw null; }
+        protected abstract int ExportCompositeMLDsaPrivateKeyCore(Span<byte> destination);
+        public byte[] ExportCompositeMLDsaPublicKey() { throw null; }
+        public int ExportCompositeMLDsaPublicKey(Span<byte> destination) { throw null; }
+        protected abstract int ExportCompositeMLDsaPublicKeyCore(Span<byte> destination);
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(string password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportPkcs8PrivateKey() { throw null; }
+        public string ExportPkcs8PrivateKeyPem() { throw null; }
+        public byte[] ExportSubjectPublicKeyInfo() { throw null; }
+        public string ExportSubjectPublicKeyInfoPem() { throw null; }
+        public static CompositeMLDsa GenerateKey(CompositeMLDsaAlgorithm algorithm) { throw null; }
+        public static CompositeMLDsa ImportCompositeMLDsaPrivateKey(CompositeMLDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static CompositeMLDsa ImportCompositeMLDsaPrivateKey(CompositeMLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static CompositeMLDsa ImportCompositeMLDsaPublicKey(CompositeMLDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static CompositeMLDsa ImportCompositeMLDsaPublicKey(CompositeMLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static CompositeMLDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, ReadOnlySpan<byte> source) { throw null; }
+        public static CompositeMLDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, ReadOnlySpan<byte> source) { throw null; }
+        public static CompositeMLDsa ImportEncryptedPkcs8PrivateKey(string password, byte[] source) { throw null; }
+        public static CompositeMLDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<byte> passwordBytes) { throw null; }
+        public static CompositeMLDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<char> password) { throw null; }
+        public static CompositeMLDsa ImportFromEncryptedPem(string source, byte[] passwordBytes) { throw null; }
+        public static CompositeMLDsa ImportFromEncryptedPem(string source, string password) { throw null; }
+        public static CompositeMLDsa ImportFromPem(ReadOnlySpan<char> source) { throw null; }
+        public static CompositeMLDsa ImportFromPem(string source) { throw null; }
+        public static CompositeMLDsa ImportPkcs8PrivateKey(byte[] source) { throw null; }
+        public static CompositeMLDsa ImportPkcs8PrivateKey(ReadOnlySpan<byte> source) { throw null; }
+        public static CompositeMLDsa ImportSubjectPublicKeyInfo(byte[] source) { throw null; }
+        public static CompositeMLDsa ImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source) { throw null; }
+        public static bool IsAlgorithmSupported(CompositeMLDsaAlgorithm algorithm) { throw null; }
+        public byte[] SignData(byte[] data, byte[]? context = null) { throw null; }
+        public int SignData(ReadOnlySpan<byte> data, Span<byte> destination, ReadOnlySpan<byte> context = default) { throw null; }
+        protected abstract int SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination);
+        public bool TryExportCompositeMLDsaPrivateKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportCompositeMLDsaPublicKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        protected abstract bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten);
+        public bool TryExportSubjectPublicKeyInfo(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool VerifyData(byte[] data, byte[] signature, byte[]? context = null) { throw null; }
+        public bool VerifyData(ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, ReadOnlySpan<byte> context = default) { throw null; }
+        protected abstract bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature);
+    }
+
+    public sealed partial class CompositeMLDsaAlgorithm : IEquatable<CompositeMLDsaAlgorithm>
+    {
+        internal CompositeMLDsaAlgorithm() { }
+        public int MaxSignatureSizeInBytes { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa44WithECDsaP256 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa44WithEd25519 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa44WithRSA2048Pkcs15 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa44WithRSA2048Pss { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithECDsaBrainpoolP256r1 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithECDsaP256 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithECDsaP384 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithEd25519 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithRSA3072Pkcs15 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithRSA3072Pss { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithRSA4096Pkcs15 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa65WithRSA4096Pss { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithECDsaBrainpoolP384r1 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithECDsaP384 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithECDsaP521 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithEd448 { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithRSA3072Pss { get { throw null; } }
+        public static CompositeMLDsaAlgorithm MLDsa87WithRSA4096Pss { get { throw null; } }
+        public string Name { get { throw null; } }
+        public override bool Equals(object? obj) { throw null; }
+        public bool Equals(CompositeMLDsaAlgorithm? other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(CompositeMLDsaAlgorithm? left, CompositeMLDsaAlgorithm? right) { throw null; }
+        public static bool operator !=(CompositeMLDsaAlgorithm? left, CompositeMLDsaAlgorithm? right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+
+    public abstract partial class MLDsa : IDisposable
+    {
+        protected MLDsa(MLDsaAlgorithm algorithm) { }
+        public MLDsaAlgorithm Algorithm { get { throw null; } }
+        public static bool IsSupported { get { throw null; } }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(string password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportMLDsaPrivateKey() { throw null; }
+        public void ExportMLDsaPrivateKey(Span<byte> destination) { }
+        protected abstract void ExportMLDsaPrivateKeyCore(Span<byte> destination);
+        public byte[] ExportMLDsaPrivateSeed() { throw null; }
+        public void ExportMLDsaPrivateSeed(Span<byte> destination) { }
+        protected abstract void ExportMLDsaPrivateSeedCore(Span<byte> destination);
+        public byte[] ExportMLDsaPublicKey() { throw null; }
+        public void ExportMLDsaPublicKey(Span<byte> destination) { }
+        protected abstract void ExportMLDsaPublicKeyCore(Span<byte> destination);
+        public byte[] ExportPkcs8PrivateKey() { throw null; }
+        public string ExportPkcs8PrivateKeyPem() { throw null; }
+        public byte[] ExportSubjectPublicKeyInfo() { throw null; }
+        public string ExportSubjectPublicKeyInfoPem() { throw null; }
+        public static MLDsa GenerateKey(MLDsaAlgorithm algorithm) { throw null; }
+        public static MLDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, ReadOnlySpan<byte> source) { throw null; }
+        public static MLDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, ReadOnlySpan<byte> source) { throw null; }
+        public static MLDsa ImportEncryptedPkcs8PrivateKey(string password, byte[] source) { throw null; }
+        public static MLDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<byte> passwordBytes) { throw null; }
+        public static MLDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<char> password) { throw null; }
+        public static MLDsa ImportFromEncryptedPem(string source, byte[] passwordBytes) { throw null; }
+        public static MLDsa ImportFromEncryptedPem(string source, string password) { throw null; }
+        public static MLDsa ImportFromPem(ReadOnlySpan<char> source) { throw null; }
+        public static MLDsa ImportFromPem(string source) { throw null; }
+        public static MLDsa ImportMLDsaPrivateKey(MLDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLDsa ImportMLDsaPrivateKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static MLDsa ImportMLDsaPrivateSeed(MLDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLDsa ImportMLDsaPrivateSeed(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static MLDsa ImportMLDsaPublicKey(MLDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLDsa ImportMLDsaPublicKey(MLDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static MLDsa ImportPkcs8PrivateKey(byte[] source) { throw null; }
+        public static MLDsa ImportPkcs8PrivateKey(ReadOnlySpan<byte> source) { throw null; }
+        public static MLDsa ImportSubjectPublicKeyInfo(byte[] source) { throw null; }
+        public static MLDsa ImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source) { throw null; }
+        public byte[] SignData(byte[] data, byte[]? context = null) { throw null; }
+        public void SignData(ReadOnlySpan<byte> data, Span<byte> destination, ReadOnlySpan<byte> context = default) { }
+        protected abstract void SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination);
+        public byte[] SignMu(byte[] externalMu) { throw null; }
+        public void SignMu(ReadOnlySpan<byte> externalMu, Span<byte> destination) { }
+        public byte[] SignMu(ReadOnlySpan<byte> externalMu) { throw null; }
+        protected abstract void SignMuCore(ReadOnlySpan<byte> externalMu, Span<byte> destination);
+        public byte[] SignPreHash(byte[] hash, string hashAlgorithmOid, byte[]? context = null) { throw null; }
+        public void SignPreHash(ReadOnlySpan<byte> hash, Span<byte> destination, string hashAlgorithmOid, ReadOnlySpan<byte> context = default) { }
+        protected abstract void SignPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, Span<byte> destination);
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        protected abstract bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten);
+        public bool TryExportSubjectPublicKeyInfo(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool VerifyData(byte[] data, byte[] signature, byte[]? context = null) { throw null; }
+        public bool VerifyData(ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, ReadOnlySpan<byte> context = default) { throw null; }
+        protected abstract bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature);
+        public bool VerifyMu(byte[] externalMu, byte[] signature) { throw null; }
+        public bool VerifyMu(ReadOnlySpan<byte> externalMu, ReadOnlySpan<byte> signature) { throw null; }
+        protected abstract bool VerifyMuCore(ReadOnlySpan<byte> externalMu, ReadOnlySpan<byte> signature);
+        public bool VerifyPreHash(byte[] hash, byte[] signature, string hashAlgorithmOid, byte[]? context = null) { throw null; }
+        public bool VerifyPreHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature, string hashAlgorithmOid, ReadOnlySpan<byte> context = default) { throw null; }
+        protected abstract bool VerifyPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, ReadOnlySpan<byte> signature);
+    }
+
+    public sealed partial class MLDsaAlgorithm : IEquatable<MLDsaAlgorithm>
+    {
+        internal MLDsaAlgorithm() { }
+        public static MLDsaAlgorithm MLDsa44 { get { throw null; } }
+        public static MLDsaAlgorithm MLDsa65 { get { throw null; } }
+        public static MLDsaAlgorithm MLDsa87 { get { throw null; } }
+        public int MuSizeInBytes { get { throw null; } }
+        public string Name { get { throw null; } }
+        public int PrivateKeySizeInBytes { get { throw null; } }
+        public int PrivateSeedSizeInBytes { get { throw null; } }
+        public int PublicKeySizeInBytes { get { throw null; } }
+        public int SignatureSizeInBytes { get { throw null; } }
+        public override bool Equals(object? obj) { throw null; }
+        public bool Equals(MLDsaAlgorithm? other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(MLDsaAlgorithm? left, MLDsaAlgorithm? right) { throw null; }
+        public static bool operator !=(MLDsaAlgorithm? left, MLDsaAlgorithm? right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+
+    public abstract partial class MLKem : IDisposable
+    {
+        protected MLKem(MLKemAlgorithm algorithm) { }
+        public MLKemAlgorithm Algorithm { get { throw null; } }
+        public static bool IsSupported { get { throw null; } }
+        public byte[] Decapsulate(byte[] ciphertext) { throw null; }
+        public void Decapsulate(ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret) { }
+        protected abstract void DecapsulateCore(ReadOnlySpan<byte> ciphertext, Span<byte> sharedSecret);
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public void Encapsulate(out byte[] ciphertext, out byte[] sharedSecret) { throw null; }
+        public void Encapsulate(Span<byte> ciphertext, Span<byte> sharedSecret) { }
+        protected abstract void EncapsulateCore(Span<byte> ciphertext, Span<byte> sharedSecret);
+        public byte[] ExportDecapsulationKey() { throw null; }
+        public void ExportDecapsulationKey(Span<byte> destination) { }
+        protected abstract void ExportDecapsulationKeyCore(Span<byte> destination);
+        public byte[] ExportEncapsulationKey() { throw null; }
+        public void ExportEncapsulationKey(Span<byte> destination) { }
+        protected abstract void ExportEncapsulationKeyCore(Span<byte> destination);
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(string password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportPkcs8PrivateKey() { throw null; }
+        public string ExportPkcs8PrivateKeyPem() { throw null; }
+        public byte[] ExportPrivateSeed() { throw null; }
+        public void ExportPrivateSeed(Span<byte> destination) { }
+        protected abstract void ExportPrivateSeedCore(Span<byte> destination);
+        public byte[] ExportSubjectPublicKeyInfo() { throw null; }
+        public string ExportSubjectPublicKeyInfoPem() { throw null; }
+        public static MLKem GenerateKey(MLKemAlgorithm algorithm) { throw null; }
+        public static MLKem ImportDecapsulationKey(MLKemAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLKem ImportDecapsulationKey(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static MLKem ImportEncapsulationKey(MLKemAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLKem ImportEncapsulationKey(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static MLKem ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, ReadOnlySpan<byte> source) { throw null; }
+        public static MLKem ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, ReadOnlySpan<byte> source) { throw null; }
+        public static MLKem ImportEncryptedPkcs8PrivateKey(string password, byte[] source) { throw null; }
+        public static MLKem ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<byte> passwordBytes) { throw null; }
+        public static MLKem ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<char> password) { throw null; }
+        public static MLKem ImportFromEncryptedPem(string source, byte[] passwordBytes) { throw null; }
+        public static MLKem ImportFromEncryptedPem(string source, string password) { throw null; }
+        public static MLKem ImportFromPem(ReadOnlySpan<char> source) { throw null; }
+        public static MLKem ImportFromPem(string source) { throw null; }
+        public static MLKem ImportPkcs8PrivateKey(byte[] source) { throw null; }
+        public static MLKem ImportPkcs8PrivateKey(ReadOnlySpan<byte> source) { throw null; }
+        public static MLKem ImportPrivateSeed(MLKemAlgorithm algorithm, byte[] source) { throw null; }
+        public static MLKem ImportPrivateSeed(MLKemAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static MLKem ImportSubjectPublicKeyInfo(byte[] source) { throw null; }
+        public static MLKem ImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        protected abstract bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten);
+        public bool TryExportSubjectPublicKeyInfo(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public sealed partial class MLKemAlgorithm : IEquatable<MLKemAlgorithm>
+    {
+        internal MLKemAlgorithm() { }
+        public int CiphertextSizeInBytes { get { throw null; } }
+        public int DecapsulationKeySizeInBytes { get { throw null; } }
+        public int EncapsulationKeySizeInBytes { get { throw null; } }
+        public static MLKemAlgorithm MLKem1024 { get { throw null; } }
+        public static MLKemAlgorithm MLKem512 { get { throw null; } }
+        public static MLKemAlgorithm MLKem768 { get { throw null; } }
+        public string Name { get { throw null; } }
+        public int PrivateSeedSizeInBytes { get { throw null; } }
+        public int SharedSecretSizeInBytes { get { throw null; } }
+        public override bool Equals(object? obj) { throw null; }
+        public bool Equals(MLKemAlgorithm? other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(MLKemAlgorithm? left, MLKemAlgorithm? right) { throw null; }
+        public static bool operator !=(MLKemAlgorithm? left, MLKemAlgorithm? right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+
+    public abstract partial class SlhDsa : IDisposable
+    {
+        protected SlhDsa(SlhDsaAlgorithm algorithm) { }
+        public SlhDsaAlgorithm Algorithm { get { throw null; } }
+        public static bool IsSupported { get { throw null; } }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(ReadOnlySpan<char> password, PbeParameters pbeParameters) { throw null; }
+        public string ExportEncryptedPkcs8PrivateKeyPem(string password, PbeParameters pbeParameters) { throw null; }
+        public byte[] ExportPkcs8PrivateKey() { throw null; }
+        public string ExportPkcs8PrivateKeyPem() { throw null; }
+        public byte[] ExportSlhDsaPrivateKey() { throw null; }
+        public void ExportSlhDsaPrivateKey(Span<byte> destination) { }
+        protected abstract void ExportSlhDsaPrivateKeyCore(Span<byte> destination);
+        public byte[] ExportSlhDsaPublicKey() { throw null; }
+        public void ExportSlhDsaPublicKey(Span<byte> destination) { }
+        protected abstract void ExportSlhDsaPublicKeyCore(Span<byte> destination);
+        public byte[] ExportSubjectPublicKeyInfo() { throw null; }
+        public string ExportSubjectPublicKeyInfoPem() { throw null; }
+        public static SlhDsa GenerateKey(SlhDsaAlgorithm algorithm) { throw null; }
+        public static SlhDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, ReadOnlySpan<byte> source) { throw null; }
+        public static SlhDsa ImportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, ReadOnlySpan<byte> source) { throw null; }
+        public static SlhDsa ImportEncryptedPkcs8PrivateKey(string password, byte[] source) { throw null; }
+        public static SlhDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<byte> passwordBytes) { throw null; }
+        public static SlhDsa ImportFromEncryptedPem(ReadOnlySpan<char> source, ReadOnlySpan<char> password) { throw null; }
+        public static SlhDsa ImportFromEncryptedPem(string source, byte[] passwordBytes) { throw null; }
+        public static SlhDsa ImportFromEncryptedPem(string source, string password) { throw null; }
+        public static SlhDsa ImportFromPem(ReadOnlySpan<char> source) { throw null; }
+        public static SlhDsa ImportFromPem(string source) { throw null; }
+        public static SlhDsa ImportPkcs8PrivateKey(byte[] source) { throw null; }
+        public static SlhDsa ImportPkcs8PrivateKey(ReadOnlySpan<byte> source) { throw null; }
+        public static SlhDsa ImportSlhDsaPrivateKey(SlhDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static SlhDsa ImportSlhDsaPrivateKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static SlhDsa ImportSlhDsaPublicKey(SlhDsaAlgorithm algorithm, byte[] source) { throw null; }
+        public static SlhDsa ImportSlhDsaPublicKey(SlhDsaAlgorithm algorithm, ReadOnlySpan<byte> source) { throw null; }
+        public static SlhDsa ImportSubjectPublicKeyInfo(byte[] source) { throw null; }
+        public static SlhDsa ImportSubjectPublicKeyInfo(ReadOnlySpan<byte> source) { throw null; }
+        public byte[] SignData(byte[] data, byte[]? context = null) { throw null; }
+        public void SignData(ReadOnlySpan<byte> data, Span<byte> destination, ReadOnlySpan<byte> context = default) { }
+        protected abstract void SignDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, Span<byte> destination);
+        public byte[] SignPreHash(byte[] hash, string hashAlgorithmOid, byte[]? context = null) { throw null; }
+        public void SignPreHash(ReadOnlySpan<byte> hash, Span<byte> destination, string hashAlgorithmOid, ReadOnlySpan<byte> context = default) { }
+        protected abstract void SignPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, Span<byte> destination);
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<byte> passwordBytes, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(ReadOnlySpan<char> password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportEncryptedPkcs8PrivateKey(string password, PbeParameters pbeParameters, Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportPkcs8PrivateKey(Span<byte> destination, out int bytesWritten) { throw null; }
+        protected virtual bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool TryExportSubjectPublicKeyInfo(Span<byte> destination, out int bytesWritten) { throw null; }
+        public bool VerifyData(byte[] data, byte[] signature, byte[]? context = null) { throw null; }
+        public bool VerifyData(ReadOnlySpan<byte> data, ReadOnlySpan<byte> signature, ReadOnlySpan<byte> context = default) { throw null; }
+        protected abstract bool VerifyDataCore(ReadOnlySpan<byte> data, ReadOnlySpan<byte> context, ReadOnlySpan<byte> signature);
+        public bool VerifyPreHash(byte[] hash, byte[] signature, string hashAlgorithmOid, byte[]? context = null) { throw null; }
+        public bool VerifyPreHash(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> signature, string hashAlgorithmOid, ReadOnlySpan<byte> context = default) { throw null; }
+        protected abstract bool VerifyPreHashCore(ReadOnlySpan<byte> hash, ReadOnlySpan<byte> context, string hashAlgorithmOid, ReadOnlySpan<byte> signature);
+    }
+
+    public sealed partial class SlhDsaAlgorithm : IEquatable<SlhDsaAlgorithm>
+    {
+        internal SlhDsaAlgorithm() { }
+        public string Name { get { throw null; } }
+        public int PrivateKeySizeInBytes { get { throw null; } }
+        public int PublicKeySizeInBytes { get { throw null; } }
+        public int SignatureSizeInBytes { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_128f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_128s { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_192f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_192s { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_256f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaSha2_256s { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake128f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake128s { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake192f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake192s { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake256f { get { throw null; } }
+        public static SlhDsaAlgorithm SlhDsaShake256s { get { throw null; } }
+        public override bool Equals(object? obj) { throw null; }
+        public bool Equals(SlhDsaAlgorithm? other) { throw null; }
+        public override int GetHashCode() { throw null; }
+        public static bool operator ==(SlhDsaAlgorithm? left, SlhDsaAlgorithm? right) { throw null; }
+        public static bool operator !=(SlhDsaAlgorithm? left, SlhDsaAlgorithm? right) { throw null; }
+        public override string ToString() { throw null; }
+    }
+
+    public sealed partial class SP800108HmacCounterKdf : IDisposable
+    {
+        public SP800108HmacCounterKdf(byte[] key, HashAlgorithmName hashAlgorithm) { }
+        public SP800108HmacCounterKdf(ReadOnlySpan<byte> key, HashAlgorithmName hashAlgorithm) { }
+        public static byte[] DeriveBytes(byte[] key, HashAlgorithmName hashAlgorithm, byte[] label, byte[] context, int derivedKeyLengthInBytes) { throw null; }
+        public static byte[] DeriveBytes(byte[] key, HashAlgorithmName hashAlgorithm, string label, string context, int derivedKeyLengthInBytes) { throw null; }
+        public static byte[] DeriveBytes(ReadOnlySpan<byte> key, HashAlgorithmName hashAlgorithm, ReadOnlySpan<byte> label, ReadOnlySpan<byte> context, int derivedKeyLengthInBytes) { throw null; }
+        public static void DeriveBytes(ReadOnlySpan<byte> key, HashAlgorithmName hashAlgorithm, ReadOnlySpan<byte> label, ReadOnlySpan<byte> context, Span<byte> destination) { }
+        public static byte[] DeriveBytes(ReadOnlySpan<byte> key, HashAlgorithmName hashAlgorithm, ReadOnlySpan<char> label, ReadOnlySpan<char> context, int derivedKeyLengthInBytes) { throw null; }
+        public static void DeriveBytes(ReadOnlySpan<byte> key, HashAlgorithmName hashAlgorithm, ReadOnlySpan<char> label, ReadOnlySpan<char> context, Span<byte> destination) { }
+        public byte[] DeriveKey(byte[] label, byte[] context, int derivedKeyLengthInBytes) { throw null; }
+        public byte[] DeriveKey(ReadOnlySpan<byte> label, ReadOnlySpan<byte> context, int derivedKeyLengthInBytes) { throw null; }
+        public void DeriveKey(ReadOnlySpan<byte> label, ReadOnlySpan<byte> context, Span<byte> destination) { }
+        public byte[] DeriveKey(ReadOnlySpan<char> label, ReadOnlySpan<char> context, int derivedKeyLengthInBytes) { throw null; }
+        public void DeriveKey(ReadOnlySpan<char> label, ReadOnlySpan<char> context, Span<byte> destination) { }
+        public byte[] DeriveKey(string label, string context, int derivedKeyLengthInBytes) { throw null; }
+        public void Dispose() { }
+    }
+}
+
+namespace System.Security.Cryptography.X509Certificates
+{
+    public sealed partial class Pkcs12LoaderLimits
+    {
+        public Pkcs12LoaderLimits() { }
+        public Pkcs12LoaderLimits(Pkcs12LoaderLimits copyFrom) { }
+        public static Pkcs12LoaderLimits DangerousNoLimits { get { throw null; } }
+        public static Pkcs12LoaderLimits Defaults { get { throw null; } }
+        public bool IgnoreEncryptedAuthSafes { get { throw null; } set { } }
+        public bool IgnorePrivateKeys { get { throw null; } set { } }
+        public int? IndividualKdfIterationLimit { get { throw null; } set { } }
+        public bool IsReadOnly { get { throw null; } }
+        public int? MacIterationLimit { get { throw null; } set { } }
+        public int? MaxCertificates { get { throw null; } set { } }
+        public int? MaxKeys { get { throw null; } set { } }
+        public bool PreserveCertificateAlias { get { throw null; } set { } }
+        public bool PreserveKeyName { get { throw null; } set { } }
+        public bool PreserveStorageProvider { get { throw null; } set { } }
+        public bool PreserveUnknownAttributes { get { throw null; } set { } }
+        public int? TotalKdfIterationLimit { get { throw null; } set { } }
+        public void MakeReadOnly() { }
+    }
+
+    public sealed partial class Pkcs12LoadLimitExceededException : CryptographicException
+    {
+        public Pkcs12LoadLimitExceededException(string propertyName) { }
+    }
+
+    public static partial class X509CertificateKeyAccessors
+    {
+        public static X509Certificate2 CopyWithPrivateKey(this X509Certificate2 certificate, CompositeMLDsa privateKey) { throw null; }
+        public static X509Certificate2 CopyWithPrivateKey(this X509Certificate2 certificate, MLDsa privateKey) { throw null; }
+        public static X509Certificate2 CopyWithPrivateKey(this X509Certificate2 certificate, MLKem privateKey) { throw null; }
+        public static X509Certificate2 CopyWithPrivateKey(this X509Certificate2 certificate, SlhDsa privateKey) { throw null; }
+        public static CompositeMLDsa? GetCompositeMLDsaPrivateKey(this X509Certificate2 certificate) { throw null; }
+        public static CompositeMLDsa? GetCompositeMLDsaPublicKey(this X509Certificate2 certificate) { throw null; }
+        public static MLDsa? GetMLDsaPrivateKey(this X509Certificate2 certificate) { throw null; }
+        public static MLDsa? GetMLDsaPublicKey(this X509Certificate2 certificate) { throw null; }
+        public static MLKem? GetMLKemPrivateKey(this X509Certificate2 certificate) { throw null; }
+        public static MLKem? GetMLKemPublicKey(this X509Certificate2 certificate) { throw null; }
+        public static SlhDsa? GetSlhDsaPrivateKey(this X509Certificate2 certificate) { throw null; }
+        public static SlhDsa? GetSlhDsaPublicKey(this X509Certificate2 certificate) { throw null; }
+    }
+
+    public static partial class X509CertificateLoader
+    {
+        public static X509Certificate2 LoadCertificate(byte[] data) { throw null; }
+        public static X509Certificate2 LoadCertificate(ReadOnlySpan<byte> data) { throw null; }
+        public static X509Certificate2 LoadCertificateFromFile(string path) { throw null; }
+        public static X509Certificate2 LoadPkcs12(byte[] data, string? password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+        public static X509Certificate2 LoadPkcs12(ReadOnlySpan<byte> data, ReadOnlySpan<char> password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+        public static X509Certificate2Collection LoadPkcs12Collection(byte[] data, string? password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+        public static X509Certificate2Collection LoadPkcs12Collection(ReadOnlySpan<byte> data, ReadOnlySpan<char> password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+        public static X509Certificate2Collection LoadPkcs12CollectionFromFile(string path, ReadOnlySpan<char> password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+        public static X509Certificate2Collection LoadPkcs12CollectionFromFile(string path, string? password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+        public static X509Certificate2 LoadPkcs12FromFile(string path, ReadOnlySpan<char> password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+        public static X509Certificate2 LoadPkcs12FromFile(string path, string? password, X509KeyStorageFlags keyStorageFlags = X509KeyStorageFlags.DefaultKeySet, Pkcs12LoaderLimits? loaderLimits = null) { throw null; }
+    }
+}

--- a/src/source-build-assets/src/referencePackages/src/microsoft.bcl.cryptography/10.0.10/microsoft.bcl.cryptography.nuspec
+++ b/src/source-build-assets/src/referencePackages/src/microsoft.bcl.cryptography/10.0.10/microsoft.bcl.cryptography.nuspec
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Bcl.Cryptography</id>
+    <version>10.0.10</version>
+    <authors>Microsoft</authors>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://dot.net/</projectUrl>
+    <description>Provides support for some cryptographic primitives for .NET Framework and .NET Standard.</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/dotnet" commit="f7d90799ce4ef09a0bb257852a57248d2a8fb8dd" />
+    <dependencies>
+      <group targetFramework="net8.0">
+        <dependency id="System.Formats.Asn1" version="10.0.10" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net9.0" />
+      <group targetFramework="net10.0" />
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Formats.Asn1" version="10.0.10" exclude="Build,Analyzers" />
+        <dependency id="System.Memory" version="4.6.3" exclude="Build,Analyzers" />
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.1">
+        <dependency id="System.Formats.Asn1" version="10.0.10" exclude="Build,Analyzers" />
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>

--- a/src/source-build-assets/src/referencePackages/src/system.formats.asn1/10.0.10/System.Formats.Asn1.10.0.10.csproj
+++ b/src/source-build-assets/src/referencePackages/src/system.formats.asn1/10.0.10/System.Formats.Asn1.10.0.10.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageId>System.Formats.Asn1</PackageId>
+    <!-- Microsoft.Bcl.Cryptography only depends on this package for these TFMs. -->
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>10.0.10</PackageVersion>
+    <AssemblyName>System.Formats.Asn1</AssemblyName>
+    <StrongNameKeyId>Open</StrongNameKeyId>
+    <Description>Provides classes that can read and write the ASN.1 BER, CER, and DER data formats.</Description>
+    <PackageProjectUrl>https://dot.net/</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReleaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</PackageReleaseNotes>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <ProjectReference Include="../../system.memory/4.6.3/System.Memory.4.6.3.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/source-build-assets/src/referencePackages/src/system.formats.asn1/10.0.10/lib/net8.0/System.Formats.Asn1.cs
+++ b/src/source-build-assets/src/referencePackages/src/system.formats.asn1/10.0.10/lib/net8.0/System.Formats.Asn1.cs
@@ -1,0 +1,279 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName = ".NET 8.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Formats.Asn1")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("IsAotCompatible", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides classes that can read and write the ASN.1 BER, CER, and DER data formats.")]
+[assembly: System.Reflection.AssemblyFileVersion("10.0.1026.32716")]
+[assembly: System.Reflection.AssemblyInformationalVersion("10.0.10+f7d90799ce4ef09a0bb257852a57248d2a8fb8dd")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Formats.Asn1")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/dotnet")]
+[assembly: System.Reflection.AssemblyVersionAttribute("10.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Formats.Asn1
+{
+    public readonly partial struct Asn1Tag : IEquatable<Asn1Tag>
+    {
+        private readonly int _dummyPrimitive;
+        public static readonly Asn1Tag Boolean;
+        public static readonly Asn1Tag ConstructedBitString;
+        public static readonly Asn1Tag ConstructedOctetString;
+        public static readonly Asn1Tag Enumerated;
+        public static readonly Asn1Tag GeneralizedTime;
+        public static readonly Asn1Tag Integer;
+        public static readonly Asn1Tag Null;
+        public static readonly Asn1Tag ObjectIdentifier;
+        public static readonly Asn1Tag PrimitiveBitString;
+        public static readonly Asn1Tag PrimitiveOctetString;
+        public static readonly Asn1Tag Sequence;
+        public static readonly Asn1Tag SetOf;
+        public static readonly Asn1Tag UtcTime;
+        public Asn1Tag(TagClass tagClass, int tagValue, bool isConstructed = false) { }
+        public Asn1Tag(UniversalTagNumber universalTagNumber, bool isConstructed = false) { }
+        public bool IsConstructed { get { throw null; } }
+        public TagClass TagClass { get { throw null; } }
+        public int TagValue { get { throw null; } }
+        public readonly Asn1Tag AsConstructed() { throw null; }
+        public readonly Asn1Tag AsPrimitive() { throw null; }
+        public readonly int CalculateEncodedSize() { throw null; }
+        public static Asn1Tag Decode(ReadOnlySpan<byte> source, out int bytesConsumed) { throw null; }
+        public readonly int Encode(Span<byte> destination) { throw null; }
+        public readonly bool Equals(Asn1Tag other) { throw null; }
+        public override readonly bool Equals(object? obj) { throw null; }
+        public override readonly int GetHashCode() { throw null; }
+        public readonly bool HasSameClassAndValue(Asn1Tag other) { throw null; }
+        public static bool operator ==(Asn1Tag left, Asn1Tag right) { throw null; }
+        public static bool operator !=(Asn1Tag left, Asn1Tag right) { throw null; }
+        public override readonly string ToString() { throw null; }
+        public static bool TryDecode(ReadOnlySpan<byte> source, out Asn1Tag tag, out int bytesConsumed) { throw null; }
+        public readonly bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public partial class AsnContentException : Exception
+    {
+        public AsnContentException() { }
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId = "SYSLIB0051", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        protected AsnContentException(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+        public AsnContentException(string? message, Exception? inner) { }
+        public AsnContentException(string? message) { }
+    }
+
+    public static partial class AsnDecoder
+    {
+        public static int? DecodeLength(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed) { throw null; }
+        public static byte[] ReadBitString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int unusedBitCount, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static bool ReadBoolean(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static string ReadCharacterString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, UniversalTagNumber encodingType, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static Asn1Tag ReadEncodedValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int contentOffset, out int contentLength, out int bytesConsumed) { throw null; }
+        public static ReadOnlySpan<byte> ReadEnumeratedBytes(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static Enum ReadEnumeratedValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, Type enumType, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static TEnum ReadEnumeratedValue<TEnum>(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) where TEnum : Enum { throw null; }
+        public static DateTimeOffset ReadGeneralizedTime(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static Numerics.BigInteger ReadInteger(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static ReadOnlySpan<byte> ReadIntegerBytes(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static Collections.BitArray ReadNamedBitList(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static Enum ReadNamedBitListValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, Type flagsEnumType, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static TFlagsEnum ReadNamedBitListValue<TFlagsEnum>(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) where TFlagsEnum : Enum { throw null; }
+        public static void ReadNull(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static string ReadObjectIdentifier(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static byte[] ReadOctetString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static void ReadSequence(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int contentOffset, out int contentLength, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static void ReadSetOf(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int contentOffset, out int contentLength, out int bytesConsumed, bool skipSortOrderValidation = false, Asn1Tag? expectedTag = null) { throw null; }
+        public static DateTimeOffset ReadUtcTime(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, int twoDigitYearMax = 2049, Asn1Tag? expectedTag = null) { throw null; }
+        public static bool TryDecodeLength(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int? decodedLength, out int bytesConsumed) { throw null; }
+        public static bool TryReadBitString(ReadOnlySpan<byte> source, Span<byte> destination, AsnEncodingRules ruleSet, out int unusedBitCount, out int bytesConsumed, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+        public static bool TryReadCharacterString(ReadOnlySpan<byte> source, Span<char> destination, AsnEncodingRules ruleSet, UniversalTagNumber encodingType, out int bytesConsumed, out int charsWritten, Asn1Tag? expectedTag = null) { throw null; }
+        public static bool TryReadCharacterStringBytes(ReadOnlySpan<byte> source, Span<byte> destination, AsnEncodingRules ruleSet, Asn1Tag expectedTag, out int bytesConsumed, out int bytesWritten) { throw null; }
+        public static bool TryReadEncodedValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out Asn1Tag tag, out int contentOffset, out int contentLength, out int bytesConsumed) { throw null; }
+        public static bool TryReadInt32(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static bool TryReadInt64(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out long value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static bool TryReadOctetString(ReadOnlySpan<byte> source, Span<byte> destination, AsnEncodingRules ruleSet, out int bytesConsumed, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+        public static bool TryReadPrimitiveBitString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int unusedBitCount, out ReadOnlySpan<byte> value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static bool TryReadPrimitiveCharacterStringBytes(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, Asn1Tag expectedTag, out ReadOnlySpan<byte> value, out int bytesConsumed) { throw null; }
+        public static bool TryReadPrimitiveOctetString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out ReadOnlySpan<byte> value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        [CLSCompliant(false)]
+        public static bool TryReadUInt32(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out uint value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        [CLSCompliant(false)]
+        public static bool TryReadUInt64(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out ulong value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+    }
+
+    public enum AsnEncodingRules
+    {
+        BER = 0,
+        CER = 1,
+        DER = 2
+    }
+
+    public partial class AsnReader
+    {
+        public AsnReader(ReadOnlyMemory<byte> data, AsnEncodingRules ruleSet, AsnReaderOptions options = default) { }
+        public bool HasData { get { throw null; } }
+        public AsnEncodingRules RuleSet { get { throw null; } }
+        public AsnReader Clone() { throw null; }
+        public ReadOnlyMemory<byte> PeekContentBytes() { throw null; }
+        public ReadOnlyMemory<byte> PeekEncodedValue() { throw null; }
+        public Asn1Tag PeekTag() { throw null; }
+        public byte[] ReadBitString(out int unusedBitCount, Asn1Tag? expectedTag = null) { throw null; }
+        public bool ReadBoolean(Asn1Tag? expectedTag = null) { throw null; }
+        public string ReadCharacterString(UniversalTagNumber encodingType, Asn1Tag? expectedTag = null) { throw null; }
+        public ReadOnlyMemory<byte> ReadEncodedValue() { throw null; }
+        public ReadOnlyMemory<byte> ReadEnumeratedBytes(Asn1Tag? expectedTag = null) { throw null; }
+        public Enum ReadEnumeratedValue(Type enumType, Asn1Tag? expectedTag = null) { throw null; }
+        public TEnum ReadEnumeratedValue<TEnum>(Asn1Tag? expectedTag = null) where TEnum : Enum { throw null; }
+        public DateTimeOffset ReadGeneralizedTime(Asn1Tag? expectedTag = null) { throw null; }
+        public Numerics.BigInteger ReadInteger(Asn1Tag? expectedTag = null) { throw null; }
+        public ReadOnlyMemory<byte> ReadIntegerBytes(Asn1Tag? expectedTag = null) { throw null; }
+        public Collections.BitArray ReadNamedBitList(Asn1Tag? expectedTag = null) { throw null; }
+        public Enum ReadNamedBitListValue(Type flagsEnumType, Asn1Tag? expectedTag = null) { throw null; }
+        public TFlagsEnum ReadNamedBitListValue<TFlagsEnum>(Asn1Tag? expectedTag = null) where TFlagsEnum : Enum { throw null; }
+        public void ReadNull(Asn1Tag? expectedTag = null) { }
+        public string ReadObjectIdentifier(Asn1Tag? expectedTag = null) { throw null; }
+        public byte[] ReadOctetString(Asn1Tag? expectedTag = null) { throw null; }
+        public AsnReader ReadSequence(Asn1Tag? expectedTag = null) { throw null; }
+        public AsnReader ReadSetOf(bool skipSortOrderValidation, Asn1Tag? expectedTag = null) { throw null; }
+        public AsnReader ReadSetOf(Asn1Tag? expectedTag = null) { throw null; }
+        public DateTimeOffset ReadUtcTime(int twoDigitYearMax, Asn1Tag? expectedTag = null) { throw null; }
+        public DateTimeOffset ReadUtcTime(Asn1Tag? expectedTag = null) { throw null; }
+        public void ThrowIfNotEmpty() { }
+        public bool TryReadBitString(Span<byte> destination, out int unusedBitCount, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+        public bool TryReadCharacterString(Span<char> destination, UniversalTagNumber encodingType, out int charsWritten, Asn1Tag? expectedTag = null) { throw null; }
+        public bool TryReadCharacterStringBytes(Span<byte> destination, Asn1Tag expectedTag, out int bytesWritten) { throw null; }
+        public bool TryReadInt32(out int value, Asn1Tag? expectedTag = null) { throw null; }
+        public bool TryReadInt64(out long value, Asn1Tag? expectedTag = null) { throw null; }
+        public bool TryReadOctetString(Span<byte> destination, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+        public bool TryReadPrimitiveBitString(out int unusedBitCount, out ReadOnlyMemory<byte> value, Asn1Tag? expectedTag = null) { throw null; }
+        public bool TryReadPrimitiveCharacterStringBytes(Asn1Tag expectedTag, out ReadOnlyMemory<byte> contents) { throw null; }
+        public bool TryReadPrimitiveOctetString(out ReadOnlyMemory<byte> contents, Asn1Tag? expectedTag = null) { throw null; }
+        [CLSCompliant(false)]
+        public bool TryReadUInt32(out uint value, Asn1Tag? expectedTag = null) { throw null; }
+        [CLSCompliant(false)]
+        public bool TryReadUInt64(out ulong value, Asn1Tag? expectedTag = null) { throw null; }
+    }
+
+    public partial struct AsnReaderOptions
+    {
+        private int _dummyPrimitive;
+        public bool SkipSetSortOrderVerification { get { throw null; } set { } }
+        public int UtcTimeTwoDigitYearMax { get { throw null; } set { } }
+    }
+
+    public sealed partial class AsnWriter
+    {
+        public AsnWriter(AsnEncodingRules ruleSet, int initialCapacity) { }
+        public AsnWriter(AsnEncodingRules ruleSet) { }
+        public AsnEncodingRules RuleSet { get { throw null; } }
+        public void CopyTo(AsnWriter destination) { }
+        public byte[] Encode() { throw null; }
+        public int Encode(Span<byte> destination) { throw null; }
+        public bool EncodedValueEquals(AsnWriter other) { throw null; }
+        public bool EncodedValueEquals(ReadOnlySpan<byte> other) { throw null; }
+        public int GetEncodedLength() { throw null; }
+        public void PopOctetString(Asn1Tag? tag = null) { }
+        public void PopSequence(Asn1Tag? tag = null) { }
+        public void PopSetOf(Asn1Tag? tag = null) { }
+        public Scope PushOctetString(Asn1Tag? tag = null) { throw null; }
+        public Scope PushSequence(Asn1Tag? tag = null) { throw null; }
+        public Scope PushSetOf(Asn1Tag? tag = null) { throw null; }
+        public void Reset() { }
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+        public void WriteBitString(ReadOnlySpan<byte> value, int unusedBitCount = 0, Asn1Tag? tag = null) { }
+        public void WriteBoolean(bool value, Asn1Tag? tag = null) { }
+        public void WriteCharacterString(UniversalTagNumber encodingType, ReadOnlySpan<char> str, Asn1Tag? tag = null) { }
+        public void WriteCharacterString(UniversalTagNumber encodingType, string value, Asn1Tag? tag = null) { }
+        public void WriteEncodedValue(ReadOnlySpan<byte> value) { }
+        public void WriteEnumeratedValue(Enum value, Asn1Tag? tag = null) { }
+        public void WriteEnumeratedValue<TEnum>(TEnum value, Asn1Tag? tag = null) where TEnum : Enum { }
+        public void WriteGeneralizedTime(DateTimeOffset value, bool omitFractionalSeconds = false, Asn1Tag? tag = null) { }
+        public void WriteInteger(long value, Asn1Tag? tag = null) { }
+        public void WriteInteger(Numerics.BigInteger value, Asn1Tag? tag = null) { }
+        public void WriteInteger(ReadOnlySpan<byte> value, Asn1Tag? tag = null) { }
+        [CLSCompliant(false)]
+        public void WriteInteger(ulong value, Asn1Tag? tag = null) { }
+        public void WriteIntegerUnsigned(ReadOnlySpan<byte> value, Asn1Tag? tag = null) { }
+        public void WriteNamedBitList(Collections.BitArray value, Asn1Tag? tag = null) { }
+        public void WriteNamedBitList(Enum value, Asn1Tag? tag = null) { }
+        public void WriteNamedBitList<TEnum>(TEnum value, Asn1Tag? tag = null) where TEnum : Enum { }
+        public void WriteNull(Asn1Tag? tag = null) { }
+        public void WriteObjectIdentifier(ReadOnlySpan<char> oidValue, Asn1Tag? tag = null) { }
+        public void WriteObjectIdentifier(string oidValue, Asn1Tag? tag = null) { }
+        public void WriteOctetString(ReadOnlySpan<byte> value, Asn1Tag? tag = null) { }
+        public void WriteUtcTime(DateTimeOffset value, int twoDigitYearMax, Asn1Tag? tag = null) { }
+        public void WriteUtcTime(DateTimeOffset value, Asn1Tag? tag = null) { }
+        public readonly partial struct Scope : IDisposable
+        {
+            private readonly object _dummy;
+            private readonly int _dummyPrimitive;
+            public readonly void Dispose() { }
+        }
+    }
+
+    public enum TagClass
+    {
+        Universal = 0,
+        Application = 64,
+        ContextSpecific = 128,
+        Private = 192
+    }
+
+    public enum UniversalTagNumber
+    {
+        EndOfContents = 0,
+        Boolean = 1,
+        Integer = 2,
+        BitString = 3,
+        OctetString = 4,
+        Null = 5,
+        ObjectIdentifier = 6,
+        ObjectDescriptor = 7,
+        External = 8,
+        InstanceOf = 8,
+        Real = 9,
+        Enumerated = 10,
+        Embedded = 11,
+        UTF8String = 12,
+        RelativeObjectIdentifier = 13,
+        Time = 14,
+        Sequence = 16,
+        SequenceOf = 16,
+        Set = 17,
+        SetOf = 17,
+        NumericString = 18,
+        PrintableString = 19,
+        T61String = 20,
+        TeletexString = 20,
+        VideotexString = 21,
+        IA5String = 22,
+        UtcTime = 23,
+        GeneralizedTime = 24,
+        GraphicString = 25,
+        ISO646String = 26,
+        VisibleString = 26,
+        GeneralString = 27,
+        UniversalString = 28,
+        UnrestrictedCharacterString = 29,
+        BMPString = 30,
+        Date = 31,
+        TimeOfDay = 32,
+        DateTime = 33,
+        Duration = 34,
+        ObjectIdentifierIRI = 35,
+        RelativeObjectIdentifierIRI = 36
+    }
+}

--- a/src/source-build-assets/src/referencePackages/src/system.formats.asn1/10.0.10/lib/netstandard2.0/System.Formats.Asn1.cs
+++ b/src/source-build-assets/src/referencePackages/src/system.formats.asn1/10.0.10/lib/netstandard2.0/System.Formats.Asn1.cs
@@ -1,0 +1,351 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Formats.Asn1")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("IsAotCompatible", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides classes that can read and write the ASN.1 BER, CER, and DER data formats.")]
+[assembly: System.Reflection.AssemblyFileVersion("10.0.1026.32716")]
+[assembly: System.Reflection.AssemblyInformationalVersion("10.0.10+f7d90799ce4ef09a0bb257852a57248d2a8fb8dd")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Formats.Asn1")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/dotnet")]
+[assembly: System.Reflection.AssemblyVersionAttribute("10.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, Inherited = false)]
+    internal sealed partial class AllowNullAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, Inherited = false)]
+    internal sealed partial class DisallowNullAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    internal sealed partial class DoesNotReturnAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed partial class DoesNotReturnIfAttribute : Attribute
+    {
+        public DoesNotReturnIfAttribute(bool parameterValue) { }
+        public bool ParameterValue { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed partial class MaybeNullAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed partial class MaybeNullWhenAttribute : Attribute
+    {
+        public MaybeNullWhenAttribute(bool returnValue) { }
+        public bool ReturnValue { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+    internal sealed partial class MemberNotNullAttribute : Attribute
+    {
+        public MemberNotNullAttribute(string member) { }
+        public MemberNotNullAttribute(params string[] members) { }
+        public string[] Members { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+    internal sealed partial class MemberNotNullWhenAttribute : Attribute
+    {
+        public MemberNotNullWhenAttribute(bool returnValue, string member) { }
+        public MemberNotNullWhenAttribute(bool returnValue, params string[] members) { }
+        public string[] Members { get { throw null; } }
+        public bool ReturnValue { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed partial class NotNullAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+    internal sealed partial class NotNullIfNotNullAttribute : Attribute
+    {
+        public NotNullIfNotNullAttribute(string parameterName) { }
+        public string ParameterName { get { throw null; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed partial class NotNullWhenAttribute : Attribute
+    {
+        public NotNullWhenAttribute(bool returnValue) { }
+        public bool ReturnValue { get { throw null; } }
+    }
+}
+
+namespace System.Formats.Asn1
+{
+    public readonly partial struct Asn1Tag : IEquatable<Asn1Tag>
+    {
+        private readonly int _dummyPrimitive;
+        public static readonly Asn1Tag Boolean;
+        public static readonly Asn1Tag ConstructedBitString;
+        public static readonly Asn1Tag ConstructedOctetString;
+        public static readonly Asn1Tag Enumerated;
+        public static readonly Asn1Tag GeneralizedTime;
+        public static readonly Asn1Tag Integer;
+        public static readonly Asn1Tag Null;
+        public static readonly Asn1Tag ObjectIdentifier;
+        public static readonly Asn1Tag PrimitiveBitString;
+        public static readonly Asn1Tag PrimitiveOctetString;
+        public static readonly Asn1Tag Sequence;
+        public static readonly Asn1Tag SetOf;
+        public static readonly Asn1Tag UtcTime;
+        public Asn1Tag(TagClass tagClass, int tagValue, bool isConstructed = false) { }
+        public Asn1Tag(UniversalTagNumber universalTagNumber, bool isConstructed = false) { }
+        public bool IsConstructed { get { throw null; } }
+        public TagClass TagClass { get { throw null; } }
+        public int TagValue { get { throw null; } }
+        public readonly Asn1Tag AsConstructed() { throw null; }
+        public readonly Asn1Tag AsPrimitive() { throw null; }
+        public readonly int CalculateEncodedSize() { throw null; }
+        public static Asn1Tag Decode(ReadOnlySpan<byte> source, out int bytesConsumed) { throw null; }
+        public readonly int Encode(Span<byte> destination) { throw null; }
+        public readonly bool Equals(Asn1Tag other) { throw null; }
+        public override readonly bool Equals(object? obj) { throw null; }
+        public override readonly int GetHashCode() { throw null; }
+        public readonly bool HasSameClassAndValue(Asn1Tag other) { throw null; }
+        public static bool operator ==(Asn1Tag left, Asn1Tag right) { throw null; }
+        public static bool operator !=(Asn1Tag left, Asn1Tag right) { throw null; }
+        public override readonly string ToString() { throw null; }
+        public static bool TryDecode(ReadOnlySpan<byte> source, out Asn1Tag tag, out int bytesConsumed) { throw null; }
+        public readonly bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+    }
+
+    public partial class AsnContentException : Exception
+    {
+        public AsnContentException() { }
+        protected AsnContentException(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+        public AsnContentException(string? message, Exception? inner) { }
+        public AsnContentException(string? message) { }
+    }
+
+    public static partial class AsnDecoder
+    {
+        public static int? DecodeLength(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed) { throw null; }
+        public static byte[] ReadBitString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int unusedBitCount, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static bool ReadBoolean(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static string ReadCharacterString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, UniversalTagNumber encodingType, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static Asn1Tag ReadEncodedValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int contentOffset, out int contentLength, out int bytesConsumed) { throw null; }
+        public static ReadOnlySpan<byte> ReadEnumeratedBytes(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static Enum ReadEnumeratedValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, Type enumType, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static TEnum ReadEnumeratedValue<TEnum>(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) where TEnum : Enum { throw null; }
+        public static DateTimeOffset ReadGeneralizedTime(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static Numerics.BigInteger ReadInteger(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static ReadOnlySpan<byte> ReadIntegerBytes(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static Collections.BitArray ReadNamedBitList(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static Enum ReadNamedBitListValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, Type flagsEnumType, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static TFlagsEnum ReadNamedBitListValue<TFlagsEnum>(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) where TFlagsEnum : Enum { throw null; }
+        public static void ReadNull(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static string ReadObjectIdentifier(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static byte[] ReadOctetString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static void ReadSequence(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int contentOffset, out int contentLength, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static void ReadSetOf(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int contentOffset, out int contentLength, out int bytesConsumed, bool skipSortOrderValidation = false, Asn1Tag? expectedTag = null) { throw null; }
+        public static DateTimeOffset ReadUtcTime(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int bytesConsumed, int twoDigitYearMax = 2049, Asn1Tag? expectedTag = null) { throw null; }
+        public static bool TryDecodeLength(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int? decodedLength, out int bytesConsumed) { throw null; }
+        public static bool TryReadBitString(ReadOnlySpan<byte> source, Span<byte> destination, AsnEncodingRules ruleSet, out int unusedBitCount, out int bytesConsumed, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+        public static bool TryReadCharacterString(ReadOnlySpan<byte> source, Span<char> destination, AsnEncodingRules ruleSet, UniversalTagNumber encodingType, out int bytesConsumed, out int charsWritten, Asn1Tag? expectedTag = null) { throw null; }
+        public static bool TryReadCharacterStringBytes(ReadOnlySpan<byte> source, Span<byte> destination, AsnEncodingRules ruleSet, Asn1Tag expectedTag, out int bytesConsumed, out int bytesWritten) { throw null; }
+        public static bool TryReadEncodedValue(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out Asn1Tag tag, out int contentOffset, out int contentLength, out int bytesConsumed) { throw null; }
+        public static bool TryReadInt32(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static bool TryReadInt64(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out long value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static bool TryReadOctetString(ReadOnlySpan<byte> source, Span<byte> destination, AsnEncodingRules ruleSet, out int bytesConsumed, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+        public static bool TryReadPrimitiveBitString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out int unusedBitCount, out ReadOnlySpan<byte> value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        public static bool TryReadPrimitiveCharacterStringBytes(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, Asn1Tag expectedTag, out ReadOnlySpan<byte> value, out int bytesConsumed) { throw null; }
+        public static bool TryReadPrimitiveOctetString(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out ReadOnlySpan<byte> value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        [CLSCompliant(false)]
+        public static bool TryReadUInt32(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out uint value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+        [CLSCompliant(false)]
+        public static bool TryReadUInt64(ReadOnlySpan<byte> source, AsnEncodingRules ruleSet, out ulong value, out int bytesConsumed, Asn1Tag? expectedTag = null) { throw null; }
+    }
+
+    public enum AsnEncodingRules
+    {
+        BER = 0,
+        CER = 1,
+        DER = 2
+    }
+
+    public partial class AsnReader
+    {
+        public AsnReader(ReadOnlyMemory<byte> data, AsnEncodingRules ruleSet, AsnReaderOptions options = default) { }
+        public bool HasData { get { throw null; } }
+        public AsnEncodingRules RuleSet { get { throw null; } }
+        public AsnReader Clone() { throw null; }
+        public ReadOnlyMemory<byte> PeekContentBytes() { throw null; }
+        public ReadOnlyMemory<byte> PeekEncodedValue() { throw null; }
+        public Asn1Tag PeekTag() { throw null; }
+        public byte[] ReadBitString(out int unusedBitCount, Asn1Tag? expectedTag = null) { throw null; }
+        public bool ReadBoolean(Asn1Tag? expectedTag = null) { throw null; }
+        public string ReadCharacterString(UniversalTagNumber encodingType, Asn1Tag? expectedTag = null) { throw null; }
+        public ReadOnlyMemory<byte> ReadEncodedValue() { throw null; }
+        public ReadOnlyMemory<byte> ReadEnumeratedBytes(Asn1Tag? expectedTag = null) { throw null; }
+        public Enum ReadEnumeratedValue(Type enumType, Asn1Tag? expectedTag = null) { throw null; }
+        public TEnum ReadEnumeratedValue<TEnum>(Asn1Tag? expectedTag = null) where TEnum : Enum { throw null; }
+        public DateTimeOffset ReadGeneralizedTime(Asn1Tag? expectedTag = null) { throw null; }
+        public Numerics.BigInteger ReadInteger(Asn1Tag? expectedTag = null) { throw null; }
+        public ReadOnlyMemory<byte> ReadIntegerBytes(Asn1Tag? expectedTag = null) { throw null; }
+        public Collections.BitArray ReadNamedBitList(Asn1Tag? expectedTag = null) { throw null; }
+        public Enum ReadNamedBitListValue(Type flagsEnumType, Asn1Tag? expectedTag = null) { throw null; }
+        public TFlagsEnum ReadNamedBitListValue<TFlagsEnum>(Asn1Tag? expectedTag = null) where TFlagsEnum : Enum { throw null; }
+        public void ReadNull(Asn1Tag? expectedTag = null) { }
+        public string ReadObjectIdentifier(Asn1Tag? expectedTag = null) { throw null; }
+        public byte[] ReadOctetString(Asn1Tag? expectedTag = null) { throw null; }
+        public AsnReader ReadSequence(Asn1Tag? expectedTag = null) { throw null; }
+        public AsnReader ReadSetOf(bool skipSortOrderValidation, Asn1Tag? expectedTag = null) { throw null; }
+        public AsnReader ReadSetOf(Asn1Tag? expectedTag = null) { throw null; }
+        public DateTimeOffset ReadUtcTime(int twoDigitYearMax, Asn1Tag? expectedTag = null) { throw null; }
+        public DateTimeOffset ReadUtcTime(Asn1Tag? expectedTag = null) { throw null; }
+        public void ThrowIfNotEmpty() { }
+        public bool TryReadBitString(Span<byte> destination, out int unusedBitCount, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+        public bool TryReadCharacterString(Span<char> destination, UniversalTagNumber encodingType, out int charsWritten, Asn1Tag? expectedTag = null) { throw null; }
+        public bool TryReadCharacterStringBytes(Span<byte> destination, Asn1Tag expectedTag, out int bytesWritten) { throw null; }
+        public bool TryReadInt32(out int value, Asn1Tag? expectedTag = null) { throw null; }
+        public bool TryReadInt64(out long value, Asn1Tag? expectedTag = null) { throw null; }
+        public bool TryReadOctetString(Span<byte> destination, out int bytesWritten, Asn1Tag? expectedTag = null) { throw null; }
+        public bool TryReadPrimitiveBitString(out int unusedBitCount, out ReadOnlyMemory<byte> value, Asn1Tag? expectedTag = null) { throw null; }
+        public bool TryReadPrimitiveCharacterStringBytes(Asn1Tag expectedTag, out ReadOnlyMemory<byte> contents) { throw null; }
+        public bool TryReadPrimitiveOctetString(out ReadOnlyMemory<byte> contents, Asn1Tag? expectedTag = null) { throw null; }
+        [CLSCompliant(false)]
+        public bool TryReadUInt32(out uint value, Asn1Tag? expectedTag = null) { throw null; }
+        [CLSCompliant(false)]
+        public bool TryReadUInt64(out ulong value, Asn1Tag? expectedTag = null) { throw null; }
+    }
+
+    public partial struct AsnReaderOptions
+    {
+        private int _dummyPrimitive;
+        public bool SkipSetSortOrderVerification { get { throw null; } set { } }
+        public int UtcTimeTwoDigitYearMax { get { throw null; } set { } }
+    }
+
+    public sealed partial class AsnWriter
+    {
+        public AsnWriter(AsnEncodingRules ruleSet, int initialCapacity) { }
+        public AsnWriter(AsnEncodingRules ruleSet) { }
+        public AsnEncodingRules RuleSet { get { throw null; } }
+        public void CopyTo(AsnWriter destination) { }
+        public byte[] Encode() { throw null; }
+        public int Encode(Span<byte> destination) { throw null; }
+        public bool EncodedValueEquals(AsnWriter other) { throw null; }
+        public bool EncodedValueEquals(ReadOnlySpan<byte> other) { throw null; }
+        public int GetEncodedLength() { throw null; }
+        public void PopOctetString(Asn1Tag? tag = null) { }
+        public void PopSequence(Asn1Tag? tag = null) { }
+        public void PopSetOf(Asn1Tag? tag = null) { }
+        public Scope PushOctetString(Asn1Tag? tag = null) { throw null; }
+        public Scope PushSequence(Asn1Tag? tag = null) { throw null; }
+        public Scope PushSetOf(Asn1Tag? tag = null) { throw null; }
+        public void Reset() { }
+        public bool TryEncode(Span<byte> destination, out int bytesWritten) { throw null; }
+        public void WriteBitString(ReadOnlySpan<byte> value, int unusedBitCount = 0, Asn1Tag? tag = null) { }
+        public void WriteBoolean(bool value, Asn1Tag? tag = null) { }
+        public void WriteCharacterString(UniversalTagNumber encodingType, ReadOnlySpan<char> str, Asn1Tag? tag = null) { }
+        public void WriteCharacterString(UniversalTagNumber encodingType, string value, Asn1Tag? tag = null) { }
+        public void WriteEncodedValue(ReadOnlySpan<byte> value) { }
+        public void WriteEnumeratedValue(Enum value, Asn1Tag? tag = null) { }
+        public void WriteEnumeratedValue<TEnum>(TEnum value, Asn1Tag? tag = null) where TEnum : Enum { }
+        public void WriteGeneralizedTime(DateTimeOffset value, bool omitFractionalSeconds = false, Asn1Tag? tag = null) { }
+        public void WriteInteger(long value, Asn1Tag? tag = null) { }
+        public void WriteInteger(Numerics.BigInteger value, Asn1Tag? tag = null) { }
+        public void WriteInteger(ReadOnlySpan<byte> value, Asn1Tag? tag = null) { }
+        [CLSCompliant(false)]
+        public void WriteInteger(ulong value, Asn1Tag? tag = null) { }
+        public void WriteIntegerUnsigned(ReadOnlySpan<byte> value, Asn1Tag? tag = null) { }
+        public void WriteNamedBitList(Collections.BitArray value, Asn1Tag? tag = null) { }
+        public void WriteNamedBitList(Enum value, Asn1Tag? tag = null) { }
+        public void WriteNamedBitList<TEnum>(TEnum value, Asn1Tag? tag = null) where TEnum : Enum { }
+        public void WriteNull(Asn1Tag? tag = null) { }
+        public void WriteObjectIdentifier(ReadOnlySpan<char> oidValue, Asn1Tag? tag = null) { }
+        public void WriteObjectIdentifier(string oidValue, Asn1Tag? tag = null) { }
+        public void WriteOctetString(ReadOnlySpan<byte> value, Asn1Tag? tag = null) { }
+        public void WriteUtcTime(DateTimeOffset value, int twoDigitYearMax, Asn1Tag? tag = null) { }
+        public void WriteUtcTime(DateTimeOffset value, Asn1Tag? tag = null) { }
+        public readonly partial struct Scope : IDisposable
+        {
+            private readonly object _dummy;
+            private readonly int _dummyPrimitive;
+            public readonly void Dispose() { }
+        }
+    }
+
+    public enum TagClass
+    {
+        Universal = 0,
+        Application = 64,
+        ContextSpecific = 128,
+        Private = 192
+    }
+
+    public enum UniversalTagNumber
+    {
+        EndOfContents = 0,
+        Boolean = 1,
+        Integer = 2,
+        BitString = 3,
+        OctetString = 4,
+        Null = 5,
+        ObjectIdentifier = 6,
+        ObjectDescriptor = 7,
+        External = 8,
+        InstanceOf = 8,
+        Real = 9,
+        Enumerated = 10,
+        Embedded = 11,
+        UTF8String = 12,
+        RelativeObjectIdentifier = 13,
+        Time = 14,
+        Sequence = 16,
+        SequenceOf = 16,
+        Set = 17,
+        SetOf = 17,
+        NumericString = 18,
+        PrintableString = 19,
+        T61String = 20,
+        TeletexString = 20,
+        VideotexString = 21,
+        IA5String = 22,
+        UtcTime = 23,
+        GeneralizedTime = 24,
+        GraphicString = 25,
+        ISO646String = 26,
+        VisibleString = 26,
+        GeneralString = 27,
+        UniversalString = 28,
+        UnrestrictedCharacterString = 29,
+        BMPString = 30,
+        Date = 31,
+        TimeOfDay = 32,
+        DateTime = 33,
+        Duration = 34,
+        ObjectIdentifierIRI = 35,
+        RelativeObjectIdentifierIRI = 36
+    }
+}

--- a/src/source-build-assets/src/referencePackages/src/system.formats.asn1/10.0.10/system.formats.asn1.nuspec
+++ b/src/source-build-assets/src/referencePackages/src/system.formats.asn1/10.0.10/system.formats.asn1.nuspec
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>System.Formats.Asn1</id>
+    <version>10.0.10</version>
+    <authors>Microsoft</authors>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://dot.net/</projectUrl>
+    <description>Provides classes that can read and write the ASN.1 BER, CER, and DER data formats.</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/dotnet" commit="f7d90799ce4ef09a0bb257852a57248d2a8fb8dd" />
+    <dependencies>
+      <group targetFramework="net8.0" />
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Memory" version="4.6.3" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>


### PR DESCRIPTION
Fixes the standalone Linux source-build-assets failure flowing through dotnet/source-build-assets#1767.

IdentityModel 8.19.2 requires the Microsoft.Bcl.Cryptography 10.0.10 API surface. Instead of adding a previously-source-built package feed, this follows the established source-build-reference-package design from `main`:

- adds generated reference packages for Microsoft.Bcl.Cryptography 10.0.10 and its System.Formats.Asn1 dependency
- builds IdentityModel against the local Microsoft.Bcl.Cryptography 10.0.10 reference package
- removes the Microsoft.Bcl.Cryptography product dependency and the feed-manipulation target
- allows the Cryptography net10 reference assembly to use the bootstrap SDK targeting pack because this release branch only carries source-built targeting packs through net9

This keeps standalone source-build-assets restore offline and does not require `PreviouslySourceBuiltNupkgCacheDir`.

Validation:
- the source-build reference-package stage builds successfully
- both 10.0.10 reference packages are emitted with the expected assets and dependency groups
- IdentityModel restore resolves Microsoft.Bcl.Cryptography 10.0.10 from the local source-build-assets package output for all target frameworks
- the external IdentityModel build proceeds through restore and into compilation; the remaining local WSL failure is an unrelated IDE0055 formatting error in the cloned upstream source