### PR TITLE
Use global.json SDK for VMR license scan

### DIFF
--- a/eng/pipelines/templates/stages/vmr-license-scan.yml
+++ b/eng/pipelines/templates/stages/vmr-license-scan.yml
@@ -123,7 +123,7 @@ stages:
     steps:
 
     - script: >
-        dotnet test
+        ./eng/common/dotnet.sh test
         $(Build.SourcesDirectory)/test/Microsoft.DotNet.SourceBuild.Tests/Microsoft.DotNet.SourceBuild.Tests.csproj
         --filter-method "Microsoft.DotNet.SourceBuild.Tests.LicenseScanTests.ScanForLicenses"
         -c Release


### PR DESCRIPTION
Internal pipeline 1301 build 3055600 repeatedly failed the `LicenseScan` tasks with Bash exit 155. The shared stage invoked bare `dotnet test` inside `azurelinuxSourceBuildTestContainer`, whose system `dotnet` does not guarantee the preview SDK pinned by the root `global.json`.

Invoke the tests through `./eng/common/dotnet.sh` so `InitializeDotNetCli` acquires the pinned SDK. All existing test arguments, including `SkipPrepareSdkArchive`, remain unchanged.

This applies the pattern proven by #8063 for the same root cause tracked by dotnet/source-build#5623.

Validation: `git diff --check`; confirmed the patch is a one-line command substitution and `eng/common/dotnet.sh` is tracked as executable.