### PR TITLE
Fix license scan SDK resolution on release/10.0.3xx

### DIFF
--- a/eng/pipelines/templates/stages/vmr-license-scan.yml
+++ b/eng/pipelines/templates/stages/vmr-license-scan.yml
@@ -123,7 +123,7 @@ stages:
     steps:
 
     - script: >
-        dotnet test
+        ./eng/common/dotnet.sh test
         $(Build.SourcesDirectory)/test/Microsoft.DotNet.SourceBuild.Tests/Microsoft.DotNet.SourceBuild.Tests.csproj
         --filter "FullyQualifiedName=Microsoft.DotNet.SourceBuild.Tests.LicenseScanTests.ScanForLicenses"
         --logger:'trx;LogFileName=$(Agent.JobName)_LicenseScan.trx'


### PR DESCRIPTION
Fixes Source Build License Scan failures in dnceng/internal builds 3055598 (`release/10.0.3xx`) and 3055608 (`internal/release/10.0.3xx`), where repeated `LicenseScan` tasks ended with Bash exit 155.

The moving `azurelinuxSourceBuildTestContainer` image does not guarantee the SDK feature band pinned by the root `global.json`. Invoke the tests through `./eng/common/dotnet.sh`, which uses `InitializeDotNetCli` to acquire the pinned SDK, while preserving all existing test arguments including `SkipPrepareSdkArchive`.

Only the public servicing branch needs this change because `internal/release/10.0.3xx` mirrors `release/10.0.3xx`.

Precedent: #8063. Related: dotnet/source-build#5623.