### PR TITLE
[release/10.0.1xx] Preserve runtime validation archive build suffix

### DIFF
--- a/src/deployment-tools/src/DotNetRuntimeValidation/Directory.Build.targets
+++ b/src/deployment-tools/src/DotNetRuntimeValidation/Directory.Build.targets
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <TempZipFolder>$(ArtifactsBinDir)DotNetRuntimeValidation\$(TargetArchitecture)\temp\zipcontents</TempZipFolder>
-    <DotNetRuntimeValidationZipFilePath>$(ArtifactsAssetsDir)DotNetRuntimeValidation-$(VersionPrefix)-$(VersionSuffix)-win-$(TargetArchitecture).zip</DotNetRuntimeValidationZipFilePath>
+    <DotNetRuntimeValidationZipFilePath>$(ArtifactsAssetsDir)DotNetRuntimeValidation-$(Version)-win-$(TargetArchitecture).zip</DotNetRuntimeValidationZipFilePath>
   </PropertyGroup>
 
   <!-- We just want to .zip these up -->

--- a/src/deployment-tools/src/DotNetRuntimeValidation/DotNetRuntimeValidation.csproj
+++ b/src/deployment-tools/src/DotNetRuntimeValidation/DotNetRuntimeValidation.csproj
@@ -10,6 +10,7 @@
     <DeployOnBuild>true</DeployOnBuild>
     <DebugType>embedded</DebugType>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    <IsShipping>false</IsShipping>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>


### PR DESCRIPTION
Fixes dotnet/deployment-tools#569

The `DotNetRuntimeValidation` archive was published as nonshipping, but the project still used Arcade's default shipping version calculation. Stable builds therefore cleared `VersionSuffix` and produced colliding names such as `DotNetRuntimeValidation-10.0.0--win-x64.zip`.

This change:
- marks the validation project as nonshipping so stable builds retain their build suffix
- names the archive with Arcade's evaluated `Version` property

Validated with:

```powershell
src\deployment-tools\build.cmd -restore -build -configuration Release -arch x64 -bl /p:DotNetBuild=true /p:OfficialBuildId=20260817.1
```

The build produced `DotNetRuntimeValidation-10.0.0-rtm.26417.1-win-x64.zip`.