### PR TITLE
[release/11.0.1xx] Update Microsoft.DiaSymReader.Native to 18.9.0-beta1.26405.2

### DIFF
--- a/src/runtime/eng/Versions.props
+++ b/src/runtime/eng/Versions.props
@@ -126,7 +126,7 @@
     <SystemThreadingTasksExtensionsToolsetVersion>4.5.4</SystemThreadingTasksExtensionsToolsetVersion>
     <!-- Not auto-updated. -->
     <MicrosoftDiaSymReaderVersion>2.0.0</MicrosoftDiaSymReaderVersion>
-    <MicrosoftDiaSymReaderNativeVersion>17.10.0-beta1.24272.1</MicrosoftDiaSymReaderNativeVersion>
+    <MicrosoftDiaSymReaderNativeVersion>18.9.0-beta1.26405.2</MicrosoftDiaSymReaderNativeVersion>
     <TraceEventVersion>3.1.28</TraceEventVersion>
     <MicrosoftDiagnosticsNetCoreClientVersion>0.2.740901</MicrosoftDiagnosticsNetCoreClientVersion>
     <NETStandardLibraryRefVersion>2.1.0</NETStandardLibraryRefVersion>


### PR DESCRIPTION
## Summary

- update `Microsoft.DiaSymReader.Native` from `17.10.0-beta1.24272.1` to `18.9.0-beta1.26405.2`
- restore the package upgrade from `4ed50da46540053a90714609b70b59cb749dd627`, which was included in the RC1 tag but omitted when the tag was merged into `release/11.0.1xx`

## Testing

Not run; this is a one-line package version update matching the original runtime commit.

> [!NOTE]
> This pull request description was generated with GitHub Copilot.