### PR TITLE
[release/10.0.4xx] Remove duplicate dependency from scenario-tests

### DIFF
--- a/src/scenario-tests/eng/Version.Details.props
+++ b/src/scenario-tests/eng/Version.Details.props
@@ -6,7 +6,7 @@ This file should be imported by eng/Versions.props
 <Project>
   <PropertyGroup>
     <!-- dotnet-dotnet dependencies -->
-    <MicrosoftDotNetArcadeSdkPackageVersion>10.0.0-beta.26361.102</MicrosoftDotNetArcadeSdkPackageVersion>
+    <MicrosoftDotNetArcadeSdkPackageVersion>10.0.0-beta.26380.110</MicrosoftDotNetArcadeSdkPackageVersion>
     <SystemCommandLinePackageVersion>2.0.11</SystemCommandLinePackageVersion>
   </PropertyGroup>
   <!--Property group for alternate package version names-->

--- a/src/scenario-tests/eng/Version.Details.xml
+++ b/src/scenario-tests/eng/Version.Details.xml
@@ -8,10 +8,6 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-dotnet</Uri>
       <Sha>e2f47b0110ed922f21a1522da67279133ce28f32</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.26361.102">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>859dbf297ab10ef1ff20d30becdd6ff69eb258ff</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="10.0.0-beta.26380.110">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>859dbf297ab10ef1ff20d30becdd6ff69eb258ff</Sha>


### PR DESCRIPTION
Removed outdated Microsoft.DotNet.Arcade.Sdk dependency.