### PR TITLE
Disable dotnet.fileBasedApps.enableAutomaticDiscovery in vscode settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "dotnet.defaultSolution": "disable",
+    "dotnet.fileBasedApps.enableAutomaticDiscovery": false,
     "workbench.colorCustomizations": {
         "activityBar.background": "#530856",
         "titleBar.activeBackground": "#740B78",


### PR DESCRIPTION
It creates a cache file in the repo root and we don't need that feature