### PR TITLE
Fix MTP handshakes in source-build test pipelines

### DIFF
--- a/eng/pipelines/templates/jobs/sdk-diff-tests.yml
+++ b/eng/pipelines/templates/jobs/sdk-diff-tests.yml
@@ -147,7 +147,6 @@ jobs:
       --filter-trait "Category=SdkContent"
       -c Release
       -bl:$(Build.SourcesDirectory)/artifacts/log/Debug/BuildTests_$(date +"%m%d%H%M%S").binlog 
-      -flp:LogFile=$(Build.SourcesDirectory)/artifacts/logs/BuildTests_$(date +"%m%d%H%M%S").log
       -clp:v=m
       /p:MsftSdkTarballPath=$(MsftSdkTarballPath)
       /p:SdkTarballPath=$(SdkTarballPath)

--- a/eng/pipelines/templates/stages/vmr-license-scan.yml
+++ b/eng/pipelines/templates/stages/vmr-license-scan.yml
@@ -128,7 +128,6 @@ stages:
         --filter-method "Microsoft.DotNet.SourceBuild.Tests.LicenseScanTests.ScanForLicenses"
         -c Release
         -bl:$(Build.SourcesDirectory)/artifacts/log/Debug/BuildTests_$(date +"%m%d%H%M%S").binlog
-        -flp:LogFile=$(Build.SourcesDirectory)/artifacts/logs/BuildTests_$(date +"%m%d%H%M%S").log
         -clp:v=m
         /p:SourceBuildTestsLicenseScanPath=$(repoPath)
         "/p:SourceBuildTestsLicenseScanIgnorePatterns=$(scanIgnorePatterns)"


### PR DESCRIPTION
## Problem

**Error or behavior:** Source-build SDK diff and license-scan tests exited with code 5 before running tests following the MTP migration in https://github.com/dotnet/dotnet/pull/8060.

**Root cause:** `dotnet test` forwarded the MSBuild `-flp` argument to the MTP xUnit application, which rejected it as an unknown option.

## Description

**Fix:** Remove `-flp` from both pipeline invocations while retaining binlog and console logging. Local validation confirmed successful MTP handshakes and filtered test discovery.