### PR TITLE
Update Guardian baseline for ESRP client

### DIFF
--- a/.config/guardian/.gdnbaselines
+++ b/.config/guardian/.gdnbaselines
@@ -8,7 +8,7 @@
     "default": {
       "name": "default",
       "createdDate": "2026-08-12 03:04:30Z",
-      "lastUpdatedDate": "2026-08-12 03:04:30Z"
+      "lastUpdatedDate": "2026-08-19 20:46:10Z"
     }
   },
   "results": {
@@ -139,6 +139,70 @@
       "tool": "binskim",
       "ruleId": "BA2007",
       "createdDate": "2026-08-12 03:04:30Z"
+    },
+    "cc990fbd632d53699419218fe0a2104d635756417a6984d39eb0c1ecd85b4172": {
+      "signature": "cc990fbd632d53699419218fe0a2104d635756417a6984d39eb0c1ecd85b4172",
+      "alternativeSignatures": [
+        "fcbbd80939925e3aa817048d72e0598a4116d2775c33f1106d13ad4339db992f",
+        "8624936ac89605a765952dc88b1d664ceb0280ce16f96b8624b6842e1f58f371",
+        "91c2b52fc60e70f0fa77db0c98050803628aa9f9b0206b30f8580c07f565c519"
+      ],
+      "target": "Microsoft.EsrpClient.2.0.14/tools/Win10.x86/psfsip.dll",
+      "uriBaseId": "file:///D:/a/_work/1/a/",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "binskim",
+      "ruleId": "BA2010",
+      "createdDate": "2026-08-19 20:46:10Z"
+    },
+    "3783c42653ff4b5d4b88a2af752b7d3dc534067e123dd61d676995ad74fce616": {
+      "signature": "3783c42653ff4b5d4b88a2af752b7d3dc534067e123dd61d676995ad74fce616",
+      "alternativeSignatures": [
+        "f218b3e6a95e9e9fc2dd7ff1cdd6b94c7f93500cb7c5ce168bc3a077a645fd43",
+        "cfc215ba8c108c023396d049cc104540af1d45774fbea9e79e32dd8edba311ba",
+        "7bd4dd9a34af4b40f4c797ab2ad5544d008b5434a117bfc998b52f1d5f33d0b2"
+      ],
+      "target": "Microsoft.EsrpClient.2.0.14/tools/Win10.x86/pysip.dll",
+      "uriBaseId": "file:///D:/a/_work/1/a/",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "binskim",
+      "ruleId": "BA2008",
+      "createdDate": "2026-08-19 20:46:10Z"
+    },
+    "c41f29e684879eaeb1c030db42cba27d8b96bd438356023371440018e3bd0eae": {
+      "signature": "c41f29e684879eaeb1c030db42cba27d8b96bd438356023371440018e3bd0eae",
+      "alternativeSignatures": [
+        "2dc3557c7863a5662ce2f164dfb9d1356edeee7f824b42ee9189a5ea473555a6",
+        "83ec75feeca809ed0a4933b9b8b319a79b48e191710d70161f9a3a025e26b1f3",
+        "a535d144bf4b729f8cbd71aa361e5069eb2319d1d76230397492e3e1994245c3"
+      ],
+      "target": "Microsoft.EsrpClient.2.0.14/tools/Win10.x86/sftsip.dll",
+      "uriBaseId": "file:///D:/a/_work/1/a/",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "binskim",
+      "ruleId": "BA2010",
+      "createdDate": "2026-08-19 20:46:10Z"
+    },
+    "02313aff47a324e5a626b62e0b734c18c7971b04d114c375eedf583db8c9281e": {
+      "signature": "02313aff47a324e5a626b62e0b734c18c7971b04d114c375eedf583db8c9281e",
+      "alternativeSignatures": [
+        "1b027b78c6710ab9005076bf285d89d76b8378e766e2a561e474f2a146647e12",
+        "3790f0b20c957741b13b07da16c9ec5984ff804557229ec3c4359e874b6d48d6",
+        "914c459f6d10df0fac48b6d690d2839e2f976aa65277015d1aaf6e91d4b272ea"
+      ],
+      "target": "Microsoft.EsrpClient.2.0.14/tools/Win10.x86/wshext.dll",
+      "uriBaseId": "file:///D:/a/_work/1/a/",
+      "memberOf": [
+        "default"
+      ],
+      "tool": "binskim",
+      "ruleId": "BA2010",
+      "createdDate": "2026-08-19 20:46:10Z"
     }
   }
 }


### PR DESCRIPTION
Updates the Guardian baseline for the four new BinSkim errors reported by [build 3052011](https://dev.azure.com/dnceng/internal/_build/results?buildId=3052011&view=results) in Microsoft.EsrpClient 2.0.14:

- BA2010: psfsip.dll
- BA2008: pysip.dll
- BA2010: sftsip.dll
- BA2010: wshext.dll

The signatures and alternative signatures were taken from the published Windows x86 and arm64 Guardian SARIF artifacts.