### PR TITLE
Dynamically downgrade bundled framework versions

### DIFF
--- a/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
+++ b/test/Microsoft.DotNet.Installer.Tests/LinuxInstallerTests.cs
@@ -279,7 +279,7 @@ public partial class LinuxInstallerTests : IDisposable
             InsertLocalPackagesPathToNuGetConfig(newNuGetConfig, "/packages");
 
             // Copy downgrade-fx-versions.sh script
-            // This script is used to update the latest known 8.0 and 9.0 framework versions in SDK's
+            // This script is used to update the latest known serviced framework versions in SDK's
             // Microsoft.NETCoreSdk.BundledVersions.props file to the versions 2 releases prior.
             // This is needed as the SDK automatically picks up servicing versions not yet released, which
             // is either one or two versions higher than publicly available versions, depending on
@@ -636,7 +636,7 @@ public partial class LinuxInstallerTests : IDisposable
         sb.AppendLine("");
 
         sb.AppendLine("");
-        sb.AppendLine("# Run the script to downgrade 8.0 and 9.0 framework versions");
+        sb.AppendLine("# Run the script to downgrade serviced framework versions");
         sb.AppendLine("RUN \\");
         sb.AppendLine($"    chmod +x {DowngradeFxVersionsScript} && \\");
         sb.AppendLine($"    ./{DowngradeFxVersionsScript}");

--- a/test/Microsoft.DotNet.Installer.Tests/assets/downgrade-fx-versions.sh
+++ b/test/Microsoft.DotNet.Installer.Tests/assets/downgrade-fx-versions.sh
@@ -39,7 +39,8 @@ find_dotnet_versions() {
 # Function to find latest framework version for a major.minor
 find_latest_version() {
     local major_minor=$1
-    grep -oP "LatestRuntimeFrameworkVersion=\"\\K${major_minor}\\.\\d+(?=\")" "$PROPS_FILE" |
+    local major_minor_pattern="${major_minor//./\\.}"
+    grep -oP "LatestRuntimeFrameworkVersion=\"\\K${major_minor_pattern}\\.\\d+(?=\")" "$PROPS_FILE" |
         sort -V |
         tail -n1
 }
@@ -113,7 +114,8 @@ done
 echo -e "\n${YELLOW}Verification:${NC}"
 for version in "${dotnet_versions[@]}"; do
     echo "${version} versions in file:"
-    grep -oP "${version}\.\d+" "$PROPS_FILE" | sort -u
+    version_pattern="${version//./\\.}"
+    grep -oP "${version_pattern}\.\d+" "$PROPS_FILE" | sort -u
     echo ""
 done
 

--- a/test/Microsoft.DotNet.Installer.Tests/assets/downgrade-fx-versions.sh
+++ b/test/Microsoft.DotNet.Installer.Tests/assets/downgrade-fx-versions.sh
@@ -29,10 +29,19 @@ fi
 echo "Creating backup: ${PROPS_FILE}${BACKUP_SUFFIX}"
 cp "$PROPS_FILE" "${PROPS_FILE}${BACKUP_SUFFIX}"
 
-# Function to find latest version for a major.minor
+# Function to find .NET versions with servicing releases
+find_dotnet_versions() {
+    grep -oP 'LatestRuntimeFrameworkVersion="\K\d+\.\d+\.\d+(?=")' "$PROPS_FILE" |
+        awk -F. '$3 >= 2 { print $1 "." $2 }' |
+        sort -Vru
+}
+
+# Function to find latest framework version for a major.minor
 find_latest_version() {
     local major_minor=$1
-    grep -oP "${major_minor}\.\d+" "$PROPS_FILE" | sort -V | tail -n1
+    grep -oP "LatestRuntimeFrameworkVersion=\"\\K${major_minor}\\.\\d+(?=\")" "$PROPS_FILE" |
+        sort -V |
+        tail -n1
 }
 
 # Function to decrement patch version by 2
@@ -90,16 +99,23 @@ process_dotnet_version() {
 }
 
 # Process .NET versions
-process_dotnet_version "9.0"
-process_dotnet_version "8.0"
+mapfile -t dotnet_versions < <(find_dotnet_versions)
+if [ "${#dotnet_versions[@]}" -eq 0 ]; then
+    echo -e "${RED}Error: No serviced .NET framework versions found${NC}"
+    exit 1
+fi
+
+for version in "${dotnet_versions[@]}"; do
+    process_dotnet_version "$version"
+done
 
 # Verify changes
 echo -e "\n${YELLOW}Verification:${NC}"
-echo "9.0 versions in file:"
-grep -oP "9\.0\.\d+" "$PROPS_FILE" | sort -u
-echo ""
-echo "8.0 versions in file:"
-grep -oP "8\.0\.\d+" "$PROPS_FILE" | sort -u
+for version in "${dotnet_versions[@]}"; do
+    echo "${version} versions in file:"
+    grep -oP "${version}\.\d+" "$PROPS_FILE" | sort -u
+    echo ""
+done
 
 echo -e "\n${GREEN}Done! Backup saved at: ${PROPS_FILE}${BACKUP_SUFFIX}${NC}"
 echo -e "${YELLOW}To restore: cp ${PROPS_FILE}${BACKUP_SUFFIX} ${PROPS_FILE}${NC}"


### PR DESCRIPTION
## Problem

Installer scenario tests only downgraded bundled .NET 8 and 9 framework versions. When .NET 10 servicing versions advanced beyond publicly available packages, restore requested unpublished targeting, runtime, and host packs and failed with `NU1102`.

## Solution

Discover serviced framework versions dynamically from `LatestRuntimeFrameworkVersion` entries and downgrade each eligible patch. This removes hardcoded framework versions and automatically handles future releases.