### PR TITLE
Fix component authoring

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/product/registrykeys.wxs
+++ b/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/product/registrykeys.wxs
@@ -4,7 +4,7 @@
 
   <Fragment>
     <ComponentGroup Id="AuthoredRegistryKeys">
-      <Component Id="SetupRegistry_x86" Directory="TARGETDIR" Bitness="always32" Guid="f1dc3d97-93c5-4f3b-baa3-24e6a84a2e15" >
+      <Component Id="SetupRegistry_x86" Directory="TARGETDIR" Bitness="always32" >
         <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\$(var.Platform)\$(var.RegKeyProductName)">
 
           <?ifdef RegKeyNugetVersionExistence?>

--- a/src/runtime/src/installer/pkg/sfx/installers/dotnet-host.proj
+++ b/src/runtime/src/installer/pkg/sfx/installers/dotnet-host.proj
@@ -7,7 +7,7 @@
     <PackageBrandNameSuffix>Host</PackageBrandNameSuffix>
     <VSInsertionShortComponentName>NetCore.SharedHost</VSInsertionShortComponentName>
     <UseCustomDirectoryHarvesting>true</UseCustomDirectoryHarvesting>
-    <WixIncludeRegistryKeys>true</WixIncludeRegistryKeys>
+    <WixIncludeRegistryKeys>false</WixIncludeRegistryKeys>
     <RegKeyProductName>sharedhost</RegKeyProductName>
     <!-- Contributes to DependencyKey which ensures stable provider key - do not change -->
     <WixDependencyKeyName>Dotnet_CLI_SharedHost</WixDependencyKeyName>


### PR DESCRIPTION
The registry key component for writing specific version information should not be fixed. This makes it a shared component that isn't always removed, so the registry contains invalid information.

Example, when you install 10.0.9 and 10.0.10, the 10.0.10 entry remains. This can cause problems for ISVs that rely on the keys to detect specific version, potentially skipping over installs. It can also trigger scanners to report older versions that aren't actually installed.

