### PR TITLE
Fix SignCheckExclusionsFile.txt for .js in source-build artifacts

### DIFF
--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -7,6 +7,7 @@
 *comhost.dll;;Template, DO-NOT-SIGN, https://github.com/dotnet/core-setup/pull/7549
 *apphosttemplateapphostexe.exe;;Template, DO-NOT-SIGN, https://github.com/dotnet/core-setup/pull/7549
 *.js|!Microsoft.DotNet.HotReload.WebAssembly.Browser.lib.module.js;; DO-NOT-SIGN, Arcade's SignTool no longer signs .js files by default https://github.com/dotnet/arcade/pull/15760
+*.js;dotnet-sdk-*-centos.*-x64.tar.gz|Private.SourceBuilt.Artifacts.*.tar.gz;DO-NOT-SIGN, all .js inside of source-build artifacts are intentionally unsigned
 
 ;; ## PGO ##
 ;dotnet-sdk-pgo-*.tar.gz; PGO builds are unsigned


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/dotnet/pull/8380

SignCheck failed on `Private.SourceBuilt.Artifacts.*.tar.gz` and `dotnet-sdk-*-centos.*-x64.tar.gz` because the `Microsoft.DotNet.HotReload.WebAssembly.Browser.lib.module.js` is actually unsigned there which is intentional.