### PR TITLE
Suppress downgrade failures

### DIFF
--- a/src/windowsdesktop/src/windowsdesktop/src/bundle/Wix.targets
+++ b/src/windowsdesktop/src/windowsdesktop/src/bundle/Wix.targets
@@ -93,11 +93,6 @@
       <DefineConstants>$(DefineConstants);NativeMachine_x64=x64</DefineConstants>
       <DefineConstants>$(DefineConstants);NativeMachine_arm64=arm64</DefineConstants>
 
-      <!-- Allow downgrade only for preview/RC builds to handle version stamp issues. Disable for GA to prevent servicing downgrades. -->
-      <SuppressDowngradeFailure Condition="'$(_IsPreReleaseBuild)' == 'true'">yes</SuppressDowngradeFailure>
-      <SuppressDowngradeFailure Condition="'$(_IsPreReleaseBuild)' != 'true'">no</SuppressDowngradeFailure>
-      <DefineConstants>$(DefineConstants);SuppressDowngradeFailure=$(SuppressDowngradeFailure)</DefineConstants>
-
       <DefineConstants>$(DefineConstants);MajorVersion=$(MajorVersion)</DefineConstants>
       <DefineConstants>$(DefineConstants);MinorVersion=$(MinorVersion)</DefineConstants>
       <DefineConstants>$(DefineConstants);DotNetRuntimeVersion=$(MicrosoftNETCoreAppRefVersion)</DefineConstants>

--- a/src/windowsdesktop/src/windowsdesktop/src/bundle/bundle.wxs
+++ b/src/windowsdesktop/src/windowsdesktop/src/bundle/bundle.wxs
@@ -35,7 +35,7 @@
       <bal:WixStandardBootstrapperApplication LicenseFile="dummyeula.rtf"
                                               LocalizationFile="theme\1033\thm.wxl"
                                               ShowVersion="yes"
-                                              SuppressDowngradeFailure="$(SuppressDowngradeFailure)"
+                                              SuppressDowngradeFailure="yes"
                                               SuppressOptionsUI="yes"
                                               Theme="rtfLicense"
                                               ThemeFile="bundle.thm" />


### PR DESCRIPTION
## Description

Windows Desktop installer is not suppressing downgrades. 

## Regression

Yes - see https://github.com/dotnet/runtime/issues/54703

## How Found

Customer reported [feedback ticket](https://developercommunity.visualstudio.com/t/NET-Desktop-Runtime-installer-x64-sho/11141946)

## Risk

Low

## Testing

Manual verification. Once official installers are built, the manifest can be examined to ensure the suppression flag is set.