### PR TITLE
Revert "Update symbol publishing exclusions for roslyn libsqlite3mc.s…

### DIFF
--- a/eng/SymbolPublishingExclusionsFile.txt
+++ b/eng/SymbolPublishingExclusionsFile.txt
@@ -6,5 +6,4 @@ tools/x86_arm/mscordbi.dll
 tools/x64_arm64/mscordaccore.dll
 tools/x64_arm64/mscordbi.dll
 tools/net10.0/linux-musl-arm64/libe_sqlite3.so
-tools/net10.0/linux-musl-arm/libe_sqlite3.so
 tools/net10.0/linux-musl-x64/libe_sqlite3.so

--- a/eng/SymbolPublishingExclusionsFile.txt
+++ b/eng/SymbolPublishingExclusionsFile.txt
@@ -5,9 +5,6 @@ tools/x86_arm/mscordaccore.dll
 tools/x86_arm/mscordbi.dll
 tools/x64_arm64/mscordaccore.dll
 tools/x64_arm64/mscordbi.dll
-tools/net10.0/linux-musl-arm64/libsqlite3mc.so
-tools/net11.0/linux-musl-arm64/libsqlite3mc.so
-tools/net10.0/linux-musl-arm/libsqlite3mc.so
-tools/net11.0/linux-musl-arm/libsqlite3mc.so
-tools/net10.0/linux-musl-x64/libsqlite3mc.so
-tools/net11.0/linux-musl-x64/libsqlite3mc.so
+tools/net10.0/linux-musl-arm64/libe_sqlite3.so
+tools/net10.0/linux-musl-arm/libe_sqlite3.so
+tools/net10.0/linux-musl-x64/libe_sqlite3.so


### PR DESCRIPTION
…o (#7425)"

This reverts commit bd6712a91ceca697ab9ea8bcaed5a3bdf957ff61.

Necessary due to https://github.com/dotnet/roslyn/pull/84692