### PR TITLE
[release/10.0.1xx] Fix component authoring

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/product/registrykeys.wxs
+++ b/src/arcade/src/Microsoft.DotNet.Build.Tasks.Installers/build/wix5/product/registrykeys.wxs
@@ -4,7 +4,7 @@
 
   <Fragment>
     <ComponentGroup Id="AuthoredRegistryKeys">
-      <Component Id="SetupRegistry_x86" Directory="TARGETDIR" Bitness="always32" Guid="f1dc3d97-93c5-4f3b-baa3-24e6a84a2e15" >
+      <Component Id="SetupRegistry_x86" Directory="TARGETDIR" Bitness="always32">
         <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\$(var.Platform)\$(var.RegKeyProductName)">
 
           <?ifdef RegKeyNugetVersionExistence?>

--- a/src/runtime/src/installer/pkg/sfx/installers/dotnet-host.proj
+++ b/src/runtime/src/installer/pkg/sfx/installers/dotnet-host.proj
@@ -7,7 +7,7 @@
     <PackageBrandNameSuffix>Host</PackageBrandNameSuffix>
     <VSInsertionShortComponentName>NetCore.SharedHost</VSInsertionShortComponentName>
     <UseCustomDirectoryHarvesting>true</UseCustomDirectoryHarvesting>
-    <WixIncludeRegistryKeys>true</WixIncludeRegistryKeys>
+    <WixIncludeRegistryKeys>false</WixIncludeRegistryKeys>
     <RegKeyProductName>sharedhost</RegKeyProductName>
     <!-- Contributes to DependencyKey which ensures stable provider key - do not change -->
     <WixDependencyKeyName>Dotnet_CLI_SharedHost</WixDependencyKeyName>


### PR DESCRIPTION
# Description

Backport of https://github.com/dotnet/dotnet/pull/8759

.NET installers write version information to the registry.  When the installers are updated, for example, 10.0.9 to 10.0.10, the version information for 10.0.9 remain even though it's no longer installed. The component that writes the registry values have a hardcoded GUID, turning it into a shared component.

The logs will show entries similar to this:

```
Disallowing uninstallation of component: {F1DC3D97-93C5-4F3B-BAA3-24E6A84A2E15} since another client exists
```

The authoring error in the host project never surfaced when building with WiX v3. GUID generation occurred during linking and since the component wasn't referenced, it compiled, but was discarded by the linker.

# Impact
.NET Runtime and Desktop Runtime - they share infra from Arcade that defines the component authoring. The SDK does not rely on the shared authoring and not impacted.

The information is intended to help detect installations, e.g., third party installers would use this to determine whether redistributed runtimes should get installed. Some scanners also use this information to identify / report vulnerable copies of dotnet so this could generate false positives.

# How Found
Customer reported

# Regression
Yes, this was regressed as part of the WiX v3->v5 update in .NET 10.0

# Risk
Low

# Testing
Manually tested - requires full unified build to test and verify all the installers
