### PR TITLE
Restrict codeflow milestones to eligible branches

### DIFF
--- a/.github/workflows/apply-milestones.yml
+++ b/.github/workflows/apply-milestones.yml
@@ -462,11 +462,31 @@ jobs:
               return a < b ? -1 : a > b ? 1 : 0;
             }
 
+            function isAllowedChildBaseBranch(codeflowBaseBranch, childBaseBranch) {
+              if (codeflowBaseBranch === 'main') {
+                return childBaseBranch === 'main';
+              }
+
+              // release/X.Y.1xx* codeflow can include changes from main or any
+              // release/X.Y* branch, regardless of the child repo's branch naming.
+              const releaseMatch = codeflowBaseBranch.match(/^release\/(\d+\.\d+)\.1xx(?:-(?:preview|rc)\d+)?$/);
+              if (!releaseMatch) return false;
+
+              const releasePrefix = `release/${releaseMatch[1]}`;
+              return childBaseBranch === 'main'
+                || childBaseBranch === releasePrefix
+                || childBaseBranch.startsWith(`${releasePrefix}.`)
+                || childBaseBranch.startsWith(`${releasePrefix}-`);
+            }
+
             // Repo-snapped preview/rc branches mean a child commit can flow into
             // dotnet/dotnet twice concurrently (via `main` and via the new release
             // branch), each potentially milestoning the same child PR differently.
-            // Rule: oldest milestone wins. Returns { action: 'skip'|'apply', reason, warn? }.
-            function decideMilestoneAction(pr, milestoneName, milestoneNumber) {
+            // Rule: oldest milestone wins. Returns { action: 'skip'|'apply', reason }.
+            function decideMilestoneAction(pr, milestoneName, milestoneNumber, codeflowBaseBranch) {
+              if (!isAllowedChildBaseBranch(codeflowBaseBranch, pr.base.ref)) {
+                return { action: 'skip', reason: `base branch "${pr.base.ref}" is not eligible for codeflow into "${codeflowBaseBranch}"` };
+              }
               // associatedPullRequests can include an open PR when a commit in the
               // flowed range is that PR's base commit rather than a commit it introduced.
               if (!pr.merged_at) {
@@ -478,9 +498,7 @@ jobs:
               if (pr.milestone) {
                 const cmp = compareMilestoneAge(milestoneName, pr.milestone.title);
                 if (cmp === null) {
-                  // Not a workflow-style milestone (e.g. generic "10.0"). Repos here
-                  // have opted in (see OPTED_OUT_REPOS), so overwrite it.
-                  return { action: 'apply', warn: true, reason: `existing milestone "${pr.milestone.title}" doesn't match the expected format — overwriting with "${milestoneName}"` };
+                  return { action: 'skip', reason: `existing milestone "${pr.milestone.title}" is not managed by this workflow` };
                 }
                 if (cmp >= 0) {
                   return { action: 'skip', reason: `existing milestone "${pr.milestone.title}" is already the same as or older than "${milestoneName}"` };
@@ -492,28 +510,26 @@ jobs:
             // The per-PR concurrency group (top of file) doesn't serialize runs for
             // DIFFERENT dotnet/dotnet PRs, so two runs can race on the same child PR.
             // Re-checking right before the write (below) narrows that window.
-            async function applyMilestone(owner, repo, prNumber, milestoneName, milestoneNumber, octokit) {
+            async function applyMilestone(owner, repo, prNumber, milestoneName, milestoneNumber, codeflowBaseBranch, octokit) {
               const { data: pr } = await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber });
-              const decision = decideMilestoneAction(pr, milestoneName, milestoneNumber);
+              const decision = decideMilestoneAction(pr, milestoneName, milestoneNumber, codeflowBaseBranch);
               if (decision.action === 'skip') {
                 core.info(`Skipping ${owner}/${repo}#${prNumber} — ${decision.reason}`);
                 return;
               }
 
               if (DRY_RUN) {
-                if (decision.warn) core.warning(`${owner}/${repo}#${prNumber}: ${decision.reason}`);
                 core.info(`[DRY RUN] Would apply milestone "${milestoneName}" to ${owner}/${repo}#${prNumber}`);
                 return;
               }
 
               // Re-check with fresh data right before writing (see comment above).
               const { data: latestPr } = await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber });
-              const finalDecision = decideMilestoneAction(latestPr, milestoneName, milestoneNumber);
+              const finalDecision = decideMilestoneAction(latestPr, milestoneName, milestoneNumber, codeflowBaseBranch);
               if (finalDecision.action === 'skip') {
                 core.info(`Skipping ${owner}/${repo}#${prNumber} after re-check — ${finalDecision.reason}`);
                 return;
               }
-              if (finalDecision.warn) core.warning(`${owner}/${repo}#${prNumber}: ${finalDecision.reason}`);
 
               await octokit.rest.issues.update({
                 owner, repo, issue_number: prNumber,
@@ -524,7 +540,7 @@ jobs:
 
             // --- Core logic: process a single dotnet/dotnet PR ---
 
-            async function processOnePR(prNumber, milestoneName) {
+            async function processOnePR(prNumber, milestoneName, codeflowBaseBranch) {
               const changes = await extractChildPRs(prNumber);
 
               for (const change of changes) {
@@ -560,7 +576,7 @@ jobs:
 
                   for (const childPR of prNumbers) {
                     try {
-                      await applyMilestone(owner, repo, childPR, milestoneName, milestoneNumber, octokit);
+                      await applyMilestone(owner, repo, childPR, milestoneName, milestoneNumber, codeflowBaseBranch, octokit);
                     } catch (e) {
                       core.warning(`Failed to milestone ${owner}/${repo}#${childPR}: ${e.message}`);
                     }
@@ -615,4 +631,4 @@ jobs:
             core.info(`Resolved milestone: ${milestoneName}`);
 
             // Process the current PR
-            await processOnePR(prNumber, milestoneName);
+            await processOnePR(prNumber, milestoneName, baseBranch);


### PR DESCRIPTION
## Summary

- For codeflow into `main`, milestone only child PRs merged into `main`.
- For codeflow into `release/X.Y.1xx*`, milestone child PRs merged into `main` or the matching `release/X.Y*` branch family.
- Preserve existing milestones that do not use the workflow-managed preview/RC format.

This prevents inter-branch merge history from applying current milestones to PRs from older release lines, and prevents overwriting milestones such as `10.0.4xx`.

## Validation

Validated the workflow YAML and exercised the embedded decision logic across main, same-release, older-release, open-PR, preview/RC ordering, and unmanaged-milestone cases.