### PR TITLE
Add Windows bootstrap validation pipeline

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -29,6 +29,11 @@ Param(
   [switch]$prepareMachine,
   [string]$projects,
   [bool] $warnAsError = $true,
+
+  # Bootstrap settings
+  [string]$withSdk,
+  [string]$withPackages,
+
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
@@ -68,14 +73,34 @@ function Get-Usage() {
   Write-Host "  -projects <value>           Project or solution file to build"
   Write-Host "  -warnAsError <value>        Sets warnaserror msbuild parameter ('true' or 'false')"
   Write-Host ""
-}
 
-. $PSScriptRoot\common\tools.ps1
+  Write-Host "Bootstrap settings:"
+  Write-Host "  -withSdk <DIR>              Use the SDK in the specified directory for bootstrapping"
+  Write-Host "  -withPackages <DIR>         Use the specified directory of previously-built packages"
+  Write-Host ""
+}
 
 if ($help) {
   Get-Usage
   exit 0
 }
+
+# This must run before tools.ps1 is loaded because that script caches global.json.
+. $PSScriptRoot\msft-toolset-init.ps1
+
+$bootstrapProperties = @()
+if ($withSdk -or $withPackages) {
+  try {
+    $bootstrapProperties = Initialize-MsftToolset (Resolve-Path "$PSScriptRoot\..").Path $withSdk $withPackages
+  }
+  catch {
+    Write-Host "##vso[task.logissue type=error]Bootstrap toolset initialization failed: $($_.Exception.Message)"
+    Write-Host $_.ScriptStackTrace
+    exit 1
+  }
+}
+
+. $PSScriptRoot\common\tools.ps1
 
 $actions = @("/p:Restore=true", "/p:Build=true", "/p:Publish=true")
 
@@ -100,6 +125,7 @@ if ($officialBuildId) { $arguments += "/p:OfficialBuildId=$officialBuildId" }
 # Flow the explicit choices down to the individual repo builds as well.
 if ($PSBoundParameters.ContainsKey('msbuildMultiThreaded')) { $arguments += "/p:DotNetBuildMT=$msbuildMultiThreaded" }
 if ($PSBoundParameters.ContainsKey('nodeReuse')) { $arguments += "/p:DotNetBuildNodeReuse=$nodeReuse" }
+$arguments += $bootstrapProperties
 
 function Build {
   $toolsetBuildProj = InitializeToolset

--- a/eng/msft-toolset-init.ps1
+++ b/eng/msft-toolset-init.ps1
@@ -105,7 +105,7 @@ function Initialize-MsftToolset([string]$repoRoot, [string]$customSdkDir, [strin
 
     Write-Host "Using bootstrap Arcade SDK version '$arcadeVersion'"
     Update-GlobalJsonMSBuildSdkVersion (Join-Path $repoRoot 'global.json') 'Microsoft.DotNet.Arcade.Sdk' $arcadeVersion
-    $extraProperties += "/p:ExtraRestoreSourcePath=$customPackagesDir"
+    $extraProperties += "/p:CustomPreviouslySourceBuiltPackagesPath=$customPackagesDir"
     $extraProperties += "/p:RestoreAdditionalProjectSources=$customPackagesDir"
   }
 

--- a/eng/msft-toolset-init.ps1
+++ b/eng/msft-toolset-init.ps1
@@ -1,0 +1,113 @@
+### Initializes a Microsoft build from an externally supplied SDK and package set.
+### This must be loaded before eng/common/tools.ps1 so the latter sees the updated global.json.
+
+function Update-GlobalJsonSdkVersion([string]$globalJsonFile, [string]$sdkVersion) {
+  $content = Get-Content -Raw -Path $globalJsonFile
+
+  $content = [regex]::Replace(
+    $content,
+    '("sdk"\s*:\s*\{[^}]*?"version"\s*:\s*")[^"]*(")',
+    { param($m) $m.Groups[1].Value + $sdkVersion + $m.Groups[2].Value })
+
+  $content = [regex]::Replace(
+    $content,
+    '("tools"\s*:\s*\{[^}]*?"dotnet"\s*:\s*")[^"]*(")',
+    { param($m) $m.Groups[1].Value + $sdkVersion + $m.Groups[2].Value })
+
+  Set-Content -Path $globalJsonFile -Value $content -NoNewline
+}
+
+function Update-GlobalJsonMSBuildSdkVersion([string]$globalJsonFile, [string]$sdkId, [string]$sdkVersion) {
+  $content = Get-Content -Raw -Path $globalJsonFile
+  $pattern = '("' + [regex]::Escape($sdkId) + '"\s*:\s*")[^"]*(")'
+
+  $content = [regex]::Replace(
+    $content,
+    $pattern,
+    { param($m) $m.Groups[1].Value + $sdkVersion + $m.Groups[2].Value })
+
+  Set-Content -Path $globalJsonFile -Value $content -NoNewline
+}
+
+function Add-NuGetSourceToConfig([string]$nuGetConfigFile, [string]$sourceName, [string]$sourcePath) {
+  if (-not (Test-Path $nuGetConfigFile)) {
+    throw "NuGet.config '$nuGetConfigFile' does not exist"
+  }
+
+  $content = Get-Content -Raw -Path $nuGetConfigFile
+  $content = [regex]::Replace($content, '[ \t]*<add\s+key="' + [regex]::Escape($sourceName) + '"[^>]*/>\r?\n', '')
+  $entry = '    <add key="' + $sourceName + '" value="' + $sourcePath + '" />'
+  $content = [regex]::Replace(
+    $content,
+    '(<packageSources>\s*<clear\s*/>|<packageSources>)',
+    { param($m) $m.Groups[1].Value + "`r`n" + $entry },
+    1)
+
+  Set-Content -Path $nuGetConfigFile -Value $content -NoNewline
+}
+
+function Find-PackageVersion([string]$packagesDir, [string]$packageId) {
+  $package = Get-ChildItem -Path $packagesDir -Recurse -File -Filter "$packageId.*.nupkg" -ErrorAction SilentlyContinue |
+    Where-Object { $_.BaseName -match ('^' + [regex]::Escape($packageId) + '\.\d') } |
+    Sort-Object Name |
+    Select-Object -First 1
+
+  if ($null -eq $package) {
+    return $null
+  }
+
+  return $package.BaseName.Substring($packageId.Length + 1)
+}
+
+function Initialize-MsftToolset([string]$repoRoot, [string]$customSdkDir, [string]$customPackagesDir) {
+  $extraProperties = @()
+
+  if ($customSdkDir) {
+    if (-not (Test-Path $customSdkDir -PathType Container)) {
+      throw "Custom SDK directory '$customSdkDir' does not exist"
+    }
+
+    $customSdkDir = (Resolve-Path $customSdkDir).Path
+    $dotnetExe = Join-Path $customSdkDir 'dotnet.exe'
+    if (-not (Test-Path $dotnetExe)) {
+      throw "Custom SDK '$dotnetExe' does not exist"
+    }
+
+    $sdkLines = @(& $dotnetExe --list-sdks)
+    if ($LASTEXITCODE -ne 0 -or $sdkLines.Count -eq 0) {
+      throw "Could not determine the SDK version of the custom SDK at '$customSdkDir'"
+    }
+
+    $sdkVersion = ($sdkLines[-1] -replace '\s*\[.*$', '').Trim()
+    if (-not (Test-Path (Join-Path $customSdkDir "sdk\$sdkVersion") -PathType Container)) {
+      throw "Custom SDK '$customSdkDir' does not contain 'sdk\$sdkVersion'"
+    }
+
+    Write-Host "Using custom bootstrap SDK from '$customSdkDir', version '$sdkVersion'"
+    Update-GlobalJsonSdkVersion (Join-Path $repoRoot 'global.json') $sdkVersion
+    $env:DOTNET_INSTALL_DIR = $customSdkDir
+    $env:DOTNET_ROOT = $customSdkDir
+  }
+
+  if ($customPackagesDir) {
+    if (-not (Test-Path $customPackagesDir -PathType Container)) {
+      throw "Custom packages directory '$customPackagesDir' does not exist"
+    }
+
+    $customPackagesDir = (Resolve-Path $customPackagesDir).Path
+    Write-Host "Using custom bootstrap packages from '$customPackagesDir'"
+    Add-NuGetSourceToConfig (Join-Path $repoRoot 'NuGet.config') 'bootstrap-packages' $customPackagesDir
+
+    $arcadeVersion = Find-PackageVersion $customPackagesDir 'Microsoft.DotNet.Arcade.Sdk'
+    if (-not $arcadeVersion) {
+      throw "Microsoft.DotNet.Arcade.Sdk package not found under '$customPackagesDir'"
+    }
+
+    Write-Host "Using bootstrap Arcade SDK version '$arcadeVersion'"
+    Update-GlobalJsonMSBuildSdkVersion (Join-Path $repoRoot 'global.json') 'Microsoft.DotNet.Arcade.Sdk' $arcadeVersion
+    $extraProperties += "/p:ExtraRestoreSourcePath=$customPackagesDir"
+    $extraProperties += "/p:RestoreAdditionalProjectSources=$customPackagesDir"
+  }
+
+  return $extraProperties
+}

--- a/eng/pipelines/bootstrap-validation.yml
+++ b/eng/pipelines/bootstrap-validation.yml
@@ -1,0 +1,28 @@
+# This yml is used by this pipeline:
+# - dotnet-unified-build-bootstrap-validation (public)
+#
+# It can also be run on a pull request with:
+# /azp run dotnet-unified-build-bootstrap-validation
+
+trigger: none
+pr: none
+
+schedules:
+- cron: "0 5 * * *"
+  displayName: Daily bootstrap validation
+  branches:
+    include:
+    - main
+  always: true
+
+variables:
+- ${{ if eq(variables['System.TeamProject'], 'public') }}:
+  - name: skipComponentGovernanceDetection
+    value: true
+  - name: Codeql.Enabled
+    value: false
+
+- template: /eng/common/templates-official/variables/pool-providers.yml@self
+
+stages:
+- template: /eng/pipelines/templates/stages/vmr-bootstrap-validation.yml

--- a/eng/pipelines/templates/jobs/vmr-build.yml
+++ b/eng/pipelines/templates/jobs/vmr-build.yml
@@ -82,6 +82,11 @@ parameters:
   type: object
   default: []
 
+# Name of a previous Microsoft-build job whose SDK and Arcade packages should bootstrap this job.
+- name: bootstrapArtifactsFrom
+  type: string
+  default: ''
+
 # Enables usage of the system libraries when building.
 - name: useSystemLibraries
   type: boolean
@@ -212,12 +217,14 @@ jobs:
         image: ${{ parameters.container.image }}
         options: $(defaultContainerOptions)
 
-  ${{ if or(gt(length(parameters.reuseBuildArtifactsFrom), 0), gt(length(parameters.dependsOn), 0)) }}:
+  ${{ if or(gt(length(parameters.reuseBuildArtifactsFrom), 0), gt(length(parameters.dependsOn), 0), ne(parameters.bootstrapArtifactsFrom, '')) }}:
     dependsOn:
     - ${{ each dep in parameters.reuseBuildArtifactsFrom }}:
       - ${{ dep }}
     - ${{ each dep in parameters.dependsOn }}:
       - ${{ dep }}
+    - ${{ if ne(parameters.bootstrapArtifactsFrom, '') }}:
+      - ${{ parameters.bootstrapArtifactsFrom }}
   variables:
   - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
     - group: AzureDevOps-Artifact-Feeds-Pats
@@ -270,6 +277,9 @@ jobs:
     value: $(Agent.TempDirectory)/previously-source-built-sdk
   - name: previouslySourceBuiltArtifactsDir
     value: $(Agent.TempDirectory)/previously-source-built-artifacts
+
+  - name: bootstrapArguments
+    value: ''
 
   - name: successfulJobArtifactName
     value: $(Agent.JobName)_Artifacts
@@ -514,6 +524,11 @@ jobs:
             targetPath: $(sourcesPath)/artifacts/
           displayName: Download Previous Build (${{ reuseBuildArtifacts }})
 
+  - ${{ if ne(parameters.bootstrapArtifactsFrom, '') }}:
+    - template: ../steps/bootstrap-toolset.yml
+      parameters:
+        artifactName: ${{ parameters.bootstrapArtifactsFrom }}_Artifacts
+
   - ${{ if eq(parameters.withPreviousSDK, 'true') }}:
     - script: |
         source "$(sourcesPath)/eng/download-source-built-archive.sh"
@@ -654,6 +669,7 @@ jobs:
         $(buildPassProperties)
         $(runtimeSourceFeedKeyProperties)
         $(_SignDiagnosticFilesArgs)
+        $(bootstrapArguments)
         ${{ parameters.extraProperties }}
       displayName: Build
       workingDirectory: ${{ variables.sourcesPath }}
@@ -687,6 +703,7 @@ jobs:
           $(baseArguments)
           $(targetProperties)
           $(buildPassProperties)
+          $(bootstrapArguments)
           ${{ parameters.extraProperties }}
           -test
           -excludeCIBinarylog

--- a/eng/pipelines/templates/stages/vmr-bootstrap-validation.yml
+++ b/eng/pipelines/templates/stages/vmr-bootstrap-validation.yml
@@ -1,0 +1,39 @@
+parameters:
+- name: pool_Windows
+  type: object
+  default:
+    name: $(defaultPoolName)
+    image: $(poolImage_Windows)
+    demands: ImageOverride -equals $(poolImage_Windows)
+    os: windows
+
+stages:
+- stage: VMR_Bootstrap_Validation
+  displayName: VMR Bootstrap Validation
+  dependsOn: []
+  variables:
+  - template: ../variables/vmr-build.yml
+    parameters:
+      desiredSigning: Unsigned
+      isOfficialBuild: false
+  jobs:
+  - template: ../jobs/vmr-build.yml
+    parameters:
+      buildName: Windows_Stage1
+      isBuiltFromVmr: true
+      sign: false
+      pool: ${{ parameters.pool_Windows }}
+      targetOS: windows
+      targetArchitecture: x64
+      brandingType: ${{ variables.brandingType }}
+
+  - template: ../jobs/vmr-build.yml
+    parameters:
+      buildName: Windows_Stage2
+      isBuiltFromVmr: true
+      sign: false
+      pool: ${{ parameters.pool_Windows }}
+      targetOS: windows
+      targetArchitecture: x64
+      brandingType: ${{ variables.brandingType }}
+      bootstrapArtifactsFrom: Windows_Stage1_x64

--- a/eng/pipelines/templates/stages/vmr-bootstrap-validation.yml
+++ b/eng/pipelines/templates/stages/vmr-bootstrap-validation.yml
@@ -19,7 +19,7 @@ stages:
   jobs:
   - template: ../jobs/vmr-build.yml
     parameters:
-      buildName: Windows_Stage1
+      buildName: Windows
       isBuiltFromVmr: true
       sign: false
       pool: ${{ parameters.pool_Windows }}
@@ -36,4 +36,4 @@ stages:
       targetOS: windows
       targetArchitecture: x64
       brandingType: ${{ variables.brandingType }}
-      bootstrapArtifactsFrom: Windows_Stage1_x64
+      bootstrapArtifactsFrom: Windows_x64

--- a/eng/pipelines/templates/steps/bootstrap-toolset.yml
+++ b/eng/pipelines/templates/steps/bootstrap-toolset.yml
@@ -14,7 +14,7 @@ steps:
   displayName: Download Bootstrap Packages
   inputs:
     artifactName: ${{ parameters.artifactName }}
-    itemPattern: packages/**/Microsoft.DotNet.Arcade.Sdk.*.nupkg
+    itemPattern: packages/*/NonShipping/arcade/**
     targetPath: $(Agent.TempDirectory)/bootstrap-packages-download
 
 - pwsh: |

--- a/eng/pipelines/templates/steps/bootstrap-toolset.yml
+++ b/eng/pipelines/templates/steps/bootstrap-toolset.yml
@@ -14,9 +14,7 @@ steps:
   displayName: Download Bootstrap Packages
   inputs:
     artifactName: ${{ parameters.artifactName }}
-    itemPattern: |
-      packages/*/NonShipping/arcade/**
-      packages/*/Shipping/arcade/**
+    itemPattern: packages/**/Microsoft.DotNet.Arcade.Sdk.*.nupkg
     targetPath: $(Agent.TempDirectory)/bootstrap-packages-download
 
 - pwsh: |

--- a/eng/pipelines/templates/steps/bootstrap-toolset.yml
+++ b/eng/pipelines/templates/steps/bootstrap-toolset.yml
@@ -1,0 +1,48 @@
+parameters:
+- name: artifactName
+  type: string
+
+steps:
+- task: DownloadPipelineArtifact@2
+  displayName: Download Bootstrap SDK
+  inputs:
+    artifactName: ${{ parameters.artifactName }}
+    itemPattern: assets/*/Sdk/**/dotnet-sdk-*-win-x64.zip
+    targetPath: $(Agent.TempDirectory)/bootstrap-sdk-download
+
+- task: DownloadPipelineArtifact@2
+  displayName: Download Bootstrap Packages
+  inputs:
+    artifactName: ${{ parameters.artifactName }}
+    itemPattern: |
+      packages/*/NonShipping/arcade/**
+      packages/*/Shipping/arcade/**
+    targetPath: $(Agent.TempDirectory)/bootstrap-packages-download
+
+- pwsh: |
+    $ErrorActionPreference = 'Stop'
+
+    $sdkArchive = Get-ChildItem -Path '$(Agent.TempDirectory)/bootstrap-sdk-download' -Recurse -File -Filter 'dotnet-sdk-*-win-x64.zip' |
+      Select-Object -First 1
+    if ($null -eq $sdkArchive) {
+      throw "No win-x64 SDK archive was downloaded from '${{ parameters.artifactName }}'."
+    }
+
+    $sdkDir = '$(Agent.TempDirectory)/bootstrap-sdk'
+    New-Item -ItemType Directory -Force -Path $sdkDir | Out-Null
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($sdkArchive.FullName, $sdkDir)
+
+    $packagesDir = '$(Agent.TempDirectory)/bootstrap-packages'
+    New-Item -ItemType Directory -Force -Path $packagesDir | Out-Null
+    Get-ChildItem -Path '$(Agent.TempDirectory)/bootstrap-packages-download' -Recurse -File -Filter '*.nupkg' |
+      ForEach-Object { Copy-Item $_.FullName -Destination $packagesDir -Force }
+
+    $packageCount = (Get-ChildItem -Path $packagesDir -File -Filter '*.nupkg').Count
+    if ($packageCount -eq 0) {
+      throw "No Arcade packages were downloaded from '${{ parameters.artifactName }}'."
+    }
+
+    Write-Host "Using bootstrap SDK '$($sdkArchive.Name)' and $packageCount package(s)."
+    Write-Host "##vso[task.setvariable variable=bootstrapArguments]-withSdk `"$sdkDir`" -withPackages `"$packagesDir`""
+  displayName: Prepare Bootstrap Toolset

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -216,7 +216,7 @@
     <AddSourceToNuGetConfig NuGetConfigFile="$(NuGetConfigFile)"
                             SourceName="$(PreviouslySourceBuiltNuGetSourceName)"
                             SourcePath="$(PreviouslySourceBuiltPackagesPath)"
-                            Condition="'$(AddPrebuiltFeeds)' == 'true'" />
+                            Condition="'$(AddPrebuiltFeeds)' == 'true' or '$(CustomPreviouslySourceBuiltPackagesPath)' != ''" />
 
     <AddSourceToNuGetConfig NuGetConfigFile="$(NuGetConfigFile)"
                             SourceName="$(PreviouslySourceBuiltSharedComponentsNuGetSourceName)"
@@ -254,6 +254,9 @@
                               $(PreviouslySourceBuiltSharedComponentsNuGetSourceName);
                               $(ReferencePackagesNuGetSourceName)"
                      Condition="'$(AddPrebuiltFeeds)' == 'true'"/>
+      <!-- Microsoft bootstrap builds supply only the stage 1 packages as a source-built input. -->
+      <_BuildSources Include="$(PreviouslySourceBuiltNuGetSourceName)"
+                     Condition="'$(AddPrebuiltFeeds)' != 'true' and '$(CustomPreviouslySourceBuiltPackagesPath)' != ''" />
       <_BuildSources Include="@(_CommonBuildSources)" />
     </ItemGroup>
 


### PR DESCRIPTION
Fixes #1071.\n\nAdds a daily and comment-triggered public pipeline that builds win-x64 twice. The second job depends on the first and bootstraps from its SDK and Arcade packages.