### PR TITLE
Prevent milestoning unmerged codeflow PRs

### DIFF
--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -467,6 +467,11 @@ jobs:
             // branch), each potentially milestoning the same child PR differently.
             // Rule: oldest milestone wins. Returns { action: 'skip'|'apply', reason, warn? }.
             function decideMilestoneAction(pr, milestoneName, milestoneNumber) {
+              // associatedPullRequests can include an open PR when a commit in the
+              // flowed range is that PR's base commit rather than a commit it introduced.
+              if (!pr.merged_at) {
+                return { action: 'skip', reason: 'PR has not been merged' };
+              }
               if (pr.milestone?.number === milestoneNumber) {
                 return { action: 'skip', reason: 'already has correct milestone' };
               }


### PR DESCRIPTION
## Summary

- Skip child PRs that do not have a merge timestamp before applying a milestone.
- Use the same guard during the final pre-write recheck.

## Context

GitHub `associatedPullRequests` can include an open PR when a commit in the flowed range is the PR base commit rather than a commit introduced by that PR. This caused [dotnet/efcore#38848](https://github.com/dotnet/efcore/pull/38848) to receive the RC2 milestone from [this workflow run](https://github.com/dotnet/dotnet/actions/runs/32746119673/job/97491945732) before it was merged.

## Validation

- Parsed the workflow YAML.
- Checked the embedded `github-script` JavaScript syntax.