### PR TITLE
Remove Emscripten manifest transport package

### DIFF
--- a/src/runtime/eng/Version.Details.props
+++ b/src/runtime/eng/Version.Details.props
@@ -23,6 +23,7 @@ This file should be imported by eng/Versions.props
     <MicrosoftDotNetCecilPackageVersion>0.11.5-preview.26431.109</MicrosoftDotNetCecilPackageVersion>
     <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.26431.109</MicrosoftDotNetCodeAnalysisPackageVersion>
     <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.26431.109</MicrosoftDotNetGenAPIPackageVersion>
+    <MicrosoftDotNetGenAPITaskPackageVersion>11.0.100-rc.1.26431.109</MicrosoftDotNetGenAPITaskPackageVersion>
     <MicrosoftDotNetGenFacadesPackageVersion>11.0.0-beta.26431.109</MicrosoftDotNetGenFacadesPackageVersion>
     <MicrosoftDotNetHelixJobMonitorPackageVersion>11.0.0-beta.26431.109</MicrosoftDotNetHelixJobMonitorPackageVersion>
     <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26431.109</MicrosoftDotNetHelixSdkPackageVersion>
@@ -35,7 +36,6 @@ This file should be imported by eng/Versions.props
     <MicrosoftNetCompilersToolsetPackageVersion>5.12.0-1.26431.109</MicrosoftNetCompilersToolsetPackageVersion>
     <MicrosoftNETRuntimeEmscriptenInternalPackageVersion>11.0.0-rc.1.26431.109</MicrosoftNETRuntimeEmscriptenInternalPackageVersion>
     <MicrosoftNETSdkILPackageVersion>11.0.0-rc.1.26431.109</MicrosoftNETSdkILPackageVersion>
-    <MicrosoftNETWorkloadEmscriptenCurrentManifest110100TransportPackageVersion>11.0.100-rc.1.26431.109</MicrosoftNETWorkloadEmscriptenCurrentManifest110100TransportPackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>11.0.0-rc.1.26431.109</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftNETCoreILAsmPackageVersion>11.0.0-rc.1.26431.109</MicrosoftNETCoreILAsmPackageVersion>
     <NuGetFrameworksPackageVersion>7.11.0-rc.43209</NuGetFrameworksPackageVersion>
@@ -137,6 +137,7 @@ This file should be imported by eng/Versions.props
     <MicrosoftDotNetCecilVersion>$(MicrosoftDotNetCecilPackageVersion)</MicrosoftDotNetCecilVersion>
     <MicrosoftDotNetCodeAnalysisVersion>$(MicrosoftDotNetCodeAnalysisPackageVersion)</MicrosoftDotNetCodeAnalysisVersion>
     <MicrosoftDotNetGenAPIVersion>$(MicrosoftDotNetGenAPIPackageVersion)</MicrosoftDotNetGenAPIVersion>
+    <MicrosoftDotNetGenAPITaskVersion>$(MicrosoftDotNetGenAPITaskPackageVersion)</MicrosoftDotNetGenAPITaskVersion>
     <MicrosoftDotNetGenFacadesVersion>$(MicrosoftDotNetGenFacadesPackageVersion)</MicrosoftDotNetGenFacadesVersion>
     <MicrosoftDotNetHelixJobMonitorVersion>$(MicrosoftDotNetHelixJobMonitorPackageVersion)</MicrosoftDotNetHelixJobMonitorVersion>
     <MicrosoftDotNetHelixSdkVersion>$(MicrosoftDotNetHelixSdkPackageVersion)</MicrosoftDotNetHelixSdkVersion>
@@ -149,7 +150,6 @@ This file should be imported by eng/Versions.props
     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNetCompilersToolsetPackageVersion)</MicrosoftNetCompilersToolsetVersion>
     <MicrosoftNETRuntimeEmscriptenInternalVersion>$(MicrosoftNETRuntimeEmscriptenInternalPackageVersion)</MicrosoftNETRuntimeEmscriptenInternalVersion>
     <MicrosoftNETSdkILVersion>$(MicrosoftNETSdkILPackageVersion)</MicrosoftNETSdkILVersion>
-    <MicrosoftNETWorkloadEmscriptenCurrentManifest110100TransportVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest110100TransportPackageVersion)</MicrosoftNETWorkloadEmscriptenCurrentManifest110100TransportVersion>
     <MicrosoftNETCoreAppRefVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftNETCoreAppRefVersion>
     <MicrosoftNETCoreILAsmVersion>$(MicrosoftNETCoreILAsmPackageVersion)</MicrosoftNETCoreILAsmVersion>
     <NuGetFrameworksVersion>$(NuGetFrameworksPackageVersion)</NuGetFrameworksVersion>

--- a/src/runtime/eng/Version.Details.xml
+++ b/src/runtime/eng/Version.Details.xml
@@ -45,10 +45,6 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-11.0.100.Transport" Version="11.0.100-rc.1.26431.109">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.NET.Runtime.Emscripten.Internal" Version="11.0.0-rc.1.26431.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
@@ -68,6 +64,10 @@
       <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.26431.109">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.GenAPI.Task" Version="11.0.100-rc.1.26431.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>4f8bdb66a033b551cc724f902111718ef5ca986c</Sha>
     </Dependency>

--- a/src/runtime/eng/Versions.props
+++ b/src/runtime/eng/Versions.props
@@ -21,13 +21,11 @@
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
     <!-- SdkVersionForWorkloadTesting is used to compute the sdk band and version for workload testing.
          The published manifests are built in dotnet/sdk so these values are for testing purposes only.
-         We use the manifest transport package version number unless it is lower
-         than the sdk version specified in global.json
-      -->
+         Use an SDK-versioned VMR package if it is newer than the SDK specified in global.json. -->
     <!-- NETCoreSdkVersion is normally set by the SDK, but for non-SDK projects we need extract from global.json -->
     <_GlobalJsonContent>$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)../global.json'))</_GlobalJsonContent>
     <_GlobalJsonSdkVersion Condition="'$(_GlobalJsonContent)' != ''">$([System.Text.RegularExpressions.Regex]::Match($(_GlobalJsonContent), '"sdk"\s*:\s*\{[^\}]*"version"\s*:\s*"([^"]+)"', System.Text.RegularExpressions.RegexOptions.Singleline).Groups[1].Value)</_GlobalJsonSdkVersion>
-    <_DotnetSdkVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest110100TransportVersion)</_DotnetSdkVersion>
+    <_DotnetSdkVersion>$(MicrosoftDotNetGenAPITaskPackageVersion)</_DotnetSdkVersion>
     <SdkVersionForWorkloadTesting Condition="$([System.String]::Compare('$(_GlobalJsonSdkVersion)', '$(_DotnetSdkVersion)')) &lt;= 0">$(_DotnetSdkVersion)</SdkVersionForWorkloadTesting>
     <SdkVersionForWorkloadTesting Condition="'$(SdkVersionForWorkloadTesting)' == ''">$(_GlobalJsonSdkVersion)</SdkVersionForWorkloadTesting>
     <SdkMajorVersion>$([System.String]::Copy('$(SdkVersionForWorkloadTesting)').Split('.')[0])</SdkMajorVersion>

--- a/src/runtime/eng/pipelines/common/xplat-setup.yml
+++ b/src/runtime/eng/pipelines/common/xplat-setup.yml
@@ -118,7 +118,6 @@ jobs:
       - ${{ if eq(parameters.archType, 'wasm') }}:
         - name: wasmDarcDependenciesChanged
           value: $[ or(
-                      eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['DarcDependenciesChanged.Microsoft_NET_Workload_Emscripten_Current_Manifest-11_0_100_Transport'], true),
                       eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['DarcDependenciesChanged.System_Runtime_TimeZoneData'], true),
                       eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['DarcDependenciesChanged.Microsoft_Net_Compilers_Toolset'], true),
                       eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['DarcDependenciesChanged.Microsoft_CodeAnalysis'], true),

--- a/src/sdk/src/Workloads/Manifests/Directory.Build.props
+++ b/src/sdk/src/Workloads/Manifests/Directory.Build.props
@@ -9,7 +9,6 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>
-    <IsShipping Condition="'$(MSBuildProjectName)' == 'Microsoft.NET.Workload.Emscripten.Current.Transport.Manifest'">false</IsShipping>
     <IsShippingPackage>$(IsShipping)</IsShippingPackage>
     <IncludeSymbols>false</IncludeSymbols>
     <PackageVersion Condition="'$(DotNet1xxWorkloadManifestVersion)' != ''">$(DotNet1xxWorkloadManifestVersion)</PackageVersion>
@@ -22,7 +21,6 @@
     <!-- Append the version iteration if it's not empty -->
     <_workloadVersionSuffix Condition="'$(_workloadVersionSuffix)' != '' and '$(PrereleaseVersionIteration)' != ''">$(_workloadVersionSuffix).$(PrereleaseVersionIteration)</_workloadVersionSuffix>
     <PackageId>$(MSBuildProjectName)-$(BuiltinWorkloadFeatureBand)$(_workloadVersionSuffix)</PackageId>
-    <PackageId Condition="'$(MSBuildProjectName)' == 'Microsoft.NET.Workload.Emscripten.Current.Transport.Manifest'">Microsoft.NET.Workload.Emscripten.Current.Manifest-$(BuiltinWorkloadFeatureBand).Transport</PackageId>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/sdk/src/Workloads/Manifests/Microsoft.NET.Workload.Emscripten.Current.Transport.Manifest/Microsoft.NET.Workload.Emscripten.Current.Transport.Manifest.proj
+++ b/src/sdk/src/Workloads/Manifests/Microsoft.NET.Workload.Emscripten.Current.Transport.Manifest/Microsoft.NET.Workload.Emscripten.Current.Transport.Manifest.proj
@@ -1,3 +1,0 @@
-<Project Sdk="Microsoft.Build.NoTargets">
-  <!-- empty package to flow the version of the manifest -->
-</Project>


### PR DESCRIPTION
## Summary

- use `Microsoft.DotNet.GenAPI.Task` to determine the SDK version for runtime workload testing. It needs to stay a non-stabilized version so the corresponding SDK can be installed via dotnet-install before it is released.
- remove the Emscripten manifest transport dependency from runtime
- stop producing the empty Emscripten manifest transport package from SDK

## Validation

- evaluated the runtime workload version properties with MSBuild
- restored and packed the SDK workload manifest traversal project

> [!NOTE]
> This pull request description was generated with GitHub Copilot.