### PR TITLE
Tag AzDO build with SDK version

### DIFF
--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -152,6 +152,11 @@ parameters:
   type: boolean
   default: false
 
+# Add the SDK version produced by this build to the Azure Pipelines build tags.
+- name: tagPipelineBuildWithSdkVersion
+  type: boolean
+  default: false
+
 #### repo parameters ####
 
 - name: isBuiltFromVmr
@@ -660,6 +665,22 @@ jobs:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
             ${{ if eq(parameters.signDac, 'true') }}:
               ESRP_TOKEN: $(System.AccessToken)
+
+    - ${{ if eq(parameters.tagPipelineBuildWithSdkVersion, true) }}:
+      - pwsh: |
+          $versionFile = Join-Path "$(sourcesPath)" "src/sdk/artifacts/packages/${{ parameters.configuration }}/Shipping/sdk-productVersion.txt"
+          if (-not (Test-Path $versionFile)) {
+            throw "SDK version file was not produced at '$versionFile'."
+          }
+
+          $sdkVersion = (Get-Content $versionFile -Raw).Trim()
+          if ([string]::IsNullOrWhiteSpace($sdkVersion)) {
+            throw "SDK version file '$versionFile' is empty."
+          }
+
+          Write-Host "Tagging build with SDK version '$sdkVersion'."
+          Write-Host "##vso[build.addbuildtag]SDK $sdkVersion"
+        displayName: Tag build with SDK version
 
     - ${{ if eq(parameters.runTests, 'True') }}:
       - script: build.cmd

--- a/eng/pipelines/templates/stages/vmr-verticals.yml
+++ b/eng/pipelines/templates/stages/vmr-verticals.yml
@@ -150,7 +150,7 @@ stages:
           pool: ${{ parameters.pool_Windows }}
           targetOS: windows
           targetArchitecture: x64
-          tagPipelineBuildWithSdkVersion: true
+          tagPipelineBuildWithSdkVersion: ${{ parameters.isOfficialBuild }}
           brandingType: ${{ variables.brandingType }}
           sourceIndexName: dotnet-dotnet-windows
           sourceIndexIncludeRepos: 'winforms wpf windowsdesktop aspnetcore'

--- a/eng/pipelines/templates/stages/vmr-verticals.yml
+++ b/eng/pipelines/templates/stages/vmr-verticals.yml
@@ -150,6 +150,7 @@ stages:
           pool: ${{ parameters.pool_Windows }}
           targetOS: windows
           targetArchitecture: x64
+          tagPipelineBuildWithSdkVersion: true
           brandingType: ${{ variables.brandingType }}
           sourceIndexName: dotnet-dotnet-windows
           sourceIndexIncludeRepos: 'winforms wpf windowsdesktop aspnetcore'


### PR DESCRIPTION
This adds an AzDO build tag with the SDK version which allows easier/faster mapping of a version to the VMR AzDO build from just the AzDO APIs/UI.