### PR TITLE
Fix release CI container shutdown and native symbol dependency

### DIFF
--- a/eng/pipelines/templates/variables/vmr-build.yml
+++ b/eng/pipelines/templates/variables/vmr-build.yml
@@ -32,7 +32,9 @@ variables:
   value: DotNetCore
 
 - name: defaultContainerOptions
-  value: --privileged
+  # Reap orphaned compiler servers so build-server shutdown does not wait on zombie processes.
+  # This can be removed when https://github.com/dotnet/roslyn/pull/83921 exists in SDK used by 10.0.1xx
+  value: --privileged --init
 
 - ${{ if eq(parameters.desiredIBC, 'Enabled') }}:
   - name: ibcEnabled

--- a/src/runtime/eng/Versions.props
+++ b/src/runtime/eng/Versions.props
@@ -120,7 +120,7 @@
     <SystemThreadingTasksExtensionsToolsetVersion>4.5.4</SystemThreadingTasksExtensionsToolsetVersion>
     <!-- Not auto-updated. -->
     <MicrosoftDiaSymReaderVersion>2.0.0</MicrosoftDiaSymReaderVersion>
-    <MicrosoftDiaSymReaderNativeVersion>17.12.0-beta1.24603.5</MicrosoftDiaSymReaderNativeVersion>
+    <MicrosoftDiaSymReaderNativeVersion>18.9.0-beta1.26405.2</MicrosoftDiaSymReaderNativeVersion>
     <TraceEventVersion>3.1.16</TraceEventVersion>
     <NETStandardLibraryRefVersion>2.1.0</NETStandardLibraryRefVersion>
     <NetStandardLibraryVersion>2.0.3</NetStandardLibraryVersion>


### PR DESCRIPTION
## Problem

CI builds on `release/10.0.1xx` hang during compiler-server shutdown instead of completing. Builds also fail with `NU1903` warnings for the existing Microsoft.DiaSymReader.Native dependency.

**Root cause:** The container's PID 1 does not reap orphaned compiler servers, leaving zombie processes that the older bootstrap SDK waits on indefinitely during shutdown. See https://github.com/dotnet/dotnet/pull/9190#issuecomment-5623930329 for more details. Separately, Microsoft.DiaSymReader.Native `17.12.0-beta1.24603.5` is affected by security advisories.

## Fix

- Enable Docker `--init` so orphaned compiler-server processes are reaped. Document that this workaround can be removed once the SDK used by `10.0.1xx` includes [dotnet/roslyn#83921](https://github.com/dotnet/roslyn/issues/83921).
- Update Microsoft.DiaSymReader.Native to the patched version `18.9.0-beta1.26405.2`, applying the equivalent of [dotnet/runtime#133508](https://github.com/dotnet/runtime/issues/133508).