### PR TITLE
Remove whitespace and git merge markers in src/runtime files

### DIFF
--- a/src/runtime/.github/workflows/ci-failure-fix.md
+++ b/src/runtime/.github/workflows/ci-failure-fix.md
@@ -289,11 +289,7 @@ Per KBE, append one outcome line to `/tmp/gh-aw/agent/coverage.txt`:
 
 `<outcome>` is one of: `fix-PR #aw_<id>` (confident), `help-PR #aw_<id>` (needs review), `loopin-comment #<kbe>`, `skipped: <reason>`.
 
-<<<<<<< ours
-Recognized skip reasons (reuse these phrasings so the feedback workflow's aggregation stays stable): `not yet area-labeled`, `KBE too fresh, defer to next run`, `open fix PR #<n> already exists`, `fix PR #<n> already merged; KBE may be stale`, `prior fix PR #<n> closed without merge within 30d`, `human PR #<n> already addressing`, `author already engaged on #<kbe>`, `loop-in comment already posted`, `signature no longer reproduces in cited build`, `candidate fix already present in source`, `no producible diff (JIT/GC/security/API/infra) — comment`, `cap reached`, `integrity-filtered candidate, needs human review`. The list is non-exhaustive but additions SHOULD reuse one of these phrasings.
-=======
 Recognized skip reasons (reuse these phrasings so the feedback workflow's aggregation stays stable): `not yet area-labeled`, `KBE too fresh, defer to next run`, `open fix PR #<n> already exists`, `fix PR #<n> already merged; KBE may be stale`, `prior fix PR #<n> closed without merge within 30d`, `human PR #<n> already addressing`, `author already engaged on #<kbe>`, `loop-in comment already posted`, `signature no longer reproduces in cited build`, `no occurrence in last 14d, likely already fixed or retired`, `failing leg retired, no longer runs at HEAD`, `fix already present at HEAD; KBE stale`, `candidate fix already present in source`, `no producible diff (JIT/GC/security/API/infra) — comment`, `cap reached`, `integrity-filtered candidate, needs human review`. The list is non-exhaustive but additions SHOULD reuse one of these phrasings.
->>>>>>> theirs
 
 At end of run, print this table to the agent log:
 

--- a/src/runtime/src/coreclr/utilcode/clrconfig.cpp
+++ b/src/runtime/src/coreclr/utilcode/clrconfig.cpp
@@ -146,7 +146,7 @@ namespace
 
         bool noPrefix = CheckLookupOption(options, LookupOptions::DontPrependPrefix);
         bool coreclrFallbackPrefix = CheckLookupOption(options, LookupOptions::CoreclrFallbackPrefix);
-        
+
         if (noPrefix)
         {
             if (namelen >= ARRAY_SIZE(buff))

--- a/src/runtime/src/coreclr/vm/callhelpers.cpp
+++ b/src/runtime/src/coreclr/vm/callhelpers.cpp
@@ -565,7 +565,6 @@ void CallDefaultConstructor(OBJECTREF ref)
 
     GCPROTECT_BEGIN (ref);
 
-    
     PCODE ctorCode;
     {
         GCX_PREEMP();


### PR DESCRIPTION
It looks like these were caused by conflict resolution and show up in VMR backflows now: https://github.com/dotnet/runtime/pull/132978