### PR TITLE
Remove .psmdcp exclusion from BuildComparer

### DIFF
--- a/eng/tools/BuildComparer/Utils.cs
+++ b/eng/tools/BuildComparer/Utils.cs
@@ -43,5 +43,5 @@ public static class Utils
     /// Determines if a package file should be ignored.
     /// </summary>
     public static bool IsIgnorablePackageFile(string filePath)
-        => filePath.EndsWith(".signature.p7s", StringComparison.OrdinalIgnoreCase) || filePath.EndsWith(".psmdcp", StringComparison.OrdinalIgnoreCase);
+        => filePath.EndsWith(".signature.p7s", StringComparison.OrdinalIgnoreCase);
 }


### PR DESCRIPTION
.psmdcp name was made deterministic in https://github.com/NuGet/NuGet.Client/pull/7503