### PR TITLE
Use global.json SDK for 3xx VMR license scan

### DIFF
--- a/eng/pipelines/templates/stages/vmr-license-scan.yml
+++ b/eng/pipelines/templates/stages/vmr-license-scan.yml
@@ -123,7 +123,7 @@ stages:
     steps:
 
     - script: >
-        dotnet test
+        ./eng/common/dotnet.sh test
         $(Build.SourcesDirectory)/test/Microsoft.DotNet.SourceBuild.Tests/Microsoft.DotNet.SourceBuild.Tests.csproj
         --filter "FullyQualifiedName=Microsoft.DotNet.SourceBuild.Tests.LicenseScanTests.ScanForLicenses"
         --logger:'trx;LogFileName=$(Agent.JobName)_LicenseScan.trx'


### PR DESCRIPTION
## What

The VMR license scan on `release/10.0.3xx` invokes the container's system `dotnet`, which only has SDK 10.0.400 installed. The branch's `global.json` requests 10.0.302, so the scan exits with code 155 before tests run.

This changes the invocation to `./eng/common/dotnet.sh test`, which acquires and uses the SDK selected by `global.json`.

## Context

This ports the fix from #8063 (follow-up to #8012) to `release/10.0.3xx`. The same approach was validated by the successful license-scan build linked in #8063.

Current failures:
- https://dev.azure.com/dnceng/internal/_build/results?buildId=3068447
- https://dev.azure.com/dnceng/internal/_build/results?buildId=3068449

Related to dotnet/source-build#5623.