### PR TITLE
Update builds table from preview7 to rc1

### DIFF
--- a/docs/builds-table.md
+++ b/docs/builds-table.md
@@ -22,19 +22,19 @@
 ### Supported Platforms
 
 --------------------------------------------------------------------------------------------------------------------------------
-| Platform | main<br>(11.0.x&nbsp;Runtime) | 11.0.1xx-preview7<br>(11.0-preview7&nbsp;Runtime) | 10.0.4xx<br>(10.0.4xx&nbsp;Runtime) |
+| Platform | main<br>(11.0.x&nbsp;Runtime) | 11.0.1xx-rc1<br>(11.0-rc1&nbsp;Runtime) | 10.0.4xx<br>(10.0.4xx&nbsp;Runtime) |
 | :--------- | :----------: | :----------: | :----------: |
-| **Windows x64** | [![][win-x64-badge-main]][win-x64-version-main]<br>[Installer][win-x64-installer-main] - [Checksum][win-x64-installer-checksum-main]<br>[tar.gz][win-x64-targz-main] - [Checksum][win-x64-targz-checksum-main]<br>[zip][win-x64-zip-main] - [Checksum][win-x64-zip-checksum-main] | [![][win-x64-badge-11.0.1xx-preview7]][win-x64-version-11.0.1xx-preview7]<br>[Installer][win-x64-installer-11.0.1xx-preview7] - [Checksum][win-x64-installer-checksum-11.0.1xx-preview7]<br>[tar.gz][win-x64-targz-11.0.1xx-preview7] - [Checksum][win-x64-targz-checksum-11.0.1xx-preview7]<br>[zip][win-x64-zip-11.0.1xx-preview7] - [Checksum][win-x64-zip-checksum-11.0.1xx-preview7] | [![][win-x64-badge-10.0.4xx]][win-x64-version-10.0.4xx]<br>[Installer][win-x64-installer-10.0.4xx] - [Checksum][win-x64-installer-checksum-10.0.4xx]<br>[zip][win-x64-zip-10.0.4xx] - [Checksum][win-x64-zip-checksum-10.0.4xx] |
-| **Windows x86** | [![][win-x86-badge-main]][win-x86-version-main]<br>[Installer][win-x86-installer-main] - [Checksum][win-x86-installer-checksum-main]<br>[tar.gz][win-x86-targz-main] - [Checksum][win-x86-targz-checksum-main]<br>[zip][win-x86-zip-main] - [Checksum][win-x86-zip-checksum-main] | [![][win-x86-badge-11.0.1xx-preview7]][win-x86-version-11.0.1xx-preview7]<br>[Installer][win-x86-installer-11.0.1xx-preview7] - [Checksum][win-x86-installer-checksum-11.0.1xx-preview7]<br>[tar.gz][win-x86-targz-11.0.1xx-preview7] - [Checksum][win-x86-targz-checksum-11.0.1xx-preview7]<br>[zip][win-x86-zip-11.0.1xx-preview7] - [Checksum][win-x86-zip-checksum-11.0.1xx-preview7] | [![][win-x86-badge-10.0.4xx]][win-x86-version-10.0.4xx]<br>[Installer][win-x86-installer-10.0.4xx] - [Checksum][win-x86-installer-checksum-10.0.4xx]<br>[zip][win-x86-zip-10.0.4xx] - [Checksum][win-x86-zip-checksum-10.0.4xx] |
-| **Windows arm64** | [![][win-arm64-badge-main]][win-arm64-version-main]<br>[Installer][win-arm64-installer-main] - [Checksum][win-arm64-installer-checksum-main]<br>[tar.gz][win-arm64-targz-main] - [Checksum][win-arm64-targz-checksum-main]<br>[zip][win-arm64-zip-main] - [Checksum][win-arm64-zip-checksum-main] | [![][win-arm64-badge-11.0.1xx-preview7]][win-arm64-version-11.0.1xx-preview7]<br>[Installer][win-arm64-installer-11.0.1xx-preview7] - [Checksum][win-arm64-installer-checksum-11.0.1xx-preview7]<br>[tar.gz][win-arm64-targz-11.0.1xx-preview7] - [Checksum][win-arm64-targz-checksum-11.0.1xx-preview7]<br>[zip][win-arm64-zip-11.0.1xx-preview7] - [Checksum][win-arm64-zip-checksum-11.0.1xx-preview7] | [![][win-arm64-badge-10.0.4xx]][win-arm64-version-10.0.4xx]<br>[Installer][win-arm64-installer-10.0.4xx] - [Checksum][win-arm64-installer-checksum-10.0.4xx]<br>[zip][win-arm64-zip-10.0.4xx] - [Checksum][win-arm64-zip-checksum-10.0.4xx] |
-| **macOS arm64**<br>(M-series CPUs) | [![][osx-arm64-badge-main]][osx-arm64-version-main]<br>[Installer][osx-arm64-installer-main] - [Checksum][osx-arm64-installer-checksum-main]<br>[tar.gz][osx-arm64-targz-main] - [Checksum][osx-arm64-targz-checksum-main] | [![][osx-arm64-badge-11.0.1xx-preview7]][osx-arm64-version-11.0.1xx-preview7]<br>[Installer][osx-arm64-installer-11.0.1xx-preview7] - [Checksum][osx-arm64-installer-checksum-11.0.1xx-preview7]<br>[tar.gz][osx-arm64-targz-11.0.1xx-preview7] - [Checksum][osx-arm64-targz-checksum-11.0.1xx-preview7] | [![][osx-arm64-badge-10.0.4xx]][osx-arm64-version-10.0.4xx]<br>[Installer][osx-arm64-installer-10.0.4xx] - [Checksum][osx-arm64-installer-checksum-10.0.4xx]<br>[tar.gz][osx-arm64-targz-10.0.4xx] - [Checksum][osx-arm64-targz-checksum-10.0.4xx] |
-| **macOS x64**<br>(Intel CPUs) | [![][osx-x64-badge-main]][osx-x64-version-main]<br>[Installer][osx-x64-installer-main] - [Checksum][osx-x64-installer-checksum-main]<br>[tar.gz][osx-x64-targz-main] - [Checksum][osx-x64-targz-checksum-main] | [![][osx-x64-badge-11.0.1xx-preview7]][osx-x64-version-11.0.1xx-preview7]<br>[Installer][osx-x64-installer-11.0.1xx-preview7] - [Checksum][osx-x64-installer-checksum-11.0.1xx-preview7]<br>[tar.gz][osx-x64-targz-11.0.1xx-preview7] - [Checksum][osx-x64-targz-checksum-11.0.1xx-preview7] | [![][osx-x64-badge-10.0.4xx]][osx-x64-version-10.0.4xx]<br>[Installer][osx-x64-installer-10.0.4xx] - [Checksum][osx-x64-installer-checksum-10.0.4xx]<br>[tar.gz][osx-x64-targz-10.0.4xx] - [Checksum][osx-x64-targz-checksum-10.0.4xx] |
-| **Linux x64** | [![][linux-badge-main]][linux-version-main]<br>[DEB Installer][linux-DEB-installer-main] - [Checksum][linux-DEB-installer-checksum-main]<br>[RPM Installer][linux-RPM-installer-main] - [Checksum][linux-RPM-installer-checksum-main]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-main] - [Checksum][linux-targz-checksum-main] | [![][linux-badge-11.0.1xx-preview7]][linux-version-11.0.1xx-preview7]<br>[DEB Installer][linux-DEB-installer-11.0.1xx-preview7] - [Checksum][linux-DEB-installer-checksum-11.0.1xx-preview7]<br>[RPM Installer][linux-RPM-installer-11.0.1xx-preview7] - [Checksum][linux-RPM-installer-checksum-11.0.1xx-preview7]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-11.0.1xx-preview7] - [Checksum][linux-targz-checksum-11.0.1xx-preview7] | [![][linux-badge-10.0.4xx]][linux-version-10.0.4xx]<br>[DEB Installer][linux-DEB-installer-10.0.4xx] - [Checksum][linux-DEB-installer-checksum-10.0.4xx]<br>[RPM Installer][linux-RPM-installer-10.0.4xx] - [Checksum][linux-RPM-installer-checksum-10.0.4xx]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-10.0.4xx] - [Checksum][linux-targz-checksum-10.0.4xx] |
-| **Linux arm** | [![][linux-arm-badge-main]][linux-arm-version-main]<br>[tar.gz][linux-arm-targz-main] - [Checksum][linux-arm-targz-checksum-main] | [![][linux-arm-badge-11.0.1xx-preview7]][linux-arm-version-11.0.1xx-preview7]<br>[tar.gz][linux-arm-targz-11.0.1xx-preview7] - [Checksum][linux-arm-targz-checksum-11.0.1xx-preview7] | [![][linux-arm-badge-10.0.4xx]][linux-arm-version-10.0.4xx]<br>[tar.gz][linux-arm-targz-10.0.4xx] - [Checksum][linux-arm-targz-checksum-10.0.4xx] |
-| **Linux arm64** | [![][linux-arm64-badge-main]][linux-arm64-version-main]<br>[tar.gz][linux-arm64-targz-main] - [Checksum][linux-arm64-targz-checksum-main] | [![][linux-arm64-badge-11.0.1xx-preview7]][linux-arm64-version-11.0.1xx-preview7]<br>[tar.gz][linux-arm64-targz-11.0.1xx-preview7] - [Checksum][linux-arm64-targz-checksum-11.0.1xx-preview7] | [![][linux-arm64-badge-10.0.4xx]][linux-arm64-version-10.0.4xx]<br>[tar.gz][linux-arm64-targz-10.0.4xx] - [Checksum][linux-arm64-targz-checksum-10.0.4xx] |
-| **Linux-musl-x64** | [![][linux-musl-x64-badge-main]][linux-musl-x64-version-main]<br>[tar.gz][linux-musl-x64-targz-main] - [Checksum][linux-musl-x64-targz-checksum-main] | [![][linux-musl-x64-badge-11.0.1xx-preview7]][linux-musl-x64-version-11.0.1xx-preview7]<br>[tar.gz][linux-musl-x64-targz-11.0.1xx-preview7] - [Checksum][linux-musl-x64-targz-checksum-11.0.1xx-preview7] | [![][linux-musl-x64-badge-10.0.4xx]][linux-musl-x64-version-10.0.4xx]<br>[tar.gz][linux-musl-x64-targz-10.0.4xx] - [Checksum][linux-musl-x64-targz-checksum-10.0.4xx] |
-| **Linux-musl-arm** | [![][linux-musl-arm-badge-main]][linux-musl-arm-version-main]<br>[tar.gz][linux-musl-arm-targz-main] - [Checksum][linux-musl-arm-targz-checksum-main] | [![][linux-musl-arm-badge-11.0.1xx-preview7]][linux-musl-arm-version-11.0.1xx-preview7]<br>[tar.gz][linux-musl-arm-targz-11.0.1xx-preview7] - [Checksum][linux-musl-arm-targz-checksum-11.0.1xx-preview7] | [![][linux-musl-arm-badge-10.0.4xx]][linux-musl-arm-version-10.0.4xx]<br>[tar.gz][linux-musl-arm-targz-10.0.4xx] - [Checksum][linux-musl-arm-targz-checksum-10.0.4xx] |
-| **Linux-musl-arm64** | [![][linux-musl-arm64-badge-main]][linux-musl-arm64-version-main]<br>[tar.gz][linux-musl-arm64-targz-main] - [Checksum][linux-musl-arm64-targz-checksum-main] | [![][linux-musl-arm64-badge-11.0.1xx-preview7]][linux-musl-arm64-version-11.0.1xx-preview7]<br>[tar.gz][linux-musl-arm64-targz-11.0.1xx-preview7] - [Checksum][linux-musl-arm64-targz-checksum-11.0.1xx-preview7] | [![][linux-musl-arm64-badge-10.0.4xx]][linux-musl-arm64-version-10.0.4xx]<br>[tar.gz][linux-musl-arm64-targz-10.0.4xx] - [Checksum][linux-musl-arm64-targz-checksum-10.0.4xx] |
+| **Windows x64** | [![][win-x64-badge-main]][win-x64-version-main]<br>[Installer][win-x64-installer-main] - [Checksum][win-x64-installer-checksum-main]<br>[tar.gz][win-x64-targz-main] - [Checksum][win-x64-targz-checksum-main]<br>[zip][win-x64-zip-main] - [Checksum][win-x64-zip-checksum-main] | [![][win-x64-badge-11.0.1xx-rc1]][win-x64-version-11.0.1xx-rc1]<br>[Installer][win-x64-installer-11.0.1xx-rc1] - [Checksum][win-x64-installer-checksum-11.0.1xx-rc1]<br>[tar.gz][win-x64-targz-11.0.1xx-rc1] - [Checksum][win-x64-targz-checksum-11.0.1xx-rc1]<br>[zip][win-x64-zip-11.0.1xx-rc1] - [Checksum][win-x64-zip-checksum-11.0.1xx-rc1] | [![][win-x64-badge-10.0.4xx]][win-x64-version-10.0.4xx]<br>[Installer][win-x64-installer-10.0.4xx] - [Checksum][win-x64-installer-checksum-10.0.4xx]<br>[zip][win-x64-zip-10.0.4xx] - [Checksum][win-x64-zip-checksum-10.0.4xx] |
+| **Windows x86** | [![][win-x86-badge-main]][win-x86-version-main]<br>[Installer][win-x86-installer-main] - [Checksum][win-x86-installer-checksum-main]<br>[tar.gz][win-x86-targz-main] - [Checksum][win-x86-targz-checksum-main]<br>[zip][win-x86-zip-main] - [Checksum][win-x86-zip-checksum-main] | [![][win-x86-badge-11.0.1xx-rc1]][win-x86-version-11.0.1xx-rc1]<br>[Installer][win-x86-installer-11.0.1xx-rc1] - [Checksum][win-x86-installer-checksum-11.0.1xx-rc1]<br>[tar.gz][win-x86-targz-11.0.1xx-rc1] - [Checksum][win-x86-targz-checksum-11.0.1xx-rc1]<br>[zip][win-x86-zip-11.0.1xx-rc1] - [Checksum][win-x86-zip-checksum-11.0.1xx-rc1] | [![][win-x86-badge-10.0.4xx]][win-x86-version-10.0.4xx]<br>[Installer][win-x86-installer-10.0.4xx] - [Checksum][win-x86-installer-checksum-10.0.4xx]<br>[zip][win-x86-zip-10.0.4xx] - [Checksum][win-x86-zip-checksum-10.0.4xx] |
+| **Windows arm64** | [![][win-arm64-badge-main]][win-arm64-version-main]<br>[Installer][win-arm64-installer-main] - [Checksum][win-arm64-installer-checksum-main]<br>[tar.gz][win-arm64-targz-main] - [Checksum][win-arm64-targz-checksum-main]<br>[zip][win-arm64-zip-main] - [Checksum][win-arm64-zip-checksum-main] | [![][win-arm64-badge-11.0.1xx-rc1]][win-arm64-version-11.0.1xx-rc1]<br>[Installer][win-arm64-installer-11.0.1xx-rc1] - [Checksum][win-arm64-installer-checksum-11.0.1xx-rc1]<br>[tar.gz][win-arm64-targz-11.0.1xx-rc1] - [Checksum][win-arm64-targz-checksum-11.0.1xx-rc1]<br>[zip][win-arm64-zip-11.0.1xx-rc1] - [Checksum][win-arm64-zip-checksum-11.0.1xx-rc1] | [![][win-arm64-badge-10.0.4xx]][win-arm64-version-10.0.4xx]<br>[Installer][win-arm64-installer-10.0.4xx] - [Checksum][win-arm64-installer-checksum-10.0.4xx]<br>[zip][win-arm64-zip-10.0.4xx] - [Checksum][win-arm64-zip-checksum-10.0.4xx] |
+| **macOS arm64**<br>(M-series CPUs) | [![][osx-arm64-badge-main]][osx-arm64-version-main]<br>[Installer][osx-arm64-installer-main] - [Checksum][osx-arm64-installer-checksum-main]<br>[tar.gz][osx-arm64-targz-main] - [Checksum][osx-arm64-targz-checksum-main] | [![][osx-arm64-badge-11.0.1xx-rc1]][osx-arm64-version-11.0.1xx-rc1]<br>[Installer][osx-arm64-installer-11.0.1xx-rc1] - [Checksum][osx-arm64-installer-checksum-11.0.1xx-rc1]<br>[tar.gz][osx-arm64-targz-11.0.1xx-rc1] - [Checksum][osx-arm64-targz-checksum-11.0.1xx-rc1] | [![][osx-arm64-badge-10.0.4xx]][osx-arm64-version-10.0.4xx]<br>[Installer][osx-arm64-installer-10.0.4xx] - [Checksum][osx-arm64-installer-checksum-10.0.4xx]<br>[tar.gz][osx-arm64-targz-10.0.4xx] - [Checksum][osx-arm64-targz-checksum-10.0.4xx] |
+| **macOS x64**<br>(Intel CPUs) | [![][osx-x64-badge-main]][osx-x64-version-main]<br>[Installer][osx-x64-installer-main] - [Checksum][osx-x64-installer-checksum-main]<br>[tar.gz][osx-x64-targz-main] - [Checksum][osx-x64-targz-checksum-main] | [![][osx-x64-badge-11.0.1xx-rc1]][osx-x64-version-11.0.1xx-rc1]<br>[Installer][osx-x64-installer-11.0.1xx-rc1] - [Checksum][osx-x64-installer-checksum-11.0.1xx-rc1]<br>[tar.gz][osx-x64-targz-11.0.1xx-rc1] - [Checksum][osx-x64-targz-checksum-11.0.1xx-rc1] | [![][osx-x64-badge-10.0.4xx]][osx-x64-version-10.0.4xx]<br>[Installer][osx-x64-installer-10.0.4xx] - [Checksum][osx-x64-installer-checksum-10.0.4xx]<br>[tar.gz][osx-x64-targz-10.0.4xx] - [Checksum][osx-x64-targz-checksum-10.0.4xx] |
+| **Linux x64** | [![][linux-badge-main]][linux-version-main]<br>[DEB Installer][linux-DEB-installer-main] - [Checksum][linux-DEB-installer-checksum-main]<br>[RPM Installer][linux-RPM-installer-main] - [Checksum][linux-RPM-installer-checksum-main]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-main] - [Checksum][linux-targz-checksum-main] | [![][linux-badge-11.0.1xx-rc1]][linux-version-11.0.1xx-rc1]<br>[DEB Installer][linux-DEB-installer-11.0.1xx-rc1] - [Checksum][linux-DEB-installer-checksum-11.0.1xx-rc1]<br>[RPM Installer][linux-RPM-installer-11.0.1xx-rc1] - [Checksum][linux-RPM-installer-checksum-11.0.1xx-rc1]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-11.0.1xx-rc1] - [Checksum][linux-targz-checksum-11.0.1xx-rc1] | [![][linux-badge-10.0.4xx]][linux-version-10.0.4xx]<br>[DEB Installer][linux-DEB-installer-10.0.4xx] - [Checksum][linux-DEB-installer-checksum-10.0.4xx]<br>[RPM Installer][linux-RPM-installer-10.0.4xx] - [Checksum][linux-RPM-installer-checksum-10.0.4xx]<br>_see installer note below_<sup>1</sup><br>[tar.gz][linux-targz-10.0.4xx] - [Checksum][linux-targz-checksum-10.0.4xx] |
+| **Linux arm** | [![][linux-arm-badge-main]][linux-arm-version-main]<br>[tar.gz][linux-arm-targz-main] - [Checksum][linux-arm-targz-checksum-main] | [![][linux-arm-badge-11.0.1xx-rc1]][linux-arm-version-11.0.1xx-rc1]<br>[tar.gz][linux-arm-targz-11.0.1xx-rc1] - [Checksum][linux-arm-targz-checksum-11.0.1xx-rc1] | [![][linux-arm-badge-10.0.4xx]][linux-arm-version-10.0.4xx]<br>[tar.gz][linux-arm-targz-10.0.4xx] - [Checksum][linux-arm-targz-checksum-10.0.4xx] |
+| **Linux arm64** | [![][linux-arm64-badge-main]][linux-arm64-version-main]<br>[tar.gz][linux-arm64-targz-main] - [Checksum][linux-arm64-targz-checksum-main] | [![][linux-arm64-badge-11.0.1xx-rc1]][linux-arm64-version-11.0.1xx-rc1]<br>[tar.gz][linux-arm64-targz-11.0.1xx-rc1] - [Checksum][linux-arm64-targz-checksum-11.0.1xx-rc1] | [![][linux-arm64-badge-10.0.4xx]][linux-arm64-version-10.0.4xx]<br>[tar.gz][linux-arm64-targz-10.0.4xx] - [Checksum][linux-arm64-targz-checksum-10.0.4xx] |
+| **Linux-musl-x64** | [![][linux-musl-x64-badge-main]][linux-musl-x64-version-main]<br>[tar.gz][linux-musl-x64-targz-main] - [Checksum][linux-musl-x64-targz-checksum-main] | [![][linux-musl-x64-badge-11.0.1xx-rc1]][linux-musl-x64-version-11.0.1xx-rc1]<br>[tar.gz][linux-musl-x64-targz-11.0.1xx-rc1] - [Checksum][linux-musl-x64-targz-checksum-11.0.1xx-rc1] | [![][linux-musl-x64-badge-10.0.4xx]][linux-musl-x64-version-10.0.4xx]<br>[tar.gz][linux-musl-x64-targz-10.0.4xx] - [Checksum][linux-musl-x64-targz-checksum-10.0.4xx] |
+| **Linux-musl-arm** | [![][linux-musl-arm-badge-main]][linux-musl-arm-version-main]<br>[tar.gz][linux-musl-arm-targz-main] - [Checksum][linux-musl-arm-targz-checksum-main] | [![][linux-musl-arm-badge-11.0.1xx-rc1]][linux-musl-arm-version-11.0.1xx-rc1]<br>[tar.gz][linux-musl-arm-targz-11.0.1xx-rc1] - [Checksum][linux-musl-arm-targz-checksum-11.0.1xx-rc1] | [![][linux-musl-arm-badge-10.0.4xx]][linux-musl-arm-version-10.0.4xx]<br>[tar.gz][linux-musl-arm-targz-10.0.4xx] - [Checksum][linux-musl-arm-targz-checksum-10.0.4xx] |
+| **Linux-musl-arm64** | [![][linux-musl-arm64-badge-main]][linux-musl-arm64-version-main]<br>[tar.gz][linux-musl-arm64-targz-main] - [Checksum][linux-musl-arm64-targz-checksum-main] | [![][linux-musl-arm64-badge-11.0.1xx-rc1]][linux-musl-arm64-version-11.0.1xx-rc1]<br>[tar.gz][linux-musl-arm64-targz-11.0.1xx-rc1] - [Checksum][linux-musl-arm64-targz-checksum-11.0.1xx-rc1] | [![][linux-musl-arm64-badge-10.0.4xx]][linux-musl-arm64-version-10.0.4xx]<br>[tar.gz][linux-musl-arm64-targz-10.0.4xx] - [Checksum][linux-musl-arm64-targz-checksum-10.0.4xx] |
 
 # .NET SDK Daily Builds
 
@@ -174,14 +174,14 @@ For the 2xx and later bands, the 1xx runtime flows to 2xx+. The version of the r
 [win-x64-zip-main]: https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-win-x64.zip
 [win-x64-zip-checksum-main]: https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-win-x64.zip.sha512
 
-[win-x64-badge-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/win_x64_Release_version_badge.svg?no-cache
-[win-x64-version-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/productCommit-win-x64.txt
-[win-x64-installer-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-win-x64.exe
-[win-x64-installer-checksum-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-win-x64.exe.sha512
-[win-x64-targz-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-win-x64.tar.gz
-[win-x64-targz-checksum-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-win-x64.tar.gz.sha512
-[win-x64-zip-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-win-x64.zip
-[win-x64-zip-checksum-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-win-x64.zip.sha512
+[win-x64-badge-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/win_x64_Release_version_badge.svg?no-cache
+[win-x64-version-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/productCommit-win-x64.txt
+[win-x64-installer-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-win-x64.exe
+[win-x64-installer-checksum-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-win-x64.exe.sha512
+[win-x64-targz-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-win-x64.tar.gz
+[win-x64-targz-checksum-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-win-x64.tar.gz.sha512
+[win-x64-zip-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-win-x64.zip
+[win-x64-zip-checksum-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-win-x64.zip.sha512
 
 [win-x64-badge-10.0.4xx]: https://aka.ms/dotnet/10.0.4xx/daily/win_x64_Release_version_badge.svg?no-cache
 [win-x64-version-10.0.4xx]: https://aka.ms/dotnet/10.0.4xx/daily/productCommit-win-x64.txt
@@ -200,14 +200,14 @@ For the 2xx and later bands, the 1xx runtime flows to 2xx+. The version of the r
 [win-x86-zip-main]: https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-win-x86.zip
 [win-x86-zip-checksum-main]: https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-win-x86.zip.sha512
 
-[win-x86-badge-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/win_x86_Release_version_badge.svg?no-cache
-[win-x86-version-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/productCommit-win-x86.txt
-[win-x86-installer-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-win-x86.exe
-[win-x86-installer-checksum-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-win-x86.exe.sha512
-[win-x86-targz-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-win-x86.tar.gz
-[win-x86-targz-checksum-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-win-x86.tar.gz.sha512
-[win-x86-zip-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-win-x86.zip
-[win-x86-zip-checksum-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-win-x86.zip.sha512
+[win-x86-badge-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/win_x86_Release_version_badge.svg?no-cache
+[win-x86-version-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/productCommit-win-x86.txt
+[win-x86-installer-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-win-x86.exe
+[win-x86-installer-checksum-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-win-x86.exe.sha512
+[win-x86-targz-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-win-x86.tar.gz
+[win-x86-targz-checksum-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-win-x86.tar.gz.sha512
+[win-x86-zip-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-win-x86.zip
+[win-x86-zip-checksum-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-win-x86.zip.sha512
 
 [win-x86-badge-10.0.4xx]: https://aka.ms/dotnet/10.0.4xx/daily/win_x86_Release_version_badge.svg?no-cache
 [win-x86-version-10.0.4xx]: https://aka.ms/dotnet/10.0.4xx/daily/productCommit-win-x86.txt
@@ -224,12 +224,12 @@ For the 2xx and later bands, the 1xx runtime flows to 2xx+. The version of the r
 [osx-x64-targz-main]: https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-osx-x64.tar.gz
 [osx-x64-targz-checksum-main]: https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-osx-x64.tar.gz.sha512
 
-[osx-x64-badge-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/osx_x64_Release_version_badge.svg?no-cache
-[osx-x64-version-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/productCommit-osx-x64.txt
-[osx-x64-installer-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-osx-x64.pkg
-[osx-x64-installer-checksum-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-osx-x64.pkg.sha512
-[osx-x64-targz-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-osx-x64.tar.gz
-[osx-x64-targz-checksum-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-osx-x64.tar.gz.sha512
+[osx-x64-badge-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/osx_x64_Release_version_badge.svg?no-cache
+[osx-x64-version-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/productCommit-osx-x64.txt
+[osx-x64-installer-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-osx-x64.pkg
+[osx-x64-installer-checksum-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-osx-x64.pkg.sha512
+[osx-x64-targz-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-osx-x64.tar.gz
+[osx-x64-targz-checksum-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-osx-x64.tar.gz.sha512
 
 [osx-x64-badge-10.0.4xx]: https://aka.ms/dotnet/10.0.4xx/daily/osx_x64_Release_version_badge.svg?no-cache
 [osx-x64-version-10.0.4xx]: https://aka.ms/dotnet/10.0.4xx/daily/productCommit-osx-x64.txt
@@ -246,12 +246,12 @@ For the 2xx and later bands, the 1xx runtime flows to 2xx+. The version of the r
 [osx-arm64-targz-main]: https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-osx-arm64.tar.gz
 [osx-arm64-targz-checksum-main]: https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-osx-arm64.tar.gz.sha512
 
-[osx-arm64-badge-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/osx_arm64_Release_version_badge.svg?no-cache
-[osx-arm64-version-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/productCommit-osx-arm64.txt
-[osx-arm64-installer-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-osx-arm64.pkg
-[osx-arm64-installer-checksum-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-osx-arm64.pkg.sha512
-[osx-arm64-targz-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-osx-arm64.tar.gz
-[osx-arm64-targz-checksum-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-osx-arm64.tar.gz.sha512
+[osx-arm64-badge-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/osx_arm64_Release_version_badge.svg?no-cache
+[osx-arm64-version-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/productCommit-osx-arm64.txt
+[osx-arm64-installer-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-osx-arm64.pkg
+[osx-arm64-installer-checksum-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-osx-arm64.pkg.sha512
+[osx-arm64-targz-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-osx-arm64.tar.gz
+[osx-arm64-targz-checksum-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-osx-arm64.tar.gz.sha512
 
 [osx-arm64-badge-10.0.4xx]: https://aka.ms/dotnet/10.0.4xx/daily/osx_arm64_Release_version_badge.svg?no-cache
 [osx-arm64-version-10.0.4xx]: https://aka.ms/dotnet/10.0.4xx/daily/productCommit-osx-arm64.txt
@@ -270,14 +270,14 @@ For the 2xx and later bands, the 1xx runtime flows to 2xx+. The version of the r
 [linux-targz-main]: https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-linux-x64.tar.gz
 [linux-targz-checksum-main]: https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-linux-x64.tar.gz.sha512
 
-[linux-badge-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/linux_x64_Release_version_badge.svg?no-cache
-[linux-version-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/productCommit-linux-x64.txt
-[linux-DEB-installer-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-x64.deb
-[linux-DEB-installer-checksum-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-x64.deb.sha512
-[linux-RPM-installer-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-x64.rpm
-[linux-RPM-installer-checksum-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-x64.rpm.sha512
-[linux-targz-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-linux-x64.tar.gz
-[linux-targz-checksum-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-linux-x64.tar.gz.sha512
+[linux-badge-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/linux_x64_Release_version_badge.svg?no-cache
+[linux-version-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/productCommit-linux-x64.txt
+[linux-DEB-installer-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-x64.deb
+[linux-DEB-installer-checksum-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-x64.deb.sha512
+[linux-RPM-installer-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-x64.rpm
+[linux-RPM-installer-checksum-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-x64.rpm.sha512
+[linux-targz-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-linux-x64.tar.gz
+[linux-targz-checksum-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-linux-x64.tar.gz.sha512
 
 [linux-badge-10.0.4xx]: https://aka.ms/dotnet/10.0.4xx/daily/linux_x64_Release_version_badge.svg?no-cache
 [linux-version-10.0.4xx]: https://aka.ms/dotnet/10.0.4xx/daily/productCommit-linux-x64.txt
@@ -294,10 +294,10 @@ For the 2xx and later bands, the 1xx runtime flows to 2xx+. The version of the r
 [linux-arm-targz-main]: https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-linux-arm.tar.gz
 [linux-arm-targz-checksum-main]: https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-linux-arm.tar.gz.sha512
 
-[linux-arm-badge-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/linux_arm_Release_version_badge.svg?no-cache
-[linux-arm-version-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/productCommit-linux-arm.txt
-[linux-arm-targz-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-linux-arm.tar.gz
-[linux-arm-targz-checksum-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-linux-arm.tar.gz.sha512
+[linux-arm-badge-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/linux_arm_Release_version_badge.svg?no-cache
+[linux-arm-version-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/productCommit-linux-arm.txt
+[linux-arm-targz-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-linux-arm.tar.gz
+[linux-arm-targz-checksum-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-linux-arm.tar.gz.sha512
 
 [linux-arm-badge-10.0.4xx]: https://aka.ms/dotnet/10.0.4xx/daily/linux_arm_Release_version_badge.svg?no-cache
 [linux-arm-version-10.0.4xx]: https://aka.ms/dotnet/10.0.4xx/daily/productCommit-linux-arm.txt
@@ -310,10 +310,10 @@ For the 2xx and later bands, the 1xx runtime flows to 2xx+. The version of the r
 [linux-arm64-targz-main]: https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-linux-arm64.tar.gz
 [linux-arm64-targz-checksum-main]: https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-linux-arm64.tar.gz.sha512
 
-[linux-arm64-badge-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/linux_arm64_Release_version_badge.svg?no-cache
-[linux-arm64-version-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/productCommit-linux-arm64.txt
-[linux-arm64-targz-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-linux-arm64.tar.gz
-[linux-arm64-targz-checksum-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-linux-arm64.tar.gz.sha512
+[linux-arm64-badge-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/linux_arm64_Release_version_badge.svg?no-cache
+[linux-arm64-version-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/productCommit-linux-arm64.txt
+[linux-arm64-targz-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-linux-arm64.tar.gz
+[linux-arm64-targz-checksum-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-linux-arm64.tar.gz.sha512
 
 [linux-arm64-badge-10.0.4xx]: https://aka.ms/dotnet/10.0.4xx/daily/linux_arm64_Release_version_badge.svg?no-cache
 [linux-arm64-version-10.0.4xx]: https://aka.ms/dotnet/10.0.4xx/daily/productCommit-linux-arm64.txt
@@ -326,10 +326,10 @@ For the 2xx and later bands, the 1xx runtime flows to 2xx+. The version of the r
 [linux-musl-x64-targz-main]: https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-linux-musl-x64.tar.gz
 [linux-musl-x64-targz-checksum-main]: https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha512
 
-[linux-musl-x64-badge-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/linux_musl_x64_Release_version_badge.svg?no-cache
-[linux-musl-x64-version-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/productCommit-linux-musl-x64.txt
-[linux-musl-x64-targz-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-linux-musl-x64.tar.gz
-[linux-musl-x64-targz-checksum-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha512
+[linux-musl-x64-badge-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/linux_musl_x64_Release_version_badge.svg?no-cache
+[linux-musl-x64-version-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/productCommit-linux-musl-x64.txt
+[linux-musl-x64-targz-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-linux-musl-x64.tar.gz
+[linux-musl-x64-targz-checksum-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-linux-musl-x64.tar.gz.sha512
 
 [linux-musl-x64-badge-10.0.4xx]: https://aka.ms/dotnet/10.0.4xx/daily/linux_musl_x64_Release_version_badge.svg?no-cache
 [linux-musl-x64-version-10.0.4xx]: https://aka.ms/dotnet/10.0.4xx/daily/productCommit-linux-musl-x64.txt
@@ -342,10 +342,10 @@ For the 2xx and later bands, the 1xx runtime flows to 2xx+. The version of the r
 [linux-musl-arm-targz-main]: https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-linux-musl-arm.tar.gz
 [linux-musl-arm-targz-checksum-main]: https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha512
 
-[linux-musl-arm-badge-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/linux_musl_arm_Release_version_badge.svg?no-cache
-[linux-musl-arm-version-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/productCommit-linux-musl-arm.txt
-[linux-musl-arm-targz-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-linux-musl-arm.tar.gz
-[linux-musl-arm-targz-checksum-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha512
+[linux-musl-arm-badge-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/linux_musl_arm_Release_version_badge.svg?no-cache
+[linux-musl-arm-version-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/productCommit-linux-musl-arm.txt
+[linux-musl-arm-targz-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-linux-musl-arm.tar.gz
+[linux-musl-arm-targz-checksum-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-linux-musl-arm.tar.gz.sha512
 
 [linux-musl-arm-badge-10.0.4xx]: https://aka.ms/dotnet/10.0.4xx/daily/linux_musl_arm_Release_version_badge.svg?no-cache
 [linux-musl-arm-version-10.0.4xx]: https://aka.ms/dotnet/10.0.4xx/daily/productCommit-linux-musl-arm.txt
@@ -358,10 +358,10 @@ For the 2xx and later bands, the 1xx runtime flows to 2xx+. The version of the r
 [linux-musl-arm64-targz-main]: https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz
 [linux-musl-arm64-targz-checksum-main]: https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha512
 
-[linux-musl-arm64-badge-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/linux_musl_arm64_Release_version_badge.svg?no-cache
-[linux-musl-arm64-version-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/productCommit-linux-musl-arm64.txt
-[linux-musl-arm64-targz-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-linux-musl-arm64.tar.gz
-[linux-musl-arm64-targz-checksum-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha512
+[linux-musl-arm64-badge-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/linux_musl_arm64_Release_version_badge.svg?no-cache
+[linux-musl-arm64-version-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/productCommit-linux-musl-arm64.txt
+[linux-musl-arm64-targz-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-linux-musl-arm64.tar.gz
+[linux-musl-arm64-targz-checksum-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-linux-musl-arm64.tar.gz.sha512
 
 [linux-musl-arm64-badge-10.0.4xx]: https://aka.ms/dotnet/10.0.4xx/daily/linux_musl_arm64_Release_version_badge.svg?no-cache
 [linux-musl-arm64-version-10.0.4xx]: https://aka.ms/dotnet/10.0.4xx/daily/productCommit-linux-musl-arm64.txt
@@ -378,14 +378,14 @@ For the 2xx and later bands, the 1xx runtime flows to 2xx+. The version of the r
 [win-arm64-zip-main]: https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-win-arm64.zip
 [win-arm64-zip-checksum-main]: https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-win-arm64.zip.sha512
 
-[win-arm64-badge-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/win_arm64_Release_version_badge.svg?no-cache
-[win-arm64-version-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/productCommit-win-arm64.txt
-[win-arm64-installer-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-win-arm64.exe
-[win-arm64-installer-checksum-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-win-arm64.exe.sha512
-[win-arm64-targz-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-win-arm64.tar.gz
-[win-arm64-targz-checksum-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-win-arm64.tar.gz.sha512
-[win-arm64-zip-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-win-arm64.zip
-[win-arm64-zip-checksum-11.0.1xx-preview7]: https://aka.ms/dotnet/11.0.1xx-preview7/daily/dotnet-sdk-win-arm64.zip.sha512
+[win-arm64-badge-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/win_arm64_Release_version_badge.svg?no-cache
+[win-arm64-version-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/productCommit-win-arm64.txt
+[win-arm64-installer-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-win-arm64.exe
+[win-arm64-installer-checksum-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-win-arm64.exe.sha512
+[win-arm64-targz-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-win-arm64.tar.gz
+[win-arm64-targz-checksum-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-win-arm64.tar.gz.sha512
+[win-arm64-zip-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-win-arm64.zip
+[win-arm64-zip-checksum-11.0.1xx-rc1]: https://aka.ms/dotnet/11.0.1xx-rc1/daily/dotnet-sdk-win-arm64.zip.sha512
 
 [win-arm64-badge-10.0.4xx]: https://aka.ms/dotnet/10.0.4xx/daily/win_arm64_Release_version_badge.svg?no-cache
 [win-arm64-version-10.0.4xx]: https://aka.ms/dotnet/10.0.4xx/daily/productCommit-win-arm64.txt


### PR DESCRIPTION
The `release/11.0.1xx-rc1` branch now exists. This updates the builds table in `docs/builds-table.md` to reference rc1 instead of preview7.