### PR TITLE
Fix build failures when building non-portable TargetRid that is different from the SDK's non-portable rid.

### DIFF
--- a/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetingPacks.BeforeCommonTargets.targets
+++ b/src/arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/TargetingPacks.BeforeCommonTargets.targets
@@ -99,38 +99,40 @@
   </ItemGroup>
 
   <!--
-    When .NET gets built from source, make the SDK aware there are bootstrap packages
-    for Microsoft.NETCore.App.Runtime.<rid> (including the NativeAOT-labeled runtime pack),
-    Microsoft.NETCore.App.Crossgen2.<rid>, and the ILCompiler packs
-    (runtime.<rid>.Microsoft.DotNet.ILCompiler / Microsoft.NETCore.App.Runtime.NativeAOT.<rid>).
-    The on-disk previous SDK does not list the build's non-portable RID in these RID sets, so
-    append it in-memory here. This allows publishing for the non-portable RID (e.g. self-contained,
-    ReadyToRun, and AOT) to validate and restore the matching source-built packs.
+    Ensure the SDK knows about NETCoreSdkRuntimeIdentifier and TargetRid.
+    - TargetRid can be an unknown rid. The build will produce assets for this rid which can then be used at later steps of the build.
+    - NETCoreSdkRuntimeIdentifier is the known rid of the SDK.
+      While the SDK knows the rid, it may not consider all assets to be available for this rid by default.
+      For example, it may always fall back to a compatible portable rid assets for the end-user.
+      For source-build such assets are available for NETCoreSdkRuntimeIdentifier either as prebuilts or as packages produced during the build.
 
-    Use $(TargetRid) (the build's non-portable RID, e.g. centos.10-x64), not
-    $(NETCoreSdkRuntimeIdentifier). In a stage 1 source-build leg the previous SDK is the Microsoft
-    portable SDK, whose $(NETCoreSdkRuntimeIdentifier) is the portable RID (e.g. linux-x64) and would
-    not unblock publishing for the build's non-portable RID.
+    ILCompiler's SingleEntry.targets can only handle the rids meant for end-users.
+    It doesn't work when using a non-portable SDK to build an SDK with a different non-portable RID.
+    We set IlcHostRuntimeIdentifier/IlcTargetOS to provide it with the information it needs.
   -->
-  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true' and '$(TargetRid)' != ''">
+  <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
+    <IlcHostRuntimeIdentifier Condition="'$(IlcHostRuntimeIdentifier)' == ''">$(NETCoreSdkRuntimeIdentifier)</IlcHostRuntimeIdentifier>
+    <IlcTargetOS Condition="'$(IlcTargetOS)' == ''">$(TargetOS)</IlcTargetOS>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <KnownFrameworkReference Update="Microsoft.NETCore.App">
-      <RuntimePackRuntimeIdentifiers>%(RuntimePackRuntimeIdentifiers);$(TargetRid)</RuntimePackRuntimeIdentifiers>
+      <RuntimePackRuntimeIdentifiers>%(RuntimePackRuntimeIdentifiers);$(NETCoreSdkRuntimeIdentifier);$(TargetRid)</RuntimePackRuntimeIdentifiers>
     </KnownFrameworkReference>
 
     <KnownFrameworkReference Update="Microsoft.AspNetCore.App">
-      <RuntimePackRuntimeIdentifiers>%(RuntimePackRuntimeIdentifiers);$(TargetRid)</RuntimePackRuntimeIdentifiers>
+      <RuntimePackRuntimeIdentifiers>%(RuntimePackRuntimeIdentifiers);$(NETCoreSdkRuntimeIdentifier);$(TargetRid)</RuntimePackRuntimeIdentifiers>
     </KnownFrameworkReference>
 
     <KnownRuntimePack Update="Microsoft.NETCore.App">
-      <RuntimePackRuntimeIdentifiers>%(RuntimePackRuntimeIdentifiers);$(TargetRid)</RuntimePackRuntimeIdentifiers>
+      <RuntimePackRuntimeIdentifiers>%(RuntimePackRuntimeIdentifiers);$(NETCoreSdkRuntimeIdentifier);$(TargetRid)</RuntimePackRuntimeIdentifiers>
     </KnownRuntimePack>
 
     <KnownCrossgen2Pack Update="Microsoft.NETCore.App.Crossgen2">
-      <Crossgen2RuntimeIdentifiers>%(Crossgen2RuntimeIdentifiers);$(TargetRid)</Crossgen2RuntimeIdentifiers>
+      <Crossgen2RuntimeIdentifiers>%(Crossgen2RuntimeIdentifiers);$(NETCoreSdkRuntimeIdentifier);$(TargetRid)</Crossgen2RuntimeIdentifiers>
     </KnownCrossgen2Pack>
 
     <KnownILCompilerPack Update="Microsoft.DotNet.ILCompiler">
-      <ILCompilerRuntimeIdentifiers>%(ILCompilerRuntimeIdentifiers);$(TargetRid)</ILCompilerRuntimeIdentifiers>
+      <ILCompilerRuntimeIdentifiers>%(ILCompilerRuntimeIdentifiers);$(NETCoreSdkRuntimeIdentifier);$(TargetRid)</ILCompilerRuntimeIdentifiers>
     </KnownILCompilerPack>
   </ItemGroup>
 

--- a/src/runtime/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
+++ b/src/runtime/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
@@ -1,6 +1,16 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup Condition="'$(RuntimeIdentifier)' != '' and '$(NETCoreSdkPortableRuntimeIdentifier)' != ''">
+    <!--
+      Based on RuntimeIdentifier we decide on the host package and target OS.
+      - Normally, the RuntimeIdentifier is a portable rid.
+        Then we use the host package for NETCoreSdkPortableRuntimeIdentifier, and determine the target OS based on the NETCoreSdkPortableRuntimeIdentifier.
+      - A special case is when the SDK is non-portable and RuntimeIdentifier matches its non-portable NETCoreSdkRuntimeIdentifier.
+        Then we use the host package for that non-portable rid, and determine the target OS based on NETCoreSdkPortableRuntimeIdentifier.
+      - When .NET itself gets built, the RuntimeIdentifier may be a non-portable rid that does not match the SDKs non-portable rid.
+        In that case, the IlcHostRuntimeIdentifier and IlcTargetOS may be used to override the above logic.
+    -->
+
     <!-- Define the name of the runtime specific compiler package to import -->
     <_hostOS>$(NETCoreSdkPortableRuntimeIdentifier.SubString(0, $(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))))</_hostOS>
 
@@ -9,16 +19,6 @@
 
     <_originalTargetOS>$(RuntimeIdentifier.SubString(0, $(RuntimeIdentifier.LastIndexOf('-'))))</_originalTargetOS>
     <_originalTargetOS Condition="'$(_targetsNonPortableSdkRid)' == 'true'">$(NETCoreSdkPortableRuntimeIdentifier.SubString(0, $(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))))</_originalTargetOS>
-    <!--
-      A non-portable RID (e.g. 'centos.10-x64') yields a version-qualified OS token ('centos.10')
-      that is not a valid ILC target OS. This happens when the running SDK is portable, so the RID is
-      not the SDK's own RID handled above, yet publishing targets a non-portable RID. Map the
-      version-qualified token to the portable base OS the SDK reports (e.g. 'linux'), mirroring the
-      non-portable SDK RID handling above. The SDK still resolves the host/target packs by the full
-      RID; only the ILC target OS needs normalizing.
-    -->
-    <_originalTargetOS Condition="'$(_targetsNonPortableSdkRid)' != 'true' and $(_originalTargetOS.Contains('.'))">$(NETCoreSdkPortableRuntimeIdentifier.SubString(0, $(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))))</_originalTargetOS>
-    <_originalTargetOS Condition="$(_originalTargetOS.Contains('.'))">$(_originalTargetOS.SubString(0, $(_originalTargetOS.IndexOf('.'))))</_originalTargetOS>
     <_originalTargetOS Condition="$(_originalTargetOS.StartsWith('win'))">win</_originalTargetOS>
 
     <!-- On non-Windows, determine _hostArchitecture from NETCoreSdkPortableRuntimeIdentifier -->
@@ -31,13 +31,11 @@
 
     <_hostPackageName>runtime.$(_hostOS)-$(_hostArchitecture).Microsoft.DotNet.ILCompiler</_hostPackageName>
     <_hostPackageName Condition="'$(_targetsNonPortableSdkRid)' == 'true'">runtime.$(RuntimeIdentifier).Microsoft.DotNet.ILCompiler</_hostPackageName>
-    <_targetPackageName>runtime.$(_originalTargetOS)-$(_targetArchitecture).Microsoft.DotNet.ILCompiler</_targetPackageName>
-    <_targetPackageName Condition="'$(_targetsNonPortableSdkRid)' == 'true'">runtime.$(RuntimeIdentifier).Microsoft.DotNet.ILCompiler</_targetPackageName>
-    <_targetRuntimePackName>Microsoft.NETCore.App.Runtime.NativeAOT.$(_originalTargetOS)-$(_targetArchitecture)</_targetRuntimePackName>
-    <_targetRuntimePackName Condition="'$(_targetsNonPortableSdkRid)' == 'true'">Microsoft.NETCore.App.Runtime.NativeAOT.$(RuntimeIdentifier)</_targetRuntimePackName>
+    <_hostPackageName Condition="'$(IlcHostRuntimeIdentifier)' != ''">runtime.$(IlcHostRuntimeIdentifier).Microsoft.DotNet.ILCompiler</_hostPackageName>
 
     <!-- Treat linux-musl and linux-bionic etc. as linux -->
     <_targetOS>$(_originalTargetOS)</_targetOS>
+    <_targetOS Condition="'$(IlcTargetOS)' != ''">$(IlcTargetOS)</_targetOS>
     <_linuxToken>linux-</_linuxToken>
     <_linuxLibcFlavor Condition="$(_targetOS.StartsWith($(_linuxToken)))">$(_targetOS.SubString($(_linuxToken.Length)))</_linuxLibcFlavor>
     <_linuxLibcFlavor Condition="'$(_targetOS)' == 'android'">bionic</_linuxLibcFlavor>


### PR DESCRIPTION
This is https://github.com/dotnet/dotnet/pull/8902 applied to main, taking into account some changes made in https://github.com/dotnet/dotnet/pull/8312.

@jkoritzinsky @akoeplinger @am11 ptal.