### PR TITLE
Fix SignCheckExclusionsFile.txt to allow signed hotreload .js file

### DIFF
--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -6,7 +6,7 @@
 *singlefilehost.exe;;Template, DO-NOT-SIGN, https://github.com/dotnet/core-setup/pull/7549
 *comhost.dll;;Template, DO-NOT-SIGN, https://github.com/dotnet/core-setup/pull/7549
 *apphosttemplateapphostexe.exe;;Template, DO-NOT-SIGN, https://github.com/dotnet/core-setup/pull/7549
-*.js;; DO-NOT-SIGN, Arcade's SignTool no longer signs .js files by default https://github.com/dotnet/arcade/pull/15760
+*.js|!Microsoft.DotNet.HotReload.WebAssembly.Browser.lib.module.js;; DO-NOT-SIGN, Arcade's SignTool no longer signs .js files by default https://github.com/dotnet/arcade/pull/15760
 
 ;; ## PGO ##
 ;dotnet-sdk-pgo-*.tar.gz; PGO builds are unsigned


### PR DESCRIPTION
Fixes https://github.com/dotnet/dotnet/issues/7943

Leverages new arcade feature from https://github.com/dotnet/arcade/pull/17334