### PR TITLE
Stop bootstrap Arcade repos from consuming shared components

### DIFF
--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -6,6 +6,8 @@
   <PropertyGroup>
     <RepositoryName>$(MSBuildProjectName)</RepositoryName>
     <UseBootstrapArcade Condition="$([System.String]::new(';$(BootstrapArcadeRepos);').Contains(';$(RepositoryName);'))">true</UseBootstrapArcade>
+    <!-- SBA must bootstrap from PSB rather than current 1xx shared components. -->
+    <_UseSharedComponentsInputs Condition="'$(RepositoryName)' != 'source-build-assets'">true</_UseSharedComponentsInputs>
 
     <BuildInParallel Condition="'$(BuildInParallel)' == ''">true</BuildInParallel>
     <RunEachTargetSeparately>false</RunEachTargetSeparately>
@@ -171,7 +173,7 @@
 
   <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <CommonArgs>$(CommonArgs) /p:PreviouslySourceBuiltNupkgCacheDir="$(PreviouslySourceBuiltPackagesPath)"</CommonArgs>
-    <CommonArgs Condition="Exists('$(SharedComponentsArtifactsPath)')">$(CommonArgs) /p:AdditionalSourceBuiltNupkgCacheDir="$(SharedComponentsArtifactsPath)"</CommonArgs>
+    <CommonArgs Condition="'$(_UseSharedComponentsInputs)' == 'true' and Exists('$(SharedComponentsArtifactsPath)')">$(CommonArgs) /p:AdditionalSourceBuiltNupkgCacheDir="$(SharedComponentsArtifactsPath)"</CommonArgs>
     <CommonArgs>$(CommonArgs) /p:ReferencePackageNupkgCacheDir="$(ReferencePackagesDir)"</CommonArgs>
     <CommonArgs>$(CommonArgs) /p:TrackPrebuiltUsageReportDir="$(ArtifactsLogRepoDir)"</CommonArgs>
   </PropertyGroup>

--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -6,8 +6,8 @@
   <PropertyGroup>
     <RepositoryName>$(MSBuildProjectName)</RepositoryName>
     <UseBootstrapArcade Condition="$([System.String]::new(';$(BootstrapArcadeRepos);').Contains(';$(RepositoryName);'))">true</UseBootstrapArcade>
-    <!-- SBA must bootstrap from PSB rather than current 1xx shared components. -->
-    <_UseSharedComponentsInputs Condition="'$(RepositoryName)' != 'source-build-assets'">true</_UseSharedComponentsInputs>
+    <!-- Bootstrap Arcade repos must bootstrap from PSB rather than current 1xx shared components. -->
+    <_UseSharedComponentsInputs Condition="!$([System.String]::new(';$(BootstrapArcadeRepos);').Contains(';$(RepositoryName);'))">true</_UseSharedComponentsInputs>
 
     <BuildInParallel Condition="'$(BuildInParallel)' == ''">true</BuildInParallel>
     <RunEachTargetSeparately>false</RunEachTargetSeparately>

--- a/repo-projects/Directory.Build.props
+++ b/repo-projects/Directory.Build.props
@@ -7,7 +7,7 @@
     <RepositoryName>$(MSBuildProjectName)</RepositoryName>
     <UseBootstrapArcade Condition="$([System.String]::new(';$(BootstrapArcadeRepos);').Contains(';$(RepositoryName);'))">true</UseBootstrapArcade>
     <!-- Bootstrap Arcade repos must bootstrap from PSB rather than current 1xx shared components. -->
-    <_UseSharedComponentsInputs Condition="!$([System.String]::new(';$(BootstrapArcadeRepos);').Contains(';$(RepositoryName);'))">true</_UseSharedComponentsInputs>
+    <_UseSharedComponentsInputs Condition="'$(UseBootstrapArcade)' != 'true'">true</_UseSharedComponentsInputs>
 
     <BuildInParallel Condition="'$(BuildInParallel)' == ''">true</BuildInParallel>
     <RunEachTargetSeparately>false</RunEachTargetSeparately>

--- a/repo-projects/Directory.Build.targets
+++ b/repo-projects/Directory.Build.targets
@@ -221,7 +221,7 @@
     <AddSourceToNuGetConfig NuGetConfigFile="$(NuGetConfigFile)"
                             SourceName="$(PreviouslySourceBuiltSharedComponentsNuGetSourceName)"
                             SourcePath="$(SharedComponentsArtifactsPath)"
-                            Condition="'$(AddPrebuiltFeeds)' == 'true' and Exists('$(SharedComponentsArtifactsPath)')" />
+                            Condition="'$(AddPrebuiltFeeds)' == 'true' and '$(_UseSharedComponentsInputs)' == 'true' and Exists('$(SharedComponentsArtifactsPath)')" />
 
     <AddSourceToNuGetConfig NuGetConfigFile="$(NuGetConfigFile)"
                             SourceName="$(ReferencePackagesNuGetSourceName)"
@@ -250,9 +250,11 @@
 
     <ItemGroup>
       <_BuildSources Include="$(PrebuiltNuGetSourceName);
-                              $(PreviouslySourceBuiltNuGetSourceName);
-                              $(PreviouslySourceBuiltSharedComponentsNuGetSourceName);
-                              $(ReferencePackagesNuGetSourceName)"
+                              $(PreviouslySourceBuiltNuGetSourceName)"
+                     Condition="'$(AddPrebuiltFeeds)' == 'true'"/>
+      <_BuildSources Include="$(PreviouslySourceBuiltSharedComponentsNuGetSourceName)"
+                     Condition="'$(AddPrebuiltFeeds)' == 'true' and '$(_UseSharedComponentsInputs)' == 'true'" />
+      <_BuildSources Include="$(ReferencePackagesNuGetSourceName)"
                      Condition="'$(AddPrebuiltFeeds)' == 'true'"/>
       <_BuildSources Include="@(_CommonBuildSources)" />
     </ItemGroup>
@@ -346,8 +348,7 @@
           SkipUnchangedFiles="true" />
   </Target>
 
-  <!-- Before a repository builds, set up the version property files that override the repo's defaults.
-       There are 3 files generated -->
+  <!-- Before a repository builds, set up the version property files that override the repo's defaults. -->
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.WritePackageVersionsProps" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
   <UsingTask TaskName="Microsoft.DotNet.UnifiedBuild.Tasks.GetKnownArtifactsFromAssetManifests" AssemblyFile="$(MicrosoftDotNetUnifiedBuildTasksAssembly)" TaskFactory="TaskHostFactory" />
   <Target Name="CreateBuildInputProps"
@@ -370,7 +371,8 @@
 
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="GetFilteredSharedComponentPackages"
-             Properties="SharedComponentFilterMode=$(_SharedComponentFilterMode)">
+             Properties="SharedComponentFilterMode=$(_SharedComponentFilterMode)"
+             Condition="'$(_UseSharedComponentsInputs)' == 'true'">
       <Output TaskParameter="TargetOutputs" ItemName="_PreviouslyBuiltSourceBuiltSharedComponentPackages" />
     </MSBuild>
 
@@ -421,7 +423,7 @@
                                VersionDetails="$(_VersionDetailsXml)"
                                OutputPath="$(PreviouslySourceBuiltSharedComponentsPackageVersionPropsPath)"
                                PropertySuffixes="@(PreviousPackageVersionPropertySuffixes)"
-                               Condition="'$(_UsePackageVersionPropsAggregation)' == 'true'" />
+                               Condition="'$(_UsePackageVersionPropsAggregation)' == 'true' and '$(_UseSharedComponentsInputs)' == 'true'" />
 
     <!-- Write a full package version props (unfiltered) that will be used to track which repo creates a package.
          Because not all repos implement the repo API (e.g. some are external), it's difficult to consistently gather
@@ -439,12 +441,20 @@
 
     <!-- Write a single file that contains imports for both the current and previously built packages -->
     <PropertyGroup>
-      <PackageVersionsPropsContents Condition="'$(_UsePackageVersionPropsAggregation)' == 'true'">
+      <PackageVersionsPropsContents Condition="'$(_UsePackageVersionPropsAggregation)' == 'true' and '$(_UseSharedComponentsInputs)' == 'true'">
         <![CDATA[
 <Project>
   <Import Project="$(PreviouslySourceBuiltPackageVersionPropsPath)" />
   <Import Project="$(CurrentSourceBuiltPackageVersionPropsPath)" />
   <Import Project="$(PreviouslySourceBuiltSharedComponentsPackageVersionPropsPath)" />
+</Project>
+]]>
+      </PackageVersionsPropsContents>
+      <PackageVersionsPropsContents Condition="'$(_UsePackageVersionPropsAggregation)' == 'true' and '$(_UseSharedComponentsInputs)' != 'true'">
+        <![CDATA[
+<Project>
+  <Import Project="$(PreviouslySourceBuiltPackageVersionPropsPath)" />
+  <Import Project="$(CurrentSourceBuiltPackageVersionPropsPath)" />
 </Project>
 ]]>
       </PackageVersionsPropsContents>
@@ -461,7 +471,9 @@
                       Overwrite="true" />
 
     <Message Text="$(RepositoryName) using package version properties saved at $(CurrentSourceBuiltPackageVersionPropsPath), $(PreviouslySourceBuiltPackageVersionPropsPath), and $(PreviouslySourceBuiltSharedComponentsPackageVersionPropsPath)"
-             Condition="'$(_UsePackageVersionPropsAggregation)' == 'true'" />
+             Condition="'$(_UsePackageVersionPropsAggregation)' == 'true' and '$(_UseSharedComponentsInputs)' == 'true'" />
+    <Message Text="$(RepositoryName) using package version properties saved at $(CurrentSourceBuiltPackageVersionPropsPath) and $(PreviouslySourceBuiltPackageVersionPropsPath)"
+             Condition="'$(_UsePackageVersionPropsAggregation)' == 'true' and '$(_UseSharedComponentsInputs)' != 'true'" />
 
     <MakeDir Directories="$(BaseIntermediateOutputPath)" />
     <Touch Files="$(BaseIntermediateOutputPath)CreateBuildInputProps.complete" AlwaysCreate="true">

--- a/test/Microsoft.DotNet.Tests/PackageSourceMappingsTests.cs
+++ b/test/Microsoft.DotNet.Tests/PackageSourceMappingsTests.cs
@@ -67,8 +67,50 @@ namespace Microsoft.DotNet.Tests
         [InlineData("sb-sba-offline.config", false)]
         public void SourceBuildSbaRepoTests(string nugetConfigFilename, bool useOnlineFeeds)
         {
-            string[] sources = [PrebuiltSourceName, PreviouslySourceBuiltSourceName, SharedComponentsSourceName, ReferencePackagesSourceName];
+            string[] sources = [PrebuiltSourceName, PreviouslySourceBuiltSourceName, ReferencePackagesSourceName];
             RunTest(nugetConfigFilename, useOnlineFeeds, sources, sourceBuild: true);
+        }
+
+        [Fact]
+        public void SourceBuildSbaDoesNotMapSharedComponents()
+        {
+            string psmAssetsDir = Path.Combine(Directory.GetCurrentDirectory(), "assets", nameof(PackageSourceMappingsTests));
+            string originalNugetConfig = Path.Combine(psmAssetsDir, "original", "sb-sba-offline.config");
+            string modifiedNugetConfig = Path.Combine(PackageSourceMappingsSetup.PackageSourceMappingsRoot, "sb-sba-with-shared-source.config");
+            Directory.CreateDirectory(Path.GetDirectoryName(modifiedNugetConfig)!);
+            File.Copy(originalNugetConfig, modifiedNugetConfig, true);
+
+            var document = XDocument.Load(modifiedNugetConfig);
+            document.Root!.Element("packageSources")!.Add(
+                new XElement("add",
+                    new XAttribute("key", SharedComponentsSourceName),
+                    new XAttribute("value", "%shared-components%")));
+            document.Save(modifiedNugetConfig);
+            UpdateNugetConfigTokens(modifiedNugetConfig);
+
+            var task = new UpdateNuGetConfigPackageSourcesMappings()
+            {
+                SbaCacheSourceName = "source-build-assets-cache",
+                SbaRepoSrcPath = TestSetup.SourceBuildAssetsRepo,
+                SourceBuiltSourceNamePrefix = "source-built-",
+                PreviousBuildPassSourceNamePrefix = "previous-build-pass-",
+                NuGetConfigFile = modifiedNugetConfig,
+                SourceBuildSources = [PrebuiltSourceName, PreviouslySourceBuiltSourceName, ReferencePackagesSourceName],
+                ReferencePackagesSourceName = ReferencePackagesSourceName,
+                PreviouslySourceBuiltSourceName = PreviouslySourceBuiltSourceName,
+                PrebuiltSourceName = PrebuiltSourceName,
+                SharedComponentsSourceName = SharedComponentsSourceName
+            };
+
+            Assert.True(task.Execute());
+
+            document = XDocument.Load(modifiedNugetConfig);
+            Assert.Contains(
+                document.Root!.Element("packageSources")!.Elements("add"),
+                element => element.Attribute("key")!.Value == SharedComponentsSourceName);
+            Assert.DoesNotContain(
+                document.Root.Element("packageSourceMapping")!.Elements("packageSource"),
+                element => element.Attribute("key")!.Value == SharedComponentsSourceName);
         }
 
         // Source build tests with shared components - test precedence behavior

--- a/test/Microsoft.DotNet.Tests/PackageSourceMappingsTests.cs
+++ b/test/Microsoft.DotNet.Tests/PackageSourceMappingsTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.Tests
         }
 
         [Fact]
-        public void SourceBuildSbaDoesNotMapSharedComponents()
+        public void SourceBuildBootstrapRepoDoesNotMapSharedComponents()
         {
             string psmAssetsDir = Path.Combine(Directory.GetCurrentDirectory(), "assets", nameof(PackageSourceMappingsTests));
             string originalNugetConfig = Path.Combine(psmAssetsDir, "original", "sb-sba-offline.config");


### PR DESCRIPTION
## Problem

Bootstrap Arcade repositories such as `arcade` and `source-build-assets` should resolve their build dependencies from previously source-built (PSB) packages. However, the VMR orchestration also supplied them with current 1xx shared-components inputs through package-version properties, NuGet source mappings, and `AdditionalSourceBuiltNupkgCacheDir`.

When PSB and shared components are at different servicing levels, the shared-components package versions can override PSB versions and create a torn bootstrap state. Bootstrap repositories can also restore incidental dependencies from the shared-components feed even though they should not depend on those components.

## Solution

Use `BootstrapArcadeRepos` to exclude every bootstrap Arcade repository from shared-components inputs while preserving the existing behavior for all other repositories. Bootstrap repositories now receive package versions and restore inputs from PSB only; shared-components version properties, NuGet mappings, and the additional package cache are omitted from their builds.