### PR TITLE
Improve scenario test process diagnostics

### DIFF
--- a/src/scenario-tests/src/Microsoft.DotNet.ScenarioTests.Common/ExecuteHelper.cs
+++ b/src/scenario-tests/src/Microsoft.DotNet.ScenarioTests.Common/ExecuteHelper.cs
@@ -23,10 +23,9 @@ public static class ExecuteHelper
         ITestOutputHelper outputHelper,
         bool logOutput = false,
         Action<Process>? configure = null,
-        int millisecondTimeout = -1)
+        int millisecondTimeout = -1,
+        Func<string, string>? outputSanitizer = null)
     {
-        outputHelper.WriteLine($"Executing: {fileName} {args}");
-
         Process process = new()
         {
             EnableRaisingEvents = true,
@@ -40,6 +39,13 @@ public static class ExecuteHelper
         };
 
         configure?.Invoke(process);
+
+        DateTimeOffset startedAt = DateTimeOffset.UtcNow;
+        string command = $"{fileName} {args}";
+        outputHelper.WriteLine(
+            $"[{startedAt:O}] Starting command: {command}{Environment.NewLine}" +
+            $"Working directory: {process.StartInfo.WorkingDirectory}{Environment.NewLine}" +
+            $"Timeout: {(millisecondTimeout < 0 ? "infinite" : $"{millisecondTimeout} ms")}");
 
         StringBuilder stdOutput = new();
         process.OutputDataReceived += new DataReceivedEventHandler(
@@ -62,47 +68,69 @@ public static class ExecuteHelper
             });
 
         process.Start();
+        int processId = process.Id;
+        outputHelper.WriteLine($"[{DateTimeOffset.UtcNow:O}] Started PID {processId}: {command}");
         process.BeginOutputReadLine();
         process.BeginErrorReadLine();
         process.WaitForExit(millisecondTimeout);
 
         if (!process.HasExited)
         {
-            outputHelper.WriteLine($"Killing: {fileName} {args}");
+            outputHelper.WriteLine(
+                $"[{DateTimeOffset.UtcNow:O}] Command timed out; killing process tree rooted at PID {processId}: {command}");
             process.Kill(true);
-            if (!process.WaitForExit(KillGraceMilliseconds))
+            bool exitedAfterKill = process.WaitForExit(KillGraceMilliseconds);
+            if (!exitedAfterKill)
             {
                 outputHelper.WriteLine("Process tree did not fully exit within the kill grace period; " +
                     "abandoning wait to avoid hanging on inherited stdout/stderr handles.");
             }
-            ProcessStartInfo startInfo = process.StartInfo;
-            string msg = $" {startInfo.FileName} {startInfo.Arguments} timed out after " +
-                $"{millisecondTimeout} milliseconds" +
-                $"{Environment.NewLine}Exit code: {process.ExitCode}";
+
+            string timedOutOutput = GetOutput(stdOutput);
+            string timedOutError = GetOutput(stdError);
+            LogOutput(timedOutOutput, timedOutError);
+
+            string msg = $"{command} (PID {processId}) timed out after {millisecondTimeout} milliseconds" +
+                $"{Environment.NewLine}Working directory: {process.StartInfo.WorkingDirectory}" +
+                $"{Environment.NewLine}Process tree exited after kill: {exitedAfterKill}" +
+                $"{Environment.NewLine}Standard output:{Environment.NewLine}{Sanitize(timedOutOutput)}" +
+                $"{Environment.NewLine}Standard error:{Environment.NewLine}{Sanitize(timedOutError)}";
             throw new InvalidOperationException(msg);
         }
 
-        string output;
-        lock (stdOutput)
+        DateTimeOffset endedAt = DateTimeOffset.UtcNow;
+        outputHelper.WriteLine(
+            $"[{endedAt:O}] Finished PID {processId} with exit code {process.ExitCode} " +
+            $"after {(endedAt - startedAt).TotalSeconds:F1} seconds: {command}");
+
+        string output = GetOutput(stdOutput);
+        string error = GetOutput(stdError);
+        LogOutput(output, error);
+
+        return (process, Sanitize(output), Sanitize(error));
+
+        string GetOutput(StringBuilder builder)
         {
-            output = stdOutput.ToString().Trim();
-        }
-        if (logOutput && !string.IsNullOrWhiteSpace(output))
-        {
-            outputHelper.WriteLine(output);
+            lock (builder)
+            {
+                return builder.ToString().Trim();
+            }
         }
 
-        string error;
-        lock (stdError)
-        {
-            error = stdError.ToString().Trim();
-        }
-        if (logOutput && !string.IsNullOrWhiteSpace(error))
-        {
-            outputHelper.WriteLine(error);
-        }
+        string Sanitize(string value) => outputSanitizer?.Invoke(value) ?? value;
 
-        return (process, output, error);
+        void LogOutput(string output, string error)
+        {
+            if (logOutput && !string.IsNullOrWhiteSpace(output))
+            {
+                outputHelper.WriteLine(Sanitize(output));
+            }
+
+            if (logOutput && !string.IsNullOrWhiteSpace(error))
+            {
+                outputHelper.WriteLine(Sanitize(error));
+            }
+        }
     }
 
     public static string ExecuteProcessValidateExitCode(string fileName, string args, ITestOutputHelper outputHelper)

--- a/src/scenario-tests/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkHelper.cs
+++ b/src/scenario-tests/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkHelper.cs
@@ -5,6 +5,7 @@
 using Microsoft.DotNet.ScenarioTests.Common;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using System.Xml.XPath;
 using System.Xml;
 using Xunit.Abstractions;
@@ -13,6 +14,8 @@ namespace Microsoft.DotNet.ScenarioTests.SdkTemplateTests;
 
 internal class DotNetSdkHelper
 {
+    internal const int DefaultCommandTimeoutMilliseconds = 10 * 60 * 1000;
+
     private readonly string? _binlogDir;
     private readonly ITestOutputHelper _outputHelper;
 
@@ -31,26 +34,50 @@ internal class DotNetSdkHelper
         _binlogDir = binlogDir;
     }
 
-    private void ExecuteCmd(string args, string workingDirectory, Action<Process>? additionalProcessConfigCallback = null, int expectedExitCode = 0, int millisecondTimeout = -1)
+    private (Process Process, string StdOut, string StdErr) ExecuteCmd(
+        string args,
+        string workingDirectory,
+        Action<Process>? additionalProcessConfigCallback = null,
+        int expectedExitCode = 0,
+        int millisecondTimeout = DefaultCommandTimeoutMilliseconds,
+        bool logOutput = false,
+        Func<string, string>? outputSanitizer = null)
     {
         if (!string.IsNullOrEmpty(SdkVersion) && !File.Exists(Path.Combine(workingDirectory, "global.json")))
         {
             ExecuteCmdImpl($"new globaljson --sdk-version {SdkVersion}", workingDirectory);
         }
 
-        ExecuteCmdImpl(args, workingDirectory, additionalProcessConfigCallback, expectedExitCode, millisecondTimeout);
+        return ExecuteCmdImpl(
+            args,
+            workingDirectory,
+            additionalProcessConfigCallback,
+            expectedExitCode,
+            millisecondTimeout,
+            logOutput,
+            outputSanitizer);
     }
 
-    private void ExecuteCmdImpl(string args, string workingDirectory, Action<Process>? additionalProcessConfigCallback = null, int expectedExitCode = 0, int millisecondTimeout = -1)
+    private (Process Process, string StdOut, string StdErr) ExecuteCmdImpl(
+        string args,
+        string workingDirectory,
+        Action<Process>? additionalProcessConfigCallback = null,
+        int expectedExitCode = 0,
+        int millisecondTimeout = DefaultCommandTimeoutMilliseconds,
+        bool logOutput = false,
+        Func<string, string>? outputSanitizer = null)
     {
         (Process Process, string StdOut, string StdErr) executeResult = ExecuteHelper.ExecuteProcess(
             DotNetExecutablePath,
             args,
             _outputHelper,
+            logOutput: logOutput,
             configure: (process) => configureProcess(process, workingDirectory),
-            millisecondTimeout: millisecondTimeout);
+            millisecondTimeout: millisecondTimeout,
+            outputSanitizer: outputSanitizer);
 
         ExecuteHelper.ValidateExitCode(executeResult, expectedExitCode);
+        return executeResult;
 
         void configureProcess(Process process, string workingDirectory)
         {
@@ -98,7 +125,26 @@ internal class DotNetSdkHelper
     /// <summary>
     /// Create a new .NET project and return the path to the created project folder.
     /// </summary>
-    public string ExecuteNew(string projectType, string projectName, string projectDirectory, string? language = null, string? customArgs = null)
+    public string ExecuteNew(
+        string projectType,
+        string projectName,
+        string projectDirectory,
+        string? language = null,
+        string? customArgs = null,
+        bool noRestore = false)
+    {
+        ExecuteCmd(GetNewArguments(projectType, projectName, projectDirectory, language, customArgs, noRestore), projectDirectory);
+
+        return projectDirectory;
+    }
+
+    internal static string GetNewArguments(
+        string projectType,
+        string projectName,
+        string projectDirectory,
+        string? language = null,
+        string? customArgs = null,
+        bool noRestore = false)
     {
         string options = $"--name {projectName} --output {projectDirectory}";
         if (language != null)
@@ -109,11 +155,52 @@ internal class DotNetSdkHelper
         {
             options += $" {customArgs}";
         }
+        if (noRestore)
+        {
+            options += " --no-restore";
+        }
 
-        ExecuteCmd($"new {projectType} {options}", projectDirectory);
-
-        return projectDirectory;
+        return $"new {projectType} {options}";
     }
+
+    public void ExecuteRestore(string projectDirectory)
+    {
+        string? restoreConfigFile = Environment.GetEnvironmentVariable("RestoreConfigFile");
+        _outputHelper.WriteLine("Effective NuGet sources (source URLs are sanitized):");
+        ExecuteCmd(
+            GetNuGetListSourceArguments(restoreConfigFile),
+            projectDirectory,
+            logOutput: true,
+            outputSanitizer: SanitizeNuGetSourceOutput);
+        ExecuteCmd(
+            GetRestoreArguments(GetBinLogOption(projectDirectory, "restore"), restoreConfigFile),
+            projectDirectory,
+            logOutput: true,
+            outputSanitizer: SanitizeNuGetSourceOutput);
+    }
+
+    internal static string GetNuGetListSourceArguments(string? restoreConfigFile) =>
+        $"nuget list source{GetConfigFileOption(restoreConfigFile)}";
+
+    internal static string GetRestoreArguments(string binLogOption, string? restoreConfigFile) =>
+        $"restore --verbosity diagnostic {binLogOption}{GetConfigFileOption(restoreConfigFile)}";
+
+    private static string GetConfigFileOption(string? restoreConfigFile) =>
+        string.IsNullOrWhiteSpace(restoreConfigFile) ? string.Empty : $" --configfile \"{restoreConfigFile}\"";
+
+    internal static string SanitizeNuGetSourceOutput(string output) =>
+        Regex.Replace(
+            output,
+            @"https?://\S+",
+            match =>
+            {
+                string value = match.Value.TrimEnd(')', ']', '}', ',', ';');
+                string suffix = match.Value[value.Length..];
+                return Uri.TryCreate(value, UriKind.Absolute, out Uri? uri)
+                    ? $"{uri.Scheme}://{uri.Host}{(uri.IsDefaultPort ? string.Empty : $":{uri.Port}")}/<redacted-path>{suffix}"
+                    : $"<redacted-source-url>{suffix}";
+            },
+            RegexOptions.IgnoreCase);
 
     public void ExecutePublish(string projectDirectory, string? rid = null, bool? selfContained = null, bool trimmed = false, bool readyToRun = false, bool? aot = false, string[]? frameworks = null)
     {
@@ -269,6 +356,7 @@ internal class DotNetSdkHelper
         string binlogDir = _binlogDir is null ?
             projectDirectory :
             Path.Combine(_binlogDir, Path.GetFileName(projectDirectory)!);
+        Directory.CreateDirectory(binlogDir);
 
         string fileName = $"{command}";
         if (!string.IsNullOrEmpty(differentiator))

--- a/src/scenario-tests/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkHelperTests.cs
+++ b/src/scenario-tests/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/DotNetSdkHelperTests.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace Microsoft.DotNet.ScenarioTests.SdkTemplateTests;
+
+public class DotNetSdkHelperTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void GetNewArgumentsCanDisableImplicitRestore()
+    {
+        string arguments = DotNetSdkHelper.GetNewArguments(
+            "webapi",
+            "WebApiProject",
+            "project-directory",
+            "C#",
+            "--no-https",
+            noRestore: true);
+
+        VerifyEqual(
+            "new webapi --name WebApiProject --output project-directory --language \"C#\" --no-https --no-restore",
+            arguments);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void GetRestoreArgumentsUseDiagnosticVerbosityBinlogAndConfigFile()
+    {
+        string arguments = DotNetSdkHelper.GetRestoreArguments(
+            "/bl:restore.binlog",
+            "NuGet.Config");
+
+        VerifyEqual(
+            "restore --verbosity diagnostic /bl:restore.binlog --configfile \"NuGet.Config\"",
+            arguments);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void SanitizeNuGetSourceOutputRemovesUrlCredentialsAndQuery()
+    {
+        const string output =
+            "Feed [Enabled]\n    https://user:password@example.test:8443/v3/index.json?token=secret";
+
+        string sanitized = DotNetSdkHelper.SanitizeNuGetSourceOutput(output);
+
+        VerifyContains("https://example.test:8443/<redacted-path>", sanitized);
+        VerifyDoesNotContain("user", sanitized);
+        VerifyDoesNotContain("password", sanitized);
+        VerifyDoesNotContain("token", sanitized);
+        VerifyDoesNotContain("secret", sanitized);
+    }
+
+    private static void VerifyEqual(string expected, string actual)
+    {
+        if (!string.Equals(expected, actual, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Expected '{expected}', but got '{actual}'.");
+        }
+    }
+
+    private static void VerifyContains(string expected, string actual)
+    {
+        if (!actual.Contains(expected, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Expected '{actual}' to contain '{expected}'.");
+        }
+    }
+
+    private static void VerifyDoesNotContain(string unexpected, string actual)
+    {
+        if (actual.Contains(unexpected, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"Expected '{actual}' not to contain '{unexpected}'.");
+        }
+    }
+}

--- a/src/scenario-tests/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTest.cs
+++ b/src/scenario-tests/src/Microsoft.DotNet.ScenarioTests.SdkTemplateTests/SdkTemplateTest.cs
@@ -39,7 +39,18 @@ public class SdkTemplateTest
         if (PreMadeSolution == null)
         {
             Directory.CreateDirectory(projectDirectory);
-            dotNetHelper.ExecuteNew(Template.GetName(), projectName, projectDirectory, Language.ToCliName(), customArgs: customNewArgs);
+            bool restoreSeparately = Template == DotNetSdkTemplate.WebApi;
+            dotNetHelper.ExecuteNew(
+                Template.GetName(),
+                projectName,
+                projectDirectory,
+                Language.ToCliName(),
+                customArgs: customNewArgs,
+                noRestore: restoreSeparately);
+            if (restoreSeparately)
+            {
+                dotNetHelper.ExecuteRestore(projectDirectory);
+            }
         }
         else
         {


### PR DESCRIPTION
Source-only validation failed here: https://dev.azure.com/dnceng/internal/_build/results?buildId=3057640&view=results

The apparent cause was a restore hang when running `dotnet new webapi` as part of the scenario tests.  These changes add additional logging and split the restore out as a separate operation from creating the template.  This should hopefully help pinpoint the failure better if in recurs.