### PR TITLE
Update SymbolPublishingExclusionsFile.txt with new paths

### DIFF
--- a/eng/SymbolPublishingExclusionsFile.txt
+++ b/eng/SymbolPublishingExclusionsFile.txt
@@ -1,6 +1,9 @@
 tools/net/runtimes/linux-musl-arm/native/libgit2-a418d9d.so
 tools/net/runtimes/linux-musl-arm64/native/libgit2-a418d9d.so
 tools/net/runtimes/linux-musl-x64/native/libgit2-a418d9d.so
+tools/net10.0/any/runtimes/linux-musl-arm/native/libgit2-a418d9d.so
+tools/net10.0/any/runtimes/linux-musl-arm64/native/libgit2-a418d9d.so
+tools/net10.0/any/runtimes/linux-musl-x64/native/libgit2-a418d9d.so
 tools/x86_arm/mscordaccore.dll
 tools/x86_arm/mscordbi.dll
 tools/x64_arm64/mscordaccore.dll


### PR DESCRIPTION
This got introduced by https://github.com/dotnet/roslyn/pull/84921.

Fixes publishing errors:

```
PublishArtifactsInManifest.proj(129,5): error : [AddPackagesToRequest/77ad3bbf-c30a-469d-89c0-3fd2b5fd54f2/Microsoft.RoslynTools.5.11.0-1.26424.106.symbols.nupkg] Invalid ELF BuildID '<null>' for C:\Users\AppData\Local\Temp\etu5ncxw.ypb\tools\net10.0\any\runtimes\linux-musl-arm\native\libgit2-a418d9d.so
PublishArtifactsInManifest.proj(129,5): error : [AddPackagesToRequest/77ad3bbf-c30a-469d-89c0-3fd2b5fd54f2/Microsoft.RoslynTools.5.11.0-1.26424.106.symbols.nupkg] Invalid ELF BuildID '<null>' for C:\Users\AppData\Local\Temp\etu5ncxw.ypb\tools\net10.0\any\runtimes\linux-musl-arm64\native\libgit2-a418d9d.so
PublishArtifactsInManifest.proj(129,5): error : [AddPackagesToRequest/77ad3bbf-c30a-469d-89c0-3fd2b5fd54f2/Microsoft.RoslynTools.5.11.0-1.26424.106.symbols.nupkg] Invalid ELF BuildID '<null>' for C:\Users\AppData\Local\Temp\etu5ncxw.ypb\tools\net10.0\any\runtimes\linux-musl-x64\native\libgit2-a418d9d.so
```