### PR TITLE
Skip EOL frameworks when downgrading installer assets

### DIFF
--- a/test/Microsoft.DotNet.Installer.Tests/assets/downgrade-fx-versions.sh
+++ b/test/Microsoft.DotNet.Installer.Tests/assets/downgrade-fx-versions.sh
@@ -32,7 +32,12 @@ cp "$PROPS_FILE" "${PROPS_FILE}${BACKUP_SUFFIX}"
 # Function to find .NET versions with servicing releases
 find_dotnet_versions() {
     grep -oP 'LatestRuntimeFrameworkVersion="\K\d+\.\d+\.\d+(?=")' "$PROPS_FILE" |
-        awk -F. '$3 >= 2 { print $1 "." $2 }' |
+        while IFS=. read -r major minor patch; do
+            # Only supported versions with at least two servicing releases can be downgraded.
+            if [ "$major" -ge 8 ] && [ "$patch" -ge 2 ]; then
+                echo "${major}.${minor}"
+            fi
+        done |
         sort -Vru
 }
 


### PR DESCRIPTION
## Problem

This regressed with https://github.com/dotnet/dotnet/pull/8610, which changed the installer test asset to dynamically process all bundled framework versions.

That included EOL versions. In particular, .NET 6.0 was downgraded from 6.0.36 to 6.0.34, but the 6.0.34 packages have been deleted from nuget.org, causing restore failures. The script also introduced a dependency on `awk`, which is not available in every test environment.

## Solution

- Only downgrade supported framework versions starting with .NET 8.
- Parse version components with Bash instead of `awk`.
- Continue requiring at least two servicing releases before downgrading.