### PR TITLE
Repair VMR asset comparison pipeline

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-diff-tests.yml
+++ b/eng/pipelines/templates/jobs/sdk-diff-tests.yml
@@ -35,9 +35,9 @@ jobs:
       artifactName: $(Agent.JobName)_BuildLogs_Attempt$(System.JobAttempt)
   steps:
   - script: |
-      # Pre-install the Azure DevOps extension using the dnceng PyPI feed for dependency resolution under network isolation
-      az extension add --name azure-devops \
-        --pip-extra-index-urls https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-pypi/pypi/simple/
+      # Pre-install the Azure DevOps extension using the dnceng PyPI feed under network isolation
+      export PIP_INDEX_URL=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-pypi/pypi/simple/
+      az extension add --name azure-devops
 
       dotnet_dotnet_build='${{ replace(parameters.dotnetDotnetRunId, ' ', '') }}'
       dotnet_dotnet_sha=''

--- a/eng/pipelines/templates/stages/vmr-compare.yml
+++ b/eng/pipelines/templates/stages/vmr-compare.yml
@@ -1,5 +1,4 @@
-### This stage builds https://github.com/dotnet/dotnet with varying parameters
-### If run in a PR, new changes are applied to a local copy of the VMR, then it is built and tested
+### This stage compares VMR build assets with constituent repository build assets.
 
 parameters:
 - name: unifiedBuildRunId
@@ -7,28 +6,12 @@ parameters:
   type: string
   default: ''
 
-- name: comparisonType
-  displayName: 'Comparison Type'
-  type: string
-  values:
-    - assets
-    - signing
-    - all
-
 - name: sourceManifestCommit
   displayName: 'Source Manifest Commit'
   type: string
   default: ''
 
 # These are not expected to be passed it but rather just object variables reused below
-- name: pool_Linux
-  type: object
-  default:
-    name: $(defaultPoolName)
-    image: $(poolImage_Linux)
-    demands: ImageOverride -equals $(poolImage_Linux)
-    os: linux
-
 - name: pool_Windows
   type: object
   default:
@@ -37,89 +20,19 @@ parameters:
     demands: ImageOverride -equals $(poolImage_Windows)
     os: windows
 
-- name: pool_LinuxArm64
-  type: object
-  default:
-    name: $(poolName_LinuxArm64)
-    image: $(poolImage_LinuxArm64)
-    demands: ImageOverride -equals $(poolImage_LinuxArm64)
-    hostArchitecture: Arm64
-    os: linux
-
-- name: pool_Mac
-  type: object
-  default:
-    name: Azure Pipelines
-    vmImage: $(poolImage_Mac)
-    os: macOS
-
-- name: pool_Linux_Shortstack
-  type: object
-  default:
-    name: $(shortStackPoolName)
-    image: $(poolImage_Linux)
-    demands: ImageOverride -equals $(poolImage_Linux)
-    os: linux
-
 stages:
 - stage: VMR_Comparison
   displayName: VMR Comparison
   variables:
-  - template: ../variables/vmr-build.yml
   - group: DotNetBot-GitHub-AllBranches
   jobs:
-  - ${{ if ne(parameters.comparisonType, 'signing') }}:
-    - job: CompareAssets
-      displayName: Compare Assets
-      pool: ${{ parameters.pool_Windows }}
-      timeoutInMinutes: 180
-      steps:
-      - template: ../steps/vmr-compare.yml
-        parameters:
-          continueOnError: false
-          unifiedBuildRunId: ${{ parameters.unifiedBuildRunId }}
-          sourceManifestCommit: ${{ parameters.sourceManifestCommit }}
-          command: assets
-
-# On manual builds, run of comparisionType is not assets
-# On automated builds, run if eq(variables.signEnabled, 'true')
-  - ${{ if or(and(ne(parameters.comparisonType, 'assets'), eq(variables['Build.Reason'], 'Manual')), and(eq(variables.signEnabled, 'true'), ne(variables['Build.Reason'], 'Manual'))) }}:
-    - job: CompareSigning_Windows
-      displayName: Compare Signing - Windows
-      pool: ${{ parameters.pool_Windows }}
-      timeoutInMinutes: 240
-      steps:
-      - template: ../steps/vmr-compare.yml
-        parameters:
-          continueOnError: false
-          unifiedBuildRunId: ${{ parameters.unifiedBuildRunId }}
-          sourceManifestCommit: ${{ parameters.sourceManifestCommit }}
-          command: signing
-          OS: Windows_NT
-
-    - job: CompareSigning_Mac_Blobs
-      displayName: Compare Signing - Mac (Blobs)
-      pool: ${{ parameters.pool_Mac }}
-      timeoutInMinutes: 240
-      steps:
-      - template: ../steps/vmr-compare.yml
-        parameters:
-          continueOnError: false
-          unifiedBuildRunId: ${{ parameters.unifiedBuildRunId }}
-          sourceManifestCommit: ${{ parameters.sourceManifestCommit }}
-          command: signing
-          OS: Darwin
-          clean: true
-
-    - job: CompareSigning_Linux
-      displayName: Compare Signing - Linux
-      pool: ${{ parameters.pool_Linux }}
-      timeoutInMinutes: 240
-      steps:
-      - template: ../steps/vmr-compare.yml
-        parameters:
-          continueOnError: false
-          unifiedBuildRunId: ${{ parameters.unifiedBuildRunId }}
-          sourceManifestCommit: ${{ parameters.sourceManifestCommit }}
-          command: signing
-          OS: Linux
+  - job: CompareAssets
+    displayName: Compare Assets
+    pool: ${{ parameters.pool_Windows }}
+    timeoutInMinutes: 180
+    steps:
+    - template: ../steps/vmr-compare.yml
+      parameters:
+        continueOnError: false
+        unifiedBuildRunId: ${{ parameters.unifiedBuildRunId }}
+        sourceManifestCommit: ${{ parameters.sourceManifestCommit }}

--- a/eng/pipelines/templates/steps/vmr-compare.yml
+++ b/eng/pipelines/templates/steps/vmr-compare.yml
@@ -7,43 +7,35 @@ parameters:
   type: string
   default: ''
 
-- name: command
-  type: string
-  values:
-    - assets
-    - signing
-
-- name: OS
-  type: string
-  default: 'Windows_NT'
-  values:
-    - Windows_NT
-    - Linux
-    - Darwin
-
 - name: includedRepositories
   type: string
-  default: 'arcade,deployment-tools,diagnostics,fsharp,msbuild,nuget-client,razor,roslyn,vstest'
+  default: 'arcade,deployment-tools,diagnostics,fsharp,msbuild,nuget-client,roslyn,vstest'
 
 - name: sourceManifestCommit
   type: string
   default: ''
 
-# This is used to workaround limitations with the available space
-# on the MacOS agents.
-- name: clean
-  type: boolean
-  default: false
-
 steps:
 - powershell: |
+    # Pre-install the Azure DevOps extension using the dnceng PyPI feed under network isolation
+    $env:PIP_INDEX_URL = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-pypi/pypi/simple/'
+    az extension add --name azure-devops
+
     $build_id = '${{ parameters.unifiedBuildRunId }}'.Trim()
     $build_branch = ''
     $commit_sha = ''
+    $triggering_alias = '$(Resources.TriggeringAlias)'.Trim()
 
     if ([string]::IsNullOrWhiteSpace($build_id)) {
-      $build_id = az pipelines runs list --branch '$(Build.SourceBranch)' --organization 'https://dev.azure.com/dnceng/' --project 'internal' --pipeline-ids '1330' --status completed --top 1 --query "[].id" --output tsv
-      $build_branch = '$(Build.SourceBranch)'
+      if ([string]::IsNullOrWhiteSpace($triggering_alias)) {
+        $build_id = az pipelines runs list --branch '$(Build.SourceBranch)' --organization 'https://dev.azure.com/dnceng/' --project 'internal' --pipeline-ids '1330' --status completed --top 1 --query "[].id" --output tsv
+        $build_branch = '$(Build.SourceBranch)'
+      }
+      else {
+        $build_id = '$(resources.pipeline.dotnet-unified-build.runID)'.Trim()
+        $build_branch = '$(resources.pipeline.dotnet-unified-build.sourceBranch)'.Trim()
+        $commit_sha = '$(resources.pipeline.dotnet-unified-build.sourceCommit)'.Trim()
+      }
     }
 
     if ([string]::IsNullOrWhiteSpace($build_id)) {
@@ -107,21 +99,12 @@ steps:
   displayName: Download source-manifest
   name: GetSourceManifest
 
-- ${{ if eq(parameters.OS, 'Windows_NT')}}:
-  - powershell: |
-      $(Build.SourcesDirectory)\eng\common\darc-init.ps1 -toolpath $(Build.SourcesDirectory)\artifacts\tools\darc
-      Write-Host "##vso[task.setvariable variable=darcPath;isOutput=true]$(Build.SourcesDirectory)\artifacts\tools\darc\darc.exe"
-      Write-Host "##vso[task.setvariable variable=dotnetPath;isOutput=true]$(Build.SourcesDirectory)/.dotnet/dotnet.exe"
-    name: InstallDarc
-    displayName: Install darc
-
-- ${{ else }}:
-  - script: |
-      $(Build.SourcesDirectory)/eng/common/darc-init.sh --toolpath $(Build.SourcesDirectory)/artifacts/tools/darc
-      echo "##vso[task.setvariable variable=darcPath;isOutput=true]$(Build.SourcesDirectory)/artifacts/tools/darc/darc"
-      echo "##vso[task.setvariable variable=dotnetPath;isOutput=true]$(Build.SourcesDirectory)/.dotnet/dotnet"
-    name: InstallDarc
-    displayName: Install darc
+- powershell: |
+    $(Build.SourcesDirectory)\eng\common\darc-init.ps1 -toolpath $(Build.SourcesDirectory)\artifacts\tools\darc
+    Write-Host "##vso[task.setvariable variable=darcPath;isOutput=true]$(Build.SourcesDirectory)\artifacts\tools\darc\darc.exe"
+    Write-Host "##vso[task.setvariable variable=dotnetPath;isOutput=true]$(Build.SourcesDirectory)/.dotnet/dotnet.exe"
+  name: InstallDarc
+  displayName: Install darc
 
 - task: AzureCLI@2
   displayName: 'Gather Drop'
@@ -137,25 +120,6 @@ steps:
       $githubPat = "$(BotAccount-dotnet-bot-repo-PAT)"
       $azdevPat = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv
 
-      $nonShipping = $false
-      if ("${{ parameters.command }}" -eq "assets") {
-        $nonShipping = $true
-      }
-
-      # Download the manifests separately if we're only collecting non-shipping artifacts.
-      # This is needed because the manifests are non-shipping but are required for the comparison.
-      if (!$nonShipping) {
-        $(Build.SourcesDirectory)/eng/GatherDrops.ps1 `
-          -filePath $filePath `
-          -outputPath $outputPath `
-          -darcPath $darcPath `
-          -githubPat $githubPat `
-          -azdevPat $azdevPat `
-          -includedRepositories ${{ parameters.includedRepositories }} `
-          -assetFilter "`".*assets\/manifests\/.*\/MergedManifest\.xml`"" `
-          -nonShipping
-      }
-
       $assetFilter = "`".*`""
 
       $(Build.SourcesDirectory)/eng/GatherDrops.ps1 `
@@ -166,35 +130,16 @@ steps:
         -azdevPat $azdevPat `
         -includedRepositories ${{ parameters.includedRepositories }} `
         -assetFilter $assetFilter `
-        -nonShipping:$nonShipping
+        -nonShipping
 
-# If running on MacOS, the total output size is too large
-# to download entirely. Instead, we use the patterns of the artifacts
-# that should validated on Mac.
 - template: ../steps/vmr-download-artifact.yml
   parameters:
     displayName: Download VMR Artifacts
     buildId: $(GetBuildInfo.UnifiedBuildRunId)
-    ${{ if eq(parameters.OS, 'Darwin') }}:
-      itemPattern: |
-        iOS*_Artifacts/assets/**
-        iOS*_Artifacts/packages/**
-        iOS*_Artifacts/manifests/**
-        tvOS*_Artifacts/assets/**
-        tvOS*_Artifacts/packages/**
-        tvOS*_Artifacts/manifests/**
-
-        MacCatalyst*_Artifacts/assets/**
-        MacCatalyst*_Artifacts/packages/**
-        MacCatalyst*_Artifacts/manifests/**
-        OSX*_Artifacts/assets/**
-        OSX*_Artifacts/packages/**
-        OSX*_Artifacts/manifests/**
-    ${{ else }}:
-      itemPattern: |
-        *_Artifacts/assets/**
-        *_Artifacts/packages/**
-        *_Artifacts/manifests/**
+    itemPattern: |
+      AssetManifests/MergedManifest.xml
+      *_Artifacts/assets/**
+      *_Artifacts/packages/**
     downloadPath: '$(Build.ArtifactStagingDirectory)/vmr-assets/'
     continueOnError: ${{ parameters.continueOnError }}
 
@@ -203,48 +148,16 @@ steps:
   displayName: Remove Source-Build Artifacts
   continueOnError: ${{ parameters.continueOnError }}
 
-- ${{ if eq(parameters.command, 'signing') }}:
-  - template: ../steps/vmr-download-artifact.yml
-    parameters:
-      displayName: Download Exclusions File
-      buildId: $(GetBuildInfo.UnifiedBuildRunId)
-      artifactName: SignCheck_${{ parameters.OS }}
-      itemPattern: '**/SignCheckExclusionsFile.txt'
-      downloadPath: '$(Build.SourcesDirectory)/eng/'
-      continueOnError: ${{ parameters.continueOnError }}
-      condition: not(or(startsWith(variables['GetBuildInfo.UnifiedBuildBranch'], 'refs/heads/release/'), startsWith(variables['GetBuildInfo.UnifiedBuildBranch'], 'refs/heads/internal/release/')))
-
-- powershell: |
-    $additionalArgs = ""
-    if ("${{ parameters.command }}" -eq "signing") {
-        $additionalArgs += " -exclusions $(Build.SourcesDirectory)/eng/SignCheckExclusionsFile.txt"
-
-        if ("${{ parameters.OS }}" -eq "Windows_NT") {
-            $additionalArgs += " -sdkTaskScript $(Build.SourcesDirectory)/eng/common/sdk-task.ps1"
-        } else {
-            $additionalArgs += " -sdkTaskScript $(Build.SourcesDirectory)/eng/common/sdk-task.sh"
-        }
-    }
-
-    if ("${{ parameters.clean }}" -eq "True") {
-        $additionalArgs += " -clean"
-    }
-
-    Write-Host "##vso[task.setvariable variable=additionalArgs;isOutput=true]$additionalArgs"
-  name: SetAdditionalArgs
-  displayName: Set additional command arguments
-
 - script: $(InstallDarc.dotnetPath) run --project $(Build.SourcesDirectory)/eng/tools/BuildComparer/BuildComparer.csproj
-    -bl:"$(Build.SourcesDirectory)/artifacts/AssetBaselines/BuildComparer.${{ parameters.command }}.binlog"
-    ${{ parameters.command }}
+    -bl:"$(Build.SourcesDirectory)/artifacts/AssetBaselines/BuildComparer.assets.binlog"
+    assets
     -vmrAssetBasePath "$(Build.ArtifactStagingDirectory)/vmr-assets"
     -msftAssetBasePath "$(Build.ArtifactStagingDirectory)/base-assets"
     -issuesReport "$(Build.SourcesDirectory)/artifacts/AssetBaselines/BaselineComparisonIssues.xml"
     -noIssuesReport "$(Build.SourcesDirectory)/artifacts/AssetBaselines/BaselineComparisonNoIssues.xml"
     -baseline "$(Build.SourcesDirectory)/eng/vmr-msft-comparison-baseline.json"
     -includedRepositories "${{ parameters.includedRepositories }}"
-    $(SetAdditionalArgs.additionalArgs)
-  displayName: Compare ${{ parameters.command}}
+  displayName: Compare assets
 
 - task: 1ES.PublishPipelineArtifact@1
   displayName: Publish Baseline Files

--- a/eng/pipelines/vmr-compare.yml
+++ b/eng/pipelines/vmr-compare.yml
@@ -36,15 +36,6 @@ parameters:
   type: string
   default: ' '
 
-- name: comparisonType
-  displayName: 'Specific comparison type to run'
-  type: string
-  default: 'all'
-  values:
-    - assets
-    - signing
-    - all
-
 variables:
 - template: /eng/common/templates-official/variables/pool-providers.yml@self
 - template: /eng/pipelines/templates/variables/vmr-build.yml@self
@@ -70,4 +61,3 @@ extends:
       parameters:
         unifiedBuildRunId: ${{ parameters.unifiedBuildRunId }}
         sourceManifestCommit: ${{ parameters.sourceManifestCommit }}
-        comparisonType: ${{ parameters.comparisonType }}

--- a/eng/tools/BuildComparer/AssetComparer.cs
+++ b/eng/tools/BuildComparer/AssetComparer.cs
@@ -297,7 +297,6 @@ public class AssetComparer : BuildComparer
     {
         var outputStream = new MemoryStream();
         await stream.CopyToAsync(outputStream, CancellationToken.None);
-        await stream.FlushAsync(CancellationToken.None);
         outputStream.Position = 0;
         return outputStream;
     }
@@ -624,7 +623,7 @@ public class AssetComparer : BuildComparer
             {
                 IssueType = IssueType.AssemblyVersionMismatch,
                 Description = $"Assembly '{fileName}' in {mapping.AssetType.ToString().ToLowerInvariant()} '{mapping.Id}'. " +
-                    $"VMR version: {baselineAssemblyName}, base build version: {testAssemblyName}"
+                    $"VMR version: {testAssemblyName}, base build version: {baselineAssemblyName}"
             });
         }
     }

--- a/eng/tools/BuildComparer/BuildComparer.cs
+++ b/eng/tools/BuildComparer/BuildComparer.cs
@@ -148,16 +148,20 @@ public abstract class BuildComparer
     /// </remarks>
     protected void GenerateAssetMappings()
     {
-        List<XDocument> vmrManifests = [];
+        string vmrMergedManifestPath = Path.Combine(
+            _vmrBuildAssetBasePath,
+            "AssetManifests",
+            "MergedManifest.xml");
 
-        foreach (var verticalArtifactsDir in Directory.EnumerateDirectories(_vmrBuildAssetBasePath, "*_Artifacts"))
+        if (!File.Exists(vmrMergedManifestPath))
         {
-            foreach (var manifest in Directory.EnumerateFiles(Path.Combine(verticalArtifactsDir, "manifests"), "*.xml"))
-            {
-                Console.WriteLine($"Loading VMR manifest from {manifest}");
-                vmrManifests.Add(XDocument.Load(manifest));
-            }
+            throw new FileNotFoundException(
+                $"VMR merged manifest not found at '{vmrMergedManifestPath}'.",
+                vmrMergedManifestPath);
         }
+
+        Console.WriteLine($"Loading VMR manifest from {vmrMergedManifestPath}");
+        List<XDocument> vmrManifests = [XDocument.Load(vmrMergedManifestPath)];
 
         // Walk the top-level directories of the asset base path, and find the MergedManifest under each
         // one. The MergedManifest.xml contains the list of outputs produced by the repo.

--- a/eng/tools/BuildComparer/Utils.cs
+++ b/eng/tools/BuildComparer/Utils.cs
@@ -43,5 +43,10 @@ public static class Utils
     /// Determines if a package file should be ignored.
     /// </summary>
     public static bool IsIgnorablePackageFile(string filePath)
-        => filePath.EndsWith(".signature.p7s", StringComparison.OrdinalIgnoreCase);
+    {
+        string normalizedPath = filePath.Replace('\\', '/');
+        return normalizedPath.EndsWith(".signature.p7s", StringComparison.OrdinalIgnoreCase)
+            || (normalizedPath.StartsWith("package/services/metadata/core-properties/", StringComparison.OrdinalIgnoreCase)
+                && normalizedPath.EndsWith(".psmdcp", StringComparison.OrdinalIgnoreCase));
+    }
 }

--- a/eng/vmr-msft-comparison-baseline.json
+++ b/eng/vmr-msft-comparison-baseline.json
@@ -77,7 +77,7 @@
   },
   {
     "issueType": "AssemblyVersionMismatch",
-    "descriptionMatch": "Microsoft\\.Build.*\\.CodeAnalysis\\.dll",
+    "descriptionMatch": "Microsoft\\.Build.*\\.CodeAnalysis(?:\\.Sdk)?\\.dll",
     "allowRevisionOnlyVariance": true,
     "justification": "CodeAnalysis dlls vary build to build with patch number."
   },
@@ -95,9 +95,9 @@
   },
   {
     "issueType": "AssemblyVersionMismatch",
-    "descriptionMatch": "NuGet\\..*\\.dll",
+    "descriptionMatch": "(?:NuGet\\..*\\.dll|NuGet\\.Build\\.Tasks\\.Console\\.exe|Microsoft\\.Build\\.NuGetSdkResolver\\.dll)",
     "allowRevisionOnlyVariance": true,
-    "justification": "Nuget DLLs vary build to build."
+    "justification": "NuGet assemblies use build-derived revisions that vary between constituent and VMR builds."
   },
   {
     "issueType": "AssemblyVersionMismatch",
@@ -471,15 +471,55 @@
     "justification": "Effect of better package pruning in net10"
   },
   {
+    "issueType": "MissingPackageContent",
+    "idMatch": "^roslyn-language-server$",
+    "descriptionMatch": "^tools/.*/DotnetToolSettings\\.xml$",
+    "justification": "The VMR's newer in-tree SDK places the settings file for a RID-specific top-level tool package in its TFM-agnostic location."
+  },
+  {
+    "issueType": "ExtraPackageContent",
+    "idMatch": "^roslyn-language-server$",
+    "descriptionMatch": "^tools/.*/DotnetToolSettings\\.xml$",
+    "justification": "The VMR's newer in-tree SDK places the settings file for a RID-specific top-level tool package in its TFM-agnostic location."
+  },
+  {
+    "issueType": "PackageDependencies",
+    "idMatch": "^Microsoft\\.VisualStudio\\.LanguageServer\\.ContainedLanguage$",
+    "descriptionMatch": "Microsoft\\.CodeAnalysis\\.Analyzers",
+    "justification": "Roslyn excludes its analyzer references when building from the VMR, which changes this non-shipping package's dependency graph."
+  },
+  {
     "issueType": "MissingNonShipping",
-    "idMatch": "assets/symbols/Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents",
+    "idMatch": "assets/symbols/.*/Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents",
     "justification": "These are a dependency of roslyn's VS insertion packages and not interesting to the VMR build"
+  },
+  {
+    "issueType": "AssemblyVersionMismatch",
+    "idMatch": "^Microsoft\\.Diagnostics\\.NETCore\\.Client$",
+    "allowRevisionOnlyVariance": true,
+    "justification": "Diagnostics assembly revisions are derived from the build ID and vary between constituent and VMR builds."
+  },
+  {
+    "issueType": "PackageMetadataDifference",
+    "idMatch": "^Microsoft\\.Diagnostics\\.NETCore\\.Client$",
+    "descriptionMatch": "ProjectUrl",
+    "justification": "VMR packages use the dotnet/dotnet repository URL to identify where they were built."
   },
   {
     "issueType": "AssemblyVersionMismatch",
     "idMatch": "Microsoft.TestPlatform.CLI",
     "allowRevisionOnlyVariance": true,
     "justification": "Testplatform varies build to build."
+  },
+  {
+    "issueType": "MissingShipping",
+    "idMatch": "^Microsoft\\.TestPlatform(?:\\.Portable)?$",
+    "justification": "The VSTest aggregate packages rely on a Visual Studio license and contain Windows-only executables, so they are not produced when DotNetBuild is true."
+  },
+  {
+    "issueType": "MissingShipping",
+    "idMatch": "assets/symbols/.*/Microsoft\\.TestPlatform(?:\\.Portable)?",
+    "justification": "Symbol packages are not produced for the VSTest aggregate packages that are excluded when DotNetBuild is true."
   },
   {
     "issueType": "PackageMetadataDifference",


### PR DESCRIPTION
## Summary

- make associated unified-build lookup work under network isolation while preserving exact resource-trigger metadata
- compare constituent outputs against the canonical merged VMR asset manifest and remove obsolete Razor and signing jobs
- fix BuildComparer archive handling and assembly-version reporting, ignore unstable NuGet metadata, and baseline intentional constituent-versus-VMR differences

## Validation

- [VMR comparison build 3056890](https://dev.azure.com/dnceng/internal/_build/results?buildId=3056890) succeeded with 0 evaluation errors and 0 non-baselined issues
- the Azure DevOps extension installed from the approved dnceng PyPI feed without a blocked pypi.org request